### PR TITLE
Implement SHL/SHR for bitshifting

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -128,7 +128,7 @@ The following is a list of supported EVM versions, and changes in the compiler i
 - ``byzantium``
    - The oldest EVM version supported by Vyper.
 - ``constantinople``
-   - The compiler behaves the same way as with byzantium.
+   - ``shift`` makes use of ``SHL``/``SHR`` opcodes.
 - ``petersburg``
    - The compiler behaves the same way as with consantinople.
 - ``istanbul`` **(default)**

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -1,5 +1,13 @@
-def test_test_bitwise(get_contract_with_gas_estimation):
-    test_bitwise = """
+import pytest
+
+from vyper.compiler import (
+    compile_code,
+)
+from vyper.opcodes import (
+    EVM_VERSIONS,
+)
+
+code = """
 @public
 def _bitwise_and(x: uint256, y: uint256) -> uint256:
     return bitwise_and(x, y)
@@ -21,7 +29,21 @@ def _shift(x: uint256, y: int128) -> uint256:
     return shift(x, y)
     """
 
-    c = get_contract_with_gas_estimation(test_bitwise)
+
+@pytest.mark.parametrize('evm_version', list(EVM_VERSIONS))
+def test_bitwise_opcodes(evm_version):
+    opcodes = compile_code(code, ['opcodes'], evm_version=evm_version)['opcodes']
+    if evm_version == "byzantium":
+        assert "SHL" not in opcodes
+        assert "SHR" not in opcodes
+    else:
+        assert "SHL" in opcodes
+        assert "SHR" in opcodes
+
+
+@pytest.mark.parametrize('evm_version', list(EVM_VERSIONS))
+def test_test_bitwise(get_contract_with_gas_estimation, evm_version):
+    c = get_contract_with_gas_estimation(code, evm_version=evm_version)
     x = 126416208461208640982146408124
     y = 7128468721412412459
     assert c._bitwise_and(x, y) == (x & y)
@@ -36,5 +58,3 @@ def _shift(x: uint256, y: int128) -> uint256:
     assert c._shift(x, -1) == x // 2
     assert c._shift(x, -3) == x // 8
     assert c._shift(x, -256) == 0
-
-    print("Passed bitwise operation tests")

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -58,3 +58,20 @@ def test_test_bitwise(get_contract_with_gas_estimation, evm_version):
     assert c._shift(x, -1) == x // 2
     assert c._shift(x, -3) == x // 8
     assert c._shift(x, -256) == 0
+
+
+@pytest.mark.parametrize('evm_version', list(EVM_VERSIONS))
+def test_literals(get_contract, evm_version):
+    code = """
+@public
+def left(x: uint256) -> uint256:
+    return shift(x, -3)
+
+@public
+def right(x: uint256) -> uint256:
+    return shift(x, 3)
+    """
+
+    c = get_contract(code, evm_version=evm_version)
+    assert c.left(80) == 10
+    assert c.right(80) == 640


### PR DESCRIPTION
### What I did
* use `SHL`/`SHR` for bitshifting when targeting `>=constantinople` EVM ruleset - closes #1268 
* bitshift bytecode optimizations

### How I did it
`functions.functions.shift`: When `_shift` is a literal, do not include `IF SLT 0` or resulting unreachable bytecode.

### How to verify it
Run the tests. I added some new test cases and parametrized existing ones.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71693578-7e543600-2db5-11ea-9388-b304b1e03620.png)
