### PR TITLE
Added coverage reporting to Python 3.7/3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
     - name: Run Tox
       run: TOXENV=py37-core tox -r
 
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+
   py38-core:
     runs-on: ubuntu-latest
 
@@ -84,3 +90,9 @@ jobs:
 
     - name: Run Tox
       run: TOXENV=py38-core tox -r
+
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml


### PR DESCRIPTION
Codecov _should_ merge these?
(see https://docs.codecov.io/docs/merging-reports)

---

This is important for catching coverage data in case we make version-specific imports for a feature