### PR TITLE
Unary operations on literals

### DIFF
--- a/tests/parser/functions/test_unary.py
+++ b/tests/parser/functions/test_unary.py
@@ -37,9 +37,8 @@ def negate(a: int128) -> int128:
     assert c.negate(val) == -val
 
 
-decimal_divisor = Decimal('1e10')
-min_decimal = (-2**127 + 1) / decimal_divisor
-max_decimal = (2**127 - 1) / decimal_divisor
+min_decimal = -2**127 + 1
+max_decimal = 2**127 - 1
 @pytest.mark.parametrize("val", [min_decimal, 0, max_decimal])
 def test_unary_sub_decimal_pass(get_contract, val):
     code = """@public
@@ -48,3 +47,39 @@ def negate(a: decimal) -> decimal:
     """
     c = get_contract(code)
     assert c.negate(val) == -val
+
+
+def test_negation_decimal(get_contract):
+    code = """
+a: constant(decimal) = 170141183460469231731687303715884105726.9999999999
+b: constant(decimal) = -170141183460469231731687303715884105726.9999999999
+
+@public
+def foo() -> decimal:
+    return -a
+
+@public
+def bar() -> decimal:
+    return -b
+    """
+
+    c = get_contract(code)
+    assert c.foo() == Decimal("-170141183460469231731687303715884105726.9999999999")
+    assert c.bar() == Decimal("170141183460469231731687303715884105726.9999999999")
+
+
+def test_negation_int128(get_contract):
+    code = """
+a: constant(int128) = -2**127
+
+@public
+def foo() -> int128:
+    return -2**127
+
+@public
+def bar() -> int128:
+    return -(a+1)
+    """
+    c = get_contract(code)
+    assert c.foo() == -2**127
+    assert c.bar() == 2**127-1

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -674,6 +674,7 @@ class Expr(object):
         if left.typ != right.typ.subtype:
             raise TypeMismatchException(
                 f"{left.typ} cannot be in a list of {right.typ.subtype}",
+                self.expr,
             )
 
         result_placeholder = self.context.new_placeholder(BaseType('bool'))
@@ -938,6 +939,7 @@ class Expr(object):
             if not is_numeric_type(operand.typ):
                 raise TypeMismatchException(
                     f"Unsupported type for negation: {operand.typ}",
+                    self.expr,
                 )
 
             if operand.typ.is_literal:

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -935,21 +935,18 @@ class Expr(object):
                     self.expr,
                 )
         elif isinstance(self.expr.op, ast.USub):
-            # Must be a signed integer
-            if not is_numeric_type(operand.typ) or operand.typ.typ.lower().startswith('u'):
+            if not is_numeric_type(operand.typ):
                 raise TypeMismatchException(
                     f"Unsupported type for negation: {operand.typ}",
-                    operand,
                 )
 
-            if operand.typ.is_literal and 'int' in operand.typ.typ:
-                num = ast.Num(n=0 - operand.value)
-                num.source_code = self.expr.source_code
-                num.lineno = self.expr.lineno
-                num.col_offset = self.expr.col_offset
-                num.end_lineno = self.expr.end_lineno
-                num.end_col_offset = self.expr.end_col_offset
-                return Expr.parse_value_expr(num, self.context)
+            if operand.typ.is_literal:
+                typ = "decimal" if operand.typ.typ == "decimal" else "int128"
+                return LLLnode.from_list(
+                    0-operand.value,
+                    typ=BaseType(typ, unit=operand.typ.unit, is_literal=True),
+                    pos=getpos(self.expr),
+                )
 
             # Clamp on minimum integer value as we cannot negate that value
             # (all other integer values are fine)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -64,7 +64,7 @@ def get_number_as_fraction(expr, context):
 
     if exponent < -10:
         raise InvalidLiteralException(
-                "`decimal` literal cannot have more than 10 decimal places: {literal}",
+                f"`decimal` literal cannot have more than 10 decimal places: {literal}",
                 expr
             )
 


### PR DESCRIPTION
### What I did
Fixed some issues with negating constants.

The following example was failing because bounds checks caught `2**127` as an overflow before applying the `-`:

```python
@public
def foo() -> int128:
    return -2**127
```

The following example was also failing with a clamping error:

```python
a: constant(decimal) = 1.1

@public
def foo() -> decimal:
    return -a
```

### How I did it
When an unary operation is applied to a constant, return the negated value without applying bounds checks on the original value.

### How to verify it
Run the tests. I added some new test cases to verify that the issue is fixed.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71548875-2c7a6d00-29bd-11ea-9fa4-4a6e2871b25e.png)
