### PR TITLE
Modifications to how ABI data types are represented

### DIFF
--- a/tests/parser/features/test_units.py
+++ b/tests/parser/features/test_units.py
@@ -22,7 +22,7 @@ def bar(a: uint256(m), b: uint256(m), c: uint256(m)) -> uint256(m**3):
     c = get_contract_with_gas_estimation(code)
 
     assert c._classic_contract.abi[0]["outputs"] == [
-        {"type": "uint256", "name": "out", "unit": "Newton-Meter per Second squared"}
+        {"type": "uint256", "name": "", "unit": "Newton-Meter per Second squared"}
     ]
     assert c._classic_contract.abi[0]["inputs"] == [
         {"type": "uint256", "name": "f", "unit": "Newton"},
@@ -30,7 +30,7 @@ def bar(a: uint256(m), b: uint256(m), c: uint256(m)) -> uint256(m**3):
         {"type": "uint256", "name": "t", "unit": "Second"},
     ]
     assert c._classic_contract.abi[1]["outputs"] == [
-        {"type": "uint256", "name": "out", "unit": "Meter**3"}
+        {"type": "uint256", "name": "", "unit": "Meter**3"}
     ]
     assert c._classic_contract.abi[1]["inputs"] == [
         {"type": "uint256", "name": "a", "unit": "Meter"},
@@ -74,8 +74,8 @@ def foo(t: uint256(s), d: uint256(m)) -> (uint256(m), uint256(s)):
     c = get_contract_with_gas_estimation(code)
 
     assert c._classic_contract.abi[0]["outputs"] == [
-        {"type": "uint256", "name": "out", "unit": "Meter"},
-        {"type": "uint256", "name": "out", "unit": "Second"},
+        {"type": "uint256", "name": "", "unit": "Meter"},
+        {"type": "uint256", "name": "", "unit": "Second"},
     ]
 
     assert c._classic_contract.abi[0]["inputs"] == [
@@ -93,7 +93,7 @@ def foo(a: uint256, b: uint256, c: uint256) -> uint256:
 
     c = get_contract_with_gas_estimation(code)
 
-    assert c._classic_contract.abi[0]["outputs"] == [{"type": "uint256", "name": "out"}]
+    assert c._classic_contract.abi[0]["outputs"] == [{"type": "uint256", "name": ""}]
     assert c._classic_contract.abi[0]["inputs"] == [
         {"type": "uint256", "name": "a"},
         {"type": "uint256", "name": "b"},

--- a/tests/parser/functions/test_abi.py
+++ b/tests/parser/functions/test_abi.py
@@ -83,12 +83,16 @@ def foo(s: MyStruct) -> MyStruct:
     func_abi = abi[0]
 
     assert func_abi["name"] == "foo"
-    assert func_abi["outputs"][0] == {
+    expected = {
         'type': 'tuple',
+        'name': '',
         'components': [
            {'type': 'address', 'name': 'a'},
            {'type': 'uint256', 'name': 'b'}
         ]
     }
 
-    assert func_abi["inputs"][0] == func_abi["outputs"][0]
+    assert func_abi["outputs"][0] == expected
+
+    expected['name'] = "s"
+    assert func_abi["inputs"][0] == expected

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -75,9 +75,9 @@ def out_literals() -> (int128, address, bytes[6]):
 
     c = get_contract_with_gas_estimation(code)
     assert c._classic_contract.abi[0]['outputs'] == [
-        {'type': 'int128', 'name': 'out'},
-        {'type': 'address', 'name': 'out'},
-        {'type': 'bytes', 'name': 'out'},
+        {'type': 'int128', 'name': ''},
+        {'type': 'address', 'name': ''},
+        {'type': 'bytes', 'name': ''},
     ]
 
 


### PR DESCRIPTION
### What I did
1. Include a `name` field in the ABI when representing tuple types. For inputs, the name is equal to the variable name of the struct. For outputs, the name is `""`. This is consistent with how Solidity represents tuples.
2. For output types, change the given name from `"out"` to `""`. Again - this makes the Vyper ABI more consistent with Solidity.

This is related to, but does require, #1842. As @michwill pointed out, there is a bug when attempting to import a JSON interface that uses structs. Adding the `"name"` field fixes the bug and leads to another conversation: we do not currently support tuple types when importing interfaces. And that will be the subject of another PR :)

### How I did it
Modifications to `vyper/signatures/function_signature.py`. See diff.

### How to verify it
Run the tests. I updated cases that were failing based on the change.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/73934534-159e3300-48f8-11ea-9495-c73db2a4d840.png)
