### PR TITLE
Ignore parallel coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ venv/
 ENV/
 
 # Coverage tests
-.coverage
+.coverage*
 .cache/
 htmlcov/
 coverage.xml


### PR DESCRIPTION
### What I did
When `pytest-xdist` runs coverage in parallel, it makes filenames with an ending in order to orchestrate it. This ignores those files.