### PR TITLE
Include private methods when checking function selector collisions

### DIFF
--- a/tests/signatures/test_method_id_conflicts.py
+++ b/tests/signatures/test_method_id_conflicts.py
@@ -51,6 +51,26 @@ def tgeo():
 def OwnerTransferV7b711143(a: uint256):
     pass
     """,
+    """
+# check collision between private method IDs
+@private
+@constant
+def gfah(): pass
+
+@private
+@constant
+def eexo(): pass
+    """,
+    """
+# check collision between private and public IDs
+@private
+@constant
+def gfah(): pass
+
+@public
+@constant
+def eexo(): pass
+    """
 ]
 
 

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -275,11 +275,10 @@ def find_signature_conflicts(sigs: Sequence[FunctionSignature]) -> Conflicts:
 
 
 def check_valid_contract_interface(global_ctx, contract_sigs):
-    public_func_sigs = [
-        sig for sig in contract_sigs.values()
-        if isinstance(sig, FunctionSignature) and not sig.private
-    ]
-    func_conflicts = find_signature_conflicts(public_func_sigs)
+    # the check for private function collisions is made to prevent future
+    # breaking changes if we switch to internal calls (@iamdefinitelyahuman)
+    func_sigs = [sig for sig in contract_sigs.values() if isinstance(sig, FunctionSignature)]
+    func_conflicts = find_signature_conflicts(func_sigs)
 
     if len(func_conflicts) > 0:
         sig_1, sig_2 = func_conflicts[0]


### PR DESCRIPTION
### What I did
Include private methods when checking for function selector collisions - closes #1687 

### How I did it
`vyper/signatures/interface.py` - do not exclude functions marked as private

### How to verify it
Run tests. I added test cases.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71740690-94b9ca80-2e65-11ea-8ecf-d6946f1fabc3.png)
