### PR TITLE
Fix abi tuple return for lists

### DIFF
--- a/vyper/codegen/abi.py
+++ b/vyper/codegen/abi.py
@@ -301,7 +301,7 @@ def o_list(lll_node, pos=None):
             ret = lll_node.args
         else:
             ks = lll_t.tuple_keys() if isinstance(lll_t, TupleLike) else \
-                    [LLLnode.from_list(i) for i in range(lll_t.count)]
+                    [LLLnode.from_list(i, 'uint256') for i in range(lll_t.count)]
 
             ret = [add_variable_offset(lll_node, k, pos, array_bounds_check=False)
                    for k in ks]


### PR DESCRIPTION
### What I did
Fix #1409. list-inside-tuple returns were mostly fixed in https://github.com/vyperlang/vyper/pull/1723 but this was a lingering bug. This also fixes #955 .

### How I did it
`add_variable_offset` expects the index to have a vyper type.

### How to verify it
check that the example in #1409 compiles.

### Description for the changelog
Fix returning of lists within tuples

### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://www.defensivecarry.com/forum/attachments/general-firearm-discussion/7052d1197744941-357-stops-kodiak-bear-hwb_slide58_fs.jpg)
