### PR TITLE
Fix #1761: potentially insufficient gas stipend for precompiled

### DIFF
--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -449,7 +449,7 @@ def ecrecover(expr, args, kwargs, context):
         ['mstore', ['add', placeholder_node, 32], args[1]],
         ['mstore', ['add', placeholder_node, 64], args[2]],
         ['mstore', ['add', placeholder_node, 96], args[3]],
-        ['pop', ['call', 3000, 1, 0, placeholder_node, 128, MemoryPositions.FREE_VAR_SPACE, 32]],
+        ['pop', ['call', ['gas'], 1, 0, placeholder_node, 128, MemoryPositions.FREE_VAR_SPACE, 32]],
         ['mload', MemoryPositions.FREE_VAR_SPACE],
     ], typ=BaseType('address'), pos=getpos(expr))
 
@@ -470,7 +470,7 @@ def ecadd(expr, args, kwargs, context):
         ['mstore', ['add', placeholder_node, 32], avo(args[0], 1, pos)],
         ['mstore', ['add', placeholder_node, 64], avo(args[1], 0, pos)],
         ['mstore', ['add', placeholder_node, 96], avo(args[1], 1, pos)],
-        ['assert', ['call', 500, 6, 0, placeholder_node, 128, placeholder_node, 64]],
+        ['assert', ['call', ['gas'], 6, 0, placeholder_node, 128, placeholder_node, 64]],
         placeholder_node,
     ], typ=ListType(BaseType('uint256'), 2), pos=getpos(expr), location='memory')
     return o
@@ -487,7 +487,7 @@ def ecmul(expr, args, kwargs, context):
         ['mstore', placeholder_node, avo(args[0], 0, pos)],
         ['mstore', ['add', placeholder_node, 32], avo(args[0], 1, pos)],
         ['mstore', ['add', placeholder_node, 64], args[1]],
-        ['assert', ['call', 40000, 7, 0, placeholder_node, 96, placeholder_node, 64]],
+        ['assert', ['call', ['gas'], 7, 0, placeholder_node, 96, placeholder_node, 64]],
         placeholder_node,
     ], typ=ListType(BaseType('uint256'), 2), pos=pos, location='memory')
     return o

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -117,7 +117,7 @@ def make_byte_array_copier(destination, source, pos=None):
         o = LLLnode.from_list([
             'with', '_source', source, [
                 'with', '_sz', ['add', 32, ['mload', '_source']], [
-                    'assert', ['call', ['add', 18, ['div', '_sz', 10]], 4, 0, '_source', '_sz', destination, '_sz']]]],  # noqa: E501
+                    'assert', ['call', ['gas'], 4, 0, '_source', '_sz', destination, '_sz']]]],  # noqa: E501
             typ=None, add_gas_estimate=gas_calculation, annotation='Memory copy'
         )
         return o
@@ -165,7 +165,7 @@ def make_byte_slice_copier(destination, source, length, max_length, pos=None):
             'with', '_l', max_length,
             [
                 'pop',
-                ['call', 18 + max_length // 10, 4, 0, source, '_l', destination, '_l']
+                ['call', ['gas'], 4, 0, source, '_l', destination, '_l']
             ]
         ], typ=None, annotation=f'copy byte slice dest: {str(destination)}')
     # Copy over data


### PR DESCRIPTION
### What I did

Fix #1761 

### How I did it

Put all available gas (i.e., `['gas']`) for calls to precompiled contracts, especially:
- `ECREC` (1)
- `ID` (4)
- `ECADD` (6)
- `ECMUL` (7)

Note that calls to `SHA256` (2) are already given the full gas.

### How to verify it

Check if the changes affect only (and all of) the calls to precompiled.

### Description for the changelog

Fix potentially insufficient gas stipend for precompiled contract calls

### Cute Animal Picture

![](https://pbs.twimg.com/profile_images/521554275713830913/TBY5IslL_400x400.jpeg)
