### PR TITLE
Updates to vyper-json

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -98,35 +98,35 @@ The following example describes the expected input format of ``vyper-json``. Com
         },
         // Optional
         "settings": {
-            "evmVersion": "byzantium"  // EVM version to compile for. Can be byzantium, constantinople or petersburg.
-        },
-        // The following is used to select desired outputs based on file names.
-        // File names are given as keys, a star as a file name matches all files.
-        // Outputs can also follow the Solidity format where second level keys
-        // denoting contract names - all 2nd level outputs are applied to the file.
-        //
-        // To select all possible compiler outputs: "outputSelection: { '*': ["*"] }"
-        // Note that this might slow down the compilation process needlessly.
-        //
-        // The available output types are as follows:
-        //
-        //    abi - The contract ABI
-        //    ast - Abstract syntax tree
-        //    interface - Derived interface of the contract, in proper Vyper syntax
-        //    ir - LLL intermediate representation of the code
-        //    evm.bytecode.object - Bytecode object
-        //    evm.bytecode.opcodes - Opcodes list
-        //    evm.deployedBytecode.object - Deployed bytecode object
-        //    evm.deployedBytecode.opcodes - Deployed opcodes list
-        //    evm.deployedBytecode.sourceMap - Deployed source mapping (useful for debugging)
-        //    evm.methodIdentifiers - The list of function hashes
-        //
-        // Using `evm`, `evm.bytecode`, etc. will select every target part of that output.
-        // Additionally, `*` can be used as a wildcard to request everything.
-        //
-        "outputSelection": {
-            "*": ["evm.bytecode", "abi"],  // Enable the abi and bytecode outputs for every single contract
-            "contracts/foo.vy": ["ast"]  // Enable the ast output for contracts/foo.vy
+            "evmVersion": "byzantium",  // EVM version to compile for. Can be byzantium, constantinople or petersburg.
+            // The following is used to select desired outputs based on file names.
+            // File names are given as keys, a star as a file name matches all files.
+            // Outputs can also follow the Solidity format where second level keys
+            // denoting contract names - all 2nd level outputs are applied to the file.
+            //
+            // To select all possible compiler outputs: "outputSelection: { '*': ["*"] }"
+            // Note that this might slow down the compilation process needlessly.
+            //
+            // The available output types are as follows:
+            //
+            //    abi - The contract ABI
+            //    ast - Abstract syntax tree
+            //    interface - Derived interface of the contract, in proper Vyper syntax
+            //    ir - LLL intermediate representation of the code
+            //    evm.bytecode.object - Bytecode object
+            //    evm.bytecode.opcodes - Opcodes list
+            //    evm.deployedBytecode.object - Deployed bytecode object
+            //    evm.deployedBytecode.opcodes - Deployed opcodes list
+            //    evm.deployedBytecode.sourceMap - Deployed source mapping (useful for debugging)
+            //    evm.methodIdentifiers - The list of function hashes
+            //
+            // Using `evm`, `evm.bytecode`, etc. will select every target part of that output.
+            // Additionally, `*` can be used as a wildcard to request everything.
+            //
+            "outputSelection": {
+                "*": ["evm.bytecode", "abi"],  // Enable the abi and bytecode outputs for every single contract
+                "contracts/foo.vy": ["ast"]  // Enable the ast output for contracts/foo.vy
+            }
         }
     }
 

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -98,7 +98,7 @@ The following example describes the expected input format of ``vyper-json``. Com
         },
         // Optional
         "settings": {
-            "evmVersion": "byzantium",  // EVM version to compile for. Can be byzantium, constantinople or petersburg.
+            "evmVersion": "byzantium",  // EVM version to compile for. Can be byzantium, constantinople, petersburg or istanbul.
             // The following is used to select desired outputs based on file names.
             // File names are given as keys, a star as a file name matches all files.
             // Outputs can also follow the Solidity format where second level keys

--- a/tests/cli/vyper_json/test_get_settings.py
+++ b/tests/cli/vyper_json/test_get_settings.py
@@ -21,6 +21,6 @@ def test_early_evm(evm_version):
         get_input_dict_settings({'settings': {'evmVersion': evm_version}})
 
 
-@pytest.mark.parametrize('evm_version', ['byzantium', 'constantinople', 'petersburg'])
+@pytest.mark.parametrize('evm_version', ['byzantium', 'constantinople', 'petersburg', 'istanbul'])
 def test_valid_evm(evm_version):
     get_input_dict_settings({'settings': {'evmVersion': evm_version}})

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -166,7 +166,7 @@ def get_input_dict_settings(input_dict: Dict) -> None:
     evm_version = input_dict['settings'].get('evmVersion', 'byzantium')
     if evm_version in ('homestead', 'tangerineWhistle', 'spuriousDragon'):
         raise JSONError("Vyper does not support pre-byzantium EVM versions")
-    if evm_version not in ('byzantium', 'constantinople', 'petersburg'):
+    if evm_version not in ('byzantium', 'constantinople', 'petersburg', 'istanbul'):
         raise JSONError(f"Unknown EVM version - '{evm_version}'")
 
 

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -215,7 +215,11 @@ def get_input_dict_interfaces(input_dict: Dict) -> Dict:
 
 def get_input_dict_output_formats(input_dict: Dict, contract_sources: ContractCodes) -> Dict:
     output_formats = {}
-    for path, outputs in input_dict['outputSelection'].items():
+    try:
+        output_selection = input_dict['settings']['outputSelection']
+    except KeyError:
+        output_selection = input_dict['outputSelection']
+    for path, outputs in output_selection.items():
         if isinstance(outputs, dict):
             # if outputs are given in solc json format, collapse them into a single list
             outputs = set(x for i in outputs.values() for x in i)


### PR DESCRIPTION
### What I did
* In the input json, allow `outputSelection` to be given as a subfield within `settings` - this is how Solidity formats it.
* Allow `istanbul` as a choice for the EVM version to target.  Though it doesn't change anything in how the compiler runs (yet), the code will still deploy and so the setting is valid.

### How I did it
Many hours of laborious coding.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71314328-d4dd7e00-245f-11ea-9b1d-95abc0a83d16.png)
