### PR TITLE
Bugfix - Importing an interface that contains an 'implements' statement

### DIFF
--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -134,3 +134,31 @@ def test():
 @pytest.mark.parametrize('good_code', valid_list)
 def test_interfaces_success(good_code):
     assert compiler.compile_code(good_code) is not None
+
+
+def test_imports_and_implements_within_interface():
+    interface_code = """
+from vyper.interfaces import ERC20
+import foo.bar as Baz
+
+implements: Baz
+
+@public
+def foobar():
+    pass
+"""
+
+    code = """
+import foo as Foo
+
+implements: Foo
+
+@public
+def foobar():
+    pass
+"""
+
+    assert compiler.compile_code(
+        code,
+        interface_codes={'Foo': {'type': "vyper", 'code': interface_code}}
+    ) is not None

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -124,11 +124,12 @@ def mk_full_signature_from_json(abi):
 
 def extract_sigs(sig_code):
     if sig_code['type'] == 'vyper':
-        interface_ast = parser.parse_to_ast(sig_code['code'])
-        return sig_utils.mk_full_signature(
-            [i for i in interface_ast if not isinstance(i, (ast.Import, ast.ImportFrom))],
-            sig_formatter=lambda x, y: x
-        )
+        interface_ast = [
+            i for i in parser.parse_to_ast(sig_code['code']) if
+            isinstance(i, ast.FunctionDef) or
+            (isinstance(i, ast.AnnAssign) and i.target.id != "implements")
+        ]
+        return sig_utils.mk_full_signature(interface_ast, sig_formatter=lambda x, y: x)
     elif sig_code['type'] == 'json':
         return mk_full_signature_from_json(sig_code['code'])
     else:


### PR DESCRIPTION
### The Issue
When importing a Vyper contract as an interface, a `StructureException` is raised if that file includes an `implements` statement.

### How I fixed it
In `vyper/signatures/interface.py`, I modified `extract_sigs` to exclude AST nodes related to `implements`.

### How to verify it
Run the tests. I added a new test case around this behavior.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71205701-601e0e80-22bc-11ea-8229-3234582662e0.png)
