### PR TITLE
Changing line of example code in Blind Auction

### DIFF
--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -151,8 +151,8 @@ While this blind auction is almost functionally identical to the blind auction i
 
 .. literalinclude:: ../examples/auctions/blind_auction.vy
   :language: python
-  :lineno-start: 22
-  :lines: 22-24
+  :lineno-start: 26
+  :lines: 26-29
 
 One key difference is that, because Vyper does not allow for dynamic arrays, we
 have limited the number of bids that can be placed by one address to 128 in this


### PR DESCRIPTION
In case to declare one key difference between Vyper and Solidity about dynamic arrays, the example code that show in documentation should be lines: 26-29 instead of lines: 22-25.

### What I did
Changing lines of example code from 26-29 to 22-25 in lines: 154-155's documentation.
### How I did it
Just delete and type it.
### How to verify it
Nothing
### Description for the changelog
Nothing
### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://thefunnybeaver.com/wp-content/uploads/2016/12/Super-Funny-And-Cute-Animal-Pictures-026.jpg)
