### PR TITLE
Support max(int128, uint256)

### DIFF
--- a/tests/parser/functions/test_minmax.py
+++ b/tests/parser/functions/test_minmax.py
@@ -17,3 +17,158 @@ def goo() -> uint256:
     assert c.goo() == 83
 
     print("Passed min/max test")
+
+
+def test_max_var_uint256_literal_int128(get_contract_with_gas_estimation):
+    """Tests to verify that max works as expected when a variable/literal uint256 and a literal int128 are passed."""
+    code = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2 ** 200
+    b: uint256 = 5
+    return max(a, 5) + max(b, 5)
+
+@public
+def goo() -> uint256:
+    a: uint256 = 2 ** 200
+    b: uint256 = 5
+    return max(5, a) + max(5, b)
+
+@public
+def bar() -> uint256:
+    a: uint256 = 2
+    b: uint256 = 5
+    return max(a, 5) + max(b, 5)
+
+@public
+def baz() -> uint256:
+    a: uint256 = 2
+    b: uint256 = 5
+    return max(5, a) + max(5, b)
+
+@public
+def both_literals() -> uint256:
+    return max(2 ** 200, 2)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 2 ** 200 + 5
+    assert c.goo() == 2 ** 200 + 5
+    assert c.bar() == 5 + 5
+    assert c.baz() == 5 + 5
+    assert c.both_literals() == 2 ** 200
+
+
+def test_min_var_uint256_literal_int128(get_contract_with_gas_estimation):
+    """Tests to verify that max works as expected when a variable/literal uint256 and a literal int128 are passed."""
+    code = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2 ** 200
+    b: uint256 = 5
+    return min(a, 5) + min(b, 5)
+
+@public
+def goo() -> uint256:
+    a: uint256 = 2 ** 200
+    b: uint256 = 5
+    return min(5, a) + min(5, b)
+
+@public
+def bar() -> uint256:
+    a: uint256 = 2
+    b: uint256 = 5
+    return min(a, 5) + min(b, 5)
+
+@public
+def baz() -> uint256:
+    a: uint256 = 2
+    b: uint256 = 5
+    return min(5, a) + min(5, b)
+
+@public
+def both_literals() -> uint256:
+    return min(2 ** 200, 2)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() == 5 + 5
+    assert c.goo() == 5 + 5
+    assert c.bar() == 2 + 5
+    assert c.baz() == 2 + 5
+    assert c.both_literals() == 2
+
+
+def test_minmax_var_uint256_var_int128(get_contract_with_gas_estimation, assert_compile_failed):
+    """Tests to verify that max throws an error if a variable uint256 and a variable int128 are passed."""
+    from vyper.exceptions import TypeMismatchException
+    code_1 = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2
+    b: int128 = 3
+    return max(a, b)
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code_1),
+        TypeMismatchException
+    )
+
+    code_2 = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2
+    b: int128 = 3
+    return max(b, a)
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code_2),
+        TypeMismatchException
+    )
+
+    code_3 = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2
+    b: int128 = 3
+    return min(a, b)
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code_3),
+        TypeMismatchException
+    )
+
+    code_4 = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2
+    b: int128 = 3
+    return min(b, a)
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code_4),
+        TypeMismatchException
+    )
+
+
+def test_minmax_var_uint256_negative_int128(get_contract_with_gas_estimation, assert_tx_failed, assert_compile_failed):
+    from vyper.exceptions import TypeMismatchException
+    code_1 = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2 ** 200
+    return max(a, -1)
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code_1),
+        TypeMismatchException
+    )
+
+    code_2 = """
+@public
+def foo() -> uint256:
+    a: uint256 = 2 ** 200
+    return min(a, -1)
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code_2),
+        TypeMismatchException
+    )

--- a/tests/parser/syntax/test_minmax.py
+++ b/tests/parser/syntax/test_minmax.py
@@ -10,11 +10,6 @@ fail_list = [
 @public
 def foo():
     y = min(7, 0x1234567890123456789012345678901234567890)
-    """,
-    """
-@public
-def foo():
-    y = min(7, convert(3, 'uint256'))
     """
 ]
 


### PR DESCRIPTION
### - What I did
Added support for `max(int128, uint256)` which returns a `uint256`.

Closes #873.

### - How I did it
If one of the parameters passed is `int128` and the other one is `uint256` for the `max` method then allow comparison rather than throwing an error.

### - How to verify it
Call `max(convert(_literal, 'uint256), _literal))`.

### - Description for the changelog
Added support for `max(int128, uint256)` which returns a `uint256`.

### - Cute Animal Picture

![36288655fbb0466af9b636b0e45514bf](https://user-images.githubusercontent.com/10276811/41068274-65b2e340-6a06-11e8-8942-ee392d4415e7.jpg)

