### PR TITLE
Fixes to source map offsets

### DIFF
--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -15,6 +15,7 @@ from vyper.parser.constants import (
 )
 from vyper.parser.parser_utils import (
     getpos,
+    set_offsets,
 )
 from vyper.signatures.function_signature import (
     ContractRecord,
@@ -460,6 +461,7 @@ class GlobalContext:
                 for getter in self.mk_getter(item.target.id, typ):
                     self._getters.append(self.parse_line('\n' * (item.lineno - 1) + getter))
                     self._getters[-1].pos = getpos(item)
+                    set_offsets(self._getters[-1], self._getters[-1].pos)
         elif self.get_call_func_name(item) == "public":
             if isinstance(item.annotation.args[0], ast.Name) and item_name in self._contracts:
                 typ = ContractType(item_name)
@@ -481,6 +483,7 @@ class GlobalContext:
             for getter in self.mk_getter(item.target.id, typ):
                 self._getters.append(self.parse_line('\n' * (item.lineno - 1) + getter))
                 self._getters[-1].pos = getpos(item)
+                set_offsets(self._getters[-1], self._getters[-1].pos)
 
         elif isinstance(item.annotation, (ast.Name, ast.Call, ast.Subscript)):
             self._globals[item.target.id] = VariableRecord(

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -264,6 +264,7 @@ def getpos(node):
 
 
 def set_offsets(node, pos):
+    # TODO replace this with a visitor pattern
     for field in node.get_slots():
         item = getattr(node, field, None)
         if isinstance(item, ast.VyperNode):

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -389,17 +389,20 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
         if location == 'storage':
             return LLLnode.from_list(['add', ['sha3_32', parent], sub],
                                      typ=subtype,
-                                     location='storage')
+                                     location='storage',
+                                     pos=pos)
         elif location == 'storage_prehashed':
             return LLLnode.from_list(['add', parent, sub],
                                      typ=subtype,
-                                     location='storage')
+                                     location='storage',
+                                     pos=pos)
         elif location in ('calldata', 'memory'):
             offset = 32 * get_size_of_type(subtype)
             return LLLnode.from_list(
                 ['add', ['mul', offset, sub], parent],
                 typ=subtype,
                 location=location,
+                pos=pos
             )
         else:
             raise TypeMismatchException("Not expecting an array access ", pos)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -263,6 +263,18 @@ def getpos(node):
     )
 
 
+def set_offsets(node, pos):
+    for field in node.get_slots():
+        item = getattr(node, field, None)
+        if isinstance(item, ast.VyperNode):
+            set_offsets(item, pos)
+        elif isinstance(item, list):
+            for i in item:
+                if isinstance(i, ast.VyperNode):
+                    set_offsets(i, pos)
+    node.lineno, node.col_offset, node.end_lineno, node.end_col_offset = pos
+
+
 # Take a value representing a memory or storage location, and descend down to
 # an element or member variable
 def add_variable_offset(parent, key, pos, array_bounds_check=True):


### PR DESCRIPTION
### What I did
* Fixed the source offsets for public getter functions
* Added source offsets to array index bounds checks

### How I did it
* `parser/parser_utils.py` - added a method `set_offsets` that recursively adjusts column and line offsets for a node and all it's children
* `parser/global_context.py` - call `set_offsets` method on each generated getter to modify offsets to the correct values
* `parser/parser_utils.py` - added `pos` to the `LLLnode`s related to array clamping


### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71314042-318a6a00-245b-11ea-9426-7cc0047bb698.png)
