### PR TITLE
Fix overspecificity in get_min_val_for_typ

### DIFF
--- a/tests/parser/functions/test_unary.py
+++ b/tests/parser/functions/test_unary.py
@@ -1,3 +1,7 @@
+from decimal import (
+    Decimal,
+)
+
 import pytest
 
 from vyper.exceptions import (
@@ -27,6 +31,19 @@ def negate(a: int128) -> int128:
 def test_unary_sub_int128_pass(get_contract, val):
     code = """@public
 def negate(a: int128) -> int128:
+    return -(a)
+    """
+    c = get_contract(code)
+    assert c.negate(val) == -val
+
+
+decimal_divisor = Decimal('1e10')
+min_decimal = (-2**127 + 1) / decimal_divisor
+max_decimal = (2**127 - 1) / decimal_divisor
+@pytest.mark.parametrize("val", [min_decimal, 0, max_decimal])
+def test_unary_sub_decimal_pass(get_contract, val):
+    code = """@public
+def negate(a: decimal) -> decimal:
     return -(a)
     """
     c = get_contract(code)

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -77,7 +77,7 @@ def get_min_val_for_type(typ: str) -> int:
     try:
         min_val, _, _ = BUILTIN_CONSTANTS[key]
     except KeyError as e:
-        raise TypeMismatchException(f"Not an integer type: {typ}") from e
+        raise TypeMismatchException(f"Not a signed type: {typ}") from e
     return min_val
 
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -73,9 +73,11 @@ ENVIRONMENT_VARIABLES = {
 
 
 def get_min_val_for_type(typ: str) -> int:
-    if "int" not in typ.lower():
-        raise Exception(f"Not an integer type: {typ}")
-    min_val, _, _ = BUILTIN_CONSTANTS['MIN_'+typ.upper()]
+    key = 'MIN_' + typ.upper()
+    try:
+        min_val, _, _ = BUILTIN_CONSTANTS[key]
+    except KeyError as e:
+        raise TypeMismatchException(f"Not an integer type: {typ}") from e
     return min_val
 
 


### PR DESCRIPTION
### What I did
Fix #1757 

### How I did it
get_min_val_for_type makes a check that the input type is an integer type, which is incorrect.

### How to verify it
see test

### Description for the changelog
Fix bug introduced in #1638 and allow decimals to be negated again

### Cute Animal Picture

![cute penguins](https://user-images.githubusercontent.com/3867501/70352230-82754e00-181f-11ea-93ba-c255d0e289a2.jpeg)

