### PR TITLE
Evm versions

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -1,8 +1,8 @@
 Compiling a Contract
 ********************
 
-Command-Line Tools
-==================
+Command-Line Compiler Tools
+===========================
 
 Vyper includes the following command-line scripts for compiling contracts:
 
@@ -37,13 +37,12 @@ The ``-p`` flag allows you to set a root path that is used when searching for in
 
     $ vyper -p yourProject yourProject/yourFileName.vy
 
+.. _vyper-json:
 
 vyper-json
 ----------
 
-``vyper-json`` provides a JSON interface for the compiler. It expects a JSON formatted input and returns the compilation result in a JSON formatted output.
-
-Where possible, the JSON formats used by this script follow those of `Solidity <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description>`_.
+``vyper-json`` provides a JSON interface for the compiler. It expects a :ref:`JSON formatted input<vyper-json-input>` and returns the compilation result in a :ref:`JSON formatted output<vyper-json-output>`.
 
 To compile from JSON supplied via ``stdin``:
 
@@ -63,8 +62,92 @@ By default, the output is sent to ``stdout``. To redirect to a file, use the ``-
 
     $ vyper-json -o compiled.json
 
+Importing Interfaces
+~~~~~~~~~~~~~~~~~~~~
+
+``vyper-json`` searches for imported interfaces in the following sequence:
+
+1. Interfaces defined in the ``interfaces`` field of the input JSON
+2. Derived interfaces generated from contracts in the ``sources`` field of the input JSON
+3. (Optional) The local filesystem, if a root path was explicitely declared via the ``-p`` flag.
+
+See :ref:`searching_for_imports` for more information on Vyper's import system.
+
+Online Compilers
+================
+
+Vyper Online Compiler
+---------------------
+
+`Vyper Online Compiler <https://vyper.online/>`_ is an online compiler which lets you experiment with the language without having to install Vyper. It allows you to compile to ``bytecode`` as well as ``LLL``.
+
+.. note::
+
+    While the vyper version of the online compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository.
+
+Remix IDE
+---------
+
+`Remix IDE <https://remix.ethereum.org>`_ is a compiler and Javascript VM for developing and testing contracts in Vyper as well as Solidity.
+
+.. note::
+
+   While the vyper version of the Remix IDE compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository. Make sure the byte code matches the output from your local compiler.
+
+
+Setting the Target EVM Version
+==============================
+
+When you compile your contract code you can specify the Ethereum virtual machine version to compile for to avoid particular features or behaviours.
+
+.. warning::
+
+    Compiling for the wrong EVM version can result in wrong, strange and failing behaviour. Please ensure, especially if running a private chain, that you use matching EVM versions.
+
+When compiling via ``vyper``, include the ``--evm-version`` flag:
+
+::
+
+    $ vyper --evm-version [VERSION]
+
+When using the JSON interface, include the ``"evmVersion"`` key within the ``"settings"`` field:
+
+.. code-block:: javascript
+
+    {
+        "settings": {
+            "evmVersion": "[VERSION]"
+        }
+    }
+
+Target Options
+--------------
+
+The following is a list of supported EVM versions, and changes in the compiler introduced with each version. Backward compatibility is not guaranteed between each version.
+
+- ``byzantium``
+   - The oldest EVM version supported by Vyper.
+- ``constantinople``
+   - The compiler behaves the same way as with byzantium.
+- ``petersburg``
+   - The compiler behaves the same way as with consantinople.
+- ``istanbul`` **(default)**
+   - The ``CHAINID`` opcode is accessible via ``chain.id``
+   - The ``SELFBALANCE`` opcode is used for calls to ``self.balance``
+   - Gas estimates changed for ``SLOAD`` and ``BALANCE``
+
+
+Compiler Input and Output JSON Description
+==========================================
+
+Especially when dealing with complex or automated setups, the recommended way to compile is to use :ref:`vyper-json` and the JSON-input-output interface.
+
+Where possible, the Vyper JSON compiler formats follow those of `Solidity <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description>`_.
+
+.. _vyper-json-input:
+
 Input JSON Description
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 The following example describes the expected input format of ``vyper-json``. Comments are of course not permitted and used here only for explanatory purposes.
 
@@ -98,7 +181,7 @@ The following example describes the expected input format of ``vyper-json``. Com
         },
         // Optional
         "settings": {
-            "evmVersion": "byzantium"  // EVM version to compile for. Can be byzantium, constantinople or petersburg.
+            "evmVersion": "istanbul"  // EVM version to compile for. Can be byzantium, constantinople, petersburg or istanbul.
         },
         // The following is used to select desired outputs based on file names.
         // File names are given as keys, a star as a file name matches all files.
@@ -130,8 +213,10 @@ The following example describes the expected input format of ``vyper-json``. Com
         }
     }
 
+.. _vyper-json-output:
+
 Output JSON Description
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 The following example describes the output format of ``vyper-json``. Comments are of course not permitted and used here only for explanatory purposes.
 
@@ -206,17 +291,6 @@ The following example describes the output format of ``vyper-json``. Comments ar
         }
     }
 
-Importing Interfaces
-~~~~~~~~~~~~~~~~~~~~
-
-``vyper-json`` searches for imported interfaces in the following sequence:
-
-1. Interfaces defined in the ``interfaces`` field of the input JSON
-2. Derived interfaces generated from contracts in the ``sources`` field of the input JSON
-3. (Optional) The local filesystem, if a root path was explicitely declared via the ``-p`` flag.
-
-See :ref:`searching_for_imports` for more information on Vyper's import system.
-
 Errors
 ~~~~~~
 
@@ -228,25 +302,3 @@ Each error includes a ``component`` field, indicating the stage at which it occu
 * ``vyper``: Unexpected errors that occur within Vyper. If you receive an error of this type, please open an issue.
 
 You can also use the ``--traceback`` flag to receive a standard Python traceback when an error is encountered.
-
-
-Online Compilers
-================
-
-Vyper Online Compiler
----------------------
-
-`Vyper Online Compiler <https://vyper.online/>`_ is an online compiler which lets you experiment with the language without having to install Vyper. It allows you to compile to ``bytecode`` as well as ``LLL``.
-
-.. note::
-
-    While the vyper version of the online compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository.
-
-Remix IDE
----------
-
-`Remix IDE <https://remix.ethereum.org>`_ is a compiler and Javascript VM for developing and testing contracts in Vyper as well as Solidity.
-
-.. note::
-
-   While the vyper version of the Remix IDE compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository. Make sure the byte code matches the output from your local compiler.

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -73,6 +73,7 @@ Name                 Type             Value
 ``block.number``     ``uint256``      Current block number
 ``block.prevhash``   ``bytes32``      Equivalent to ``blockhash(block.number - 1)``
 ``block.timestamp``  ``uint256``      Current block epoch timestamp
+``chain.id``         ``uint256``      Chain ID
 ``msg.gas``          ``uint256``      Remaining gas
 ``msg.sender``       ``address``      Sender of the message (current call)
 ``msg.value``        ``uint256(wei)`` Number of wei sent with the message

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -121,6 +121,7 @@ def _get_contract(w3, source_code, *args, **kwargs):
         source_code,
         ['abi', 'bytecode'],
         interface_codes=kwargs.pop('interface_codes', None),
+        evm_version=kwargs.pop('evm_version', None),
     )
     abi = out['abi']
     bytecode = out['bytecode']

--- a/tests/cli/vyper_compile/test_compile_files.py
+++ b/tests/cli/vyper_compile/test_compile_files.py
@@ -20,3 +20,27 @@ def test_combined_json_keys(tmp_path):
 def test_invalid_root_path():
     with pytest.raises(FileNotFoundError):
         compile_files([], [], root_folder="path/that/does/not/exist")
+
+
+def test_evm_versions(tmp_path):
+    # should compile differently because of SELFBALANCE
+    code = """
+@public
+def foo() -> uint256(wei):
+    return self.balance
+"""
+
+    bar_path = tmp_path.joinpath('bar.vy')
+    with bar_path.open('w') as fp:
+        fp.write(code)
+
+    compile_data = compile_files(
+        [bar_path],
+        output_formats=['bytecode_runtime'],
+        evm_version="byzantium"
+    )
+    assert compile_data != compile_files(
+        [bar_path],
+        output_formats=['bytecode_runtime'],
+        evm_version="istanbul"
+    )

--- a/tests/cli/vyper_compile/test_compile_files.py
+++ b/tests/cli/vyper_compile/test_compile_files.py
@@ -34,13 +34,19 @@ def foo() -> uint256(wei):
     with bar_path.open('w') as fp:
         fp.write(code)
 
-    compile_data = compile_files(
+    byzantium_bytecode = compile_files(
         [bar_path],
-        output_formats=['bytecode_runtime'],
+        output_formats=['bytecode'],
         evm_version="byzantium"
-    )
-    assert compile_data != compile_files(
+    )[str(bar_path)]['bytecode']
+    istanbul_bytecode = compile_files(
         [bar_path],
-        output_formats=['bytecode_runtime'],
+        output_formats=['bytecode'],
         evm_version="istanbul"
-    )
+    )[str(bar_path)]['bytecode']
+
+    assert byzantium_bytecode != istanbul_bytecode
+
+    # SELFBALANCE opcode is 0x47
+    assert "47" not in byzantium_bytecode
+    assert "47" in istanbul_bytecode

--- a/tests/cli/vyper_json/test_compile_from_input_dict.py
+++ b/tests/cli/vyper_json/test_compile_from_input_dict.py
@@ -25,6 +25,10 @@ import contracts.bar as Bar
 @public
 def foo(a: address) -> bool:
     return Bar(a).bar(1)
+
+@public
+def baz() -> uint256(wei):
+    return self.balance
 """
 
 BAR_CODE = """
@@ -125,3 +129,12 @@ def test_outputs():
     result, _ = compile_from_input_dict(INPUT_JSON)
     assert sorted(result.keys()) == ['contracts/bar.vy', 'contracts/foo.vy']
     assert sorted(result['contracts/bar.vy'].keys()) == sorted(TRANSLATE_MAP.values())
+
+
+def test_evm_version():
+    # should compile differently because of SELFBALANCE
+    input_json = deepcopy(INPUT_JSON)
+    input_json['settings'] = {'evmVersion': "byzantium"}
+    compiled = compile_from_input_dict(input_json)
+    input_json['settings'] = {'evmVersion': "istanbul"}
+    assert compiled != compile_from_input_dict(input_json)

--- a/tests/cli/vyper_json/test_get_settings.py
+++ b/tests/cli/vyper_json/test_get_settings.py
@@ -8,6 +8,9 @@ from vyper.cli.vyper_json import (
 from vyper.exceptions import (
     JSONError,
 )
+from vyper.opcodes import (
+    DEFAULT_EVM_VERSION,
+)
 
 
 def test_unknown_evm():
@@ -23,4 +26,9 @@ def test_early_evm(evm_version):
 
 @pytest.mark.parametrize('evm_version', ['byzantium', 'constantinople', 'petersburg'])
 def test_valid_evm(evm_version):
-    get_input_dict_settings({'settings': {'evmVersion': evm_version}})
+    settings = get_input_dict_settings({'settings': {'evmVersion': evm_version}})
+    assert settings == {'evm_version': evm_version}
+
+
+def test_default_evm():
+    get_input_dict_settings({}) == {'evm_version': DEFAULT_EVM_VERSION}

--- a/tests/compiler/test_opcodes.py
+++ b/tests/compiler/test_opcodes.py
@@ -1,4 +1,17 @@
+import pytest
+
 import vyper
+from vyper import (
+    opcodes,
+)
+
+
+@pytest.fixture(params=list(opcodes.EVM_VERSIONS))
+def evm_version(request):
+    default = opcodes.active_evm_version
+    opcodes.active_evm_version = opcodes.EVM_VERSIONS[request.param]
+    yield request.param
+    opcodes.active_evm_version = default
 
 
 def test_opcodes():
@@ -12,3 +25,32 @@ def a() -> bool:
 
     assert len(out['opcodes']) > len(out['opcodes_runtime'])
     assert out['opcodes_runtime'] in out['opcodes']
+
+
+def test_version_check_no_begin_or_end():
+    with pytest.raises(AssertionError):
+        opcodes.version_check()
+
+
+def test_version_check(evm_version):
+    assert opcodes.version_check(begin=evm_version)
+    assert opcodes.version_check(end=evm_version)
+    assert opcodes.version_check(begin=evm_version, end=evm_version)
+    if evm_version != "byzantium":
+        assert not opcodes.version_check(end="byzantium")
+    if evm_version != "istanbul":
+        assert not opcodes.version_check(begin="istanbul")
+
+
+def test_get_opcodes(evm_version):
+    op = opcodes.get_opcodes()
+    if evm_version == "istanbul":
+        assert "CHAINID" in op
+        assert op['SLOAD'][-1] == 800
+    else:
+        assert "CHAINID" not in op
+        assert op['SLOAD'][-1] == 200
+    if evm_version == "byzantium":
+        assert "CREATE2" not in op
+    else:
+        assert op["CREATE2"][-1] == 32000

--- a/tests/compiler/test_opcodes.py
+++ b/tests/compiler/test_opcodes.py
@@ -4,6 +4,9 @@ import vyper
 from vyper import (
     opcodes,
 )
+from vyper.exceptions import (
+    CompilerPanic,
+)
 
 
 @pytest.fixture(params=list(opcodes.EVM_VERSIONS))
@@ -28,7 +31,7 @@ def a() -> bool:
 
 
 def test_version_check_no_begin_or_end():
-    with pytest.raises(AssertionError):
+    with pytest.raises(CompilerPanic):
         opcodes.version_check()
 
 

--- a/tests/parser/syntax/test_self_balance.py
+++ b/tests/parser/syntax/test_self_balance.py
@@ -1,0 +1,30 @@
+import pytest
+
+from vyper.opcodes import (
+    EVM_VERSIONS,
+)
+
+
+@pytest.mark.parametrize('evm_version', list(EVM_VERSIONS))
+def test_self_balance(w3, get_contract_with_gas_estimation, evm_version):
+    code = """
+@public
+@constant
+def get_balance() -> uint256(wei):
+    a: uint256(wei) = self.balance
+    return a
+
+@public
+@payable
+def __default__():
+    pass
+    """
+    c = get_contract_with_gas_estimation(code, evm_version=evm_version)
+
+    if evm_version == "istanbul":
+        assert 0x47 in c._classic_contract.bytecode
+    else:
+        assert 0x47 not in c._classic_contract.bytecode
+
+    w3.eth.sendTransaction({'to': c.address, 'value': 1337})
+    assert c.get_balance() == 1337

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -19,6 +19,10 @@ from typing import (
 import warnings
 
 import vyper
+from vyper.opcodes import (
+    DEFAULT_EVM_VERSION,
+    EVM_VERSIONS,
+)
 from vyper.parser import (
     parser_utils,
 )
@@ -86,6 +90,12 @@ def _parse_args(argv):
         default='bytecode', dest='format',
     )
     parser.add_argument(
+        '--evm-version',
+        help=f'Select desired EVM version (default {DEFAULT_EVM_VERSION})',
+        choices=list(EVM_VERSIONS),
+        default=DEFAULT_EVM_VERSION, dest='evm_version',
+    )
+    parser.add_argument(
         '--traceback-limit',
         help='Set the traceback limit for error messages reported by the compiler',
         type=int,
@@ -124,7 +134,8 @@ def _parse_args(argv):
         args.input_files,
         final_formats,
         args.root_folder,
-        args.show_gas_estimates
+        args.show_gas_estimates,
+        args.evm_version,
     )
 
     if output_formats == ('combined_json',):
@@ -208,7 +219,8 @@ def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
 def compile_files(input_files: Iterable[str],
                   output_formats: OutputFormats,
                   root_folder: str = '.',
-                  show_gas_estimates: bool = False) -> OrderedDict:
+                  show_gas_estimates: bool = False,
+                  evm_version: str = DEFAULT_EVM_VERSION) -> OrderedDict:
 
     if show_gas_estimates:
         parser_utils.LLLnode.repr_show_gas = True
@@ -238,7 +250,8 @@ def compile_files(input_files: Iterable[str],
         contract_sources,
         output_formats,
         exc_handler=exc_handler,
-        interface_codes=get_interface_codes(root_path, contract_sources)
+        interface_codes=get_interface_codes(root_path, contract_sources),
+        evm_version=evm_version,
     )
     if show_version:
         compiler_data['version'] = vyper.__version__

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -164,7 +164,7 @@ def _standardize_path(path_str: str) -> str:
     return path.as_posix()
 
 
-def get_input_dict_settings(input_dict: Dict) -> None:
+def get_input_dict_settings(input_dict: Dict) -> Dict:
     if 'settings' not in input_dict:
         return {'evm_version': DEFAULT_EVM_VERSION}
 

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -15,6 +15,9 @@ import vyper
 from vyper.exceptions import (
     ParserException,
 )
+from vyper.opcodes import (
+    DEFAULT_EVM_VERSION,
+)
 from vyper.parser import (
     lll_node,
 )
@@ -104,6 +107,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             out_dict = vyper.compile_codes(
                 {'': code},
                 vyper.compiler.OUTPUT_FORMATS.keys(),
+                evm_version=data.get('evm_version', DEFAULT_EVM_VERSION)
             )['']
             out_dict['ir'] = str(out_dict['ir'])
         except ParserException as e:

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -11,7 +11,7 @@ from vyper.utils import (
 )
 
 from .opcodes import (
-    OPCODES,
+    get_opcodes,
 )
 
 PUSH_OFFSET = 0x5f
@@ -100,7 +100,7 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
         raise CompilerPanic(f"Incorrect type for existing_labels: {type(existing_labels)}")
 
     # Opcodes
-    if isinstance(code.value, str) and code.value.upper() in OPCODES:
+    if isinstance(code.value, str) and code.value.upper() in get_opcodes():
         o = []
         for i, c in enumerate(code.args[::-1]):
             o.extend(compile_to_assembly(c, withargs, existing_labels, break_dest, height + i))
@@ -534,8 +534,8 @@ def assembly_to_evm(assembly, start_pos=0):
                 o += bytes([PUSH_OFFSET + 2, posmap[item] // 256, posmap[item] % 256])
         elif isinstance(item, int):
             o += bytes([item])
-        elif isinstance(item, str) and item.upper() in OPCODES:
-            o += bytes([OPCODES[item.upper()][0]])
+        elif isinstance(item, str) and item.upper() in get_opcodes():
+            o += bytes([get_opcodes()[item.upper()][0]])
         elif item[:4] == 'PUSH':
             o += bytes([PUSH_OFFSET + int(item[4:])])
         elif item[:3] == 'DUP':

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -14,13 +14,11 @@ import asttokens
 
 from vyper import (
     compile_lll,
+    opcodes,
     optimizer,
 )
 from vyper.ast_utils import (
     ast_to_dict,
-)
-from vyper.opcodes import (
-    OPCODES,
 )
 from vyper.parser import (
     parser,
@@ -203,7 +201,7 @@ def get_opcodes(code, contract_name, bytecodes_runtime=False, interface_codes=No
         interface_codes=interface_codes
     ).hex().upper()
     bytecode = deque(bytecode[i:i + 2] for i in range(0, len(bytecode), 2))
-    opcode_map = dict((v[0], k) for k, v in OPCODES.items())
+    opcode_map = dict((v[0], k) for k, v in opcodes.get_opcodes().items())
     opcode_str = ""
 
     while bytecode:

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -20,6 +20,9 @@ from vyper import (
 from vyper.ast_utils import (
     ast_to_dict,
 )
+from vyper.opcodes import (
+    evm_wrapper
+)
 from vyper.parser import (
     parser,
 )
@@ -291,6 +294,7 @@ OUTPUT_FORMATS = {
 }
 
 
+@evm_wrapper
 def compile_codes(contract_sources: ContractCodes,
                   output_formats: Union[OutputDict, OutputFormats, None] = None,
                   exc_handler: Union[Callable, None] = None,
@@ -338,11 +342,12 @@ def compile_codes(contract_sources: ContractCodes,
 UNKNOWN_CONTRACT_NAME = '<unknown>'
 
 
-def compile_code(code, output_formats=None, interface_codes=None):
+def compile_code(code, output_formats=None, interface_codes=None, evm_version="byzantium"):
     contract_sources = {UNKNOWN_CONTRACT_NAME: code}
 
     return compile_codes(
         contract_sources,
         output_formats,
         interface_codes=interface_codes,
+        evm_version=evm_version
     )[UNKNOWN_CONTRACT_NAME]

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -21,7 +21,8 @@ from vyper.ast_utils import (
     ast_to_dict,
 )
 from vyper.opcodes import (
-    evm_wrapper
+    DEFAULT_EVM_VERSION,
+    evm_wrapper,
 )
 from vyper.parser import (
     parser,
@@ -342,7 +343,11 @@ def compile_codes(contract_sources: ContractCodes,
 UNKNOWN_CONTRACT_NAME = '<unknown>'
 
 
-def compile_code(code, output_formats=None, interface_codes=None, evm_version="byzantium"):
+def compile_code(code,
+                 output_formats=None,
+                 interface_codes=None,
+                 evm_version=DEFAULT_EVM_VERSION):
+
     contract_sources = {UNKNOWN_CONTRACT_NAME: code}
 
     return compile_codes(

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -109,6 +109,10 @@ class ArrayIndexException(ParserException):
     pass
 
 
+class EvmVersionException(ParserException):
+    pass
+
+
 class CompilerPanic(Exception):
 
     def __init__(self, message):

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -4,7 +4,7 @@ from typing import (
     Optional,
 )
 
-active_evm_version: int = None
+active_evm_version = None
 
 EVM_VERSIONS = {
     'byzantium': 0,
@@ -188,9 +188,18 @@ PSEUDO_OPCODES: Dict[str, List[Optional[int]]] = {
 COMB_OPCODES: Dict[str, List[Optional[int]]] = {**OPCODES, **PSEUDO_OPCODES}
 
 
-def set_evm_version(version_name):
-    global active_evm_version
-    active_evm_version = EVM_VERSIONS[version_name]
+def evm_wrapper(fn, *args, **kwargs):
+
+    def _wrapper(*args, **kwargs):
+        global active_evm_version
+        evm_version = kwargs.pop('evm_version', 'byzantium')
+        active_evm_version = EVM_VERSIONS[evm_version]
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            active_evm_version = None
+
+    return _wrapper
 
 
 def _gas(opcode_name):

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -9,8 +9,8 @@ active_evm_version: int = None
 EVM_VERSIONS = {
     'byzantium': 0,
     'constantinople': 1,
-    'petersburg': 2,
-    'istanbul': 3,
+    'petersburg': 1,
+    'istanbul': 2,
 }
 
 # opcode as hex value, number of values removed from stack, added to stack, gas cost
@@ -38,9 +38,12 @@ OPCODES: Dict[str, List[Optional[int]]] = {
     'XOR': [0x18, 2, 1, 3],
     'NOT': [0x19, 1, 1, 3],
     'BYTE': [0x1a, 2, 1, 3],
+    'SHL': [0x1b, 2, 1, (None, 3)],
+    'SHR': [0x1c, 2, 1, (None, 3)],
+    'SAR': [0x1d, 2, 1, (None, 3)],
     'SHA3': [0x20, 2, 1, 30],
     'ADDRESS': [0x30, 0, 1, 2],
-    'BALANCE': [0x31, 1, 1, 700],  # Updated Istanbul Ruleset
+    'BALANCE': [0x31, 1, 1, (400, 400, 700)],
     'ORIGIN': [0x32, 0, 1, 2],
     'CALLER': [0x33, 0, 1, 2],
     'CALLVALUE': [0x34, 0, 1, 2],
@@ -52,18 +55,22 @@ OPCODES: Dict[str, List[Optional[int]]] = {
     'GASPRICE': [0x3a, 0, 1, 2],
     'EXTCODESIZE': [0x3b, 1, 1, 700],
     'EXTCODECOPY': [0x3c, 4, 0, 700],
+    'RETURNDATASIZE': [0x3d, 0, 1, 2],
+    'RETURNDATACOPY': [0x3e, 3, 0, 3],
+    'EXTCODEHASH': [0x3f, 1, 1, (None, 400, 700)],
     'BLOCKHASH': [0x40, 1, 1, 20],
     'COINBASE': [0x41, 0, 1, 2],
     'TIMESTAMP': [0x42, 0, 1, 2],
     'NUMBER': [0x43, 0, 1, 2],
     'DIFFICULTY': [0x44, 0, 1, 2],
     'GASLIMIT': [0x45, 0, 1, 2],
-    'CHAINID': [0x46, 0, 1, 2],  # Added Istanbul Ruleset
+    'CHAINID': [0x46, 0, 1, (None, None, 2)],
+    'SELFBALANCE': [0x47, 0, 1, (None, None, 5)],
     'POP': [0x50, 1, 0, 2],
     'MLOAD': [0x51, 1, 1, 3],
     'MSTORE': [0x52, 2, 0, 3],
     'MSTORE8': [0x53, 2, 0, 3],
-    'SLOAD': [0x54, 1, 1, 800],  # Updated Istanbul Ruleset
+    'SLOAD': [0x54, 1, 1, (200, 200, 800)],
     'SSTORE': [0x55, 2, 0, 20000],
     'JUMP': [0x56, 1, 0, 8],
     'JUMPI': [0x57, 2, 0, 10],
@@ -145,7 +152,7 @@ OPCODES: Dict[str, List[Optional[int]]] = {
     'CALLCODE': [0xf2, 7, 1, 700],
     'RETURN': [0xf3, 2, 0, 0],
     'DELEGATECALL': [0xf4, 6, 1, 700],
-    'CALLBLACKBOX': [0xf5, 7, 1, 700],
+    'CREATE2': [0xf5, 4, 1, (None, 32000)],
     'SELFDESTRUCT': [0xff, 1, 0, 25000],
     'STATICCALL': [0xfa, 6, 1, 40],
     'REVERT': [0xfd, 2, 0, 0],
@@ -189,6 +196,8 @@ def set_evm_version(version_name):
 def _gas(opcode_name):
     if isinstance(COMB_OPCODES[opcode_name][3], int):
         return COMB_OPCODES[opcode_name][3]
+    if len(COMB_OPCODES[opcode_name][3]) <= active_evm_version:
+        return COMB_OPCODES[opcode_name][3][-1]
     return COMB_OPCODES[opcode_name][3][active_evm_version]
 
 

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -4,6 +4,7 @@ from typing import (
 )
 
 from vyper.typing import (
+    OpcodeGasCost,
     OpcodeMap,
     OpcodeRulesetMap,
     OpcodeRulesetValue,
@@ -214,7 +215,7 @@ def evm_wrapper(fn, *args, **kwargs):
 
 
 def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:
-    gas = value[3]
+    gas: OpcodeGasCost = value[3]
     if isinstance(gas, int):
         return value[:3] + (gas,)
     if len(gas) <= idx:

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -11,7 +11,7 @@ EVM_VERSIONS: Dict[str, int] = {
     'petersburg': 1,
     'istanbul': 2,
 }
-DEFAULT_EVM_VERSION: str = "byzantium"
+DEFAULT_EVM_VERSION: str = "istanbul"
 
 
 # opcode as hex value

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -4,7 +4,7 @@ from typing import (
     Optional,
 )
 
-active_evm_version = None
+active_evm_version = 0
 
 EVM_VERSIONS = {
     'byzantium': 0,
@@ -12,6 +12,8 @@ EVM_VERSIONS = {
     'petersburg': 1,
     'istanbul': 2,
 }
+DEFAULT_EVM_VERSION = "byzantium"
+
 
 # opcode as hex value, number of values removed from stack, added to stack, gas cost
 OPCODES: Dict[str, List[Optional[int]]] = {
@@ -192,12 +194,12 @@ def evm_wrapper(fn, *args, **kwargs):
 
     def _wrapper(*args, **kwargs):
         global active_evm_version
-        evm_version = kwargs.pop('evm_version', 'byzantium')
+        evm_version = kwargs.pop('evm_version', DEFAULT_EVM_VERSION)
         active_evm_version = EVM_VERSIONS[evm_version]
         try:
             return fn(*args, **kwargs)
         finally:
-            active_evm_version = None
+            active_evm_version = EVM_VERSIONS[DEFAULT_EVM_VERSION]
 
     return _wrapper
 
@@ -211,12 +213,8 @@ def _gas(opcode_name):
 
 
 def get_opcodes():
-    if active_evm_version is None:
-        raise
     return dict((k, v[:3]+[_gas(k)]) for k, v in OPCODES.items() if _gas(k) is not None)
 
 
 def get_comb_opcodes():
-    if active_evm_version is None:
-        raise
     return dict((k, v[:3]+[_gas(k)]) for k, v in COMB_OPCODES.items() if _gas(k) is not None)

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -1,6 +1,13 @@
 from typing import (
     Dict,
-    List,
+    Optional,
+)
+
+from vyper.typing import (
+    OpcodeMap,
+    OpcodeRulesetMap,
+    OpcodeRulesetValue,
+    OpcodeValue,
 )
 
 active_evm_version: int = 0
@@ -18,178 +25,178 @@ DEFAULT_EVM_VERSION: str = "istanbul"
 # number of values removed from stack
 # number of values added to stack
 # gas cost (byzantium, constantinople, istanbul)
-OPCODES: Dict[str, List] = {
-    'STOP': [0x00, 0, 0, 0],
-    'ADD': [0x01, 2, 1, 3],
-    'MUL': [0x02, 2, 1, 5],
-    'SUB': [0x03, 2, 1, 3],
-    'DIV': [0x04, 2, 1, 5],
-    'SDIV': [0x05, 2, 1, 5],
-    'MOD': [0x06, 2, 1, 5],
-    'SMOD': [0x07, 2, 1, 5],
-    'ADDMOD': [0x08, 3, 1, 8],
-    'MULMOD': [0x09, 3, 1, 8],
-    'EXP': [0x0a, 2, 1, 10],
-    'SIGNEXTEND': [0x0b, 2, 1, 5],
-    'LT': [0x10, 2, 1, 3],
-    'GT': [0x11, 2, 1, 3],
-    'SLT': [0x12, 2, 1, 3],
-    'SGT': [0x13, 2, 1, 3],
-    'EQ': [0x14, 2, 1, 3],
-    'ISZERO': [0x15, 1, 1, 3],
-    'AND': [0x16, 2, 1, 3],
-    'OR': [0x17, 2, 1, 3],
-    'XOR': [0x18, 2, 1, 3],
-    'NOT': [0x19, 1, 1, 3],
-    'BYTE': [0x1a, 2, 1, 3],
-    'SHL': [0x1b, 2, 1, (None, 3)],
-    'SHR': [0x1c, 2, 1, (None, 3)],
-    'SAR': [0x1d, 2, 1, (None, 3)],
-    'SHA3': [0x20, 2, 1, 30],
-    'ADDRESS': [0x30, 0, 1, 2],
-    'BALANCE': [0x31, 1, 1, (400, 400, 700)],
-    'ORIGIN': [0x32, 0, 1, 2],
-    'CALLER': [0x33, 0, 1, 2],
-    'CALLVALUE': [0x34, 0, 1, 2],
-    'CALLDATALOAD': [0x35, 1, 1, 3],
-    'CALLDATASIZE': [0x36, 0, 1, 2],
-    'CALLDATACOPY': [0x37, 3, 0, 3],
-    'CODESIZE': [0x38, 0, 1, 2],
-    'CODECOPY': [0x39, 3, 0, 3],
-    'GASPRICE': [0x3a, 0, 1, 2],
-    'EXTCODESIZE': [0x3b, 1, 1, 700],
-    'EXTCODECOPY': [0x3c, 4, 0, 700],
-    'RETURNDATASIZE': [0x3d, 0, 1, 2],
-    'RETURNDATACOPY': [0x3e, 3, 0, 3],
-    'EXTCODEHASH': [0x3f, 1, 1, (None, 400, 700)],
-    'BLOCKHASH': [0x40, 1, 1, 20],
-    'COINBASE': [0x41, 0, 1, 2],
-    'TIMESTAMP': [0x42, 0, 1, 2],
-    'NUMBER': [0x43, 0, 1, 2],
-    'DIFFICULTY': [0x44, 0, 1, 2],
-    'GASLIMIT': [0x45, 0, 1, 2],
-    'CHAINID': [0x46, 0, 1, (None, None, 2)],
-    'SELFBALANCE': [0x47, 0, 1, (None, None, 5)],
-    'POP': [0x50, 1, 0, 2],
-    'MLOAD': [0x51, 1, 1, 3],
-    'MSTORE': [0x52, 2, 0, 3],
-    'MSTORE8': [0x53, 2, 0, 3],
-    'SLOAD': [0x54, 1, 1, (200, 200, 800)],
-    'SSTORE': [0x55, 2, 0, 20000],
-    'JUMP': [0x56, 1, 0, 8],
-    'JUMPI': [0x57, 2, 0, 10],
-    'PC': [0x58, 0, 1, 2],
-    'MSIZE': [0x59, 0, 1, 2],
-    'GAS': [0x5a, 0, 1, 2],
-    'JUMPDEST': [0x5b, 0, 0, 1],
-    'PUSH1': [0x60, 0, 1, 3],
-    'PUSH2': [0x61, 0, 1, 3],
-    'PUSH3': [0x62, 0, 1, 3],
-    'PUSH4': [0x63, 0, 1, 3],
-    'PUSH5': [0x64, 0, 1, 3],
-    'PUSH6': [0x65, 0, 1, 3],
-    'PUSH7': [0x66, 0, 1, 3],
-    'PUSH8': [0x67, 0, 1, 3],
-    'PUSH9': [0x68, 0, 1, 3],
-    'PUSH10': [0x69, 0, 1, 3],
-    'PUSH11': [0x6a, 0, 1, 3],
-    'PUSH12': [0x6b, 0, 1, 3],
-    'PUSH13': [0x6c, 0, 1, 3],
-    'PUSH14': [0x6d, 0, 1, 3],
-    'PUSH15': [0x6e, 0, 1, 3],
-    'PUSH16': [0x6f, 0, 1, 3],
-    'PUSH17': [0x70, 0, 1, 3],
-    'PUSH18': [0x71, 0, 1, 3],
-    'PUSH19': [0x72, 0, 1, 3],
-    'PUSH20': [0x73, 0, 1, 3],
-    'PUSH21': [0x74, 0, 1, 3],
-    'PUSH22': [0x75, 0, 1, 3],
-    'PUSH23': [0x76, 0, 1, 3],
-    'PUSH24': [0x77, 0, 1, 3],
-    'PUSH25': [0x78, 0, 1, 3],
-    'PUSH26': [0x79, 0, 1, 3],
-    'PUSH27': [0x7a, 0, 1, 3],
-    'PUSH28': [0x7b, 0, 1, 3],
-    'PUSH29': [0x7c, 0, 1, 3],
-    'PUSH30': [0x7d, 0, 1, 3],
-    'PUSH31': [0x7e, 0, 1, 3],
-    'PUSH32': [0x7f, 0, 1, 3],
-    'DUP1': [0x80, 1, 2, 3],
-    'DUP2': [0x81, 1, 2, 3],
-    'DUP3': [0x82, 1, 2, 3],
-    'DUP4': [0x83, 1, 2, 3],
-    'DUP5': [0x84, 1, 2, 3],
-    'DUP6': [0x85, 1, 2, 3],
-    'DUP7': [0x86, 1, 2, 3],
-    'DUP8': [0x87, 1, 2, 3],
-    'DUP9': [0x88, 1, 2, 3],
-    'DUP10': [0x89, 1, 2, 3],
-    'DUP11': [0x8a, 1, 2, 3],
-    'DUP12': [0x8b, 1, 2, 3],
-    'DUP13': [0x8c, 1, 2, 3],
-    'DUP14': [0x8d, 1, 2, 3],
-    'DUP15': [0x8e, 1, 2, 3],
-    'DUP16': [0x8f, 1, 2, 3],
-    'SWAP1': [0x90, 2, 2, 3],
-    'SWAP2': [0x91, 2, 2, 3],
-    'SWAP3': [0x92, 2, 2, 3],
-    'SWAP4': [0x93, 2, 2, 3],
-    'SWAP5': [0x94, 2, 2, 3],
-    'SWAP6': [0x95, 2, 2, 3],
-    'SWAP7': [0x96, 2, 2, 3],
-    'SWAP8': [0x97, 2, 2, 3],
-    'SWAP9': [0x98, 2, 2, 3],
-    'SWAP10': [0x99, 2, 2, 3],
-    'SWAP11': [0x9a, 2, 2, 3],
-    'SWAP12': [0x9b, 2, 2, 3],
-    'SWAP13': [0x9c, 2, 2, 3],
-    'SWAP14': [0x9d, 2, 2, 3],
-    'SWAP15': [0x9e, 2, 2, 3],
-    'SWAP16': [0x9f, 2, 2, 3],
-    'LOG0': [0xa0, 2, 0, 375],
-    'LOG1': [0xa1, 3, 0, 750],
-    'LOG2': [0xa2, 4, 0, 1125],
-    'LOG3': [0xa3, 5, 0, 1500],
-    'LOG4': [0xa4, 6, 0, 1875],
-    'CREATE': [0xf0, 3, 1, 32000],
-    'CALL': [0xf1, 7, 1, 700],
-    'CALLCODE': [0xf2, 7, 1, 700],
-    'RETURN': [0xf3, 2, 0, 0],
-    'DELEGATECALL': [0xf4, 6, 1, 700],
-    'CREATE2': [0xf5, 4, 1, (None, 32000)],
-    'SELFDESTRUCT': [0xff, 1, 0, 25000],
-    'STATICCALL': [0xfa, 6, 1, 40],
-    'REVERT': [0xfd, 2, 0, 0],
-    'INVALID': [0xfe, 0, 0, 0],
-    'DEBUG': [0xa5, 1, 0, 0]
+OPCODES: OpcodeMap = {
+    'STOP': (0x00, 0, 0, 0),
+    'ADD': (0x01, 2, 1, 3),
+    'MUL': (0x02, 2, 1, 5),
+    'SUB': (0x03, 2, 1, 3),
+    'DIV': (0x04, 2, 1, 5),
+    'SDIV': (0x05, 2, 1, 5),
+    'MOD': (0x06, 2, 1, 5),
+    'SMOD': (0x07, 2, 1, 5),
+    'ADDMOD': (0x08, 3, 1, 8),
+    'MULMOD': (0x09, 3, 1, 8),
+    'EXP': (0x0a, 2, 1, 10),
+    'SIGNEXTEND': (0x0b, 2, 1, 5),
+    'LT': (0x10, 2, 1, 3),
+    'GT': (0x11, 2, 1, 3),
+    'SLT': (0x12, 2, 1, 3),
+    'SGT': (0x13, 2, 1, 3),
+    'EQ': (0x14, 2, 1, 3),
+    'ISZERO': (0x15, 1, 1, 3),
+    'AND': (0x16, 2, 1, 3),
+    'OR': (0x17, 2, 1, 3),
+    'XOR': (0x18, 2, 1, 3),
+    'NOT': (0x19, 1, 1, 3),
+    'BYTE': (0x1a, 2, 1, 3),
+    'SHL': (0x1b, 2, 1, (None, 3)),
+    'SHR': (0x1c, 2, 1, (None, 3)),
+    'SAR': (0x1d, 2, 1, (None, 3)),
+    'SHA3': (0x20, 2, 1, 30),
+    'ADDRESS': (0x30, 0, 1, 2),
+    'BALANCE': (0x31, 1, 1, (400, 400, 700)),
+    'ORIGIN': (0x32, 0, 1, 2),
+    'CALLER': (0x33, 0, 1, 2),
+    'CALLVALUE': (0x34, 0, 1, 2),
+    'CALLDATALOAD': (0x35, 1, 1, 3),
+    'CALLDATASIZE': (0x36, 0, 1, 2),
+    'CALLDATACOPY': (0x37, 3, 0, 3),
+    'CODESIZE': (0x38, 0, 1, 2),
+    'CODECOPY': (0x39, 3, 0, 3),
+    'GASPRICE': (0x3a, 0, 1, 2),
+    'EXTCODESIZE': (0x3b, 1, 1, 700),
+    'EXTCODECOPY': (0x3c, 4, 0, 700),
+    'RETURNDATASIZE': (0x3d, 0, 1, 2),
+    'RETURNDATACOPY': (0x3e, 3, 0, 3),
+    'EXTCODEHASH': (0x3f, 1, 1, (None, 400, 700)),
+    'BLOCKHASH': (0x40, 1, 1, 20),
+    'COINBASE': (0x41, 0, 1, 2),
+    'TIMESTAMP': (0x42, 0, 1, 2),
+    'NUMBER': (0x43, 0, 1, 2),
+    'DIFFICULTY': (0x44, 0, 1, 2),
+    'GASLIMIT': (0x45, 0, 1, 2),
+    'CHAINID': (0x46, 0, 1, (None, None, 2)),
+    'SELFBALANCE': (0x47, 0, 1, (None, None, 5)),
+    'POP': (0x50, 1, 0, 2),
+    'MLOAD': (0x51, 1, 1, 3),
+    'MSTORE': (0x52, 2, 0, 3),
+    'MSTORE8': (0x53, 2, 0, 3),
+    'SLOAD': (0x54, 1, 1, (200, 200, 800)),
+    'SSTORE': (0x55, 2, 0, 20000),
+    'JUMP': (0x56, 1, 0, 8),
+    'JUMPI': (0x57, 2, 0, 10),
+    'PC': (0x58, 0, 1, 2),
+    'MSIZE': (0x59, 0, 1, 2),
+    'GAS': (0x5a, 0, 1, 2),
+    'JUMPDEST': (0x5b, 0, 0, 1),
+    'PUSH1': (0x60, 0, 1, 3),
+    'PUSH2': (0x61, 0, 1, 3),
+    'PUSH3': (0x62, 0, 1, 3),
+    'PUSH4': (0x63, 0, 1, 3),
+    'PUSH5': (0x64, 0, 1, 3),
+    'PUSH6': (0x65, 0, 1, 3),
+    'PUSH7': (0x66, 0, 1, 3),
+    'PUSH8': (0x67, 0, 1, 3),
+    'PUSH9': (0x68, 0, 1, 3),
+    'PUSH10': (0x69, 0, 1, 3),
+    'PUSH11': (0x6a, 0, 1, 3),
+    'PUSH12': (0x6b, 0, 1, 3),
+    'PUSH13': (0x6c, 0, 1, 3),
+    'PUSH14': (0x6d, 0, 1, 3),
+    'PUSH15': (0x6e, 0, 1, 3),
+    'PUSH16': (0x6f, 0, 1, 3),
+    'PUSH17': (0x70, 0, 1, 3),
+    'PUSH18': (0x71, 0, 1, 3),
+    'PUSH19': (0x72, 0, 1, 3),
+    'PUSH20': (0x73, 0, 1, 3),
+    'PUSH21': (0x74, 0, 1, 3),
+    'PUSH22': (0x75, 0, 1, 3),
+    'PUSH23': (0x76, 0, 1, 3),
+    'PUSH24': (0x77, 0, 1, 3),
+    'PUSH25': (0x78, 0, 1, 3),
+    'PUSH26': (0x79, 0, 1, 3),
+    'PUSH27': (0x7a, 0, 1, 3),
+    'PUSH28': (0x7b, 0, 1, 3),
+    'PUSH29': (0x7c, 0, 1, 3),
+    'PUSH30': (0x7d, 0, 1, 3),
+    'PUSH31': (0x7e, 0, 1, 3),
+    'PUSH32': (0x7f, 0, 1, 3),
+    'DUP1': (0x80, 1, 2, 3),
+    'DUP2': (0x81, 1, 2, 3),
+    'DUP3': (0x82, 1, 2, 3),
+    'DUP4': (0x83, 1, 2, 3),
+    'DUP5': (0x84, 1, 2, 3),
+    'DUP6': (0x85, 1, 2, 3),
+    'DUP7': (0x86, 1, 2, 3),
+    'DUP8': (0x87, 1, 2, 3),
+    'DUP9': (0x88, 1, 2, 3),
+    'DUP10': (0x89, 1, 2, 3),
+    'DUP11': (0x8a, 1, 2, 3),
+    'DUP12': (0x8b, 1, 2, 3),
+    'DUP13': (0x8c, 1, 2, 3),
+    'DUP14': (0x8d, 1, 2, 3),
+    'DUP15': (0x8e, 1, 2, 3),
+    'DUP16': (0x8f, 1, 2, 3),
+    'SWAP1': (0x90, 2, 2, 3),
+    'SWAP2': (0x91, 2, 2, 3),
+    'SWAP3': (0x92, 2, 2, 3),
+    'SWAP4': (0x93, 2, 2, 3),
+    'SWAP5': (0x94, 2, 2, 3),
+    'SWAP6': (0x95, 2, 2, 3),
+    'SWAP7': (0x96, 2, 2, 3),
+    'SWAP8': (0x97, 2, 2, 3),
+    'SWAP9': (0x98, 2, 2, 3),
+    'SWAP10': (0x99, 2, 2, 3),
+    'SWAP11': (0x9a, 2, 2, 3),
+    'SWAP12': (0x9b, 2, 2, 3),
+    'SWAP13': (0x9c, 2, 2, 3),
+    'SWAP14': (0x9d, 2, 2, 3),
+    'SWAP15': (0x9e, 2, 2, 3),
+    'SWAP16': (0x9f, 2, 2, 3),
+    'LOG0': (0xa0, 2, 0, 375),
+    'LOG1': (0xa1, 3, 0, 750),
+    'LOG2': (0xa2, 4, 0, 1125),
+    'LOG3': (0xa3, 5, 0, 1500),
+    'LOG4': (0xa4, 6, 0, 1875),
+    'CREATE': (0xf0, 3, 1, 32000),
+    'CALL': (0xf1, 7, 1, 700),
+    'CALLCODE': (0xf2, 7, 1, 700),
+    'RETURN': (0xf3, 2, 0, 0),
+    'DELEGATECALL': (0xf4, 6, 1, 700),
+    'CREATE2': (0xf5, 4, 1, (None, 32000)),
+    'SELFDESTRUCT': (0xff, 1, 0, 25000),
+    'STATICCALL': (0xfa, 6, 1, 40),
+    'REVERT': (0xfd, 2, 0, 0),
+    'INVALID': (0xfe, 0, 0, 0),
+    'DEBUG': (0xa5, 1, 0, 0)
 }
 
-PSEUDO_OPCODES: Dict[str, List] = {
-    'CLAMP': [None, 3, 1, 70],
-    'UCLAMPLT': [None, 2, 1, 25],
-    'UCLAMPLE': [None, 2, 1, 30],
-    'CLAMP_NONZERO': [None, 1, 1, 19],
-    'ASSERT': [None, 1, 0, 85],
-    'ASSERT_REASON': [None, 3, 0, 85],
-    'ASSERT_UNREACHABLE': [None, 1, 0, 17],
-    'PASS': [None, 0, 0, 0],
-    'BREAK': [None, 0, 0, 20],
-    'CONTINUE': [None, 0, 0, 20],
-    'SHA3_32': [None, 1, 1, 72],
-    'SHA3_64': [None, 2, 1, 109],
-    'SLE': [None, 2, 1, 10],
-    'SGE': [None, 2, 1, 10],
-    'LE': [None, 2, 1, 10],
-    'GE': [None, 2, 1, 10],
-    'CEIL32': [None, 1, 1, 20],
-    'SET': [None, 2, 0, 20],
-    'NE': [None, 2, 1, 6],
-    'DEBUGGER': [None, 0, 0, 0],
-    'LABEL': [None, 1, 0, 1],
-    'GOTO': [None, 1, 0, 8]
+PSEUDO_OPCODES: OpcodeMap = {
+    'CLAMP': (None, 3, 1, 70),
+    'UCLAMPLT': (None, 2, 1, 25),
+    'UCLAMPLE': (None, 2, 1, 30),
+    'CLAMP_NONZERO': (None, 1, 1, 19),
+    'ASSERT': (None, 1, 0, 85),
+    'ASSERT_REASON': (None, 3, 0, 85),
+    'ASSERT_UNREACHABLE': (None, 1, 0, 17),
+    'PASS': (None, 0, 0, 0),
+    'BREAK': (None, 0, 0, 20),
+    'CONTINUE': (None, 0, 0, 20),
+    'SHA3_32': (None, 1, 1, 72),
+    'SHA3_64': (None, 2, 1, 109),
+    'SLE': (None, 2, 1, 10),
+    'SGE': (None, 2, 1, 10),
+    'LE': (None, 2, 1, 10),
+    'GE': (None, 2, 1, 10),
+    'CEIL32': (None, 1, 1, 20),
+    'SET': (None, 2, 0, 20),
+    'NE': (None, 2, 1, 6),
+    'DEBUGGER': (None, 0, 0, 0),
+    'LABEL': (None, 1, 0, 1),
+    'GOTO': (None, 1, 0, 8)
 }
 
-COMB_OPCODES: Dict[str, List] = {**OPCODES, **PSEUDO_OPCODES}
+COMB_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 
 def evm_wrapper(fn, *args, **kwargs):
@@ -206,40 +213,50 @@ def evm_wrapper(fn, *args, **kwargs):
     return _wrapper
 
 
-def _gas(value, idx):
-    if isinstance(value[3], int):
-        return value
-    if len(value[3]) <= idx:
-        return value[:3] + [value[3][-1]]
-    if value[3][idx] is None:
+def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:
+    gas = value[3]
+    if isinstance(gas, int):
+        return value[:3] + (gas,)
+    if len(gas) <= idx:
+        return value[:3] + (gas[-1],)
+    if gas[idx] is None:
         return None
-    return value[:3] + [value[3][idx]]
+    return value[:3] + (gas[idx],)
 
 
-def _mk_version_opcodes(opcodes, idx):
-    return dict((k, _gas(v, idx)) for k, v in opcodes.items() if _gas(v, idx) is not None)
+def _mk_version_opcodes(opcodes: OpcodeMap, idx: int) -> OpcodeRulesetMap:
+    return dict(
+        (k, _gas(v, idx)) for k, v in opcodes.items()  # type: ignore
+        if _gas(v, idx) is not None
+    )
 
 
-_evm_opcodes = dict((v, _mk_version_opcodes(OPCODES, v)) for v in EVM_VERSIONS.values())
-_evm_combined = dict((v, _mk_version_opcodes(COMB_OPCODES, v)) for v in EVM_VERSIONS.values())
+_evm_opcodes: Dict[int, OpcodeRulesetMap] = dict(
+    (v, _mk_version_opcodes(OPCODES, v))
+    for v in EVM_VERSIONS.values()
+)
+_evm_combined: Dict[int, OpcodeRulesetMap] = dict(
+    (v, _mk_version_opcodes(COMB_OPCODES, v))
+    for v in EVM_VERSIONS.values()
+)
 
 
-def get_opcodes():
+def get_opcodes() -> OpcodeRulesetMap:
     return _evm_opcodes[active_evm_version]
 
 
-def get_comb_opcodes():
+def get_comb_opcodes() -> OpcodeRulesetMap:
     return _evm_combined[active_evm_version]
 
 
-def version_check(begin=None, end=None):
+def version_check(begin: Optional[str] = None, end: Optional[str] = None) -> bool:
     assert begin is not None or end is not None
     if begin is None:
-        begin = min(EVM_VERSIONS.values())
+        begin_idx = min(EVM_VERSIONS.values())
     else:
-        begin = EVM_VERSIONS[begin]
+        begin_idx = EVM_VERSIONS[begin]
     if end is None:
-        end = max(EVM_VERSIONS.values())
+        end_idx = max(EVM_VERSIONS.values())
     else:
-        end = EVM_VERSIONS[end]
-    return begin <= active_evm_version <= end
+        end_idx = EVM_VERSIONS[end]
+    return begin_idx <= active_evm_version <= end_idx

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -4,6 +4,16 @@ from typing import (
     Optional,
 )
 
+active_evm_version: int = None
+
+EVM_VERSIONS = {
+    'byzantium': 0,
+    'constantinople': 1,
+    'petersburg': 2,
+    'istanbul': 3,
+}
+
+# opcode as hex value, number of values removed from stack, added to stack, gas cost
 OPCODES: Dict[str, List[Optional[int]]] = {
     'STOP': [0x00, 0, 0, 0],
     'ADD': [0x01, 2, 1, 3],
@@ -169,3 +179,26 @@ PSEUDO_OPCODES: Dict[str, List[Optional[int]]] = {
 }
 
 COMB_OPCODES: Dict[str, List[Optional[int]]] = {**OPCODES, **PSEUDO_OPCODES}
+
+
+def set_evm_version(version_name):
+    global active_evm_version
+    active_evm_version = EVM_VERSIONS[version_name]
+
+
+def _gas(opcode_name):
+    if isinstance(COMB_OPCODES[opcode_name][3], int):
+        return COMB_OPCODES[opcode_name][3]
+    return COMB_OPCODES[opcode_name][3][active_evm_version]
+
+
+def get_opcodes():
+    if active_evm_version is None:
+        raise
+    return dict((k, v[:3]+[_gas(k)]) for k, v in OPCODES.items() if _gas(k) is not None)
+
+
+def get_comb_opcodes():
+    if active_evm_version is None:
+        raise
+    return dict((k, v[:3]+[_gas(k)]) for k, v in COMB_OPCODES.items() if _gas(k) is not None)

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -1,25 +1,24 @@
 from typing import (
     Dict,
     List,
-    Optional,
 )
 
-active_evm_version = 0
+active_evm_version: int = 0
 
-EVM_VERSIONS = {
+EVM_VERSIONS: Dict[str, int] = {
     'byzantium': 0,
     'constantinople': 1,
     'petersburg': 1,
     'istanbul': 2,
 }
-DEFAULT_EVM_VERSION = "byzantium"
+DEFAULT_EVM_VERSION: str = "byzantium"
 
 
 # opcode as hex value
 # number of values removed from stack
 # number of values added to stack
 # gas cost (byzantium, constantinople, istanbul)
-OPCODES: Dict[str, List[Optional[int]]] = {
+OPCODES: Dict[str, List] = {
     'STOP': [0x00, 0, 0, 0],
     'ADD': [0x01, 2, 1, 3],
     'MUL': [0x02, 2, 1, 5],
@@ -165,7 +164,7 @@ OPCODES: Dict[str, List[Optional[int]]] = {
     'DEBUG': [0xa5, 1, 0, 0]
 }
 
-PSEUDO_OPCODES: Dict[str, List[Optional[int]]] = {
+PSEUDO_OPCODES: Dict[str, List] = {
     'CLAMP': [None, 3, 1, 70],
     'UCLAMPLT': [None, 2, 1, 25],
     'UCLAMPLE': [None, 2, 1, 30],
@@ -190,7 +189,7 @@ PSEUDO_OPCODES: Dict[str, List[Optional[int]]] = {
     'GOTO': [None, 1, 0, 8]
 }
 
-COMB_OPCODES: Dict[str, List[Optional[int]]] = {**OPCODES, **PSEUDO_OPCODES}
+COMB_OPCODES: Dict[str, List] = {**OPCODES, **PSEUDO_OPCODES}
 
 
 def evm_wrapper(fn, *args, **kwargs):

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -233,5 +233,14 @@ def get_comb_opcodes():
     return _evm_combined[active_evm_version]
 
 
-def get_active_evm_id():
-    return active_evm_version
+def version_check(begin=None, end=None):
+    assert begin is not None or end is not None
+    if begin is None:
+        begin = min(EVM_VERSIONS.values())
+    else:
+        begin = EVM_VERSIONS[begin]
+    if end is None:
+        end = max(EVM_VERSIONS.values())
+    else:
+        end = EVM_VERSIONS[end]
+    return begin <= active_evm_version <= end

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -3,6 +3,9 @@ from typing import (
     Optional,
 )
 
+from vyper.exceptions import (
+    CompilerPanic,
+)
 from vyper.typing import (
     OpcodeGasCost,
     OpcodeMap,
@@ -251,7 +254,8 @@ def get_comb_opcodes() -> OpcodeRulesetMap:
 
 
 def version_check(begin: Optional[str] = None, end: Optional[str] = None) -> bool:
-    assert begin is not None or end is not None
+    if begin is None and end is None:
+        raise CompilerPanic("Either beginning or end fork ruleset must be set.")
     if begin is None:
         begin_idx = min(EVM_VERSIONS.values())
     else:

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -197,7 +197,7 @@ def evm_wrapper(fn, *args, **kwargs):
 
     def _wrapper(*args, **kwargs):
         global active_evm_version
-        evm_version = kwargs.pop('evm_version', DEFAULT_EVM_VERSION)
+        evm_version = kwargs.pop('evm_version', None) or DEFAULT_EVM_VERSION
         active_evm_version = EVM_VERSIONS[evm_version]
         try:
             return fn(*args, **kwargs)
@@ -231,3 +231,7 @@ def get_opcodes():
 
 def get_comb_opcodes():
     return _evm_combined[active_evm_version]
+
+
+def get_active_evm_id():
+    return active_evm_version

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -11,7 +11,7 @@ from vyper.exceptions import (
     VariableDeclarationException,
 )
 from vyper.opcodes import (
-    get_active_evm_id,
+    version_check,
 )
 from vyper.parser import (
     external_call,
@@ -291,7 +291,7 @@ class Expr(object):
     def attribute(self):
         # x.balance: balance of address x
         if self.expr.attr == 'balance':
-            if self.expr.value.id == "self" and get_active_evm_id() >= 2:
+            if self.expr.value.id == "self" and version_check(begin="istanbul"):
                 return LLLnode.from_list(
                     ['selfbalance'],
                     typ=BaseType('uint256', {'wei': 1}),
@@ -393,7 +393,7 @@ class Expr(object):
             elif key == "tx.origin":
                 return LLLnode.from_list(['origin'], typ='address', pos=getpos(self.expr))
             elif key == "chain.id":
-                if get_active_evm_id() < 2:
+                if not version_check(begin="istanbul"):
                     raise EvmVersionException(
                         "chain.id is unavailable prior to istanbul ruleset",
                         self.expr

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -2,12 +2,16 @@ import warnings
 
 from vyper import ast
 from vyper.exceptions import (
+    EvmVersionException,
     InvalidLiteralException,
     NonPayableViolationException,
     ParserException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
+)
+from vyper.opcodes import (
+    get_active_evm_id,
 )
 from vyper.parser import (
     external_call,
@@ -382,6 +386,11 @@ class Expr(object):
             elif key == "tx.origin":
                 return LLLnode.from_list(['origin'], typ='address', pos=getpos(self.expr))
             elif key == "chain.id":
+                if get_active_evm_id() < 2:
+                    raise EvmVersionException(
+                        "chain.id is unavailable prior to istanbul ruleset",
+                        self.expr
+                    )
                 return LLLnode.from_list(['chainid'], typ='uint256', pos=getpos(self.expr))
             else:
                 raise ParserException("Unsupported keyword: " + key, self.expr)

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -291,6 +291,13 @@ class Expr(object):
     def attribute(self):
         # x.balance: balance of address x
         if self.expr.attr == 'balance':
+            if self.expr.value.id == "self" and get_active_evm_id() >= 2:
+                return LLLnode.from_list(
+                    ['selfbalance'],
+                    typ=BaseType('uint256', {'wei': 1}),
+                    location=None,
+                    pos=getpos(self.expr),
+                )
             addr = Expr.parse_value_expr(self.expr.value, self.context)
             if not is_base_type(addr.typ, 'address'):
                 raise TypeMismatchException(

--- a/vyper/parser/lll_node.py
+++ b/vyper/parser/lll_node.py
@@ -4,7 +4,7 @@ from vyper.exceptions import (
     CompilerPanic,
 )
 from vyper.opcodes import (
-    COMB_OPCODES,
+    get_comb_opcodes,
 )
 from vyper.settings import (
     VYPER_COLOR_OUTPUT,
@@ -88,8 +88,8 @@ class LLLnode:
             self.gas = 5
         elif isinstance(self.value, str):
             # Opcodes and pseudo-opcodes (e.g. clamp)
-            if self.value.upper() in COMB_OPCODES:
-                _, ins, outs, gas = COMB_OPCODES[self.value.upper()]
+            if self.value.upper() in get_comb_opcodes():
+                _, ins, outs, gas = get_comb_opcodes()[self.value.upper()]
                 self.valency = outs
                 if len(self.args) != ins:
                     raise CompilerPanic(
@@ -257,7 +257,7 @@ class LLLnode:
     def _colorise_keywords(val):
         if val.lower() in VALID_LLL_MACROS:  # highlight macro
             return OKLIGHTMAGENTA + val + ENDC
-        elif val.upper() in COMB_OPCODES.keys():
+        elif val.upper() in get_comb_opcodes().keys():
             return OKMAGENTA + val + ENDC
         return val
 

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -55,12 +55,18 @@ LIMIT_MEMORY_SET: List[Any] = [
     ['mstore', pos, limit_size]
     for pos, limit_size in LOADED_LIMITS.items()
 ]
-FUNC_INIT_LLL = LLLnode.from_list(
-    STORE_CALLDATA + LIMIT_MEMORY_SET, typ=None
-)
-INIT_FUNC_INIT_LLL = LLLnode.from_list(
-    ['seq'] + LIMIT_MEMORY_SET, typ=None
-)
+
+
+def func_init_lll():
+    return LLLnode.from_list(
+        STORE_CALLDATA + LIMIT_MEMORY_SET, typ=None
+    )
+
+
+def init_func_init_lll():
+    return LLLnode.from_list(
+        ['seq'] + LIMIT_MEMORY_SET, typ=None
+    )
 
 
 def parse_events(sigs, global_ctx):
@@ -119,8 +125,8 @@ def parse_other_functions(o,
                           global_ctx,
                           default_function,
                           runtime_only):
-    sub = ['seq', FUNC_INIT_LLL]
-    add_gas = FUNC_INIT_LLL.gas
+    sub = ['seq', func_init_lll()]
+    add_gas = func_init_lll().gas
 
     for _def in otherfuncs:
         sub.append(
@@ -189,7 +195,7 @@ def parse_tree_to_lll(code, origcode, runtime_only=False, interface_codes=None):
         external_contracts = parse_external_contracts(external_contracts, global_ctx)
     # If there is an init func...
     if initfunc:
-        o.append(INIT_FUNC_INIT_LLL)
+        o.append(init_func_init_lll())
         o.append(parse_function(
             initfunc[0],
             {**{'self': sigs}, **external_contracts},

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -24,7 +24,8 @@ InterfaceImports = Dict[InterfaceAsName, InterfaceImportPath]
 InterfaceDict = Dict[ContractPath, InterfaceImports]
 
 # Opcodes
-OpcodeValue = Tuple[Optional[int], int, int, Union[int, Tuple]]
+OpcodeGasCost = Union[int, Tuple]
+OpcodeValue = Tuple[Optional[int], int, int, OpcodeGasCost]
 OpcodeMap = Dict[str, OpcodeValue]
 OpcodeRulesetValue = Tuple[Optional[int], int, int, int]
 OpcodeRulesetMap = Dict[str, OpcodeRulesetValue]

--- a/vyper/typing.py
+++ b/vyper/typing.py
@@ -1,7 +1,9 @@
 from typing import (
     Dict,
+    Optional,
     Sequence,
     Tuple,
+    Union,
 )
 
 # Parser
@@ -20,3 +22,9 @@ InterfaceAsName = str
 InterfaceImportPath = str
 InterfaceImports = Dict[InterfaceAsName, InterfaceImportPath]
 InterfaceDict = Dict[ContractPath, InterfaceImports]
+
+# Opcodes
+OpcodeValue = Tuple[Optional[int], int, int, Union[int, Tuple]]
+OpcodeMap = Dict[str, OpcodeValue]
+OpcodeRulesetValue = Tuple[Optional[int], int, int, int]
+OpcodeRulesetMap = Dict[str, OpcodeRulesetValue]


### PR DESCRIPTION
### What I did
* Add the ability to target multiple EVM versions - closes #1230 
* Use the `SELFBALANCE` opcode when targeting istanbul - closes #1654 

### How I did it
* Expanded `vyper/opcodes.py`:
  * Added missing opcodes
  * Where gas cost changes between versions, a tuple is used instead of an integer. Values correspond to (byzantium, constantinople, istanbul) - `None` means the opcode is not available, and where the length is < 3 it means the price does not change for future versions.
  * Use getter functions for opcodes, instead of directly importing constants into other modules
* `vyper.compiler.compile_codes` now accepts `evm_version` as a kwarg. If not given, the default value is used (`vyper.opcodes.DEFAULT_EVM_VERSION`, currently byzantium)
* Added the option to select EVM version in `vyper.cli` modules 

### How to verify it
Run the tests.  I've added new test cases and parametrized a few existing ones.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71493763-fbc5f680-2849-11ea-9ea3-33cff22101f7.png)
