### PR TITLE
improvements to for loop exceptions

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -9,36 +9,48 @@ from vyper.exceptions import (
     VariableDeclarationException,
 )
 
-
-def test_basic_for_in_list(get_contract_with_gas_estimation):
-    code = """
+BASIC_FOR_LOOP_CODE = [
+    # basic for-in-list memory
+    ("""
 @public
 def data() -> int128:
     s: int128[5] = [1, 2, 3, 4, 5]
     for i in s:
         if i >= 3:
             return i
-    return -1
-    """
-
-    c = get_contract_with_gas_estimation(code)
-
-    assert c.data() == 3
-
-
-def test_basic_for_list_liter(get_contract_with_gas_estimation):
-    code = """
+    return -1""", 3),
+    # basic for-in-list literal
+    ("""
 @public
 def data() -> int128:
     for i in [3, 5, 7, 9]:
         if i > 5:
             return i
-    return -1
-    """
+    return -1""", 7),
+    # basic for-in-list addresses
+    ("""
+@public
+def data() -> address:
+    addresses: address[3] = [
+        0x7d577a597B2742b498Cb5Cf0C26cDCD726d39E6e,
+        0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1,
+        0xDCEceAF3fc5C0a63d195d69b1A90011B7B19650D
+    ]
+    count: int128 = 0
+    for i in addresses:
+        count += 1
+        if count == 2:
+            return i
+    return 0x0000000000000000000000000000000000000000
+    """, "0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1"),
+]
 
-    c = get_contract_with_gas_estimation(code)
 
-    assert c.data() == 7
+@pytest.mark.parametrize('code', BASIC_FOR_LOOP_CODE)
+def test_basic_for_in_lists(code, get_contract):
+    code, data = code
+    c = get_contract(code)
+    assert c.data() == data
 
 
 def test_basic_for_list_storage(get_contract_with_gas_estimation):
@@ -62,91 +74,6 @@ def data() -> int128:
     assert c.data() == -1
     c.set(transact={})
     assert c.data() == 7
-
-
-def test_basic_for_list_address(get_contract_with_gas_estimation):
-    code = """
-@public
-def data() -> address:
-    addresses: address[3] = [
-        0x7d577a597B2742b498Cb5Cf0C26cDCD726d39E6e,
-        0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1,
-        0xDCEceAF3fc5C0a63d195d69b1A90011B7B19650D
-    ]
-    count: int128 = 0
-    for i in addresses:
-        count += 1
-        if count == 2:
-            return i
-    return 0x0000000000000000000000000000000000000000
-    """
-
-    c = get_contract_with_gas_estimation(code)
-
-    assert c.data() == "0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1"
-
-
-def test_multiple_for_loops_1(get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    p: int128 = 0
-    for i in range(3):
-        p += i
-    for i in range(4):
-        p += i
-"""
-    get_contract_with_gas_estimation(code)
-
-
-def test_multiple_for_loops_2(get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    p: int128 = 0
-    for i in range(3):
-        p += i
-    for i in [1, 2, 3, 4]:
-        p += i
-"""
-    get_contract_with_gas_estimation(code)
-
-
-def test_multiple_for_loops_3(get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    p: int128 = 0
-    for i in [1, 2, 3, 4]:
-        p += i
-    for i in [1, 2, 3, 4]:
-        p += i
-"""
-    get_contract_with_gas_estimation(code)
-
-
-def test_multiple_loops_4(get_contract_with_gas_estimation):
-    code = """
-@public
-def foo():
-    for i in range(10):
-        pass
-    for i in range(20):
-        pass
-"""
-    get_contract_with_gas_estimation(code)
-
-
-def test_using_index_variable_after_loop(get_contract_with_gas_estimation):
-    code = """
-@public
-def foo():
-    for i in range(10):
-        pass
-    i: int128 = 100  # create new variable i
-    i = 200  # look up the variable i and check whether it is in forvars
-"""
-    get_contract_with_gas_estimation(code)
 
 
 def test_basic_for_list_storage_address(get_contract_with_gas_estimation):
@@ -213,153 +140,6 @@ def i_return(break_count: int128) -> decimal:
     assert c.ret(0) == c.i_return(0) == Decimal('0.0001')
 
 
-def test_altering_list_within_for_loop_1(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
-@public
-def data() -> int128:
-    s: int128[6] = [1, 2, 3, 4, 5, 6]
-    count: int128 = 0
-    for i in s:
-        s[count] = 1  # this should not be allowed.
-        if i >= 3:
-            return i
-        count += 1
-    return -1
-    """
-
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
-
-
-def test_altering_list_within_for_loop_2(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
-@public
-def foo():
-    s: int128[6] = [1, 2, 3, 4, 5, 6]
-    count: int128 = 0
-    for i in s:
-        s[count] += 1
-"""
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
-
-
-def test_altering_list_within_for_loop_storage(assert_compile_failed,
-                                               get_contract_with_gas_estimation):
-    code = """
-s: int128[6]
-
-@public
-def set():
-    self.s = [1, 2, 3, 4, 5, 6]
-
-@public
-def data() -> int128:
-    count: int128 = 0
-    for i in self.s:
-        self.s[count] = 1  # this should not be allowed.
-        if i >= 3:
-            return i
-        count += 1
-    return -1
-    """
-
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
-
-
-def test_invalid_nested_for_loop_1(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    for i in range(4):
-        for i in range(5):
-            pass
-"""
-    assert_compile_failed(
-        lambda: get_contract_with_gas_estimation(code), VariableDeclarationException
-    )
-
-
-def test_invalid_nested_for_loop_2(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    for i in [1,2]:
-        for i in [1,2]:
-            pass
-"""
-    assert_compile_failed(
-        lambda: get_contract_with_gas_estimation(code), VariableDeclarationException,
-    )
-
-
-def test_invalid_iterator_assignment_1(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    for i in [1,2]:
-        i = 2
-"""
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
-
-
-def test_invalid_iterator_assignment_2(assert_compile_failed, get_contract_with_gas_estimation):
-    code = """
-@public
-def foo(x: int128):
-    for i in [1,2]:
-        i += 2
-"""
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
-
-
-def test_range_constant(get_contract_with_gas_estimation):
-    code = """
-TREE_FIDDY: constant(int128)  = 350
-
-
-@public
-def a() -> uint256:
-    x: uint256 = 0
-    for i in range(TREE_FIDDY):
-        x += 1
-    return x
-    """
-
-    c = get_contract_with_gas_estimation(code)
-
-    assert c.a() == 350
-
-    code = """
-ONE_HUNDRED: constant(int128)  = 100
-
-@public
-def a() -> uint256:
-    x: uint256 = 0
-    for i in range(1, 1 + ONE_HUNDRED):
-        x += 1
-    return x
-    """
-
-    c = get_contract_with_gas_estimation(code)
-
-    assert c.a() == 100
-
-    code = """
-START: constant(int128)  = 100
-END: constant(int128)  = 199
-
-@public
-def a() -> uint256:
-    x: uint256 = 0
-    for i in range(START, END):
-        x += 1
-    return x
-    """
-
-    c = get_contract_with_gas_estimation(code)
-
-    assert c.a() == 99
-
-
 def test_for_in_list_iter_type(get_contract_with_gas_estimation):
     code = """
 @public
@@ -379,7 +159,177 @@ def func(amounts: wei_value[3]) -> wei_value:
     assert c.func([100, 200, 300]) == 600
 
 
+GOOD_CODE = [
+    # multiple for loops
+    """
+@public
+def foo(x: int128):
+    p: int128 = 0
+    for i in range(3):
+        p += i
+    for i in range(4):
+        p += i
+    """,
+    """
+@public
+def foo(x: int128):
+    p: int128 = 0
+    for i in range(3):
+        p += i
+    for i in [1, 2, 3, 4]:
+        p += i
+    """,
+    """
+@public
+def foo(x: int128):
+    p: int128 = 0
+    for i in [1, 2, 3, 4]:
+        p += i
+    for i in [1, 2, 3, 4]:
+        p += i
+    """,
+    """
+@public
+def foo():
+    for i in range(10):
+        pass
+    for i in range(20):
+        pass
+    """,
+    # using index variable after loop
+    """
+@public
+def foo():
+    for i in range(10):
+        pass
+    i: int128 = 100  # create new variable i
+    i = 200  # look up the variable i and check whether it is in forvars
+    """,
+]
+
+
+@pytest.mark.parametrize('code', GOOD_CODE)
+def test_good_code(code, get_contract):
+    get_contract(code)
+
+
+RANGE_CONSTANT_CODE = [
+    ("""
+TREE_FIDDY: constant(int128)  = 350
+
+
+@public
+def a() -> uint256:
+    x: uint256 = 0
+    for i in range(TREE_FIDDY):
+        x += 1
+    return x""", 350),
+    ("""
+ONE_HUNDRED: constant(int128)  = 100
+
+@public
+def a() -> uint256:
+    x: uint256 = 0
+    for i in range(1, 1 + ONE_HUNDRED):
+        x += 1
+    return x""", 100),
+    ("""
+START: constant(int128)  = 100
+END: constant(int128)  = 199
+
+@public
+def a() -> uint256:
+    x: uint256 = 0
+    for i in range(START, END):
+        x += 1
+    return x""", 99),
+    ("""
+@public
+def a() -> int128:
+    x: int128 = 0
+    for i in range(-5, -1):
+        x += i
+    return x""", -14)
+]
+
+
+@pytest.mark.parametrize('code', RANGE_CONSTANT_CODE)
+def test_range_constant(get_contract, code):
+    code, result = code
+    c = get_contract(code)
+
+    assert c.a() == result
+
+
 BAD_CODE = [
+    # altering list within loop
+    """
+@public
+def data() -> int128:
+    s: int128[6] = [1, 2, 3, 4, 5, 6]
+    count: int128 = 0
+    for i in s:
+        s[count] = 1  # this should not be allowed.
+        if i >= 3:
+            return i
+        count += 1
+    return -1
+    """,
+    """
+@public
+def foo():
+    s: int128[6] = [1, 2, 3, 4, 5, 6]
+    count: int128 = 0
+    for i in s:
+        s[count] += 1
+    """,
+    # alter storage list within for loop
+    """
+s: int128[6]
+
+@public
+def set():
+    self.s = [1, 2, 3, 4, 5, 6]
+
+@public
+def data() -> int128:
+    count: int128 = 0
+    for i in self.s:
+        self.s[count] = 1  # this should not be allowed.
+        if i >= 3:
+            return i
+        count += 1
+    return -1
+    """,
+    # invalid nested loop
+    ("""
+@public
+def foo(x: int128):
+    for i in range(4):
+        for i in range(5):
+            pass
+    """, VariableDeclarationException),
+    ("""
+@public
+def foo(x: int128):
+    for i in [1,2]:
+        for i in [1,2]:
+            pass
+     """, VariableDeclarationException),
+    # invalid iterator assignment
+    """
+@public
+def foo(x: int128):
+    for i in [1,2]:
+        i = 2
+    """,
+    """
+@public
+def foo(x: int128):
+    for i in [1,2]:
+        i += 2
+    """,
+    # range of < 1
     """
 @public
 def foo():
@@ -422,5 +372,8 @@ def foo():
 
 
 @pytest.mark.parametrize('code', BAD_CODE)
-def test_invalid_for_in_range(assert_compile_failed, get_contract_with_gas_estimation, code):
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
+def test_bad_code(assert_compile_failed, get_contract, code):
+    err = StructureException
+    if not isinstance(code, str):
+        code, err = code
+    assert_compile_failed(lambda: get_contract(code), err)

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -46,9 +46,8 @@ def data() -> address:
 ]
 
 
-@pytest.mark.parametrize('code', BASIC_FOR_LOOP_CODE)
-def test_basic_for_in_lists(code, get_contract):
-    code, data = code
+@pytest.mark.parametrize('code, data', BASIC_FOR_LOOP_CODE)
+def test_basic_for_in_lists(code, data, get_contract):
     c = get_contract(code)
     assert c.data() == data
 
@@ -253,9 +252,8 @@ def a() -> int128:
 ]
 
 
-@pytest.mark.parametrize('code', RANGE_CONSTANT_CODE)
-def test_range_constant(get_contract, code):
-    code, result = code
+@pytest.mark.parametrize('code, result', RANGE_CONSTANT_CODE)
+def test_range_constant(get_contract, code, result):
     c = get_contract(code)
 
     assert c.a() == result
@@ -368,6 +366,59 @@ def foo():
     for i in range(a,a-3):
         pass
     """,
+    # invalid argument length
+    """
+@public
+def foo():
+    for i in range():
+        pass
+    """,
+    """
+@public
+def foo():
+    for i in range(0,1,2):
+        pass
+    """,
+    # non-iterables
+    """
+@public
+def foo():
+    for i in b"asdf":
+        pass
+    """,
+    """
+@public
+def foo():
+    for i in 31337:
+        pass
+    """,
+    """
+@public
+def foo():
+    for i in bar():
+        pass
+    """,
+    """
+@public
+def foo():
+    for i in self.bar():
+        pass
+    """,
+    # nested lists
+    """
+@public
+def foo():
+    x: uint256[5][2] = [[0, 1, 2, 3, 4], [2, 4, 6, 8, 10]]
+    for i in x:
+        pass
+    """,
+    """
+@public
+def foo():
+    x: uint256[5][2] = [[0, 1, 2, 3, 4], [2, 4, 6, 8, 10]]
+    for i in x[1]:
+        pass
+    """
 ]
 
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -519,9 +519,6 @@ class Stmt(object):
         return arg_expr.value
 
     def parse_for(self):
-        # from .parser import (
-        #     parse_body,
-        # )
         # Type 0 for, e.g. for i in list(): ...
         if self._is_list_iter():
             return self.parse_for_list()
@@ -582,6 +579,14 @@ class Stmt(object):
 
                 rounds = self._get_range_const_value(arg1.right)
                 start = Expr.parse_value_expr(arg0, self.context)
+
+            r = rounds if isinstance(rounds, int) else rounds.value
+            if r < 1:
+                raise StructureException(
+                    f"For loop has invalid number of iterations ({r}),"
+                    " the value must be greater than zero",
+                    self.stmt.iter
+                )
 
             varname = self.stmt.target.id
             pos = self.context.new_variable(varname, BaseType('int128'), pos=getpos(self.stmt))

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -504,15 +504,16 @@ class Stmt(object):
             arg_expr = Expr.parse_value_expr(arg_ast_node, self.context)
 
         is_integer_literal = (
-            isinstance(arg_expr.typ, BaseType) and arg_expr.typ.is_literal
-        ) and arg_expr.typ.typ in {'uint256', 'int128'}
-
-        if is_integer_literal:
-            return True, arg_expr
-        else:
-            if raise_exception:
-                raise StructureException("Range only accepts literal (constant) values", arg_expr)
-            return False, arg_expr
+            isinstance(arg_expr.typ, BaseType) and
+            arg_expr.typ.is_literal and
+            arg_expr.typ.typ in {'uint256', 'int128'}
+        )
+        if not is_integer_literal and raise_exception:
+            raise StructureException(
+                "Range only accepts literal (constant) values of type uint256 or int128",
+                arg_ast_node
+            )
+        return is_integer_literal, arg_expr
 
     def _get_range_const_value(self, arg_ast_node):
         _, arg_expr = self._check_valid_range_constant(arg_ast_node)
@@ -523,18 +524,22 @@ class Stmt(object):
         if self._is_list_iter():
             return self.parse_for_list()
 
-        is_invalid_for_statement = any((
-            not isinstance(self.stmt.iter, ast.Call),
-            not isinstance(self.stmt.iter.func, ast.Name),
-            not isinstance(self.stmt.target, ast.Name),
-            self.stmt.iter.func.id != "range",
-            len(self.stmt.iter.args) not in {1, 2},
-        ))
-        if is_invalid_for_statement:
-            raise StructureException((
-                "For statements must be of the form `for i in range(rounds): "
-                "..` or `for i in range(start, start + rounds): ..`"
-            ), self.stmt.iter)
+        if not isinstance(self.stmt.iter, ast.Call):
+            if isinstance(self.stmt.iter, ast.Subscript):
+                raise StructureException("Cannot iterate over a nested list", self.stmt.iter)
+            raise StructureException(
+                f"Cannot iterate over '{type(self.stmt.iter).__name__}' object",
+                self.stmt.iter
+            )
+        if getattr(self.stmt.iter.func, 'id', None) != "range":
+            raise StructureException(
+                "Non-literals cannot be used as loop range", self.stmt.iter.func
+            )
+        if len(self.stmt.iter.args) not in {1, 2}:
+            raise StructureException(
+                f"Range expects between 1 and 2 arguments, got {len(self.stmt.iter.args)}",
+                self.stmt.iter.func
+            )
 
         block_scope_id = id(self.stmt)
         with self.context.make_blockscope(block_scope_id):


### PR DESCRIPTION
### What I did
* Raise `StructureException` while parsing, when the number of rounds on a for loop is less than 1. Previously this wasn't caught until the LLL stage and raised a `CompilerPanic` - fixes #1655
* Improve error messages for invalid range argument count, non-iterables, decimals in a range and nested lists - closes #1427, closes #1709

### How I did it
Added and expanded checks in `vyper/parser/stmt.py`

### How to verify it
Run the tests. I added some test cases. I also got a bit carried away and parametrized the rest of the test module.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71783066-d1aacc00-2fe1-11ea-825b-1cbcf5b40f20.png)
