### PR TITLE
Support for EXTCODEHASH

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -283,3 +283,7 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
     .. note::
 
         The EVM only provides access to the most 256 blocks. This function will return 0 if the block number is greater than or equal to the current block number or more than 256 blocks behind the current block.
+
+.. py:function:: get_extcodehash(addr: address) -> bytes32
+
+    Returns the keccak hash of the code at ``addr``, or ``EMPTY_BYTES32`` if the account does not exist or is empty.

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -128,6 +128,7 @@ The following is a list of supported EVM versions, and changes in the compiler i
 - ``byzantium``
    - The oldest EVM version supported by Vyper.
 - ``constantinople``
+   - The ``EXTCODEHASH`` opcode is accessible via ``get_extcodehash``
    - ``shift`` makes use of ``SHL``/``SHR`` opcodes.
 - ``petersburg``
    - The compiler behaves the same way as with consantinople.

--- a/tests/parser/functions/test_get_hash.py
+++ b/tests/parser/functions/test_get_hash.py
@@ -1,0 +1,63 @@
+
+import pytest
+
+from vyper.compiler import (
+    compile_code,
+)
+from vyper.exceptions import (
+    EvmVersionException,
+)
+from vyper.opcodes import (
+    EVM_VERSIONS,
+)
+from vyper.utils import (
+    keccak256,
+)
+
+
+@pytest.mark.parametrize('evm_version', list(EVM_VERSIONS))
+def test_get_extcodehash(get_contract, evm_version):
+    code = """
+a: address
+
+@public
+def __init__():
+    self.a = self
+
+@public
+def foo(x: address) -> bytes32:
+    return get_extcodehash(x)
+
+@public
+def foo2(x: address) -> bytes32:
+    b: address = x
+    return get_extcodehash(b)
+
+@public
+def foo3() -> bytes32:
+    return get_extcodehash(self)
+
+@public
+def foo4() -> bytes32:
+    return get_extcodehash(self.a)
+    """
+
+    if evm_version == "byzantium":
+        with pytest.raises(EvmVersionException):
+            compile_code(code, evm_version=evm_version)
+        return
+
+    compiled = compile_code(code, ['bytecode_runtime'], evm_version=evm_version)
+    bytecode = bytes.fromhex(compiled['bytecode_runtime'][2:])
+    hash_ = keccak256(bytecode)
+
+    c = get_contract(code, evm_version=evm_version)
+
+    assert c.foo(c.address) == hash_
+    assert not int(c.foo("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF").hex(), 16)
+
+    assert c.foo2(c.address) == hash_
+    assert not int(c.foo2("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF").hex(), 16)
+
+    assert c.foo3() == hash_
+    assert c.foo4() == hash_


### PR DESCRIPTION
### What I did
Add `get_hash` method for access to `EXTCODEHASH` opcode - closes #1765

This is a draft pending discussion at #1759 - once the syntax is finalized I'll edit and mark as ready for review.

### How I did it
* `vyper/functions/functions.py`:
   * add `get_hash` method with checks for EVM ruleset >= constantinople
   * include method in `DISPATCH_TABLE`

### How to verify it
Run the tests. I added new cases.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71749532-62689700-2e7e-11ea-82e5-b7598bc58d03.png)
