### PR TITLE
Change calling convention for private functions

### DIFF
--- a/vyper/codegen/abi.py
+++ b/vyper/codegen/abi.py
@@ -412,7 +412,7 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     lll_ret = ['with', dst_begin, dst,
                ['with', dst_loc, dst_begin, lll_ret]]
 
-    return LLLnode.from_list(lll_ret)
+    return LLLnode.from_list(lll_ret, annotation=f'ABI encode {dst.typ}')
 
 
 # lll_node is the destination LLL item, src is the input buffer.

--- a/vyper/codegen/abi.py
+++ b/vyper/codegen/abi.py
@@ -339,6 +339,8 @@ def o_list(lll_node, pos=None):
 # performance note: takes O(n^2) compilation time
 # where n is depth of data type, could be optimized but unlikely
 # that users will provide deeply nested data.
+# (returns param: whether or not to push a stack item with the runtime
+#   length of the encoded data)
 def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     parent_abi_t = abi_type_of(lll_node.typ)
     size_bound = parent_abi_t.static_size() + parent_abi_t.dynamic_size_bound()
@@ -351,6 +353,12 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     dst_begin = 'dst'      # pointer to beginning of buffer
     dst_loc = 'dst_loc'    # pointer to write location in static section
     os = o_list(lll_node, pos=pos)
+
+    #print(f'TYP {lll_node.typ}')
+    #print(f'STATIC SIZE {parent_abi_t.static_size()}')
+    #print(f'DYN SIZE {parent_abi_t.dynamic_size_bound()}')
+    #print(f'IS DYNAMIC {parent_abi_t.is_dynamic()}')
+    #print(f'IS TUPLE {parent_abi_t.is_tuple()}')
 
     for i, o in enumerate(os):
         abi_t = abi_type_of(o.typ)
@@ -412,7 +420,7 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     lll_ret = ['with', dst_begin, dst,
                ['with', dst_loc, dst_begin, lll_ret]]
 
-    return LLLnode.from_list(lll_ret, annotation=f'ABI encode {dst.typ}')
+    return LLLnode.from_list(lll_ret, annotation=f'ABI encode {lll_node.typ}')
 
 
 # lll_node is the destination LLL item, src is the input buffer.

--- a/vyper/codegen/abi.py
+++ b/vyper/codegen/abi.py
@@ -348,6 +348,8 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     if bufsz is not None and bufsz < size_bound:
         raise CompilerPanic('buffer provided to abi_encode not large enough')
 
+    # TODO reject dst where location is not memory
+
     lll_ret = ['seq']
     dyn_ofst = 'dyn_ofst'  # current offset in the dynamic section
     dst_begin = 'dst'      # pointer to beginning of buffer

--- a/vyper/codegen/abi.py
+++ b/vyper/codegen/abi.py
@@ -342,7 +342,8 @@ def o_list(lll_node, pos=None):
 def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     parent_abi_t = abi_type_of(lll_node.typ)
     size_bound = parent_abi_t.static_size() + parent_abi_t.dynamic_size_bound()
-    if bufsz is not None and bufsz < 32 * size_bound:
+
+    if bufsz is not None and bufsz < size_bound:
         raise CompilerPanic('buffer provided to abi_encode not large enough')
 
     lll_ret = ['seq']

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -44,9 +44,9 @@ def make_return_stmt(stmt, context, begin_pos, _size, loop_memory_position=None)
         # in reverse order so it can be popped of in order.
         if isinstance(begin_pos, int) and isinstance(_size, int):
             # static values, unroll the mloads instead.
-            mloads = [
-                ['mload', pos] for pos in range(begin_pos, begin_pos + _size, 32)
-            ]
+            mloads = [ ['mload', pos]
+                    for pos in range(begin_pos, begin_pos + _size, 32) ]
+            mloads = list(reversed(mloads))
             return ['seq_unchecked'] + mloads + nonreentrant_post + \
                 [['jump', ['mload', context.callback_ptr]]]
         else:
@@ -110,7 +110,6 @@ def gen_tuple_return(stmt, context, sub):
         dst = LLLnode(mem_pos, location='memory', typ=context.return_type)
         os = ['seq',
               make_setter(dst, sub, 'memory', pos=getpos(stmt)),
-              LLLnode.from_list('pass', annotation='HEY'),
               make_return_stmt(stmt, context, mem_pos, mem_size)]
         return LLLnode.from_list(os,
                 pos=getpos(stmt),

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -87,6 +87,7 @@ def gen_tuple_return(stmt, context, sub):
     # for certain arguments (to return), we can skip some copies and
     # return the return buffer directly
     if sub.args and len(sub.args[0].args) > 0 and sub.args[0].args[0].value == 'call':
+        #print(f'DBG SELF CALL PUB')
         # self-call to public.
         mem_pos = sub
         # TODO more accurate: abi size bound.
@@ -99,6 +100,7 @@ def gen_tuple_return(stmt, context, sub):
     # static (in the ABI sense), we can return the buffer directly
     is_private_call = sub.annotation and 'Internal Call' in sub.annotation
     if is_private_call and not abi_type_of(sub.typ).is_dynamic():
+        #print(f'DBG CALL PRIV STATIC')
         mem_pos = sub.args[-1].value \
                 if sub.value == 'seq_unchecked' \
                 else sub.args[0].args[-1]
@@ -109,6 +111,7 @@ def gen_tuple_return(stmt, context, sub):
 
     # if we are in a private call, just return the data unencoded
     if context.is_private:
+        #print(f'DBG IS PRIVATE')
         mem_pos = context.new_placeholder(context.return_type)
         mem_size = get_size_of_type(context.return_type) * 32
         dst = LLLnode(mem_pos, location='memory', typ=context.return_type)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -291,6 +291,7 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
                 raise TypeMismatch(
                     f"Expecting a static index; cannot access element {key}", pos
                 )
+            subtype = typ.members[key]
             attrs = list(range(len(typ.members)))
             index = key
             annotation = None

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -294,19 +294,21 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
             subtype = typ.members[key]
             attrs = list(range(len(typ.members)))
             index = key
-            annotation = None
+            annotation = subtype
 
         if location == 'storage':
             return LLLnode.from_list(
                 ['add', ['sha3_32', parent], LLLnode.from_list(index, annotation=annotation)],
                 typ=subtype,
                 location='storage',
+                annotation=annotation,
             )
         elif location == 'storage_prehashed':
             return LLLnode.from_list(
                 ['add', parent, LLLnode.from_list(index, annotation=annotation)],
                 typ=subtype,
                 location='storage',
+                annotation=annotation,
             )
         elif location in ('calldata', 'memory'):
             offset = 0
@@ -317,7 +319,11 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
                                      location=location,
                                      annotation=annotation)
         else:
-            raise TypeMismatch("Not expecting a member variable access", pos)
+            print(parent.value, parent.args, parent.typ)
+            raise TypeMismatch(
+                f"bad location for {parent} in add_variable_offset {location}",
+                pos
+            )
 
     elif isinstance(typ, MappingType):
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -806,30 +806,8 @@ class Stmt(object):
                     self.stmt.value,
                 )
 
-            # loop memory has to be allocated first.
-            loop_memory_position = self.context.new_placeholder(typ=BaseType('uint256'))
-            # len & bytez placeholder have to be declared after each other at all times.
-            len_placeholder = self.context.new_placeholder(typ=BaseType('uint256'))
-            bytez_placeholder = self.context.new_placeholder(typ=sub.typ)
-
             if sub.location in ('storage', 'memory'):
-                return LLLnode.from_list([
-                    'seq',
-                    make_byte_array_copier(
-                        LLLnode(bytez_placeholder, location='memory', typ=sub.typ),
-                        sub,
-                        pos=getpos(self.stmt)
-                    ),
-                    zero_pad(bytez_placeholder),
-                    ['mstore', len_placeholder, 32],
-                    make_return_stmt(
-                        self.stmt,
-                        self.context,
-                        len_placeholder,
-                        ['ceil32', ['add', ['mload', bytez_placeholder], 64]],
-                        loop_memory_position=loop_memory_position,
-                    )
-                ], typ=None, pos=getpos(self.stmt), valency=0)
+                return gen_tuple_return(self.stmt, self.context, sub)
             else:
                 raise Exception(f"Invalid location: {sub.location}")
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -806,10 +806,8 @@ class Stmt(object):
                     self.stmt.value,
                 )
 
-            if sub.location in ('storage', 'memory'):
-                return gen_tuple_return(self.stmt, self.context, sub)
-            else:
-                raise Exception(f"Invalid location: {sub.location}")
+            #if sub.location in ('storage', 'memory'):
+            return gen_tuple_return(self.stmt, self.context, sub)
 
         elif isinstance(sub.typ, ListType):
             loop_memory_position = self.context.new_placeholder(typ=BaseType('uint256'))

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -410,3 +410,11 @@ def is_base_type(typ, btypes):
     if not isinstance(btypes, tuple):
         btypes = (btypes, )
     return isinstance(typ, BaseType) and typ.typ in btypes
+
+
+# turn non-[list/tuple/struct] vyper types into tuple
+# this is important for abi stuff
+def ensure_vyper_tuple(typ):
+    if isinstance(typ, TupleLike) or isinstance(typ, ListType):
+        return typ
+    return TupleType([typ])

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -349,6 +349,8 @@ def get_size_of_type(typ):
     elif isinstance(typ, ByteArrayLike):
         # 1 word for offset (in static section), 1 word for length,
         # up to maxlen words for actual data.
+        # TODO: byte arrays should only take ceil32(maxlen)//32 + 1 in memory,
+        # fix this once all the pack/unpack code is refactored.
         return ceil32(typ.maxlen) // 32 + 2
     elif isinstance(typ, ListType):
         return get_size_of_type(typ.subtype) * typ.count


### PR DESCRIPTION
### What I did
Return unpacked (not ABI-encoded) data from private functions. Hopefully this simplifies code, reduces code size and fixes decoding of return data from private functions (https://github.com/vyperlang/vyper/issues/1847#issuecomment-583671694)

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
