### PR TITLE
Upgrade to use as many CPUs as available locally

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
-addopts = -n 4
+# use as many CPUs as available (via pytest-xdist)
+addopts = -n auto
           # Coverage Test Config
           --cov-branch
           --cov-report term


### PR DESCRIPTION
### What I did
`pytest-xdist` adds the ability to parallelize tests using the `-n [NUM]` flag. It also allows dynamically checking how many are available: https://github.com/pytest-dev/pytest-xdist#speed-up-test-runs-by-sending-tests-to-multiple-cpus

### Cute Animal Picture
![roadrunner](https://i.pinimg.com/originals/c3/a6/90/c3a690a3780257ae69ba2d7a059b2a94.jpg)