### PR TITLE
Minor bugfixes

### DIFF
--- a/tests/parser/ast_utils/test_ast_dict.py
+++ b/tests/parser/ast_utils/test_ast_dict.py
@@ -83,6 +83,11 @@ def test_dict_to_ast():
 @public
 def test() -> int128:
     a: uint256 = 100
+    b: int128 = -22
+    c: decimal = 3.31337
+    d: bytes[11] = b"oh hai mark"
+    e: address = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+    f: bool = False
     return 123
     """
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -61,6 +61,14 @@ def test(VAL: uint256):
 C1: constant(uint256) = block.number
 C2: constant(uint256) = convert(C1, uint256)
     """, InvalidLiteralException),
+    # cannot assign function result to a constant
+    """
+@public
+def foo() -> uint256:
+    return 42
+
+c1: constant(uint256) = foo()
+     """
 ]
 
 

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -144,10 +144,10 @@ def ast_to_dict(node: vyper_ast.VyperNode) -> dict:
         return _ast_to_dict(node)
     elif isinstance(node, list):
         return _ast_to_list(node)
-    elif node is None or isinstance(node, (str, int)):
+    elif node is None or isinstance(node, (str, int, bytes)):
         return node
     else:
-        raise CompilerPanic('Unknown vyper AST node provided.')
+        raise CompilerPanic(f'Unknown vyper AST node provided: "{type(node)}".')
 
 
 def dict_to_ast(ast_struct: dict) -> vyper_ast.VyperNode:

--- a/vyper/ast_utils.py
+++ b/vyper/ast_utils.py
@@ -144,7 +144,7 @@ def ast_to_dict(node: vyper_ast.VyperNode) -> dict:
         return _ast_to_dict(node)
     elif isinstance(node, list):
         return _ast_to_list(node)
-    elif node is None or isinstance(node, (str, int, bytes)):
+    elif node is None or isinstance(node, (str, int, bytes, float)):
         return node
     else:
         raise CompilerPanic(f'Unknown vyper AST node provided: "{type(node)}".')
@@ -164,10 +164,10 @@ def dict_to_ast(ast_struct: dict) -> vyper_ast.VyperNode:
             dict_to_ast(x)
             for x in ast_struct
         ]
-    elif ast_struct is None or isinstance(ast_struct, (str, int)):
+    elif ast_struct is None or isinstance(ast_struct, (str, int, bytes, float)):
         return ast_struct
     else:
-        raise CompilerPanic('Unknown ast_struct provided.')
+        raise CompilerPanic(f'Unknown ast_struct provided: "{type(ast_struct)}".')
 
 
 def to_python_ast(vyper_ast_node: vyper_ast.VyperNode) -> python_ast.AST:

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -110,19 +110,9 @@ def _parse_args(argv):
 
     output_formats = tuple(uniq(args.format.split(',')))
 
-    translate_map = {
-        'abi_python': 'abi',
-        'json': 'abi',
-        'ast': 'ast_dict'
-    }
-    final_formats = []
-
-    for f in output_formats:
-        final_formats.append(translate_map.get(f, f))
-
     compiled = compile_files(
         args.input_files,
-        final_formats,
+        output_formats,
         args.root_folder,
         args.show_gas_estimates
     )
@@ -131,13 +121,12 @@ def _parse_args(argv):
         print(json.dumps(compiled))
         return
 
-    for contract_data in list(compiled.values()):
-        for f in output_formats:
-            o = contract_data[translate_map.get(f, f)]
-            if f in ('abi', 'json', 'ast', 'source_map'):
-                print(json.dumps(o))
+    for key in args.input_files:
+        for data in compiled[key].values():
+            if isinstance(data, (list, dict)):
+                print(json.dumps(data))
             else:
-                print(o)
+                print(data)
 
 
 def uniq(seq: Iterable[T]) -> Iterator[T]:
@@ -234,9 +223,16 @@ def compile_files(input_files: Iterable[str],
         output_formats = ['bytecode', 'bytecode_runtime', 'abi', 'source_map', 'method_identifiers']
         show_version = True
 
+    translate_map = {
+        'abi_python': 'abi',
+        'json': 'abi',
+        'ast': 'ast_dict'
+    }
+    final_formats = [translate_map.get(i, i) for i in output_formats]
+
     compiler_data = vyper.compile_codes(
         contract_sources,
-        output_formats,
+        final_formats,
         exc_handler=exc_handler,
         interface_codes=get_interface_codes(root_path, contract_sources)
     )

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -42,7 +42,7 @@ class Context:
         # Global variables, in the form (name, storage location, type)
         self.globals = global_ctx._globals
         # ABI objects, in the form {classname: ABI JSON}
-        self.sigs = sigs or {}
+        self.sigs = sigs or {'self': {}}
         # Variables defined in for loops, e.g. for i in range(6): ...
         self.forvars = forvars or {}
         # Return type of the function

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -36,7 +36,7 @@ def to_bool(expr, args, kwargs, context):
     if input_type == 'bytes':
         if in_arg.typ.maxlen > 32:
             raise TypeMismatchException(
-                f"Cannot convert bytes array of max length {in_arg.value} to bool",
+                f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to bool",
                 expr,
             )
         else:
@@ -122,7 +122,7 @@ def to_int128(expr, args, kwargs, context):
     elif input_type in ('string', 'bytes'):
         if in_arg.typ.maxlen > 32:
             raise TypeMismatchException(
-                f"Cannot convert bytes array of max length {in_arg.value} to int128",
+                f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to int128",
                 expr,
             )
         return byte_array_to_num(in_arg, expr, 'int128')
@@ -226,7 +226,7 @@ def to_uint256(expr, args, kwargs, context):
     elif isinstance(in_arg, LLLnode) and input_type == 'bytes':
         if in_arg.typ.maxlen > 32:
             raise InvalidLiteralException(
-                f"Cannot convert bytes array of max length {in_arg.value} to uint256",
+                f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to uint256",
                 expr,
             )
         return byte_array_to_num(in_arg, expr, 'uint256')
@@ -243,7 +243,7 @@ def to_decimal(expr, args, kwargs, context):
     if input_type == 'bytes':
         if in_arg.typ.maxlen > 32:
             raise TypeMismatchException(
-                f"Cannot convert bytes array of max length {in_arg.value} to decimal",
+                f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to decimal",
                 expr,
             )
         num = byte_array_to_num(in_arg, expr, 'int128')


### PR DESCRIPTION
### What I did
Fix several low-hanging fruit issues.

* `KeyError: self` when attempting to assign a function to a constant - closes #1671 
* Allow bytes literal when creating AST dict - closes #1788 
* In `vyper.cli.vyper_compile`, move `translate_map` to `compile_files` to allow consistency with CLI inputs - closes #1670 
* Fix `convert` max length error messages - closes #1700 

### How I did it
See code.  All of these were very minor fixes, the implementations should be obvious.

### How to verify it
Run tests.

### Cute Animal Picture
![Hello? Yes, this is duck.](https://user-images.githubusercontent.com/35276322/71544452-4188d900-2988-11ea-8d6b-e9676794eca2.png)
