### PR TITLE
Add zeroing function for arrays

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -33,11 +33,13 @@ contracts.
 
     For more details on available type conversions, see :ref:`type_conversions`.
 
-.. py:function:: clear(var: Any) -> None
+.. py:function:: empty(typename) -> Any
 
-    Clears a variable's contents to the default value of its type.
+    Returns a value which is the default (zeroed) value of its type.
 
-    * ``var``: Variable to clear
+    * ``typename``: Name of the type
+
+    For instance, `xs: uint256[5] = empty(uint256[5])`
 
 .. py:function:: as_wei_value(value: int, unit: str) -> uint256
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -443,7 +443,7 @@ Initial Values
 **************
 
 In Vyper, there is no ``null`` option like most programming languages have. Thus, every variable type has a default value. In order to check if a variable is empty, you will need to compare it to its type's default value.
-If you would like to reset a variable to its type's default value, use the built-in ``clear()`` function.
+If you would like to reset a variable to its type's default value, assign to it the built-in ``empty()`` function which constructs a zero value for that type.
 
 .. note::
 

--- a/examples/crowdfund.vy
+++ b/examples/crowdfund.vy
@@ -56,6 +56,6 @@ def refund():
             return
 
         send(self.funders[i].sender, self.funders[i].value)
-        clear(self.funders[i])
+        self.funders[i] = empty(Funder)
 
     self.refundIndex = ind + 30

--- a/tests/parser/functions/test_clear.py
+++ b/tests/parser/functions/test_clear.py
@@ -1,6 +1,7 @@
 from vyper.exceptions import (
-    TypeMismatchException
+    TypeMismatchException,
 )
+
 
 def test_clear_basic_type(get_contract_with_gas_estimation):
     contracts = [  # noqa: E122
@@ -418,7 +419,7 @@ def delete():
 
 
 def test_clear_typecheck(get_contract, assert_compile_failed):
-    contracts = [
+    contracts = [  # noqa: E122
     """
 @public
 def foo():

--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -1,5 +1,5 @@
 from vyper.exceptions import (
-    TypeMismatchException,
+    TypeMismatch,
 )
 
 
@@ -55,8 +55,8 @@ def foo():
     self.foobar = 1.0
     bar: decimal = 1.0
 
-    self.foobar = empty(bool)
-    bar = empty(bool)
+    self.foobar = empty(decimal)
+    bar = empty(decimal)
 
     assert self.foobar == 0.0
     assert bar == 0.0
@@ -252,7 +252,7 @@ def foo() -> address:
 @public
 def foo():
     x: uint256 = 1
-    clear(x)
+    empty(x)
     """
     ]
 
@@ -279,8 +279,8 @@ def foo() -> (bytes[5], bytes[5]):
     """
 
     c = get_contract_with_gas_estimation(code)
-    a, b, c = c.foo()
-    assert a == b == c == b''
+    a, b = c.foo()
+    assert a == b == b''
 
 
 def test_empty_struct(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -3,7 +3,7 @@ from vyper.exceptions import (
 )
 
 
-def test_clear_basic_type(get_contract_with_gas_estimation):
+def test_empty_basic_type(get_contract_with_gas_estimation):
     contracts = [  # noqa: E122
     """
 foobar: int128
@@ -13,8 +13,8 @@ def foo():
     self.foobar = 1
     bar: int128 = 1
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(int128)
+    bar = empty(int128)
 
     assert self.foobar == 0
     assert bar == 0
@@ -27,8 +27,8 @@ def foo():
     self.foobar = 1
     bar: uint256 = 1
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(uint256)
+    bar = empty(uint256)
 
     assert self.foobar == 0
     assert bar == 0
@@ -41,8 +41,8 @@ def foo():
     self.foobar = True
     bar: bool = True
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(bool)
+    bar = empty(bool)
 
     assert self.foobar == False
     assert bar == False
@@ -55,8 +55,8 @@ def foo():
     self.foobar = 1.0
     bar: decimal = 1.0
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(bool)
+    bar = empty(bool)
 
     assert self.foobar == 0.0
     assert bar == 0.0
@@ -69,8 +69,8 @@ def foo():
     self.foobar = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
     bar: bytes32 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(bytes32)
+    bar = empty(bytes32)
 
     assert self.foobar == 0x0000000000000000000000000000000000000000000000000000000000000000
     assert bar == 0x0000000000000000000000000000000000000000000000000000000000000000
@@ -83,8 +83,8 @@ def foo():
     self.foobar = msg.sender
     bar: address = msg.sender
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(address)
+    bar = empty(address)
 
     assert self.foobar == ZERO_ADDRESS
     assert bar == ZERO_ADDRESS
@@ -96,7 +96,7 @@ def foo():
         c.foo()
 
 
-def test_clear_basic_type_lists(get_contract_with_gas_estimation):
+def test_empty_basic_type_lists(get_contract_with_gas_estimation):
     contracts = [  # noqa: E122
     """
 foobar: int128[3]
@@ -106,8 +106,8 @@ def foo():
     self.foobar = [1, 2, 3]
     bar: int128[3] = [1, 2, 3]
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(int128[3])
+    bar = empty(int128[3])
 
     assert self.foobar[0] == 0
     assert self.foobar[1] == 0
@@ -124,8 +124,8 @@ def foo():
     self.foobar = [1, 2, 3]
     bar: uint256[3] = [1, 2, 3]
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(uint256[3])
+    bar = empty(uint256[3])
 
     assert self.foobar[0] == 0
     assert self.foobar[1] == 0
@@ -142,8 +142,8 @@ def foo():
     self.foobar = [True, True, True]
     bar: bool[3] = [True, True, True]
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(bool[3])
+    bar = empty(bool[3])
 
     assert self.foobar[0] == False
     assert self.foobar[1] == False
@@ -160,8 +160,8 @@ def foo():
     self.foobar = [1.0, 2.0, 3.0]
     bar: decimal[3] = [1.0, 2.0, 3.0]
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(decimal[3])
+    bar = empty(decimal[3])
 
     assert self.foobar[0] == 0.0
     assert self.foobar[1] == 0.0
@@ -186,8 +186,8 @@ def foo():
         0x00000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
     ]
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(bytes32[3])
+    bar = empty(bytes32[3])
 
     assert self.foobar[0] == 0x0000000000000000000000000000000000000000000000000000000000000000
     assert self.foobar[1] == 0x0000000000000000000000000000000000000000000000000000000000000000
@@ -204,8 +204,8 @@ def foo():
     self.foobar = [msg.sender, msg.sender, msg.sender]
     bar: address[3] = [msg.sender, msg.sender, msg.sender]
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(address[3])
+    bar = empty(address[3])
 
     assert self.foobar[0] == ZERO_ADDRESS
     assert self.foobar[1] == ZERO_ADDRESS
@@ -225,28 +225,34 @@ def test_clear_literals(assert_compile_failed, get_contract_with_gas_estimation)
     contracts = [  # noqa: E122
     """
 @public
-def foo():
-    clear(1)
+def foo() -> uint256:
+    return empty(1)
+    """,
+    """
+@public
+def foo() -> bool:
+    return empty(bool)
+    """,
+    """
+@public
+def foo() -> decimal:
+    return empty(1.0)
+    """,
+    """
+@public
+def foo() -> bytes32:
+    return empty(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+    """,
+    """
+@public
+def foo() -> address:
+    return empty(0xF5D4020dCA6a62bB1efFcC9212AAF3c9819E30D7)
     """,
     """
 @public
 def foo():
-    clear(True)
-    """,
-    """
-@public
-def foo():
-    clear(1.0)
-    """,
-    """
-@public
-def foo():
-    clear(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-    """,
-    """
-@public
-def foo():
-    clear(0xF5D4020dCA6a62bB1efFcC9212AAF3c9819E30D7)
+    x: uint256 = 1
+    clear(x)
     """
     ]
 
@@ -257,22 +263,19 @@ def foo():
         )
 
 
-def test_clear_bytes(get_contract_with_gas_estimation):
+def test_empty_bytes(get_contract_with_gas_estimation):
     code = """
 foobar: bytes[5]
 
 @public
-def foo() -> (bytes[5], bytes[5], bytes[5]):
+def foo() -> (bytes[5], bytes[5]):
     self.foobar = b'Hello'
     bar: bytes[5] = b'World'
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(bytes[5])
+    bar = empty(bytes[5])
 
-    baz: bytes[5] = 'world'
-    baz = clear(bytes[5])
-
-    return (self.foobar, bar, baz)
+    return (self.foobar, bar)
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -280,7 +283,7 @@ def foo() -> (bytes[5], bytes[5], bytes[5]):
     assert a == b == c == b''
 
 
-def test_clear_struct(get_contract_with_gas_estimation):
+def test_empty_struct(get_contract_with_gas_estimation):
     code = """
 struct FOOBAR:
     a: int128
@@ -311,8 +314,8 @@ def foo():
         f: msg.sender
     })
 
-    clear(self.foobar)
-    clear(bar)
+    self.foobar = empty(FOOBAR)
+    bar = empty(FOOBAR)
 
     assert self.foobar.a == 0
     assert self.foobar.b == 0
@@ -347,7 +350,7 @@ def get(key: bytes32) -> bytes32:
 
 @public
 def delete(key: bytes32):
-    clear(self.big_storage[key])
+    self.big_storage[key] = empty(bytes32)
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -373,7 +376,7 @@ def get(key1: bytes32, key2: bytes32) -> bytes32:
 
 @public
 def delete(key1: bytes32, key2: bytes32):
-    clear(self.big_storage[key1][key2])
+    self.big_storage[key1][key2] = empty(bytes32)
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -406,7 +409,7 @@ def get() -> (int128, int128):
 
 @public
 def delete():
-    clear(self.structmap[123])
+    self.structmap[123] = empty(X)
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -423,17 +426,17 @@ def test_clear_typecheck(get_contract, assert_compile_failed):
     """
 @public
 def foo():
-    xs: uint256[10] = clear(uint256[11])
+    xs: uint256[10] = empty(uint256[11])
     """,
     """
 @public
 def bar():
-    ys: bytes[33] = clear(bytes[32])
+    ys: bytes[33] = empty(bytes[32])
     """
     ]
 
     for contract in contracts:
         assert_compile_failed(
             lambda: get_contract(contract),
-            TypeMismatchException
+            TypeMismatch
         )

--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -27,25 +27,25 @@ def gop() -> int128: # Following a standard naming scheme; nothing to do with th
 
 @public
 def hoo() -> int128:
-    clear(self.dog)
+    self.dog = empty(int128[3])
     return(self.dog[0] + self.dog[1] * 10 + self.dog[2] * 100)
 
 @public
 def hop() -> int128:
-    clear(self.bar[1])
+    self.bar[1] = empty(int128[3])
     return self.bar[0][0] + self.bar[0][1] * 10 + self.bar[0][2] * 100 + \
         self.bar[1][0] * 1000 + self.bar[1][1] * 10000 + self.bar[1][2] * 100000
 
 @public
 def joo() -> int128:
     god: int128[3] = [1, 2, 3]
-    clear(god)
+    god = empty(int128[3])
     return(god[0] + god[1] * 10 + god[2] * 100)
 
 @public
 def jop() -> int128:
     gar: int128[3][3] = [[1, 2, 3], [4, 5, 6], [0, 0, 0]]
-    clear(gar[1])
+    gar[1] = empty(int128[3])
     return gar[0][0] + gar[0][1] * 10 + gar[0][2] * 100 + \
         gar[1][0] * 1000 + gar[1][1] * 10000 + gar[1][2] * 100000
 
@@ -216,8 +216,8 @@ def fop() -> int128:
 @public
 def foq() -> int128:
     popp: Mom = Mom({a: [C({c: 1}), C({c: 2}), C({c: 3})], b: 4})
-    clear(popp.a[0])
-    clear(popp.a[2])
+    popp.a[0] = empty(C)
+    popp.a[2] = empty(C)
     return popp.a[0].c + popp.a[1].c * 10 + popp.a[2].c * 100 + popp.b * 1000
     """
 

--- a/tests/parser/integration/test_crowdfund.py
+++ b/tests/parser/integration/test_crowdfund.py
@@ -148,7 +148,7 @@ def refund():
             self.refundIndex = self.nextFunderIndex
             return
         send(self.funders[i].sender, self.funders[i].value)
-        clear(self.funders[i])
+        self.funders[i] = empty(Funder)
     self.refundIndex = ind + 30
 
     """

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -140,6 +140,20 @@ def test() -> int128:
 def test() -> int128:
     a = [1, 2, True]
     return a[0]
+    """,
+    """
+@public
+def test():
+    xs: uint256[2] = [1,2]
+    ys: uint256[3] = [1,2,3]
+    xs = ys
+    """,
+    """
+@public
+def test():
+    xs: uint256[3] = [1,2,3]
+    ys: uint256[2] = [1,2]
+    xs = ys
     """
 ]
 

--- a/tests/parser/syntax/test_structs.py
+++ b/tests/parser/syntax/test_structs.py
@@ -261,7 +261,7 @@ struct Nom:
 nom: Nom
 @public
 def foo():
-    clear(self.nom)
+    self.nom = empty(Nom)
     """,
     """
 struct C:

--- a/tests/parser/types/test_node_types.py
+++ b/tests/parser/types/test_node_types.py
@@ -7,19 +7,11 @@ from vyper.types import (
     ByteArrayType,
     ListType,
     MappingType,
-    NullType,
     StructType,
     TupleType,
     canonicalize_type,
     get_size_of_type,
 )
-
-
-def test_null_type():
-    node1 = NullType()
-    node2 = NullType()
-
-    assert node1 == node2
 
 
 def test_bytearray_node_type():

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -72,7 +72,7 @@ def get_node(
     if not vy_class:
         if ast_struct['ast_type'] == "Delete":
             _raise_syntax_exc(
-                "Deleting is not supported, use built-in clear() function", ast_struct
+                "Deleting is not supported", ast_struct
             )
         elif ast_struct['ast_type'] in ("ExtSlice", "Slice"):
             _raise_syntax_exc("Vyper does not support slicing", ast_struct)

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -41,7 +41,6 @@ from vyper.types import (
     ByteArrayLike,
     ByteArrayType,
     ListType,
-    NullType,
     StringType,
     TupleType,
     get_size_of_type,
@@ -1229,8 +1228,8 @@ else:
 def clear(expr, context):
     if len(expr.args) != 1:
         raise ParserException('function expects two parameters.', expr)
-    output_type = context.parse_type(expr.args[0], expr.args[0].value.id)
-    return LLLnode(None, typ=NullType(output_type), pos=getpos(expr))
+    output_type = context.parse_type(expr.args[0], expr.args[0])
+    return LLLnode(None, typ=output_type, pos=getpos(expr))
 
 
 DISPATCH_TABLE = {

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -7,9 +7,9 @@ from vyper import (
     ast as vy_ast,
 )
 from vyper.exceptions import (
+    ArgumentException,
     ConstancyViolation,
     InvalidLiteral,
-    ParserException,
     StructureException,
     TypeMismatch,
 )
@@ -1227,7 +1227,7 @@ else:
 
 def empty(expr, context):
     if len(expr.args) != 1:
-        raise ParserException('function expects two parameters.', expr)
+        raise ArgumentException('function expects two parameters.', expr)
     output_type = context.parse_type(expr.args[0], expr.args[0])
     return LLLnode(None, typ=output_type, pos=getpos(expr))
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1225,7 +1225,7 @@ else:
     )
 
 
-def clear(expr, context):
+def empty(expr, context):
     if len(expr.args) != 1:
         raise ParserException('function expects two parameters.', expr)
     output_type = context.parse_type(expr.args[0], expr.args[0])
@@ -1262,7 +1262,7 @@ DISPATCH_TABLE = {
     'create_forwarder_to': create_forwarder_to,
     'min': _min,
     'max': _max,
-    'clear': clear,
+    'empty': empty,
 }
 
 STMT_DISPATCH_TABLE = {

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -41,6 +41,7 @@ from vyper.types import (
     ByteArrayLike,
     ByteArrayType,
     ListType,
+    NullType,
     StringType,
     TupleType,
     get_size_of_type,
@@ -1225,12 +1226,11 @@ else:
     )
 
 
-def _clear():
-    raise CompilerPanic(
-        "This function should never be called! `clear()` is currently handled "
-        "differently than other functions as it self modifies its input argument "
-        "statement. Please see `_clear()` in `stmt.py`"
-    )
+def clear(expr, context):
+    if len(expr.args) != 1:
+        raise ParserException('function expects two parameters.', expr)
+    output_type = context.parse_type(expr.args[0], expr.args[0].value.id)
+    return LLLnode(None, typ=NullType(output_type), pos=getpos(expr))
 
 
 DISPATCH_TABLE = {
@@ -1263,11 +1263,11 @@ DISPATCH_TABLE = {
     'create_forwarder_to': create_forwarder_to,
     'min': _min,
     'max': _max,
+    'clear': clear,
 }
 
 STMT_DISPATCH_TABLE = {
     'assert_modifiable': assert_modifiable,
-    'clear': _clear,
     'send': send,
     'selfdestruct': selfdestruct,
     'raw_call': raw_call,

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -7,9 +7,9 @@ from vyper import (
     ast as vy_ast,
 )
 from vyper.exceptions import (
-    CompilerPanic,
     ConstancyViolation,
     InvalidLiteral,
+    ParserException,
     StructureException,
     TypeMismatch,
 )

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -259,7 +259,7 @@ class Expr(object):
             # block None
             raise InvalidLiteral(
                     'None is not allowed in vyper'
-                    '(use a default value or built-in `clear()`')
+                    '(use a default value or built-in `empty()`')
         else:
             raise Exception(f"Unknown name constant: {self.expr.value.value}")
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -257,7 +257,10 @@ class Expr(object):
                 pos=getpos(self.expr),
             )
         elif self.expr.value is None:
-            return LLLnode.from_list(None, typ=NullType(), pos=getpos(self.expr))
+            # block None
+            raise InvalidLiteralException(
+                    'None is not allowed in vyper'
+                    '(use a default value or built-in `clear()`')
         else:
             raise Exception(f"Unknown name constant: {self.expr.value.value}")
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -257,7 +257,7 @@ class Expr(object):
             )
         elif self.expr.value is None:
             # block None
-            raise InvalidLiteralException(
+            raise InvalidLiteral(
                     'None is not allowed in vyper'
                     '(use a default value or built-in `clear()`')
         else:

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -39,7 +39,6 @@ from vyper.types import (
     ContractType,
     ListType,
     MappingType,
-    NullType,
     StringType,
     StructType,
     TupleType,
@@ -782,7 +781,7 @@ class Expr(object):
         left = Expr.parse_value_expr(self.expr.left, self.context)
         right = Expr.parse_value_expr(self.expr.right, self.context)
 
-        if isinstance(right.typ, NullType):
+        if right.value is None:
             raise InvalidLiteral(
                 'Comparison to None is not allowed, compare against a default value.',
                 self.expr,

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -19,7 +19,6 @@ from vyper.settings import (
 from vyper.types import (
     BaseType,
     NodeType,
-    NullType,
     ceil32,
 )
 from vyper.utils import (
@@ -236,7 +235,8 @@ class LLLnode:
                     self.gas = sum([arg.gas for arg in self.args]) + 30
                 if self.value == 'if_unchecked':
                     self.gas = self.args[0].gas + self.args[1].gas + 17
-        elif self.value is None and isinstance(self.typ, NullType):
+        elif self.value is None:
+            # TODO revisit this
             self.valency = 1
             self.gas = 5
         else:

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -236,9 +236,10 @@ class LLLnode:
                 if self.value == 'if_unchecked':
                     self.gas = self.args[0].gas + self.args[1].gas + 17
         elif self.value is None:
-            # TODO revisit this
             self.valency = 1
-            self.gas = 5
+            # None LLLnodes always get compiled into something else, e.g.
+            # mzero or PUSH1 0, and the gas will get re-estimated then.
+            self.gas = 3
         else:
             raise CompilerPanic(f"Invalid value for LLL AST node: {self.value}")
         assert isinstance(self.args, list)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -22,7 +22,6 @@ from vyper.types import (
     ByteArrayType,
     ListType,
     MappingType,
-    NullType,
     StringType,
     StructType,
     TupleLike,
@@ -72,7 +71,7 @@ def get_number_as_fraction(expr, context):
 
 # Copies byte array
 def make_byte_array_copier(destination, source, pos=None):
-    if not isinstance(source.typ, (ByteArrayLike, NullType)):
+    if not isinstance(source.typ, ByteArrayLike):
         btype = 'byte array' if isinstance(destination.typ, ByteArrayType) else 'string'
         raise TypeMismatch(f"Can only set a {btype} to another {btype}", pos)
     if isinstance(source.typ, ByteArrayLike) and source.typ.maxlen > destination.typ.maxlen:
@@ -93,7 +92,7 @@ def make_byte_array_copier(destination, source, pos=None):
 
     pos_node = LLLnode.from_list('_pos', typ=source.typ, location=source.location)
     # Get the length
-    if isinstance(source.typ, NullType):
+    if source.value is None:
         length = 1
     elif source.location == "memory":
         length = ['add', ['mload', '_pos'], 32]
@@ -113,10 +112,10 @@ def make_byte_array_copier(destination, source, pos=None):
             location=destination.location,
         )
     # Maximum theoretical length
-    max_length = 32 if isinstance(source.typ, NullType) else source.typ.maxlen + 32
+    max_length = 32 if source.value is None else source.typ.maxlen + 32
     return LLLnode.from_list([
         'with', '_pos',
-        0 if isinstance(source.typ, NullType) else source,
+        0 if source.value is None else source,
         make_byte_slice_copier(destination, pos_node, length, max_length, pos=pos)
     ], typ=None)
 
@@ -138,7 +137,7 @@ def make_byte_slice_copier(destination, source, length, max_length, pos=None):
             ]
         ], typ=None, annotation=f'copy byte slice dest: {str(destination)}')
     # special case: rhs is zero
-    if isinstance(source.typ, NullType):
+    if source.value is None:
         return mzero(destination, max_length)
     # Copy over data
     if source.location == "memory":
@@ -388,6 +387,7 @@ def base_type_conversion(orig, frm, to, pos, in_function_call=False):
         is_base_type(frm, 'int128') and is_base_type(to, 'decimal')
     )
 
+<<<<<<< HEAD
     if getattr(frm, 'is_literal', False):
         if frm.typ in ('int128', 'uint256'):
             if not SizeLimits.in_bounds(frm.typ, orig.value):
@@ -397,7 +397,7 @@ def base_type_conversion(orig, frm, to, pos, in_function_call=False):
             if not SizeLimits.in_bounds(to.typ, orig.value):
                 raise InvalidLiteral(f"Number out of range: {orig.value}", pos)
 
-    if not isinstance(frm, (BaseType, NullType)) or not isinstance(to, BaseType):
+    if not isinstance(frm, BaseType) or not isinstance(to, BaseType):
         raise TypeMismatch(
             f"Base type conversion from or to non-base type: {frm} {to}", pos
         )
@@ -410,13 +410,6 @@ def base_type_conversion(orig, frm, to, pos, in_function_call=False):
             ['mul', orig, DECIMAL_DIVISOR],
             typ=BaseType('decimal'),
         )
-    elif isinstance(frm, NullType):
-        if to.typ not in ('int128', 'bool', 'uint256', 'address', 'bytes32', 'decimal'):
-            # This is only to future proof the use of  base_type_conversion.
-            raise TypeMismatch(  # pragma: no cover
-                f"Cannot convert null-type object to type {to}", pos
-            )
-        return LLLnode.from_list(0, typ=to)
     # Integer literal conversion.
     elif (frm.typ, to.typ, frm.is_literal) == ('int128', 'uint256', True):
         return LLLnode(orig.value, orig.args, typ=to, add_gas_estimate=orig.add_gas_estimate)
@@ -526,9 +519,6 @@ def pack_arguments(signature, args, context, stmt_expr, return_placeholder=True)
 
 # Create an x=y statement, where the types may be compound
 def make_setter(left, right, location, pos, in_function_call=False):
-    if isinstance(right.typ, NullType):
-        if right.typ.typ is not None and right.typ.typ != left.typ:
-            raise TypeMismatchException('attempt to clear {left.typ} but provided {right.typ.typ}')
     # Basic types
     if isinstance(left.typ, BaseType):
         right = base_type_conversion(
@@ -553,24 +543,20 @@ def make_setter(left, right, location, pos, in_function_call=False):
         # Cannot do something like [a, b, c] = [1, 2, 3]
         if left.value == "multi":
             raise Exception("Target of set statement must be a single item")
-        if not isinstance(right.typ, (ListType, NullType)):
+
+        if not isinstance(right.typ, ListType):
             raise TypeMismatch(
-                f"Setter type mismatch: left side is array, right side is {right.typ}", pos
+                f"Setter type mismatch: left side is {left.typ}, right side is {right.typ}", pos
             )
+        if right.typ.count != left.typ.count:
+            raise TypeMismatch("Mismatched number of elements", pos)
+
         left_token = LLLnode.from_list('_L', typ=left.typ, location=left.location)
         if left.location == "storage":
             left = LLLnode.from_list(['sha3_32', left], typ=left.typ, location="storage_prehashed")
             left_token.location = "storage_prehashed"
-        # Type checks
-        if not isinstance(right.typ, NullType):
-            if not isinstance(right.typ, ListType):
-                raise TypeMismatch("Left side is array, right side is not", pos)
-            if left.typ.count != right.typ.count:
-                raise TypeMismatch("Mismatched number of elements", pos)
         # If the right side is a literal
         if right.value == "multi":
-            if len(right.args) != left.typ.count:
-                raise TypeMismatch("Mismatched number of elements", pos)
             subs = []
             for i in range(left.typ.count):
                 subs.append(make_setter(add_variable_offset(
@@ -580,7 +566,7 @@ def make_setter(left, right, location, pos, in_function_call=False):
                     array_bounds_check=False,
                 ), right.args[i], location, pos=pos))
             return LLLnode.from_list(['with', '_L', left, ['seq'] + subs], typ=None)
-        elif isinstance(right.typ, NullType):
+        elif right.value is None:
             if left.location == 'memory':
                 return mzero(left, get_size_of_type(left.typ))
 
@@ -591,7 +577,7 @@ def make_setter(left, right, location, pos, in_function_call=False):
                     LLLnode.from_list(i, typ='int128'),
                     pos=pos,
                     array_bounds_check=False,
-                ), LLLnode.from_list(None, typ=NullType(left.typ)), location, pos=pos))
+                ), LLLnode.from_list(None, typ=left.typ.subtype), location, pos=pos))
             return LLLnode.from_list(['with', '_L', left, ['seq'] + subs], typ=None)
         # If the right side is a variable
         else:
@@ -617,7 +603,7 @@ def make_setter(left, right, location, pos, in_function_call=False):
     elif isinstance(left.typ, TupleLike):
         if left.value == "multi" and isinstance(left.typ, StructType):
             raise Exception("Target of set statement must be a single item")
-        if not isinstance(right.typ, NullType):
+        if right.value is not None:
             if not isinstance(right.typ, left.typ.__class__):
                 raise TypeMismatch(
                     f"Setter type mismatch: left side is {left.typ}, right side is {right.typ}",
@@ -626,6 +612,7 @@ def make_setter(left, right, location, pos, in_function_call=False):
             if isinstance(left.typ, StructType):
                 for k in right.args:
                     if k.value is None:
+                        raise CompilerPanic("Unreachable", pos)
                         raise InvalidLiteral(
                             'Setting struct value to None is not allowed, use a default value.',
                             pos,
@@ -682,15 +669,15 @@ def make_setter(left, right, location, pos, in_function_call=False):
                 ))
             return LLLnode.from_list(['with', '_L', left, ['seq'] + subs], typ=None)
         # If the right side is a null
-        elif isinstance(right.typ, NullType):
+        elif right.value is None:
             if left.location == 'memory':
                 return mzero(left, get_size_of_type(left.typ))
 
             subs = []
-            for typ, loc in zip(keyz, locations):
+            for key, loc in zip(keyz, locations):
                 subs.append(make_setter(
-                    add_variable_offset(left_token, typ, pos=pos),
-                    LLLnode.from_list(None, typ=NullType(typ)),
+                    add_variable_offset(left_token, key, pos=pos),
+                    LLLnode.from_list(None, typ=left.typ.members[key]),
                     loc,
                     pos=pos,
                 ))

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -634,13 +634,6 @@ def make_setter(left, right, location, pos, in_function_call=False):
                     pos,
                 )
             if isinstance(left.typ, StructType):
-                for k in right.args:
-                    if k.value is None:
-                        raise CompilerPanic("Unreachable", pos)
-                        raise InvalidLiteral(
-                            'Setting struct value to None is not allowed, use a default value.',
-                            pos,
-                        )
                 for k in left.typ.members:
                     if k not in right.typ.members:
                         raise TypeMismatch(

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -591,6 +591,10 @@ def make_setter(left, right, location, pos, in_function_call=False):
                 ), right.args[i], location, pos=pos))
             return LLLnode.from_list(['with', '_L', left, ['seq'] + subs], typ=None)
         elif right.value is None:
+            if right.typ != left.typ:
+                raise TypeMismatch(
+                    f"left side is {left.typ}, right side is {right.typ}", pos
+                )
             if left.location == 'memory':
                 return mzero(left, 32*get_size_of_type(left.typ))
 
@@ -687,6 +691,11 @@ def make_setter(left, right, location, pos, in_function_call=False):
             return LLLnode.from_list(['with', '_L', left, ['seq'] + subs], typ=None)
         # If the right side is a null
         elif right.value is None:
+            if left.typ != right.typ:
+                raise TypeMismatch(
+                    f"left side is {left.typ}, right side is {right.typ}", pos
+                )
+
             if left.location == 'memory':
                 return mzero(left, 32*get_size_of_type(left.typ))
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -8,11 +8,11 @@ from vyper import (
 )
 from vyper.exceptions import (
     ArrayIndexException,
+    CompilerPanic,
     ConstancyViolation,
     InvalidLiteral,
     StructureException,
     TypeMismatch,
-    CompilerPanic,
 )
 from vyper.parser.lll_node import (
     LLLnode,

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -694,7 +694,7 @@ def make_setter(left, right, location, pos, in_function_call=False):
             for key, loc in zip(keyz, locations):
                 subs.append(make_setter(
                     add_variable_offset(left_token, key, pos=pos),
-                    LLLnode.from_list(None, typ=left.typ.members[key]),
+                    LLLnode.from_list(None, typ=right.typ.members[key]),
                     loc,
                     pos=pos,
                 ))

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -116,7 +116,7 @@ def make_byte_array_copier(destination, source, pos=None):
             location=source.location,
         )
     else:
-        raise CompilerPanic("Unsupported location:" + source.location)
+        raise CompilerPanic(f"Unsupported location: {source.location}")
     if destination.location == "storage":
         destination = LLLnode.from_list(
             ['sha3_32', destination],
@@ -163,7 +163,7 @@ def make_byte_slice_copier(destination, source, length, max_length, pos=None):
     elif source.location == "storage":
         loader = ['sload', ['add', '_pos', ['mload', MemoryPositions.FREE_LOOP_INDEX]]]
     else:
-        raise CompilerPanic(f'Unsupported location: {source}')
+        raise CompilerPanic(f'Unsupported location: {source.location}')
     # Where to paste it?
     if destination.location == "memory":
         setter = [
@@ -174,7 +174,7 @@ def make_byte_slice_copier(destination, source, length, max_length, pos=None):
     elif destination.location == "storage":
         setter = ['sstore', ['add', '_opos', ['mload', MemoryPositions.FREE_LOOP_INDEX]], loader]
     else:
-        raise CompilerPanic("Unsupported location:" + destination.location)
+        raise CompilerPanic(f"Unsupported location: {destination.location}")
     # Check to see if we hit the length
     checker = [
         'if',

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -82,10 +82,11 @@ def make_byte_array_copier(destination, source, pos=None):
         )
 
     # stricter check for zeroing a byte array.
-    if isinstance(source.typ, ByteArrayLike) and source.value is None and source.typ.maxlen != destination.typ.maxlen:
-        raise TypeMismatchException(
-                f"Bad type for clearing bytes: expected {destination.typ}"
-                f" but got {source.typ}")
+    if isinstance(source.typ, ByteArrayLike):
+        if source.value is None and source.typ.maxlen != destination.typ.maxlen:
+            raise TypeMismatchException(
+                    f"Bad type for clearing bytes: expected {destination.typ}"
+                    f" but got {source.typ}")
 
     # Special case: memory to memory
     if source.location == "memory" and destination.location == "memory":

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -84,7 +84,7 @@ def make_byte_array_copier(destination, source, pos=None):
     # stricter check for zeroing a byte array.
     if isinstance(source.typ, ByteArrayLike):
         if source.value is None and source.typ.maxlen != destination.typ.maxlen:
-            raise TypeMismatchException(
+            raise TypeMismatch(
                     f"Bad type for clearing bytes: expected {destination.typ}"
                     f" but got {source.typ}")
 
@@ -406,7 +406,6 @@ def base_type_conversion(orig, frm, to, pos, in_function_call=False):
         is_base_type(frm, 'int128') and is_base_type(to, 'decimal')
     )
 
-<<<<<<< HEAD
     if getattr(frm, 'is_literal', False):
         if frm.typ in ('int128', 'uint256'):
             if not SizeLimits.in_bounds(frm.typ, orig.value):

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -601,7 +601,7 @@ def make_setter(left, right, location, pos, in_function_call=False):
                     LLLnode.from_list(i, typ='int128'),
                     pos=pos,
                     array_bounds_check=False,
-                ), LLLnode.from_list(None, typ=left.typ.subtype), location, pos=pos))
+                ), LLLnode.from_list(None, typ=right.typ.subtype), location, pos=pos))
             return LLLnode.from_list(['with', '_L', left, ['seq'] + subs], typ=None)
         # If the right side is a variable
         else:

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -108,6 +108,11 @@ class Stmt(object):
             isinstance(self.stmt.annotation, vy_ast.Name) and
             self.stmt.annotation.id == 'bytes32'
         ):
+            # CMC 04/07/2020 this check could be much clearer, more like:
+            # if isinstance(ByteArrayLike) and maxlen == 32
+            #   or isinstance(BaseType) and typ.typ == 'bytes32'
+            #   then GOOD
+            #   else RAISE
             if isinstance(sub.typ, ByteArrayLike):
                 if sub.typ.maxlen != 32:
                     raise TypeMismatch(
@@ -119,9 +124,12 @@ class Stmt(object):
                     raise TypeMismatch('Invalid type, expected: bytes32', self.stmt)
                 return
             else:
+                raise TypeMismatch(
+                    f"Invalid type, expected: bytes32", self.stmt
+                )
         elif isinstance(self.stmt.annotation, vy_ast.Subscript):
             # check list assign:
-            if not isinstance(sub.typ, (ListType, ByteArrayLike))
+            if not isinstance(sub.typ, (ListType, ByteArrayLike)):
                 raise TypeMismatch(
                     f'Invalid type, expected: {self.stmt.annotation.value.id},'
                     f' got: {sub.typ}', self.stmt
@@ -341,7 +349,7 @@ class Stmt(object):
             isinstance(self.stmt.func, vy_ast.Attribute)
         ) and isinstance(self.stmt.func.value, vy_ast.Name) and self.stmt.func.value.id == 'log'
 
-        if isinstance(self.stmt.func, ast.Name):
+        if isinstance(self.stmt.func, vy_ast.Name):
             funcname = self.stmt.func.id
             if funcname in STMT_DISPATCH_TABLE:
                 return STMT_DISPATCH_TABLE[funcname](self.stmt, self.context)

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -343,8 +343,6 @@ class Stmt(object):
 
         if isinstance(self.stmt.func, ast.Name):
             funcname = self.stmt.func.id
-            if funcname == 'clear':
-                return self._clear()
             if funcname in STMT_DISPATCH_TABLE:
                 return STMT_DISPATCH_TABLE[funcname](self.stmt, self.context)
             elif funcname in DISPATCH_TABLE:

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -124,9 +124,7 @@ class Stmt(object):
                     raise TypeMismatch('Invalid type, expected: bytes32', self.stmt)
                 return
             else:
-                raise TypeMismatch(
-                    f"Invalid type, expected: bytes32", self.stmt
-                )
+                raise TypeMismatch("Invalid type, expected: bytes32", self.stmt)
         elif isinstance(self.stmt.annotation, vy_ast.Subscript):
             # check list assign:
             if not isinstance(sub.typ, (ListType, ByteArrayLike)):
@@ -328,17 +326,6 @@ class Stmt(object):
                 typ=None, pos=getpos(self.stmt)
             )
         return o
-
-    def _clear(self):
-        # Get target variable
-        target = self.get_target(self.stmt.args[0])
-
-        pos = getpos(self.stmt)
-
-        zero = LLLnode(None, typ=target.typ, pos=pos)
-
-        # Generate LLL node to set to zero
-        return make_setter(target, zero, target.location, pos=pos)
 
     def call(self):
         is_self_function = (

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -233,7 +233,6 @@ class Stmt(object):
                 pos=getpos(self.stmt),
             )
             o = make_setter(variable_loc, sub, 'memory', pos=getpos(self.stmt))
-            # o.pos = getpos(self.stmt) # TODO: Should this be here like in assign()?
 
             return o
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -330,9 +330,7 @@ class Stmt(object):
         zero = LLLnode(None, typ=target.typ, pos=pos)
 
         # Generate LLL node to set to zero
-        o = make_setter(target, zero, target.location, pos=pos)
-
-        return o
+        return make_setter(target, zero, target.location, pos=pos)
 
     def call(self):
         is_self_function = (

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -165,8 +165,11 @@ class TupleType(TupleLike):
         return list(enumerate(self.members))
 
 
-# Data structure for the type used by None/null
+# Sentinel type to represent zeroing operations
 class NullType(NodeType):
+    def __init__(self, typ=None):
+        self.typ = typ # optional type for typechecking
+
     def eq(self, other):
         return True
 

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -165,15 +165,6 @@ class TupleType(TupleLike):
         return list(enumerate(self.members))
 
 
-# Sentinel type to represent zeroing operations
-class NullType(NodeType):
-    def __init__(self, typ=None):
-        self.typ = typ # optional type for typechecking
-
-    def eq(self, other):
-        return True
-
-
 # Convert type into common form used in ABI
 def canonicalize_type(t, is_indexed=False):
     if isinstance(t, ByteArrayLike):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -179,7 +179,7 @@ RESERVED_KEYWORDS = {
     # None sentinal value
     'none',
     # more special operations
-    'clear',
+    'empty',
     # denominations
     'ether', 'wei', 'finney', 'szabo', 'shannon', 'lovelace', 'ada', 'babbage',
     'gwei', 'kwei', 'mwei', 'twei', 'pwei',


### PR DESCRIPTION
### What I did
- Fix #1675 by introducing syntax for initializing new arrays with zero

### How I did it
- Get rid of NullType from codebase. Zeroing operations are now from the None sentinel value alone.
- Factor mzero into a function

### How to verify it
See tests

### Description for the changelog
- Introduce syntax for initializing new arrays with zero
- Check array assignment is always between arrays of same length

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://4.bp.blogspot.com/-qsO2RvLvLmg/UondIOh8zhI/AAAAAAAAD44/BUxiC4DlzSQ/s1600/Manta_Ray_.jpg)
