### PR TITLE
Fix/struct constants do not parse correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/modules.rst
 
 # IDEs
 .idea/
+.vscode/
 
 .tox
 .mypy_cache

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -80,7 +80,9 @@ class Constants(object):
                     is_special_case_uint256_literal = (
                         is_instances([expr.typ, annotation_type], StructType)
                     ) and (
-                        [str(annotation_type.members[key2]), str(expr.typ.members[key1])] == ['uint256', 'int128']
+                        str(annotation_type.members[key2]) == 'uint256'
+                    ) and (
+                        str(expr.typ.members[key1]) == 'int128'
                     ) and SizeLimits.in_bounds('uint256', expr[1][0])
 
                     is_special_case_int256_literal = (

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -88,7 +88,9 @@ class Constants(object):
                     is_special_case_int256_literal = (
                         is_instances([expr.typ, annotation_type], StructType)
                     ) and (
-                        [str(annotation_type.members[key2]), str(expr.typ.members[key1])] == ['int128', 'int128']
+                        str(annotation_type.members[key2]) == 'int128'
+                    ) and (
+                        str(expr.typ.members[key1]) == 'int128'
                     ) and SizeLimits.in_bounds('int128', expr[1][0])
 
                 if is_special_case_uint256_literal or is_special_case_int256_literal:

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -94,7 +94,6 @@ class Constants(object):
                 if is_special_case_uint256_literal or is_special_case_int256_literal:
                     fail = False
 
-
         if fail:
             raise TypeMismatchException(
                 'Invalid value for constant type, expected %r got %r instead' % (

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -78,7 +78,7 @@ class Constants(object):
                 annotation_type_keys = list(annotation_type.members.keys())
                 for key1, key2 in expr_keys, annotation_type_keys:
                     is_special_case_uint256_literal = (
-                    is_instances([expr.typ, annotation_type], StructType)
+                        is_instances([expr.typ, annotation_type], StructType)
                     ) and (
                         [str(annotation_type.members[key2]), str(expr.typ.members[key1])] == ['uint256', 'int128']
                     ) and SizeLimits.in_bounds('uint256', expr[1][0])

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -72,7 +72,7 @@ class Constants(object):
             if is_special_case_uint256_literal or is_special_case_int256_literal:
                 fail = False
 
-            #For StructType
+            # For StructType
             if is_instances([expr.typ, annotation_type], StructType):
                 expr_keys = list(expr.typ.members.keys())
                 annotation_type_keys = list(annotation_type.members.keys())

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -74,24 +74,22 @@ class Constants(object):
 
             # For StructType
             if is_instances([expr.typ, annotation_type], StructType):
-                expr_keys = list(expr.typ.members.keys())
-                annotation_type_keys = list(annotation_type.members.keys())
-                for key1, key2 in expr_keys, annotation_type_keys:
+                for x, y, z in zip(expr.typ.members.keys(), annotation_type.members.keys(), expr.args):
                     is_special_case_uint256_literal = (
                         is_instances([expr.typ, annotation_type], StructType)
                     ) and (
-                        str(annotation_type.members[key2]) == 'uint256'
+                        str(annotation_type.members[y]) == 'uint256'
                     ) and (
-                        str(expr.typ.members[key1]) == 'int128'
-                    ) and SizeLimits.in_bounds('uint256', expr[1][0])
+                        str(expr.typ.members[x]) == 'int128'
+                    ) and SizeLimits.in_bounds('uint256', z.value)
 
                     is_special_case_int256_literal = (
                         is_instances([expr.typ, annotation_type], StructType)
                     ) and (
-                        str(annotation_type.members[key2]) == 'int128'
+                        str(annotation_type.members[y]) == 'int128'
                     ) and (
-                        str(expr.typ.members[key1]) == 'int128'
-                    ) and SizeLimits.in_bounds('int128', expr[1][0])
+                        str(expr.typ.members[x]) == 'int128'
+                    ) and SizeLimits.in_bounds('int128', z.value)
 
                 if is_special_case_uint256_literal or is_special_case_int256_literal:
                     fail = False

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -18,6 +18,7 @@ from vyper.parser.memory_allocator import (
 from vyper.types.types import (
     BaseType,
     ByteArrayType,
+    StructType
 )
 from vyper.utils import (
     SizeLimits,
@@ -70,6 +71,27 @@ class Constants(object):
 
             if is_special_case_uint256_literal or is_special_case_int256_literal:
                 fail = False
+
+            #For StructType
+            if is_instances([expr.typ, annotation_type], StructType):
+                expr_keys = list(expr.typ.members.keys())
+                annotation_type_keys = list(annotation_type.members.keys())
+                for key1, key2 in expr_keys, annotation_type_keys:
+                    is_special_case_uint256_literal = (
+                    is_instances([expr.typ, annotation_type], StructType)
+                    ) and (
+                        [str(annotation_type.members[key2]), str(expr.typ.members[key1])] == ['uint256', 'int128']
+                    ) and SizeLimits.in_bounds('uint256', expr[1][0])
+
+                    is_special_case_int256_literal = (
+                        is_instances([expr.typ, annotation_type], StructType)
+                    ) and (
+                        [str(annotation_type.members[key2]), str(expr.typ.members[key1])] == ['int128', 'int128']
+                    ) and SizeLimits.in_bounds('int128', expr[1][0])
+
+                if is_special_case_uint256_literal or is_special_case_int256_literal:
+                    fail = False
+
 
         if fail:
             raise TypeMismatchException(

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -18,7 +18,7 @@ from vyper.parser.memory_allocator import (
 from vyper.types.types import (
     BaseType,
     ByteArrayType,
-    StructType
+    StructType,
 )
 from vyper.utils import (
     SizeLimits,


### PR DESCRIPTION
### What I did
Fixed #1430 Struct constants do not parse correctly

### How I did it
Added a case to check for constants in StructType

### How to verify it
vyper fileName.vy (that has constant structure assignment), it returns bytecode

### Description for the changelog
Fix: Struct constants Do Not Parse Correctly

### Note
Though I have added the logic, however, in the SizeLimits.in_bounds(arg1, arg2), and **arg2's** logic has to be more generic.
I tried with **expr[1][0]:** However, this has to be generic, I read about list, traversing list etc, but could not find a generic way to code, it, thus, if anybody can help me on this it will be much appreciated.
All we need to do is **expr** should take indices in a **generic** manner and not in a **hardcoded** way.

### Cute Animal Picture
![PR4](https://user-images.githubusercontent.com/32358081/57824101-883e1000-77b7-11e9-9b0c-5f62d4abd943.jpeg)

