### PR TITLE
Tuple constancy checks

### DIFF
--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -84,7 +84,21 @@ def test(a: bytes32) -> (bytes32, uint256, int128):
     a, b, c = self._test(a)
     assert d == 123
     return a, b, c
-    """, ConstancyViolationException)
+    """, ConstancyViolationException),
+    ("""
+x: public(uint256)
+
+@private
+@constant
+def return_two() -> (uint256, uint256):
+    return 1, 2
+
+@public
+@constant
+def foo():
+    a: uint256 = 0
+    a, self.x = self.return_two()
+     """, ConstancyViolationException),
 ]
 
 


### PR DESCRIPTION
### What I did
Add constancy checks for tuple assignment - fixes #1711 

### How I did it
Minor tweak to `vyper/parser/stmt.py`

### How to verify it
Run the tests, I added a test case using the example from #1711

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71526799-27e08680-28e1-11ea-982d-f43dcc548392.png)
