### PR TITLE
Ast refactor part 3

### DIFF
--- a/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
+++ b/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
@@ -46,7 +46,7 @@ def test_it_annotates_ast_with_source_code():
 
     class AssertSourceCodePresent(AssertionVisitor):
         def assert_about_node(self, node):
-            assert node.source_code is reformatted_code
+            assert node.full_source_code is reformatted_code
 
     AssertSourceCodePresent().visit(contract_ast)
 

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -33,7 +33,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
     def generic_visit(self, node):
         # Decorate every node with the original source code to allow pretty-printing errors
-        node.source_code = self._source_code
+        node.full_source_code = self._source_code
         node.node_id = self.counter
         node.ast_type = node.__class__.__name__
         self.counter += 1
@@ -51,6 +51,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
             start_pos = node.first_token.startpos
             end_pos = node.last_token.endpos
             node.src = f"{start_pos}:{end_pos-start_pos}:{self._source_id}"
+            node.node_source_code = self._source_code[start_pos:end_pos]
 
         return super().generic_visit(node)
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -242,37 +242,53 @@ class keyword(VyperNode):
     __slots__ = ('arg', 'value')
 
 
-class Str(VyperNode):
-    __slots__ = ('s', )
-    _translated_fields = {'value': 's'}
-
-
 class Compare(VyperNode):
     __slots__ = ('comparators', 'ops', 'left', 'right')
 
 
-class Int(VyperNode):
+class Constant(VyperNode):
+    # inherited class for all simple constant node types
+    __slots__ = ()
+
+
+class NameConstant(Constant):
+    __slots__ = ('value', )
+
+
+class Bytes(Constant):
+    __slots__ = ('s', )
+    _translated_fields = {'value': 's'}
+
+
+class Str(Constant):
+    __slots__ = ('s', )
+    _translated_fields = {'value': 's'}
+
+
+class Num(Constant):
+    # inherited class for all numeric constant node types
     __slots__ = ('n', )
+    _translated_fields = {'value': 'n'}
 
 
-class Decimal(VyperNode):
-    __slots__ = ('n', )
+class Int(Num):
+    __slots__ = ()
 
 
-class Hex(VyperNode):
-    __slots__ = ('value', )
+class Decimal(Num):
+    __slots__ = ()
 
 
-class Binary(VyperNode):
-    __slots__ = ('value', )
+class Hex(Num):
+    __slots__ = ()
 
 
-class Octal(VyperNode):
-    __slots__ = ('value', )
+class Binary(Num):
+    __slots__ = ()
 
 
-class NameConstant(VyperNode):
-    __slots__ = ('value', )
+class Octal(Num):
+    __slots__ = ()
 
 
 class Attribute(VyperNode):
@@ -280,6 +296,7 @@ class Attribute(VyperNode):
 
 
 class Op(VyperNode):
+    # inherited class for all operation node types
     __slots__ = ('op', 'left', 'right')
 
 
@@ -301,11 +318,6 @@ class List(VyperNode):
 
 class Dict(VyperNode):
     __slots__ = ('keys', 'values')
-
-
-class Bytes(VyperNode):
-    __slots__ = ('s', )
-    _translated_fields = {'value': 's'}
 
 
 class Add(VyperNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -20,12 +20,13 @@ BASE_NODE_ATTRIBUTES = (
     'col_offset',
     'end_col_offset',
     'end_lineno',
+    'full_source_code',
     'lineno',
     'node_id',
-    'source_code',
+    'node_source_code',
     'src',
 )
-DICT_AST_SKIPLIST = ('source_code', )
+DICT_AST_SKIPLIST = ('full_source_code', 'node_source_code')
 
 
 def get_node(
@@ -153,7 +154,7 @@ class VyperNode:
         class_repr = f'{cls.__module__}.{cls.__qualname__}'
 
         source_annotation = annotate_source_code(
-            self.source_code,
+            self.full_source_code,
             self.lineno,
             self.col_offset,
             context_lines=VYPER_ERROR_CONTEXT_LINES,

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -269,6 +269,7 @@ class Num(Constant):
     # inherited class for all numeric constant node types
     __slots__ = ('n', )
     _translated_fields = {'value': 'n'}
+    _python_ast_type = "Num"
 
 
 class Int(Num):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -251,9 +251,24 @@ class Compare(VyperNode):
     __slots__ = ('comparators', 'ops', 'left', 'right')
 
 
-class Num(VyperNode):
+class Int(VyperNode):
     __slots__ = ('n', )
-    _translated_fields = {'value': 'n'}
+
+
+class Decimal(VyperNode):
+    __slots__ = ('n', )
+
+
+class Hex(VyperNode):
+    __slots__ = ('value', )
+
+
+class Binary(VyperNode):
+    __slots__ = ('value', )
+
+
+class Octal(VyperNode):
+    __slots__ = ('value', )
 
 
 class NameConstant(VyperNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -99,7 +99,7 @@ class VyperNode:
     _only_empty_fields: typing.Tuple = ()
     _translated_fields: typing.Dict = {}
 
-    def __init__(self, parent: typing.Optional["VyperNode"] = None, **kwargs):
+    def __init__(self, parent: typing.Optional["VyperNode"] = None, **kwargs: dict):
         """
         AST node initializer method.
 
@@ -114,7 +114,7 @@ class VyperNode:
             Dictionary of fields to be included within the node.
         """
         self._parent = parent
-        self._children = set()
+        self._children: set = set()
 
         for field_name, value in kwargs.items():
             if field_name in self._translated_fields:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -14,6 +14,8 @@ from vyper.utils import (
 )
 
 BASE_NODE_ATTRIBUTES = (
+    '_children',
+    '_parent',
     'ast_type',
     'col_offset',
     'end_col_offset',
@@ -26,7 +28,10 @@ BASE_NODE_ATTRIBUTES = (
 DICT_AST_SKIPLIST = ('source_code', )
 
 
-def get_node(ast_struct: typing.Union[typing.Dict, python_ast.AST]) -> "VyperNode":
+def get_node(
+    ast_struct: typing.Union[typing.Dict, python_ast.AST],
+    parent: typing.Optional["VyperNode"] = None
+) -> "VyperNode":
     """
     Converts an AST structure to a vyper AST node.
 
@@ -37,6 +42,8 @@ def get_node(ast_struct: typing.Union[typing.Dict, python_ast.AST]) -> "VyperNod
     ----------
     ast_struct: (dict, AST)
         Annotated python AST node or vyper AST dict to generate the node from.
+    parent: VyperNode, optional
+        Parent node of the node being created.
 
     Returns
     -------
@@ -54,12 +61,12 @@ def get_node(ast_struct: typing.Union[typing.Dict, python_ast.AST]) -> "VyperNod
             ast_struct
         )
 
-    return vy_class(**ast_struct)
+    return vy_class(parent=parent, **ast_struct)
 
 
-def _to_node(value):
+def _to_node(value, parent):
     if isinstance(value, (dict, python_ast.AST)):
-        return get_node(value)
+        return get_node(value, parent)
     return value
 
 
@@ -91,7 +98,7 @@ class VyperNode:
     _only_empty_fields: typing.Tuple = ()
     _translated_fields: typing.Dict = {}
 
-    def __init__(self, **kwargs):
+    def __init__(self, parent: typing.Optional["VyperNode"] = None, **kwargs):
         """
         AST node initializer method.
 
@@ -100,9 +107,13 @@ class VyperNode:
 
         Parameters
         ----------
+        parent: VyperNode, optional
+            Node which contains this node.
         **kwargs : dict
             Dictionary of fields to be included within the node.
         """
+        self._parent = parent
+        self._children = set()
 
         for field_name, value in kwargs.items():
             if field_name in self._translated_fields:
@@ -110,9 +121,9 @@ class VyperNode:
 
             if field_name in self.get_slots():
                 if isinstance(value, list):
-                    value = [_to_node(i) for i in value]
+                    value = [_to_node(i, self) for i in value]
                 else:
-                    value = _to_node(value)
+                    value = _to_node(value, self)
                 setattr(self, field_name, value)
 
             elif value and field_name in self._only_empty_fields:
@@ -120,6 +131,14 @@ class VyperNode:
                     f'Unsupported non-empty value (valid in Python, but invalid in Vyper) \n'
                     f' field_name: {field_name}, class: {type(self)} value: {value}'
                 )
+
+        # add to children of parent last to ensure an accurate hash is generated
+        if parent is not None:
+            parent._children.add(self)
+
+    def __hash__(self):
+        values = [getattr(self, i, None) for i in BASE_NODE_ATTRIBUTES if not i.startswith('_')]
+        return hash(tuple(values))
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
@@ -148,7 +167,8 @@ class VyperNode:
         """
         Returns a set of field names for this node.
         """
-        return set(x for i in cls.__mro__ for x in getattr(i, '__slots__', []))
+        slot_fields = [x for i in cls.__mro__ for x in getattr(i, '__slots__', [])]
+        return set(i for i in slot_fields if not i.startswith('_'))
 
     def to_dict(self) -> typing.Dict:
         """

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -86,9 +86,9 @@ def to_python_ast(vyper_ast_node: vy_ast.VyperNode) -> python_ast.AST:
         ]
     elif isinstance(vyper_ast_node, vy_ast.VyperNode):
 
-        class_name = vyper_ast_node.ast_type
+        class_name = vyper_ast_node.ast_type  # type: ignore
         if hasattr(vyper_ast_node, "_python_ast_type"):
-            class_name = vyper_ast_node._python_ast_type
+            class_name = vyper_ast_node._python_ast_type  # type: ignore
 
         if hasattr(python_ast, class_name):
             py_klass = getattr(python_ast, class_name)

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -85,7 +85,11 @@ def to_python_ast(vyper_ast_node: vy_ast.VyperNode) -> python_ast.AST:
             for n in vyper_ast_node
         ]
     elif isinstance(vyper_ast_node, vy_ast.VyperNode):
-        class_name = vyper_ast_node.ast_type  # type: ignore
+
+        class_name = vyper_ast_node.ast_type
+        if hasattr(vyper_ast_node, "_python_ast_type"):
+            class_name = vyper_ast_node._python_ast_type
+
         if hasattr(python_ast, class_name):
             py_klass = getattr(python_ast, class_name)
             return py_klass(**{

--- a/vyper/functions/signatures.py
+++ b/vyper/functions/signatures.py
@@ -11,9 +11,6 @@ from vyper.exceptions import (
 from vyper.parser.expr import (
     Expr,
 )
-from vyper.parser.parser_utils import (
-    get_original_if_0_prefixed,
-)
 from vyper.types import (
     BaseType,
     ByteArrayType,
@@ -42,10 +39,10 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
         if expected_arg == 'num_literal':
             if context.constants.is_constant_of_base_type(arg, ('uint256', 'int128')):
                 return context.constants.get_constant(arg.id, None).value
-            if isinstance(arg, vy_ast.Num) and get_original_if_0_prefixed(arg, context) is None:
+            if isinstance(arg, (vy_ast.Int, vy_ast.Decimal)):
                 return arg.n
         elif expected_arg == 'str_literal':
-            if isinstance(arg, vy_ast.Str) and get_original_if_0_prefixed(arg, context) is None:
+            if isinstance(arg, vy_ast.Str):
                 bytez = b''
                 for c in arg.s:
                     if ord(c) >= 256:

--- a/vyper/parser/constants.py
+++ b/vyper/parser/constants.py
@@ -43,7 +43,7 @@ class Constants(object):
             Context(
                 vars=None,
                 global_ctx=global_ctx,
-                origcode=const.source_code,
+                origcode=const.full_source_code,
                 memory_allocator=MemoryAllocator()
             ),
         )

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -511,7 +511,8 @@ class Expr(object):
                 )
 
             num = vy_ast.Num(n=val)
-            num.source_code = self.expr.source_code
+            num.full_source_code = self.expr.full_source_code
+            num.node_source_code = self.expr.node_source_code
             num.lineno = self.expr.lineno
             num.col_offset = self.expr.col_offset
             num.end_lineno = self.expr.end_lineno

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -79,26 +79,6 @@ def get_number_as_fraction(expr, context):
     return context_slice, top, bottom
 
 
-# Is a number of decimal form (e.g. 65281) or 0x form (e.g. 0xff01) or 0b binary form (e.g. 0b0001)
-def get_original_if_0_prefixed(expr, context):
-    context_slice = context.origcode.splitlines()[expr.lineno - 1][expr.col_offset:]
-    type_prefix = context_slice[:2]
-
-    if type_prefix not in ('0x', '0b'):
-        return None
-
-    if type_prefix == '0x':
-        t = 0
-        while t + 2 < len(context_slice) and context_slice[t + 2] in '0123456789abcdefABCDEF':
-            t += 1
-        return context_slice[:t + 2]
-    elif type_prefix == '0b':
-        t = 0
-        while t + 2 < len(context_slice) and context_slice[t + 2] in '01':
-            t += 1
-        return context_slice[:t + 2]
-
-
 # Copies byte array
 def make_byte_array_copier(destination, source, pos=None):
     if not isinstance(source.typ, (ByteArrayLike, NullType)):

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -463,8 +463,7 @@ def validate_default_values(node):
         return
     if isinstance(node, vy_ast.Attribute) and node.value.id in parser.expr.ENVIRONMENT_VARIABLES:
         return
-    allowed_types = (vy_ast.Num, vy_ast.Str, vy_ast.Bytes, vy_ast.List, vy_ast.NameConstant)
-    if not isinstance(node, allowed_types):
+    if not isinstance(node, (vy_ast.Constant, vy_ast.List)):
         raise FunctionDeclarationException(
             "Default value must be a literal, built-in constant, or environment variable.",
             node

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -68,7 +68,7 @@ def abi_type_to_ast(atype, expected_size):
         # expected_size is the maximum length for inputs, minimum length for outputs
         return vy_ast.Subscript(
             value=vy_ast.Name(id=atype),
-            slice=vy_ast.Index(value=vy_ast.Num(n=expected_size))
+            slice=vy_ast.Index(value=vy_ast.Int(n=expected_size))
         )
     else:
         raise ParserException(f'Type {atype} not supported by vyper.')

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -287,7 +287,7 @@ def parse_unit(item, custom_units):
         if (item.id not in VALID_UNITS) and (custom_units is not None) and (item.id not in custom_units):  # noqa: E501
             raise InvalidTypeException("Invalid base unit", item)
         return {item.id: 1}
-    elif isinstance(item, vy_ast.Num) and item.n == 1:
+    elif isinstance(item, vy_ast.Int) and item.n == 1:
         return {}
     elif not isinstance(item, vy_ast.BinOp):
         raise InvalidTypeException("Invalid unit expression", item)
@@ -300,7 +300,7 @@ def parse_unit(item, custom_units):
     elif isinstance(item.op, vy_ast.Pow):
         if not isinstance(item.left, vy_ast.Name):
             raise InvalidTypeException("Can only raise a base type to an exponent", item)
-        if not isinstance(item.right, vy_ast.Num) or not isinstance(item.right.n, int) or item.right.n <= 0:  # noqa: E501
+        if not isinstance(item.right, vy_ast.Int) or not isinstance(item.right.n, int) or item.right.n <= 0:  # noqa: E501
             raise InvalidTypeException("Exponent must be positive integer", item)
         return {item.left.id: item.right.n}
     else:
@@ -428,7 +428,7 @@ def parse_type(item, location, sigs=None, custom_units=None, custom_structs=None
             )
         # Fixed size lists or bytearrays, e.g. num[100]
         is_constant_val = constants.ast_is_constant(item.slice.value)
-        if isinstance(item.slice.value, vy_ast.Num) or is_constant_val:
+        if isinstance(item.slice.value, vy_ast.Int) or is_constant_val:
             n_val = (
                 constants.get_constant(item.slice.value.id, context=None).value
                 if is_constant_val


### PR DESCRIPTION
### What I did
Step three and (hopefully) my last major PR related to ASTs prior to starting on #1806 properly.

1. Link vyper nodes to one another via `_parent` and `_children` members.  This is a first step toward methods for traversing the node which should be in my next PR.
2. Add `node_source_code` member to nodes, and move `source_code` to `full_source_code`.
3. Split vyper `Num` node class into `Int`, `Decimal`, `Binary`, `Hex` and `Octal`, refactor accordingly.

### How I did it
1. When generating nodes, the parent node includes itself during as an arg the call to `get_node`. The child node then adds itself to the parent's `_children` set at the end of it's `__init__` method.
2. `node_source_code` is generated using the end offsets that are made available by `asttokens`. This is useful in a few places, notably determining the actual value for hexadecimal or binary integers.
3.
   a. `Hex`, `Binary` and `Octal` types are determined if the associated source offset is prefixed with `0x`, `0b`, or `0o`. In each of these cases, python will not parse invalid values and so we can rely on the prefix as validation.
   b. `Decimal` and `Int` are determined by checking if the type of `Num.n` is `float` or `int`.
   c. I added a class member `_python_ast_type` to allow converting back to python AST types.
   d. I added base node types `Num` (which all of the new types inherit) and `Constant` (also inherited by `String`, `NameConstant`, and `Bytes`) to simplify usage of `isinstance`.

### How to verify it
Run the tests.

Also check out how much cleaner `parser/expr.py` looks because of the new types :) There are likely many other places we could refactor to utilize them, for now I only made enough edits to get the tests passing. I don't want to start rewriting other code yet in case it becomes redundant once type checking is done.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/74566921-0a00db00-4f8e-11ea-8057-04709109f2e3.png)
