### PR TITLE
Fix Windows path issue when importing interfaces

### DIFF
--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -152,9 +152,10 @@ def exc_handler_to_dict(file_path: Union[str, None],
 
 
 def _standardize_path(path_str: str) -> str:
-    path = Path("/__vyper/" + path_str.lstrip('/')).resolve()
+    root_path = Path('/__vyper').resolve()
+    path = root_path.joinpath(path_str.lstrip('/')).resolve()
     try:
-        path = path.relative_to("/__vyper")
+        path = path.relative_to(root_path)
     except ValueError:
         raise JSONError(f"{path_str} - path exists outside base folder")
     return path.as_posix()


### PR DESCRIPTION
### The Issue
To prevent imports outside of the the root path, `vyper-json` prepends import paths with `/__vyper` and then ensures the final resolved path is still a subfolder of that path.  On Windows this check is failing with `ValueError: 'C:\\__vyper\\path.vy' does not start with '\\__vyper'`.  Oopsies.

You can see a detailed traceback for the issue [here](https://travis-ci.com/iamdefinitelyahuman/brownie/jobs/269839445).

### How I fixed it
Perform the `relative_to` check against a `Path` object, so that it works on any filesystem.

### How to verify it
I confirmed that it works in a Windows 10 VM. Not sure if anyone wants to add Windows to the CI...

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71383123-549c5180-25f4-11ea-9f0a-48a0db554807.png)
