### PR TITLE
Bugfix: generating method identifier for struct return type

### DIFF
--- a/vyper/signatures/sig_utils.py
+++ b/vyper/signatures/sig_utils.py
@@ -106,6 +106,7 @@ def mk_method_identifiers(code, interface_codes=None):
             code,
             sigs=global_ctx._contracts,
             custom_units=global_ctx._custom_units,
+            custom_structs=global_ctx._structs,
             constants=global_ctx._constants,
         )
         if not sig.private:


### PR DESCRIPTION
### What I did
Fix a compiler issue when generating method identifiers for a function returning a struct.  Related to #1838 (in that I found the bug while examining that issue)

### How I did it
Add a missing kwarg in `vyper/signatures/sig_utils.py`

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/73695745-29794780-46f4-11ea-808d-381b41644fa0.png)
