### PR TITLE
ABI interface fixes

### DIFF
--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -1,4 +1,6 @@
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 import pytest
 
@@ -453,13 +455,13 @@ def test_json_interface_calls(get_contract, type_str, value):
     abi = compile_code(code, ['abi'])['abi']
     c1 = get_contract(code)
 
-    code = """
+    code = f"""
 import jsonabi as jsonabi
 
 @public
 @constant
-def test_call(a: address, b: {0}) -> {0}:
+def test_call(a: address, b: {type_str}) -> {type_str}:
     return jsonabi(a).test_json(b)
-    """.format(type_str)
+    """
     c2 = get_contract(code, interface_codes={'jsonabi': {'type': 'json', 'code': abi}})
     assert c2.test_call(c1.address, value) == value

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -59,8 +59,8 @@ def render_return(sig):
 def abi_type_to_ast(atype):
     if atype in ('int128', 'uint256', 'bool', 'address', 'bytes32'):
         return ast.Name(id=atype)
-    elif atype == 'decimal':
-        return ast.Name(id='int128')
+    elif atype == 'fixed168x10':
+        return ast.Name(id='decimal')
     elif atype == 'bytes':
         return ast.Subscript(
             value=ast.Name(id='bytes'),


### PR DESCRIPTION
### What I did
Fix issues with `bytes`, `string` and `fixed168x10` when importing an ABI as an interface. Fixes #1832  

### How I did it
1. When determining if an interface has been implemented, ignore the length on `bytes` and `string`.
2. Substitute `fixed168x10` for `decimal` when converting ABI to AST.
3. For `bytes` and `string` arrays, use a length of `1024*1024` in inputs, `1` in outputs. The compiler does not implicitly truncate values so this does not create an issue when a limit is exceeded.

### How to verify it
Run the tests. I expanded the cases around ABIs as interfaces to check each type as an input and output.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/73690341-8cb1ac80-46e9-11ea-8f87-553ed3365a00.png)
