### PR TITLE
Feature: Allow scientific notation for literals

### DIFF
--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -121,11 +121,6 @@ def overflow2() -> uint256:
     a: uint256 = 2**256
     return a
     """,
-    """
-@public
-def scientific_notation() -> decimal:
-    return 2e-8  # not valid decimal literal
-    """,
 ]
 
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -143,7 +143,13 @@ BYTE32_LIST: constant(bytes32[2]) = [
     """,
     """
 ZERO_LIST: constant(int128[8]) = [0, 0, 0, 0, 0, 0, 0, 0]
+    """,
     """
+MY_DECIMAL: constant(decimal) = 1e-10
+    """,
+    """
+MY_DECIMAL: constant(decimal) = -1e38
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -58,9 +58,6 @@ def test(VAL: uint256):
     pass
     """, FunctionDeclarationException),
     ("""
-VAL: constant(decimal) = 2e-8
-    """, InvalidLiteralException),
-    ("""
 C1: constant(uint256) = block.number
 C2: constant(uint256) = convert(C1, uint256)
     """, InvalidLiteralException),

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -1,6 +1,9 @@
 from decimal import (
     Decimal,
+    getcontext,
 )
+
+getcontext().prec = 78  # MAX_UINT256 < 1e78
 
 
 def test_decimal_test(get_contract_with_gas_estimation):
@@ -142,3 +145,19 @@ def minimum():
 
     assert c.maximum() == []
     assert c.minimum() == []
+
+
+def test_scientific_notation(get_contract_with_gas_estimation):
+    code = """
+@public
+def foo() -> decimal:
+    return 1e-10
+
+@public
+def bar(num: decimal) -> decimal:
+    return num + -1e38
+    """
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.foo() == Decimal('1e-10')  # Smallest possible decimal
+    assert c.bar(Decimal('1e37')) == Decimal('-9e37')  # Math lines up

--- a/tests/parser/types/value/test_as_wei_value.py
+++ b/tests/parser/types/value/test_as_wei_value.py
@@ -1,4 +1,4 @@
-def test_test_wei(get_contract_with_gas_estimation):
+def test_wei_conversion(get_contract_with_gas_estimation):
     test_wei = """
 @public
 def return_2_finney() -> wei_value:
@@ -18,7 +18,7 @@ def return_3p5_ether() -> wei_value:
 
 @public
 def return_2pow64_wei() -> wei_value:
-    return as_wei_value(18446744.073709551616, "szabo")
+    return as_wei_value(18446744073.709551616, "gwei")
     """
 
     c = get_contract_with_gas_estimation(test_wei)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -813,6 +813,8 @@ class RewriteUnarySubVisitor(python_ast.NodeTransformer):
         self.generic_visit(node)
         if isinstance(node.op, python_ast.USub) and isinstance(node.operand, python_ast.Num):
             node.operand.n = 0 - node.operand.n
+            # NOTE: This is done so that decimal literal now sees the negative sign as part of it
+            node.operand.col_offset = node.col_offset
             return node.operand
         else:
             return node

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -1,6 +1,7 @@
 import ast as python_ast
 from decimal import (
     Decimal,
+    getcontext,
 )
 from typing import (
     Any,
@@ -50,6 +51,8 @@ from vyper.utils import (
     MemoryPositions,
     SizeLimits,
 )
+
+getcontext().prec = 78  # MAX_UINT256 < 1e78
 
 
 # Get a decimal number as a fraction with denominator multiple of 10


### PR DESCRIPTION
### What I did
Actual solution to #1680, allowing scientific notation literals (e.g. `3e6`, `1e-10`) to be used in vyper programs.
See: https://python-reference.readthedocs.io/en/latest/docs/float/scientific.html

### Work remaining
- ~~Need to work out semantics. Does a positive exponent get translated to an integer literal, or remain a decimal? Should it always be parsed a decimal?~~ Parsing as a decimal always works
- ~~Needs significant test cases to prove equivalency of constant expressions to their runtime equivalent (avoid issues like #1693)~~ Increased precision in fde6d2b avoids floating point issues

### Description for the changelog
Added support for decimal literals using scientific notation

### Cute Animal Picture
![Hamster](https://farm3.staticflickr.com/2526/3986920911_bbf4229f24_z.jpg)
