### PR TITLE
Updated docker image to Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.7-slim
 
 # Specify label-schema specific arguments and labels.
 ARG BUILD_DATE


### PR DESCRIPTION
I updated the build to Python 3.7 because I couldn't get 3.6 to work, and also it was time.

Note: Larger build size