### PR TITLE
Absolute import fix

### DIFF
--- a/tests/cli/vyper_compile/test_parse_args.py
+++ b/tests/cli/vyper_compile/test_parse_args.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+
+from vyper.cli.vyper_compile import (
+    _parse_args,
+)
+
+
+@pytest.fixture
+def chdir_path(tmp_path):
+    orig_path = os.getcwd()
+    yield tmp_path
+    os.chdir(orig_path)
+
+
+def test_paths(chdir_path):
+    code = """
+@public
+def foo() -> bool:
+    return True
+"""
+    bar_path = chdir_path.joinpath('bar.vy')
+    with bar_path.open('w') as fp:
+        fp.write(code)
+    _parse_args([str(bar_path)])  # absolute path
+    os.chdir(chdir_path.parent)
+    _parse_args([str(bar_path)])  # absolute path, subfolder of cwd
+    _parse_args([str(bar_path.relative_to(chdir_path.parent))])  # relative path

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -132,8 +132,8 @@ def _parse_args(argv):
         print(json.dumps(compiled))
         return
 
-    for key in args.input_files:
-        for data in compiled[key].values():
+    for contract_data in compiled.values():
+        for data in contract_data.values():
             if isinstance(data, (list, dict)):
                 print(json.dumps(data))
             else:


### PR DESCRIPTION
### What I did
Fix #1828 

### How I did it
In `vyper/compile.py`, iterate directly over the returned compile data rather than the input args. This is required because when the original path is relative to the current working directory, it is changed to a relative path prior to being returned.

### How to verify it
Run the tests. I added a new test that checks the `vyper` cli behavior for an absolute path, a relative path, and an absolute path that is in a subfolder of the current working directory.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/72110181-d7811400-3337-11ea-9420-e9882e48e72d.png)
