### PR TITLE
Changes to extcodehash

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -283,7 +283,3 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
     .. note::
 
         The EVM only provides access to the most 256 blocks. This function will return 0 if the block number is greater than or equal to the current block number or more than 256 blocks behind the current block.
-
-.. py:function:: get_extcodehash(addr: address) -> bytes32
-
-    Returns the keccak hash of the code at ``addr``, or ``EMPTY_BYTES32`` if the account does not exist or is empty.

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -128,7 +128,7 @@ The following is a list of supported EVM versions, and changes in the compiler i
 - ``byzantium``
    - The oldest EVM version supported by Vyper.
 - ``constantinople``
-   - The ``EXTCODEHASH`` opcode is accessible via ``get_extcodehash``
+   - The ``EXTCODEHASH`` opcode is accessible via ``address.codehash``
    - ``shift`` makes use of ``SHL``/``SHR`` opcodes.
 - ``petersburg``
    - The compiler behaves the same way as with consantinople.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -259,11 +259,17 @@ Members
 Member           Description
 ===============  =========================================================
 ``balance``      Query the balance of an address. Returns ``wei_value``.
+``codehash``     Returns the ``bytes32`` keccak of the code at an address, or ``EMPTY_BYTES32`` if the account does not currently have code.
 ``codesize``     Query the code size of an address. Returns ``int128``.
 ``is_contract``  Query whether it is a contract address. Returns ``bool``.
 ===============  =========================================================
 
 Syntax as follows: ``_address.<member>``, where ``_address`` is of the type ``address`` and ``<member>`` is one of the above keywords.
+
+.. note::
+
+    Operations such as ``SELFDESTRUCT`` and ``CREATE2`` allow for the removal and replacement of bytecode at an address. You should never assume that values of address members will not change in the future.
+
 
 Unit Types
 ==========

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -25,7 +25,7 @@ def __init__(_exchange_codehash: bytes32):
 @public
 def register():
     # Verify code hash is the exchange's code hash
-    assert get_extcodehash(msg.sender) == self.exchange_codehash
+    assert msg.sender.codehash == self.exchange_codehash
     # Save a lookup for the exchange
     # NOTE: Use exchange's token address because it should be globally unique
     # NOTE: Should do checks that it hasn't already been set,

--- a/tests/parser/syntax/test_codehash.py
+++ b/tests/parser/syntax/test_codehash.py
@@ -26,20 +26,20 @@ def __init__():
 
 @public
 def foo(x: address) -> bytes32:
-    return get_extcodehash(x)
+    return x.codehash
 
 @public
 def foo2(x: address) -> bytes32:
     b: address = x
-    return get_extcodehash(b)
+    return b.codehash
 
 @public
 def foo3() -> bytes32:
-    return get_extcodehash(self)
+    return self.codehash
 
 @public
 def foo4() -> bytes32:
-    return get_extcodehash(self.a)
+    return self.a.codehash
     """
 
     if evm_version in ("byzantium", "atlantis"):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -3,7 +3,6 @@ import hashlib
 from vyper import ast
 from vyper.exceptions import (
     ConstancyViolationException,
-    EvmVersionException,
     InvalidLiteralException,
     ParserException,
     StructureException,
@@ -422,20 +421,6 @@ def sha256(expr, args, kwargs, context):
     else:
         # This should never happen, but just left here for future compiler-writers.
         raise Exception(f"Unsupported location: {sub.location}")  # pragma: no test
-
-
-@signature('address')
-def get_extcodehash(expr, args, kwargs, context):
-    if not version_check(begin="constantinople"):
-        raise EvmVersionException(
-            "get_extcodehash is unavailable prior to constantinople ruleset",
-            expr
-        )
-    return LLLnode.from_list(
-        ['extcodehash', args[0]],
-        typ=BaseType('bytes32'),
-        pos=getpos(expr)
-    )
 
 
 @signature('str_literal', 'name_literal')
@@ -1311,7 +1296,6 @@ DISPATCH_TABLE = {
     'concat': concat,
     'sha3': _sha3,
     'sha256': sha256,
-    'get_extcodehash': get_extcodehash,
     'method_id': method_id,
     'keccak256': _keccak256,
     'ecrecover': ecrecover,

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -332,6 +332,25 @@ class Expr(object):
                 location=None,
                 pos=getpos(self.expr),
             )
+        # x.codehash: keccak of address x
+        elif self.expr.attr == 'codehash':
+            addr = Expr.parse_value_expr(self.expr.value, self.context)
+            if not is_base_type(addr.typ, 'address'):
+                raise TypeMismatchException(
+                    "codehash keyword expects an address as input",
+                    self.expr,
+                )
+            if not version_check(begin="constantinople"):
+                raise EvmVersionException(
+                    "address.codehash is unavailable prior to constantinople ruleset",
+                    self.expr
+                )
+            return LLLnode.from_list(
+                ['extcodehash', addr],
+                typ=BaseType('bytes32'),
+                location=None,
+                pos=getpos(self.expr)
+            )
         # self.x: global attribute
         elif isinstance(self.expr.value, ast.Name) and self.expr.value.id == "self":
             if self.expr.attr not in self.context.globals:


### PR DESCRIPTION
### What I did
Modify #1801, change syntax for accessing `EXTCODEHASH` from `get_extcodehash` to `address.codehash`

### How I did it
See code.

### How to verify it
Run tests. I updated the related test cases.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/71913788-80811080-3178-11ea-9dea-3545152d78b6.png)
