### PR TITLE
Fix inconsistent AST offsets in Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     python_requires='>=3.6',
     py_modules=['vyper'],
     install_requires=[
-        'asttokens==1.1.13',
+        'asttokens==2.0.3',
         'pycryptodome>=3.5.1,<4',
     ],
     setup_requires=[

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -60,7 +60,7 @@ def _build_vyper_ast_init_kwargs(
         yield ('class_type', node.class_type)  # type: ignore
 
     for field_name in vyper_class.get_slots():
-        if hasattr(node, field_name):
+        if field_name not in vyper_ast.BASE_NODE_ATTRIBUTES and hasattr(node, field_name):
             yield (
                 field_name,
                 parse_python_ast(


### PR DESCRIPTION
### The Issue

Python 3.8 has changed how line-based offsets are determined for some nodes. For example, with a `FunctionDef` that includes decorators, the decorators are included within the offsets in `<3.8`, they are not in `3.8`.

`asttokens` determines offsets using tokens - it does not have the same inconsistency between Python versions.

In `vyper/ast_utils.py` when generating the fields for nodes in `_build_vyper_ast_init_kwargs`, `asttokens` is used for both the line-based offsets and the absolute offset field `src`. The line-based offsets are then replaced by the Python AST offsets during the `get_slots()` iteration, creating an inconsistency between them and `src`.

### How I fixed it
Ignore all fields returned by `get_slots()` if they are in `vyper.ast.BASE_NODE_ATTRIBUTES`.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71376322-7b4d8e80-25da-11ea-8e05-ff2c4a6d067a.png)
