### PR TITLE
Ast refactor step 2

### DIFF
--- a/tests/grammar/test_grammar.py
+++ b/tests/grammar/test_grammar.py
@@ -16,6 +16,7 @@ from conftest import (
     get_lark_grammar,
 )
 from vyper.ast import (
+    Module,
     parse_to_ast,
 )
 
@@ -125,4 +126,4 @@ def from_grammar(start: str = "file_input") -> st.SearchStrategy[str]:
 def test_grammar_bruteforce(code):
     if utf8_encodable(code):
         tree = parse_to_ast(code + "\n")
-        assert isinstance(tree, list)
+        assert isinstance(tree, Module)

--- a/tests/parser/ast_utils/test_ast_dict.py
+++ b/tests/parser/ast_utils/test_ast_dict.py
@@ -45,7 +45,7 @@ def test_basic_ast():
 a: int128
     """
     dict_out = compiler.compile_code(code, ['ast_dict'])
-    assert dict_out['ast_dict']['ast'][0] == {
+    assert dict_out['ast_dict']['ast']['body'][0] == {
       'annotation': {
         'ast_type': 'Name',
         'col_offset': 3,

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -82,9 +82,9 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
     def visit_UnaryOp(self, node):
         self.generic_visit(node)
         # NOTE: This is done so that decimal literal now sees the negative sign as part of it
-        if isinstance(node.op, python_ast.USub) and isinstance(
-            node.operand, python_ast.Num
-        ):
+        is_sub = isinstance(node.op, python_ast.USub)
+        is_num = isinstance(node.operand, python_ast.Num)
+        if is_sub and is_num:
             node.operand.n = 0 - node.operand.n
             node.operand.col_offset = node.col_offset
             return node.operand

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -18,7 +18,13 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
     _source_code: str
     _class_types: ClassTypes
 
-    def __init__(self, source_code: str, class_types: Optional[ClassTypes] = None):
+    def __init__(
+        self,
+        source_code: str,
+        class_types: Optional[ClassTypes] = None,
+        source_id: int = 0,
+    ):
+        self._source_id = source_id
         self._source_code: str = source_code
         self.counter: int = 0
         if class_types is not None:
@@ -27,12 +33,25 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
             self._class_types = {}
 
     def generic_visit(self, node):
-        # Decorate every node in the AST with the original source code. This is
-        # necessary to facilitate error pretty-printing.
+        # Decorate every node with the original source code to allow pretty-printing errors
         node.source_code = self._source_code
         node.node_id = self.counter
         node.ast_type = node.__class__.__name__
         self.counter += 1
+
+        # Decorate every node with source end offsets
+        start = node.first_token.start if hasattr(node, "first_token") else (None, None)
+        end = node.last_token.end if hasattr(node, "last_token") else (None, None)
+
+        node.lineno = start[0]
+        node.col_offset = start[1]
+        node.end_lineno = end[0]
+        node.end_col_offset = end[1]
+
+        if hasattr(node, "last_token"):
+            start_pos = node.first_token.startpos
+            end_pos = node.last_token.endpos
+            node.src = f"{start_pos}:{end_pos-start_pos}:{self._source_id}"
 
         return super().generic_visit(node)
 
@@ -61,39 +80,17 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         return node
 
-
-class RewriteUnarySubVisitor(python_ast.NodeTransformer):
     def visit_UnaryOp(self, node):
         self.generic_visit(node)
-        if isinstance(node.op, python_ast.USub) and isinstance(node.operand, python_ast.Num):
+        # NOTE: This is done so that decimal literal now sees the negative sign as part of it
+        if isinstance(node.op, python_ast.USub) and isinstance(
+            node.operand, python_ast.Num
+        ):
             node.operand.n = 0 - node.operand.n
-            # NOTE: This is done so that decimal literal now sees the negative sign as part of it
             node.operand.col_offset = node.col_offset
             return node.operand
         else:
             return node
-
-
-class AddSourceOffsetVisitor(python_ast.NodeTransformer):
-
-    def __init__(self, source_id):
-        self._source_id = source_id
-
-    def generic_visit(self, node):
-        start = node.first_token.start if hasattr(node, 'first_token') else (None, None)
-        end = node.last_token.end if hasattr(node, 'last_token') else (None, None)
-
-        node.lineno = start[0]
-        node.col_offset = start[1]
-        node.end_lineno = end[0]
-        node.end_col_offset = end[1]
-
-        if hasattr(node, 'last_token'):
-            start_pos = node.first_token.startpos
-            end_pos = node.last_token.endpos
-            node.src = f"{start_pos}:{end_pos-start_pos}:{self._source_id}"
-
-        return super().generic_visit(node)
 
 
 def annotate_python_ast(
@@ -117,8 +114,6 @@ def annotate_python_ast(
     :param class_types: A mapping of class names to original class types.
     :return: The annotated and optmized AST.
     """
-    AnnotatingVisitor(source_code, class_types).visit(parsed_ast)
-    RewriteUnarySubVisitor().visit(parsed_ast)
 
     asttokens.ASTTokens(source_code, tree=parsed_ast)
-    AddSourceOffsetVisitor(source_id).visit(parsed_ast)
+    AnnotatingVisitor(source_code, class_types, source_id).visit(parsed_ast)

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -66,7 +66,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
     def visit_Constant(self, node):
         self.generic_visit(node)
 
-        # for python3.8, identify the which Constant based on the value type
+        # special case to deal with Constant type in Python >=3.8
         if node.value is None or isinstance(node.value, bool):
             node.ast_type = "NameConstant"
         elif isinstance(node.value, (int, float)):

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -1,7 +1,6 @@
 import ast as python_ast
 from typing import (
     Optional,
-    Union,
 )
 
 import asttokens
@@ -94,11 +93,11 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
 
 def annotate_python_ast(
-    parsed_ast: Union[python_ast.AST, python_ast.Module],
+    parsed_ast: python_ast.AST,
     source_code: str,
     class_types: Optional[ClassTypes] = None,
     source_id: int = 0,
-) -> None:
+) -> python_ast.AST:
     """
     Performs annotation and optimization on a parsed python AST by doing the
     following:
@@ -109,11 +108,21 @@ def annotate_python_ast(
     * Substituting negative values for unary subtractions
     * Annotating all AST nodes with complete source offsets
 
-    :param parsed_ast: The AST to be annotated and optimized.
-    :param source_code: The originating source code of the AST.
-    :param class_types: A mapping of class names to original class types.
-    :return: The annotated and optmized AST.
+    Parameters
+    ----------
+    parsed_ast : AST
+        The AST to be annotated and optimized.
+    source_code : str
+        The originating source code of the AST.
+    class_types : dict, optional
+        A mapping of class names to their original class types.
+
+    Returns
+    -------
+        The annotated and optimized AST.
     """
 
     asttokens.ASTTokens(source_code, tree=parsed_ast)
     AnnotatingVisitor(source_code, class_types, source_id).visit(parsed_ast)
+
+    return parsed_ast

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -167,6 +167,18 @@ class VyperNode:
 class Module(VyperNode):
     __slots__ = ('body', )
 
+    def __getitem__(self, key):
+        return self.body[key]
+
+    def __iter__(self):
+        return iter(self.body)
+
+    def __len__(self):
+        return len(self.body)
+
+    def __contains__(self, obj):
+        return obj in self.body
+
 
 class Name(VyperNode):
     __slots__ = ('id', )

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -28,15 +28,15 @@ DICT_AST_SKIPLIST = ('source_code', )
 
 def get_node(ast_struct: typing.Union[typing.Dict, python_ast.AST]) -> "VyperNode":
     """
-    Converts an AST structure to a Vyper AST node.
+    Converts an AST structure to a vyper AST node.
 
     This is a recursive call, all child nodes of the input value are also
-    converted to Vyper nodes.
+    converted to vyper nodes.
 
     Attributes
     ----------
     ast_struct: (dict, AST)
-        Annotated python AST node or Vyper AST dict to generate the node from.
+        Annotated python AST node or vyper AST dict to generate the node from.
 
     Returns
     -------
@@ -73,7 +73,7 @@ class VyperNode:
     """
     Base class for all vyper AST nodes.
 
-    Vyper nodes are generated from, and closely resemble, their Python counterparts.
+    Vyper nodes are generated from, and closely resemble, their python counterparts.
 
     Attributes
     ----------
@@ -81,11 +81,11 @@ class VyperNode:
         Allowed field names for the node.
     _only_empty_fields : Tuple
         Field names that, if present, must be set to None or a SyntaxException is
-        raised. This attribute is used to exclude syntax that is valid in Python
+        raised. This attribute is used to exclude syntax that is valid in python
         but not in vyper.
     _translated_fields:
         Field names that should be reassigned if encountered. Used to normalize
-        fields across different Python versions.
+        fields across different python versions.
     """
     __slots__ = BASE_NODE_ATTRIBUTES
     _only_empty_fields: typing.Tuple = ()
@@ -103,6 +103,7 @@ class VyperNode:
         **kwargs : dict
             Dictionary of fields to be included within the node.
         """
+
         for field_name, value in kwargs.items():
             if field_name in self._translated_fields:
                 field_name = self._translated_fields[field_name]

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -21,7 +21,8 @@ BASE_NODE_ATTRIBUTES = (
     'lineno',
     'end_col_offset',
     'end_lineno',
-    'src'
+    'src',
+    'ast_type',
 )
 
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -23,6 +23,7 @@ BASE_NODE_ATTRIBUTES = (
     'src',
     'ast_type',
 )
+DICT_AST_SKIPLIST = ('source_code', )
 
 
 def get_node(node):
@@ -45,7 +46,14 @@ def _to_node(value):
     return value
 
 
+def _to_dict(value):
+    if isinstance(value, VyperNode):
+        return value.to_dict()
+    return value
+
+
 class VyperNode:
+
     __slots__ = BASE_NODE_ATTRIBUTES
     _only_empty_fields: typing.Tuple = ()
     _translated_fields: typing.Dict = {}
@@ -94,6 +102,16 @@ class VyperNode:
         )
 
         return f'{class_repr}:\n{source_annotation}'
+
+    def to_dict(self):
+        ast_dict = {}
+        for key in [i for i in self.get_slots() if i not in DICT_AST_SKIPLIST]:
+            value = getattr(self, key, None)
+            if isinstance(value, list):
+                ast_dict[key] = [_to_dict(i) for i in value]
+            else:
+                ast_dict[key] = _to_dict(value)
+        return ast_dict
 
 
 class Module(VyperNode):

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -79,9 +79,17 @@ def pre_parse(code: str) -> Tuple[ClassTypes, str]:
     Also returns a mapping of detected contract and struct names to their
     respective vyper class types ("contract" or "struct").
 
-    :param code: The vyper source code to be re-formatted.
-    :return: A tuple including the class type mapping and the reformatted python
-        source string.
+    Parameters
+    ----------
+    code : str
+        The vyper source code to be re-formatted.
+
+    Returns
+    -------
+    dict
+        Mapping of class types for the given source.
+    str
+        Reformatted python source string.
     """
     result = []
     previous_keyword = None

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -21,7 +21,7 @@ from vyper.exceptions import (
 )
 
 
-def parse_to_ast(source_code: str, source_id: int = 0) -> list:
+def parse_to_ast(source_code: str, source_id: int = 0) -> vy_ast.Module:
     """
     Parses a vyper source string and generates basic vyper AST nodes.
 
@@ -48,7 +48,7 @@ def parse_to_ast(source_code: str, source_id: int = 0) -> list:
     annotate_python_ast(py_ast, source_code, class_types, source_id)
 
     # Convert to Vyper AST.
-    return vy_ast.get_node(py_ast).body  # type: ignore
+    return vy_ast.get_node(py_ast)  # type: ignore
 
 
 def ast_to_dict(ast_struct: Union[vy_ast.VyperNode, List]) -> Union[Dict, List]:
@@ -102,8 +102,4 @@ def to_python_ast(vyper_ast_node: vy_ast.VyperNode) -> python_ast.AST:
 
 def ast_to_string(vyper_ast_node: vy_ast.VyperNode) -> str:
     py_ast_node = to_python_ast(vyper_ast_node)
-    return python_ast.dump(
-        python_ast.Module(
-            body=py_ast_node
-        )
-    )
+    return python_ast.dump(py_ast_node)

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -48,8 +48,9 @@ def _build_vyper_ast_init_kwargs(
     yield ('end_lineno', node.end_lineno)
     yield ('end_col_offset', node.end_col_offset)
     if hasattr(node, 'src'):
-        yield ('src', node.src)
+        yield ('src', node.src)  # type: ignore
 
+    yield ('ast_type', node.ast_type)  # type: ignore
     if isinstance(node, python_ast.ClassDef):
         yield ('class_type', node.class_type)  # type: ignore
 
@@ -71,17 +72,7 @@ def parse_python_ast(source_code: str,
     if not isinstance(node, python_ast.AST):
         return node
 
-    class_name = node.__class__.__name__
-    if isinstance(node, python_ast.Constant):
-        if node.value is None or isinstance(node.value, bool):
-            class_name = "NameConstant"
-        elif isinstance(node.value, (int, float)):
-            class_name = "Num"
-        elif isinstance(node.value, str):
-            class_name = "Str"
-        elif isinstance(node.value, bytes):
-            class_name = "Bytes"
-
+    class_name = node.ast_type  # type: ignore
     if not hasattr(vy_ast, class_name):
         raise SyntaxException(f'Invalid syntax (unsupported "{class_name}" Python AST node).', node)
 

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -16,77 +16,12 @@ from vyper.exceptions import (
     CompilerPanic,
     ParserException,
     PythonSyntaxException,
-    SyntaxException,
 )
 from vyper.utils import (
     iterable_cast,
 )
 
 DICT_AST_SKIPLIST = ('source_code', )
-
-
-@iterable_cast(list)
-def _build_vyper_ast_list(source_code: str, node: list) -> Generator:
-    for n in node:
-        yield parse_python_ast(
-            source_code=source_code,
-            node=n,
-        )
-
-
-@iterable_cast(dict)
-def _build_vyper_ast_init_kwargs(
-    source_code: str,
-    node: python_ast.AST,
-    vyper_class: vy_ast.VyperNode,
-) -> Generator:
-    yield ('col_offset', node.col_offset)
-    yield ('lineno', node.lineno)
-    yield ('node_id', node.node_id)  # type: ignore
-    yield ('source_code', source_code)
-
-    yield ('end_lineno', node.end_lineno)
-    yield ('end_col_offset', node.end_col_offset)
-    if hasattr(node, 'src'):
-        yield ('src', node.src)  # type: ignore
-
-    yield ('ast_type', node.ast_type)  # type: ignore
-    if isinstance(node, python_ast.ClassDef):
-        yield ('class_type', node.class_type)  # type: ignore
-
-    for field_name in vyper_class.get_slots():
-        if field_name not in vy_ast.BASE_NODE_ATTRIBUTES and hasattr(node, field_name):
-            yield (
-                field_name,
-                parse_python_ast(
-                    source_code=source_code,
-                    node=getattr(node, field_name),
-                )
-            )
-
-
-def parse_python_ast(source_code: str,
-                     node: python_ast.AST) -> vy_ast.VyperNode:
-    if isinstance(node, list):
-        return _build_vyper_ast_list(source_code, node)
-    if not isinstance(node, python_ast.AST):
-        return node
-
-    class_name = node.ast_type  # type: ignore
-    if not hasattr(vy_ast, class_name):
-        raise SyntaxException(f'Invalid syntax (unsupported "{class_name}" Python AST node).', node)
-
-    vyper_class = getattr(vy_ast, class_name)
-    for field_name in vyper_class.only_empty_fields:
-        if field_name in node._fields and getattr(node, field_name, None):
-            raise SyntaxException(
-                f'Invalid Vyper Syntax. "{field_name}" is an unsupported attribute field '
-                f'on Python AST "{class_name}" class.',
-                field_name
-            )
-
-    init_kwargs = _build_vyper_ast_init_kwargs(source_code, node, vyper_class)
-    return vyper_class(**init_kwargs)
 
 
 def parse_to_ast(source_code: str, source_id: int = 0) -> list:
@@ -99,12 +34,9 @@ def parse_to_ast(source_code: str, source_id: int = 0) -> list:
         # TODO: Ensure 1-to-1 match of source_code:reformatted_code SyntaxErrors
         raise PythonSyntaxException(e, source_code) from e
     annotate_python_ast(py_ast, source_code, class_types, source_id)
+
     # Convert to Vyper AST.
-    vy_ast = parse_python_ast(
-        source_code=source_code,
-        node=py_ast,
-    )
-    return vy_ast.body  # type: ignore
+    return vy_ast.get_node(py_ast).body  # type: ignore
 
 
 @iterable_cast(list)
@@ -133,23 +65,11 @@ def ast_to_dict(node: vy_ast.VyperNode) -> dict:
 
 
 def dict_to_ast(ast_struct: dict) -> vy_ast.VyperNode:
-    if isinstance(ast_struct, dict) and 'ast_type' in ast_struct:
-        vyper_class = getattr(vy_ast, ast_struct['ast_type'])
-        klass = vyper_class(**{
-            k: dict_to_ast(v)
-            for k, v in ast_struct.items()
-            if k in vyper_class.get_slots()
-        })
-        return klass
-    elif isinstance(ast_struct, list):
-        return [
-            dict_to_ast(x)
-            for x in ast_struct
-        ]
-    elif ast_struct is None or isinstance(ast_struct, (str, int, bytes, float)):
-        return ast_struct
-    else:
-        raise CompilerPanic(f'Unknown ast_struct provided: "{type(ast_struct)}".')
+    if isinstance(ast_struct, dict):
+        return vy_ast.get_node(ast_struct)
+    if isinstance(ast_struct, list):
+        return [vy_ast.get_node(i) for i in ast_struct]
+    raise CompilerPanic(f'Unknown ast_struct provided: "{type(ast_struct)}".')
 
 
 def to_python_ast(vyper_ast_node: vy_ast.VyperNode) -> python_ast.AST:

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -23,7 +23,7 @@ from vyper.exceptions import (
 
 def parse_to_ast(source_code: str, source_id: int = 0) -> list:
     """
-    Parses a vyper source string and generates vyper AST nodes.
+    Parses a vyper source string and generates basic vyper AST nodes.
 
     Parameters
     ----------
@@ -35,7 +35,7 @@ def parse_to_ast(source_code: str, source_id: int = 0) -> list:
     Returns
     -------
     list
-        Generated vyper AST nodes.
+        Untyped, unoptimized vyper AST nodes.
     """
     if '\x00' in source_code:
         raise ParserException('No null bytes (\\x00) allowed in the source code.')

--- a/vyper/functions/utils.py
+++ b/vyper/functions/utils.py
@@ -20,5 +20,5 @@ def generate_inline_function(code, variables, memory_allocator):
         memory_allocator=memory_allocator,
         origcode=code
     )
-    generated_lll = parse_body(ast_code, new_context)
+    generated_lll = parse_body(ast_code.body, new_context)
     return new_context, generated_lll


### PR DESCRIPTION
### What I did
1. Refactor logic when generating AST nodes.
2. Add / expand docstrings using [NumPy style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy).

This is another step toward #1806.

### How I did it
1. `ast/utils.py`:
   a. Eliminate `parse_python_ast` and `_build_vyper_ast_init_kwargs` methods. Additional fields for the init kwargs is now added to the python nodes during annotation, and the logic around generating the vyper nodes happens within `VyperNode.__init__`.
2. `ast/nodes.py`:
   a. Individual nodes are now created using the `get_node` method. They can be generated from a python node, or dict.
   b. For compatibility with python3.8's  `Constant` node, I added a `_translated_fields` class attribute that remaps `value` to `n` or `s`.
   c. Nodes are converted to dicts using the `VyperNode.to_dict` method.

See the code for more detail.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/74389135-ba4bd380-4e16-11ea-97d5-09942ea1299e.png)

