### PR TITLE
Add Python AST compatibility to VyperNode classes

### DIFF
--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -37,6 +37,12 @@ class VyperNode:
             for klass in cls.__class__.mro(cls)
         ))
 
+    @property
+    def _fields(self):
+        # NOTE: Returns all the fields of a node in a manner compliant
+        #       with the expectations of the Python AST module
+        return self.get_slots()
+
     def __init__(self, **kwargs):
 
         for field_name, value in kwargs.items():

--- a/vyper/ast.py
+++ b/vyper/ast.py
@@ -1,3 +1,4 @@
+from ast import AST
 from itertools import (
     chain,
 )
@@ -25,7 +26,13 @@ BASE_NODE_ATTRIBUTES = (
 )
 
 
-class VyperNode:
+class VyperNode(AST):
+    """
+    Base class for all Vyper AST nodes
+
+    Subclasses the Python AST base node so we can use methods from the ast module
+    """
+    # NOTE: __slots__ has an integration with MyPy
     __slots__ = BASE_NODE_ATTRIBUTES
     ignored_fields: typing.Tuple = ('ctx', )
     only_empty_fields: typing.Tuple = ()


### PR DESCRIPTION
### What I did
Added property `_fields` and made `VyperNode` a subclass of Python's `ast.AST` class, giving us the ability to directly use features from Python's `ast` module on our own ast objects.

### How to verify it
```python
>>> from vyper.parser import parser
>>> src = open('examples/name_registry/name_registry.vy', 'r').read()
>>> ast = parser.parse_to_ast(src); [print(n.__class__.__name__) for n in ast]
AnnAssign
FunctionDef
FunctionDef
>>> from ast import iter_fields
>>> [print(n, "=", v.__class__.__name__) for n, v in iter_fields(ast[0])]
# AnnAssign fields:
target = Name
annotation = Call
value = NoneType
simple = int
# VyperNode fields:
source_code = str
node_id = int
src = str
lineno = int
col_offset = int
end_lineno = int
end_col_offset = int
```

### Cute Animal Picture
![silly llama](https://image.shutterstock.com/image-photo/funny-alpaca-smile-teeth-white-260nw-540327637.jpg)