### PR TITLE
vyper-json - expect outputSelection within settings

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -181,35 +181,35 @@ The following example describes the expected input format of ``vyper-json``. Com
         },
         // Optional
         "settings": {
-            "evmVersion": "istanbul"  // EVM version to compile for. Can be byzantium, constantinople, petersburg or istanbul.
-        },
-        // The following is used to select desired outputs based on file names.
-        // File names are given as keys, a star as a file name matches all files.
-        // Outputs can also follow the Solidity format where second level keys
-        // denoting contract names - all 2nd level outputs are applied to the file.
-        //
-        // To select all possible compiler outputs: "outputSelection: { '*': ["*"] }"
-        // Note that this might slow down the compilation process needlessly.
-        //
-        // The available output types are as follows:
-        //
-        //    abi - The contract ABI
-        //    ast - Abstract syntax tree
-        //    interface - Derived interface of the contract, in proper Vyper syntax
-        //    ir - LLL intermediate representation of the code
-        //    evm.bytecode.object - Bytecode object
-        //    evm.bytecode.opcodes - Opcodes list
-        //    evm.deployedBytecode.object - Deployed bytecode object
-        //    evm.deployedBytecode.opcodes - Deployed opcodes list
-        //    evm.deployedBytecode.sourceMap - Deployed source mapping (useful for debugging)
-        //    evm.methodIdentifiers - The list of function hashes
-        //
-        // Using `evm`, `evm.bytecode`, etc. will select every target part of that output.
-        // Additionally, `*` can be used as a wildcard to request everything.
-        //
-        "outputSelection": {
-            "*": ["evm.bytecode", "abi"],  // Enable the abi and bytecode outputs for every single contract
-            "contracts/foo.vy": ["ast"]  // Enable the ast output for contracts/foo.vy
+            "evmVersion": "istanbul",  // EVM version to compile for. Can be byzantium, constantinople, petersburg or istanbul.
+            // The following is used to select desired outputs based on file names.
+            // File names are given as keys, a star as a file name matches all files.
+            // Outputs can also follow the Solidity format where second level keys
+            // denoting contract names - all 2nd level outputs are applied to the file.
+            //
+            // To select all possible compiler outputs: "outputSelection: { '*': ["*"] }"
+            // Note that this might slow down the compilation process needlessly.
+            //
+            // The available output types are as follows:
+            //
+            //    abi - The contract ABI
+            //    ast - Abstract syntax tree
+            //    interface - Derived interface of the contract, in proper Vyper syntax
+            //    ir - LLL intermediate representation of the code
+            //    evm.bytecode.object - Bytecode object
+            //    evm.bytecode.opcodes - Opcodes list
+            //    evm.deployedBytecode.object - Deployed bytecode object
+            //    evm.deployedBytecode.opcodes - Deployed opcodes list
+            //    evm.deployedBytecode.sourceMap - Deployed source mapping (useful for debugging)
+            //    evm.methodIdentifiers - The list of function hashes
+            //
+            // Using `evm`, `evm.bytecode`, etc. will select every target part of that output.
+            // Additionally, `*` can be used as a wildcard to request everything.
+            //
+            "outputSelection": {
+                "*": ["evm.bytecode", "abi"],  // Enable the abi and bytecode outputs for every single contract
+                "contracts/foo.vy": ["ast"]  // Enable the ast output for contracts/foo.vy
+            }
         }
     }
 

--- a/tests/cli/vyper_json/test_compile_from_input_dict.py
+++ b/tests/cli/vyper_json/test_compile_from_input_dict.py
@@ -66,7 +66,10 @@ INPUT_JSON = {
     'interfaces': {
         'contracts/bar.json': {'abi': BAR_ABI}
     },
-    'outputSelection': {'*': ["*"]}
+    'settings': {
+        'outputSelection': {'*': ["*"]}
+    }
+
 }
 
 
@@ -119,7 +122,7 @@ def test_exc_handler_to_dict_compiler():
 
 def test_source_ids_increment():
     input_json = deepcopy(INPUT_JSON)
-    input_json['outputSelection'] = {'*': ['evm.deployedBytecode.sourceMap']}
+    input_json['settings']['outputSelection'] = {'*': ['evm.deployedBytecode.sourceMap']}
     result, _ = compile_from_input_dict(input_json)
     assert result['contracts/bar.vy']['source_map']['pc_pos_map_compressed'].startswith('-1:-1:0')
     assert result['contracts/foo.vy']['source_map']['pc_pos_map_compressed'].startswith('-1:-1:1')
@@ -134,7 +137,7 @@ def test_outputs():
 def test_evm_version():
     # should compile differently because of SELFBALANCE
     input_json = deepcopy(INPUT_JSON)
-    input_json['settings'] = {'evmVersion': "byzantium"}
+    input_json['settings']['evmVersion'] = "byzantium"
     compiled = compile_from_input_dict(input_json)
-    input_json['settings'] = {'evmVersion': "istanbul"}
+    input_json['settings']['evmVersion'] = "istanbul"
     assert compiled != compile_from_input_dict(input_json)

--- a/tests/cli/vyper_json/test_compile_json.py
+++ b/tests/cli/vyper_json/test_compile_json.py
@@ -48,7 +48,9 @@ INPUT_JSON = {
     'interfaces': {
         'contracts/bar.json': {'abi': BAR_ABI}
     },
-    'outputSelection': {'*': ["*"]}
+    'settings': {
+        'outputSelection': {'*': ["*"]}
+    }
 }
 
 

--- a/tests/cli/vyper_json/test_output_selection.py
+++ b/tests/cli/vyper_json/test_output_selection.py
@@ -17,14 +17,14 @@ def test_no_outputs():
 
 
 def test_invalid_output():
-    input_json = {'outputSelection': {'foo.vy': ['abi', 'foobar']}}
+    input_json = {'settings': {'outputSelection': {'foo.vy': ['abi', 'foobar']}}}
     sources = {'foo.vy': ""}
     with pytest.raises(JSONError):
         get_input_dict_output_formats(input_json, sources)
 
 
 def test_unknown_contract():
-    input_json = {'outputSelection': {'bar.vy': ['abi']}}
+    input_json = {'settings': {'outputSelection': {'bar.vy': ['abi']}}}
     sources = {'foo.vy': ""}
     with pytest.raises(JSONError):
         get_input_dict_output_formats(input_json, sources)
@@ -32,13 +32,13 @@ def test_unknown_contract():
 
 @pytest.mark.parametrize('output', TRANSLATE_MAP.items())
 def test_translate_map(output):
-    input_json = {'outputSelection': {'foo.vy': [output[0]]}}
+    input_json = {'settings': {'outputSelection': {'foo.vy': [output[0]]}}}
     sources = {'foo.vy': ""}
     assert get_input_dict_output_formats(input_json, sources) == {'foo.vy': [output[1]]}
 
 
 def test_star():
-    input_json = {'outputSelection': {'*': ['*']}}
+    input_json = {'settings': {'outputSelection': {'*': ['*']}}}
     sources = {'foo.vy': "", 'bar.vy': ""}
     expected = sorted(TRANSLATE_MAP.values())
     result = get_input_dict_output_formats(input_json, sources)
@@ -46,7 +46,7 @@ def test_star():
 
 
 def test_evm():
-    input_json = {'outputSelection': {'foo.vy': ['abi', 'evm']}}
+    input_json = {'settings': {'outputSelection': {'foo.vy': ['abi', 'evm']}}}
     sources = {'foo.vy': ""}
     expected = ['abi'] + sorted(v for k, v in TRANSLATE_MAP.items() if k.startswith('evm'))
     result = get_input_dict_output_formats(input_json, sources)
@@ -54,6 +54,6 @@ def test_evm():
 
 
 def test_solc_style():
-    input_json = {'outputSelection': {'foo.vy': {'': ['abi'], 'foo.vy': ['ir']}}}
+    input_json = {'settings': {'outputSelection': {'foo.vy': {'': ['abi'], 'foo.vy': ['ir']}}}}
     sources = {'foo.vy': ""}
     assert get_input_dict_output_formats(input_json, sources) == {'foo.vy': ['abi', 'ir']}

--- a/tests/cli/vyper_json/test_parse_args_vyperjson.py
+++ b/tests/cli/vyper_json/test_parse_args_vyperjson.py
@@ -47,7 +47,9 @@ INPUT_JSON = {
     'interfaces': {
         'contracts/bar.json': {'abi': BAR_ABI}
     },
-    'outputSelection': {'*': ["*"]}
+    'settings': {
+        'outputSelection': {'*': ["*"]}
+    }
 }
 
 

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -223,7 +223,7 @@ def get_input_dict_interfaces(input_dict: Dict) -> Dict:
 
 def get_input_dict_output_formats(input_dict: Dict, contract_sources: ContractCodes) -> Dict:
     output_formats = {}
-    for path, outputs in input_dict['outputSelection'].items():
+    for path, outputs in input_dict['settings']['outputSelection'].items():
         if isinstance(outputs, dict):
             # if outputs are given in solc json format, collapse them into a single list
             outputs = set(x for i in outputs.values() for x in i)


### PR DESCRIPTION
### What I did
* In the input json, allow `outputSelection` to be given as a subfield within `settings` - this is how Solidity formats it.

This is a cherry-pick from #1778 now that #1783 has merged.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71680255-48ea2100-2d92-11ea-9547-79866ab2e20b.png)
