### PR TITLE
Factory example

### DIFF
--- a/examples/factory/Exchange.vy
+++ b/examples/factory/Exchange.vy
@@ -1,6 +1,4 @@
-contract Token:
-    def transfer(_to: address, _amt: uint256) -> bool: modifying
-    def transferFrom(_from: address, _to: address, _amt: uint256) -> bool: modifying
+from vyper.interfaces import ERC20
 
 
 contract Factory:
@@ -23,13 +21,20 @@ def initialize():
     Factory(self.factory).register()
 
 
+# NOTE: This contract restricts trading to only be done by the factory.
+#       A practical implementation would probably want counter-pairs
+#       and liquidity management features for each exchange pool.
+
+
 @public
 def receive(_from: address, _amt: uint256):
-    success: bool = Token(self.token).transferFrom(_from, self, _amt)
+    assert msg.sender == self.factory
+    success: bool = ERC20(self.token).transferFrom(_from, self, _amt)
     assert success
 
 
 @public
 def transfer(_to: address, _amt: uint256):
-    success: bool = Token(self.token).transfer(_to, _amt)
+    assert msg.sender == self.factory
+    success: bool = ERC20(self.token).transfer(_to, _amt)
     assert success

--- a/examples/factory/Exchange.vy
+++ b/examples/factory/Exchange.vy
@@ -1,0 +1,35 @@
+contract Token:
+    def transfer(_to: address, _amt: uint256) -> bool: modifying
+    def transferFrom(_from: address, _to: address, _amt: uint256) -> bool: modifying
+
+
+contract Factory:
+    def register(): modifying
+
+
+token: public(address)
+factory: address
+
+
+@public
+def __init__(_token: address, _factory: address):
+    self.token = _token
+    self.factory = _factory
+
+
+@public
+def initialize():
+    # Anyone can safely call this function because of EXTCODEHASH
+    Factory(self.factory).register()
+
+
+@public
+def receive(_from: address, _amt: uint256):
+    success: bool = Token(self.token).transferFrom(_from, self, _amt)
+    assert success
+
+
+@public
+def transfer(_to: address, _amt: uint256):
+    success: bool = Token(self.token).transfer(_to, _amt)
+    assert success

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -3,9 +3,10 @@ contract Exchange:
     def receive(_from: address, _amt: uint256): modifying
     def transfer(_to: address, _amt: uint256): modifying
 
+
 exchange_codehash: public(bytes32)
 # Maps token addresses to exchange addresses
-exchanges: map(address, address)
+exchanges: public(map(address, address))
 
 
 @public
@@ -14,17 +15,27 @@ def __init__(_exchange_codehash: bytes32):
     self.exchange_codehash = _exchange_codehash
 
 
+# NOTE: Could implement fancier upgrade logic around self.exchange_codehash
+#       For example, allowing the deployer of this contract to change this
+#       value allows them to use a new contract if the old one has an issue.
+#       This would trigger a cascade effect across all exchanges that would
+#       need to be handled appropiately.
+
+
 @public
 def register():
     # Verify code hash is the exchange's code hash
     assert get_extcodehash(msg.sender) == self.exchange_codehash
     # Save a lookup for the exchange
     # NOTE: Use exchange's token address because it should be globally unique
+    # NOTE: Should do checks that it hasn't already been set,
+    #       which has to be rectified with any upgrade strategy.
     self.exchanges[Exchange(msg.sender).token()] = msg.sender
 
 
 @public
 def trade(_token1: address, _token2: address, _amt: uint256):
     # Perform a straight exchange of token1 to token 2 (1:1 price)
+    # NOTE: Any practical implementation would need to solve the price oracle problem
     Exchange(self.exchanges[_token1]).receive(msg.sender, _amt)
     Exchange(self.exchanges[_token2]).transfer(msg.sender, _amt)

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -1,0 +1,30 @@
+contract Exchange:
+    def token() -> address: constant
+    def receive(_from: address, _amt: uint256): modifying
+    def transfer(_to: address, _amt: uint256): modifying
+
+exchange_codehash: public(bytes32)
+# Maps token addresses to exchange addresses
+exchanges: map(address, address)
+
+
+@public
+def __init__(_exchange_codehash: bytes32):
+    # Register the exchange code hash during deployment of the factory
+    self.exchange_codehash = _exchange_codehash
+
+
+@public
+def register():
+    # Verify code hash is the exchange's code hash
+    assert get_extcodehash(msg.sender) == self.exchange_codehash
+    # Save a lookup for the exchange
+    # NOTE: Use exchange's token address because it should be globally unique
+    self.exchanges[Exchange(msg.sender).token()] = msg.sender
+
+
+@public
+def trade(_token1: address, _token2: address, _amt: uint256):
+    # Perform a straight exchange of token1 to token 2 (1:1 price)
+    Exchange(self.exchanges[_token1]).receive(msg.sender, _amt)
+    Exchange(self.exchanges[_token2]).transfer(msg.sender, _amt)

--- a/tests/examples/factory/test_factory.py
+++ b/tests/examples/factory/test_factory.py
@@ -1,0 +1,68 @@
+from eth_utils import (
+    keccak,
+)
+import pytest
+
+import vyper
+
+
+@pytest.fixture
+def create_token(get_contract):
+    with open('examples/tokens/ERC20.vy') as f:
+        code = f.read()
+
+    def create_token():
+        return get_contract(code, *['VyperCoin', 'FANG', 0, 0])
+
+    return create_token
+
+
+@pytest.fixture
+def create_exchange(w3, get_contract):
+    with open('examples/factory/Exchange.vy') as f:
+        code = f.read()
+
+    def create_exchange(token, factory):
+        exchange = get_contract(code, *[token.address, factory.address])
+        # NOTE: Must initialize exchange to register it with factory
+        exchange.initialize(transact={'from': w3.eth.accounts[0]})
+        return exchange
+
+    return create_exchange
+
+
+@pytest.fixture
+def factory(get_contract):
+    with open('examples/factory/Exchange.vy') as f:
+        code = f.read()
+
+    exchange_interface = vyper.compile_code(code, output_formats=['bytecode_runtime'])
+    exchange_deployed_bytecode = exchange_interface['bytecode_runtime']
+
+    with open('examples/factory/Factory.vy') as f:
+        code = f.read()
+
+    # NOTE: We deploy the factory with the hash of the exchange's expected deployment bytecode
+    return get_contract(code, keccak(hexstr=exchange_deployed_bytecode))
+
+
+def test_exchange(w3, factory, create_token, create_exchange):
+    a = w3.eth.accounts[0]
+    token1 = create_token()
+    exchange1 = create_exchange(token1, factory)
+    token2 = create_token()
+    exchange2 = create_exchange(token2, factory)
+
+    # user has token 1
+    token1.mint(a, 1, transact={'from': a})
+    # exchange has token 2
+    token2.mint(exchange2.address, 1, transact={'from': a})
+    # So approval doesn't fail for transferFrom
+    token1.approve(exchange1.address, 1, transact={'from': a})
+
+    # trade token 1 for token 2
+    assert token1.balanceOf(a) == 1
+    assert token2.balanceOf(a) == 0
+    factory.trade(token1.address, token2.address, 1, transact={'from': a})
+    assert token1.balanceOf(a) == 0
+    assert token2.balanceOf(a) == 1


### PR DESCRIPTION
### What I did
Added an example showing how to use `get_extcodehash` to create a registrar pattern where a child contract is deployed and registered separately from the parent, but the relationship is safely enforced.

### Cute Animal Picture
![lazy tiger](https://i1.trekearth.com/photos/42820/img_7325-1.jpg)