### PR TITLE
Use full hash for private method selectors

### DIFF
--- a/tests/signatures/test_method_id_conflicts.py
+++ b/tests/signatures/test_method_id_conflicts.py
@@ -58,3 +58,17 @@ def OwnerTransferV7b711143(a: uint256):
 def test_method_id_conflicts(failing_contract_code):
     with pytest.raises(StructureException):
         compiler.compile_code(failing_contract_code)
+
+
+def test_private_id_4byte_conflict():
+    # these methods have the same first 4 bytes in their selectors
+    code = """
+@private
+@constant
+def gfah(): pass
+
+@private
+@constant
+def eexo(): pass
+    """
+    compiler.compile_code(code)

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -300,8 +300,12 @@ class FunctionSignature:
         # Get the canonical function signature
         sig = cls.get_full_sig(name, code.args.args, sigs, custom_units, custom_structs, constants)
 
-        # Take the first 4 bytes of the hash of the sig to get the method ID
-        method_id = fourbytes_to_int(keccak256(bytes(sig, 'utf-8'))[:4])
+        if private:
+            # for private functions, the method ID is the entire hash of the sig
+            method_id = int(keccak256(bytes(sig, 'utf-8')).hex(), 16)
+        else:
+            # for public functions, use only the first 4 bytes of the hash
+            method_id = fourbytes_to_int(keccak256(bytes(sig, 'utf-8'))[:4])
         return cls(
             name,
             args,


### PR DESCRIPTION
### What I did
Use the full keccak hash for private method selectors to prevent unnecessary collisions - closes #1687 

### How I did it
Minor edit to `vyper/signatures/function_signature.py` that returns the entire hash if method is private.

### How to verify it
Run the tests.  I added a test case based on the example in #1687 that would fail if only the first 4 bytes were used.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71738002-f8d89080-2e5d-11ea-85d6-13ec4623d1a6.png)
