### PR TITLE
Expand and document custom exceptions

### DIFF
--- a/docs/compiler-exceptions.rst
+++ b/docs/compiler-exceptions.rst
@@ -14,7 +14,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
 
 .. py:exception:: ArrayIndexException
 
-    This exception will occur when an invalid index number of an array is referenced.  The terminal will point out the line 
+    This exception will occur when an invalid index number of an array is referenced.  The terminal will point out the line
     which contains the error.
 
 .. py:exception:: ConstancyViolationException
@@ -63,10 +63,10 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
             deposit: msg.value
         })
             self.bidCounts[msg.sender] += 1
-    
+
         pendingReturns: map(address, wei_value)
 
-    ``FunctionDeclarationException`` happens when a function name is used for two different functions or when a reserved word 
+    ``FunctionDeclarationException`` happens when a function name is used for two different functions or when a reserved word
     is used to name a function.
 
     .. code-block:: bash
@@ -78,7 +78,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         vyper.exceptions.FunctionDeclarationException: Function name shadowing a variable name: pendingReturns
 
     The warning generated in the terminal does not specify any line numbers.  ``pendingReturns`` is named as the identifier
-    used incorrectly to declare the function throwing the error.  
+    used incorrectly to declare the function throwing the error.
 
 .. py:exception:: InvalidLiteralException
 
@@ -87,7 +87,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         @public
         def foo():
             bar: address = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
-        
+
     Raised when attempting to use a literal value where the type is correct, but the value is still invalid in some way. For example, an address that is not check-summed.
 
 .. py:exception:: InvalidTypeException
@@ -97,13 +97,13 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         bids: map(address, Bid[128])
         bidCounts: map(adddress, int128)
 
-    The variable type ``address`` is misspelled.  Any word that is not a reserved word, and declares a variable type will 
+    The variable type ``address`` is misspelled.  Any word that is not a reserved word, and declares a variable type will
     return this error.
 
     .. code-block:: bash
 
-        $ vyper blind_auction.vy 
-        Error compiling: blind.auction.vy /usr/lib/python3/dist-packages/apport/report.py:13: 
+        $ vyper blind_auction.vy
+        Error compiling: blind.auction.vy /usr/lib/python3/dist-packages/apport/report.py:13:
         DeprecationWarning: the imp module is deprecated in favour of
         importlib; see the module's documentation for alternative uses
         import fnmatch, glob, traceback, errno, sys, atexit, locale, imp
@@ -127,7 +127,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         @private
         def _foo():
             bar: uint256 = msg.value
-       
+
     Raised when attempting to access ``msg.value`` from within a private function.
 
 .. py:exception:: ParserException
@@ -147,20 +147,6 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         ---> 3 def foo(a: address = msg.sender): pass
         ----------------------------^
 
-    See ``PythonSyntaxException``.  This error is not commonly used and typically refers to an error of one of the other types.
-
-.. py:exception:: PythonSyntaxException
-
-    .. code-block:: python3
-
-        >>> while True print('Hello world')
-            File "<stdin>", line 1
-            while True print('Hello world')
-                   ^
-            SyntaxError: invalid syntax
-     
-    This exception is raised due to a python based syntax exception.  It is also known as a parser exception.  In this case there is a colon missing after the word print.  See `Python Errors and Exceptions <https://docs.python.org/3/tutorial/errors.html>`_ for more details.
-
 .. py:exception:: StructureException
 
     .. code-block:: python3
@@ -170,7 +156,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
 
         '''
 
-    The inclusion of punctuation that is syntactically incorrect and not a part of the normal vyper flow will throw a 
+    The inclusion of punctuation that is syntactically incorrect and not a part of the normal vyper flow will throw a
     ``StructureException``.
 
     .. code-block:: bash
@@ -179,27 +165,21 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
              180
         ---> 181 '''
         ---------^
-             182  
+             182
     The terminal displays the line number and points directly to the problem.
 
 .. py:exception:: SyntaxException
 
-    .. code-block:: python3
-
-        struct Bid:
-            blindedBid bytes32
-            deposit: wei_value
-
-    A syntax error is thrown in the declaration of this ``struct`` variable.
+    Raised due to invalid syntax within a contract.
 
     .. code-block:: bash
 
-            $ vyper blind_auction.vy
-            vyper.exceptions.PythonSyntaxException: line 4:20 SyntaxError: invalid syntax
-                 3 struct Bid:
-            ---> 4   blindedBid bytes32
-            ---------------------------^
-                 5   deposit: wei_value
+        $ vyper blind_auction.vy
+        vyper.exceptions.SyntaxException: line 4:20 SyntaxError: invalid syntax
+                3 struct Bid:
+        ---> 4   blindedBid bytes32
+        ---------------------------^
+                5   deposit: wei_value
 
     The terminal output of a syntax error will generally show exactly where it happened.  In this case there is a semi
     colon missing after ``blindedBid`` in the declaration of the struct.
@@ -213,7 +193,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         a: uint256 = 42
         b: bytes32 = a
 
-    This exception occurs when a variable is assigned a value that is inconsistent with the type. 
+    This exception occurs when a variable is assigned a value that is inconsistent with the type.
 
     .. code-block:: bash
 
@@ -232,7 +212,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         # Final auction state
         highestBid: public(wei_value)
         highestBidder: public(address)
-    
+
         @private
         def placeBid(bidder: address, value: wei_value) -> bool:
         # If bid is less than highest bid, bid fails
@@ -266,7 +246,7 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
 
 .. py:exceptions:: ZeroDivisionException
 
-    This exception will occur when a divide by zero or ``modulo`` zero situation arises.  The terminal will point out the line 
+    This exception will occur when a divide by zero or ``modulo`` zero situation arises.  The terminal will point out the line
     which contains the error.
 
 CompilerPanic
@@ -276,12 +256,12 @@ CompilerPanic
 
     .. code-block:: python3
 
-        $ vyper v.vy 
+        $ vyper v.vy
         Error compiling: v.vy
         vyper.exceptions.CompilerPanic: Number of times repeated
         must be a constant nonzero positive integer: 0 Please create an issue.
 
-    A compiler panic error indicates that there is a problem internally to the compiler and an issue should be reported right 
+    A compiler panic error indicates that there is a problem internally to the compiler and an issue should be reported right
     away on the Vyper Github page.  Open an issue if you are experiencing this error. Please `Open an Issue <https://github.com/vyperlang/vyper/issues>`_
 
 

--- a/docs/compiler-exceptions.rst
+++ b/docs/compiler-exceptions.rst
@@ -1,86 +1,46 @@
-.. index:: compiling, compiler, InvalidTypeException, common, exceptions, StructureException, ConstancyViolationException, NonPayableViolationException, InvalidLiteralException, TypeMismatchException, EventDeclarationException, VersionException, SyntaxException, ArrayIndexException, ZeroDivisionException, EvmVersionException, CompilerPanic, VariableDeclarationException
+.. _compiler-exceptions:
 
 Compiler Exceptions
-*******************
+###################
 
-.. _exceptions-common::
+.. _exceptions-common:
 
-Compiler Exceptions
-===================
+Vyper raises one or more of the following exceptions when an issue is encountered while compiling a contract.
 
-These are examples of the compiler exception errors that you could see when
-compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
+Whenever possible, exceptions include a source highlight displaying the location
+of the error within the code:
 
+.. code-block:: python
+
+    vyper.exceptions.VariableDeclarationException: line 79:17 Persistent variable undeclared: highstBid
+         78     # If bid is less than highest bid, bid fails
+    ---> 79     if (value <= self.highstBid):
+    -------------------------^
+         80         return False
 
 .. py:exception:: ArrayIndexException
 
-    This exception will occur when an invalid index number of an array is referenced.  The terminal will point out the line
-    which contains the error.
+    Raises when an array index is out of bounds.
 
 .. py:exception:: ConstancyViolationException
 
-    This exception occurs when a variable or function that is returning a constant has another instance that is trying
-    to change the value.
+    Raises when attempting to modify state from inside a function marked as constant.
 
 .. py:exception:: EventDeclarationException
 
-    This exception will occur when the identifier used to declare an event is in conflict with a reserved word
-    or previously declared structure with the same name.  The terminal output will state the line which contains the error.
+    Raises when an event declaration is invalid.
 
 .. py:exception:: EMVVersionException
 
-    .. code-block:: python3
-
-        {
-            "settings": {
-                "evmVersion": "[VERSION]"
-            }
-        }
-
-    Default version is ``istanbul``.  Other version choices include ``byzantium``, ``constantinople``, and ``petersburg``.  This
-    exception will occur when the compiler version is not compatible with the EVM version declared in the code.
+    Raises when a contract contains an action that cannot be performed with the active EVM ruleset.
 
 .. py:exception:: FunctionDeclarationException
 
-    .. code-block:: python3
-
-        struct Bid:
-            blindedBid: bytes32
-            deposit: wei_value
-        @public
-        @payable
-            def pendingReturns(_blindedBid: bytes32):
-        # Check if bidding period is still open
-        assert block.timestamp < self.biddingEnd
-
-        # Check that payer hasn't already placed maximum number of bids
-        numBids: int128 = self.bidCounts[msg.sender]
-        assert numBids < MAX_BIDS
-
-        # Add bid to mapping of all bids
-        self.bids[msg.sender][numBids] = Bid({
-            blindedBid: _blindedBid,
-            deposit: msg.value
-        })
-            self.bidCounts[msg.sender] += 1
-
-        pendingReturns: map(address, wei_value)
-
-    ``FunctionDeclarationException`` happens when a function name is used for two different functions or when a reserved word
-    is used to name a function.
-
-    .. code-block:: bash
-
-        $ vyper blind_auction.vy
-        Error compiling: blind_auction.vy
-        /usr/lib/python3/dist-packages/apport/report.py:13: DeprecationWarning: the imp module is deprecated in favour of             importlib; see the module's documentation for alternative uses
-        import fnmatch, glob, traceback, errno, sys, atexit, locale, imp
-        vyper.exceptions.FunctionDeclarationException: Function name shadowing a variable name: pendingReturns
-
-    The warning generated in the terminal does not specify any line numbers.  ``pendingReturns`` is named as the identifier
-    used incorrectly to declare the function throwing the error.
+    Raises when a function declaration is invalid.
 
 .. py:exception:: InvalidLiteralException
+
+    Raises when attempting to use a literal value where the type is correct, but the value is still invalid in some way. For example, an address that is not check-summed.
 
     .. code-block:: python3
 
@@ -88,39 +48,39 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         def foo():
             bar: address = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
-    Raised when attempting to use a literal value where the type is correct, but the value is still invalid in some way. For example, an address that is not check-summed.
-
 .. py:exception:: InvalidTypeException
+
+    Raises when attempting to assign to an invalid type, or perform an action on a variable of the wrong type.
 
     .. code-block:: python3
 
         bids: map(address, Bid[128])
-        bidCounts: map(adddress, int128)
+        bidCounts: map(addres, int128)
 
-    The variable type ``address`` is misspelled.  Any word that is not a reserved word, and declares a variable type will
+    In the above example, the variable type ``address`` is misspelled.  Any word that is not a reserved word, and declares a variable type will
     return this error.
 
     .. code-block:: bash
 
         $ vyper blind_auction.vy
         Error compiling: blind.auction.vy /usr/lib/python3/dist-packages/apport/report.py:13:
-        DeprecationWarning: the imp module is deprecated in favour of
-        importlib; see the module's documentation for alternative uses
-        import fnmatch, glob, traceback, errno, sys, atexit, locale, imp
-        vyper.exceptions.InvalidTypeException: line 28:15 Invalid base type: adddress
+        vyper.exceptions.InvalidTypeException: line 28:15 Invalid base type: addres
                  27 bids: map(address, Bid[128])
-            ---> 28 bidCounts: map(adddress, int128)
+            ---> 28 bidCounts: map(addres, int128)
             -----------------------^
                  29
 
-    The terminal returns a compiling error warning.  Reading the entire warning is critical to understanding exactly what
-    is causing the error.  The message displays the line numbers that contain the error.  In this example ``map(_KeyType, _ValueType)`` cannot compile because the type ``address`` is misspelled.
-
 .. py:exception:: JSONError
 
-    Vyper has the ability to pass information back and forth using JSON.  If you are using JSON and receiving a JSON error then you can find out more details about the error at `Oracle JSON Errors <https://docs.python.org/3/tutorial/errors.html>`_.
+    Raises when the compiler JSON input is malformed.
+
+.. py:exception:: NamespaceCollision
+
+    Raises when attempting to assign a variable to a name that is already in use.
 
 .. py:exception:: NonPayableViolationException
+
+    Raises when attempting to access ``msg.value`` from within a private function.
 
     .. code-block:: python3
 
@@ -128,36 +88,13 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         def _foo():
             bar: uint256 = msg.value
 
-    Raised when attempting to access ``msg.value`` from within a private function.
+.. py:exception:: OverflowException
 
-.. py:exception:: ParserException
-
-    .. code-block:: python3
-
-        @private
-        def foo(a: address = msg.sender):
-            pass
-
-    This function is invalid because ``msg.sender`` cannot be accessed inside of a private function.
-
-    .. code-block:: bash
-
-        vyper.exceptions.ParserException: line 3:21 msg.sender not allowed in private functions.
-             2 @private
-        ---> 3 def foo(a: address = msg.sender): pass
-        ----------------------------^
+    Raises when a numeric value is out of bounds for the given type.
 
 .. py:exception:: StructureException
 
-    .. code-block:: python3
-
-        # Transfer funds to beneficiary
-        send(self.beneficiary, self.highestBid)
-
-        '''
-
-    The inclusion of punctuation that is syntactically incorrect and not a part of the normal vyper flow will throw a
-    ``StructureException``.
+    Raises on syntax that is parsable, but invalid in some way.
 
     .. code-block:: bash
 
@@ -166,34 +103,23 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
         ---> 181 '''
         ---------^
              182
-    The terminal displays the line number and points directly to the problem.
 
 .. py:exception:: SyntaxException
 
-    Raised due to invalid syntax within a contract.
+    Raises on invalid syntax that cannot be parsed.
 
     .. code-block:: bash
 
         $ vyper blind_auction.vy
-        vyper.exceptions.SyntaxException: line 4:20 SyntaxError: invalid syntax
+        vyper.exceptions.SyntaxException: line 4:20 invalid syntax
                 3 struct Bid:
         ---> 4   blindedBid bytes32
         ---------------------------^
                 5   deposit: wei_value
 
-    The terminal output of a syntax error will generally show exactly where it happened.  In this case there is a semi
-    colon missing after ``blindedBid`` in the declaration of the struct.
-
 .. py:exception:: TypeMismatchException
 
-    .. code-block:: python3
-
-        @public
-        def foo():
-        a: uint256 = 42
-        b: bytes32 = a
-
-    This exception occurs when a variable is assigned a value that is inconsistent with the type.
+    Raises when attempting to perform an action between multiple objects of incompatible types.
 
     .. code-block:: bash
 
@@ -204,55 +130,34 @@ compiling a ``vyper`` file for deployment on the Ethereum Virtual Machine.
 
     ``b`` has been set as type ``bytes32`` but the assignment is to ``a`` which is ``uint256``.
 
+.. py:exception:: UndeclaredDefinition
+
+    Raises when attempting to access an object that has not been declared.
 
 .. py:exception:: VariableDeclarationException
 
-    .. code-block:: python3
-
-        # Final auction state
-        highestBid: public(wei_value)
-        highestBidder: public(address)
-
-        @private
-        def placeBid(bidder: address, value: wei_value) -> bool:
-        # If bid is less than highest bid, bid fails
-        if (value <= self.highstBid):
-            return False
-
-    ``VariableDeclarationException`` is a compiling error in which a variable is being used that has not been declared.
+    Raises on an invalid variable declaration.
 
     .. code-block:: bash
 
-        $ vyper blind_auction.vy
-        Error compiling: blind_auction.vy
-        /usr/lib/python3/dist-packages/apport/report.py:13: DeprecationWarning: the imp module is deprecated in favour of             importlib; see the module's documentation for alternative uses import fnmatch, glob, traceback, errno, sys, atexit,           locale, imp
         vyper.exceptions.VariableDeclarationException: line 79:17 Persistent variable undeclared: highstBid
              78     # If bid is less than highest bid, bid fails
         ---> 79     if (value <= self.highstBid):
-        ------------------------^
+        -------------------------^
              80         return False
-
-    ``self.highestBid`` is using a misspelled modified version of the public variable ``highestBidder``.
 
 .. py:exception:: VersionException
 
-    .. code-block:: python3
+    Raises when a contract version string is malformed or incompatible with the current compiler version.
 
-        @version 0.1.0b13
+.. py:exception:: ZeroDivisionException
 
-    This exception will happen when a version pragma is being compiled with a future compiler.  Version pragma
-    declaration should be the first line of the file.
-
-
-.. py:exceptions:: ZeroDivisionException
-
-    This exception will occur when a divide by zero or ``modulo`` zero situation arises.  The terminal will point out the line
-    which contains the error.
+    Raises when a divide by zero or modulo zero situation arises.
 
 CompilerPanic
 =============
 
-.. py:exception:: CompilerPanicException
+.. py:exception:: CompilerPanic
 
     .. code-block:: python3
 
@@ -263,5 +168,3 @@ CompilerPanic
 
     A compiler panic error indicates that there is a problem internally to the compiler and an issue should be reported right
     away on the Vyper Github page.  Open an issue if you are experiencing this error. Please `Open an Issue <https://github.com/vyperlang/vyper/issues>`_
-
-

--- a/tests/cli/vyper_json/test_compile_from_input_dict.py
+++ b/tests/cli/vyper_json/test_compile_from_input_dict.py
@@ -15,7 +15,7 @@ from vyper.cli.vyper_json import (
 )
 from vyper.exceptions import (
     JSONError,
-    PythonSyntaxException,
+    SyntaxException,
     TypeMismatchException,
 )
 
@@ -86,7 +86,7 @@ def test_wrong_language():
 def test_exc_handler_raises_syntax():
     input_json = deepcopy(INPUT_JSON)
     input_json['sources']['badcode.vy'] = {'content': BAD_SYNTAX_CODE}
-    with pytest.raises(PythonSyntaxException):
+    with pytest.raises(SyntaxException):
         compile_from_input_dict(input_json, exc_handler_raises)
 
 
@@ -98,7 +98,7 @@ def test_exc_handler_to_dict_syntax():
     assert len(result['errors']) == 1
     error = result['errors'][0]
     assert error['component'] == "parser"
-    assert error['type'] == "PythonSyntaxException"
+    assert error['type'] == "SyntaxException"
 
 
 def test_exc_handler_raises_compiler():

--- a/tests/parser/exceptions/test_vyper_exception_pos.py
+++ b/tests/parser/exceptions/test_vyper_exception_pos.py
@@ -3,15 +3,15 @@ from pytest import (
 )
 
 from vyper.exceptions import (
-    ParserException,
+    VyperException,
 )
 
 
 def test_type_exception_pos():
     pos = (1, 2)
 
-    with raises(ParserException) as e:
-        raise ParserException('Fail!', pos)
+    with raises(VyperException) as e:
+        raise VyperException('Fail!', pos)
 
     assert e.value.lineno == 1
     assert e.value.col_offset == 2

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -1,7 +1,7 @@
 from vyper.exceptions import (
     ConstancyViolationException,
     InvalidLiteralException,
-    ParserException,
+    SyntaxException,
     TypeMismatchException,
 )
 
@@ -129,7 +129,7 @@ def foo2() -> uint256:
     x = 3 ^ 3  # invalid operator
     return x
 """
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), ParserException)
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), SyntaxException)
 
 
 # See #838. Confirm that nested keys and structs work properly.

--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -7,7 +7,7 @@ from vyper.exceptions import (
     FunctionDeclarationException,
     InvalidLiteralException,
     NonPayableViolationException,
-    ParserException,
+    StructureException,
     TypeMismatchException,
 )
 
@@ -311,7 +311,7 @@ def foo(a: uint256 = msg.value): pass
 # msg.sender in a private function
 @private
 def foo(a: address = msg.sender): pass
-    """, ParserException),
+    """, StructureException),
 ]
 
 

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -7,7 +7,7 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
-    PythonSyntaxException,
+    SyntaxException,
     TypeMismatchException,
 )
 
@@ -22,7 +22,7 @@ def foo():
 @public
 def foo():
     True = 3
-    """, PythonSyntaxException),
+    """, SyntaxException),
     """
 @public
 def foo():

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -7,7 +7,7 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
-    PythonSyntaxException,
+    SyntaxException,
 )
 
 fail_list = [
@@ -21,7 +21,7 @@ def foo():
 
 @pytest.mark.parametrize('bad_code', fail_list)
 def test_type_mismatch_exception(bad_code):
-    with raises(PythonSyntaxException):
+    with raises(SyntaxException):
         compiler.compile_code(bad_code)
 
 

--- a/tests/parser/syntax/test_functions_call.py
+++ b/tests/parser/syntax/test_functions_call.py
@@ -7,7 +7,6 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
-    ParserException,
     StructureException,
 )
 
@@ -25,7 +24,7 @@ def foo() -> uint256:
     return convert(2, uint256)
 
     """,
-    ("""
+    """
 @private
 def test(a : uint256):
     pass
@@ -34,19 +33,15 @@ def test(a : uint256):
 @public
 def burn(_value: uint256):
     self.test(msg.sender._value)
-    """, ParserException)
+    """,
 ]
 
 
 @pytest.mark.parametrize('bad_code', fail_list)
 def test_functions_call_fail(bad_code):
 
-    if isinstance(bad_code, tuple):
-        with raises(bad_code[1]):
-            compiler.compile_code(bad_code[0])
-    else:
-        with raises(StructureException):
-            compiler.compile_code(bad_code)
+    with raises(StructureException):
+        compiler.compile_code(bad_code)
 
 
 valid_list = [

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -7,7 +7,7 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
-    PythonSyntaxException,
+    SyntaxException,
     TypeMismatchException,
 )
 
@@ -16,7 +16,7 @@ fail_list = [
 @public
 def foo():
     x: bytes[9] = raw_call(0x1234567890123456789012345678901234567890, b"cow", outsize=4, outsize=9)
-    """, PythonSyntaxException),
+    """, SyntaxException),
     """
 @public
 def foo():

--- a/tests/parser/types/test_identifier_naming.py
+++ b/tests/parser/types/test_identifier_naming.py
@@ -2,7 +2,7 @@ import pytest
 
 from vyper.exceptions import (
     FunctionDeclarationException,
-    PythonSyntaxException,
+    SyntaxException,
     VariableDeclarationException,
 )
 from vyper.functions import (
@@ -33,14 +33,14 @@ def test():
     {constant}: int128 = 31337
     """
     assert_compile_failed(lambda: get_contract(code),
-                          (PythonSyntaxException, VariableDeclarationException))
+                          (SyntaxException, VariableDeclarationException))
 
 
 @pytest.mark.parametrize('constant', sorted(ALL_RESERVED_KEYWORDS))
 def test_reserved_keywords_storage(constant, get_contract, assert_compile_failed):
     code = f"{constant}: int128"
     assert_compile_failed(lambda: get_contract(code),
-                          (PythonSyntaxException, VariableDeclarationException))
+                          (SyntaxException, VariableDeclarationException))
 
 
 @pytest.mark.parametrize('constant', sorted(ALL_RESERVED_KEYWORDS))
@@ -51,7 +51,7 @@ def test({constant}: int128):
     pass
     """
     assert_compile_failed(lambda: get_contract(code),
-                          (PythonSyntaxException, FunctionDeclarationException))
+                          (SyntaxException, FunctionDeclarationException))
 
 
 RESERVED_KEYWORDS_NOT_WHITELISTED = sorted(ALL_RESERVED_KEYWORDS.difference(FUNCTION_WHITELIST))
@@ -65,4 +65,4 @@ def {constant}(var: int128):
     pass
     """
     assert_compile_failed(lambda: get_contract(code),
-                          (PythonSyntaxException, FunctionDeclarationException))
+                          (SyntaxException, FunctionDeclarationException))

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -76,7 +76,12 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         elif isinstance(node.value, bytes):
             node.ast_type = "Bytes"
         else:
-            raise SyntaxException(f"Invalid syntax (unsupported Python Constant AST node).", node)
+            raise SyntaxException(
+                f"Invalid syntax (unsupported Python Constant AST node).",
+                self._source_code,
+                node.lineno,
+                node.col_offset,
+            )
 
         return node
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -59,7 +59,9 @@ def get_node(
     if vy_class is None:
         raise SyntaxException(
             f"Invalid syntax (unsupported '{ast_struct['ast_type']}' Python AST node).",
-            ast_struct
+            ast_struct['full_source_code'],
+            ast_struct['lineno'],
+            ast_struct['col_offset'],
         )
 
     return vy_class(parent=parent, **ast_struct)
@@ -128,12 +130,12 @@ class VyperNode:
                 setattr(self, field_name, value)
 
             elif value and field_name in self._only_empty_fields:
-                if isinstance(value, list):
-                    value = value[0]
                 raise SyntaxException(
                     f"Syntax is valid Python but not valid for Vyper\n"
                     f"class: {type(self).__name__}, field_name: {field_name}",
-                    value
+                    kwargs['full_source_code'],
+                    kwargs['lineno'],
+                    kwargs['col_offset'],
                 )
 
         # add to children of parent last to ensure an accurate hash is generated

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -58,7 +58,7 @@ def get_node(
 
     if vy_class is None:
         raise SyntaxException(
-            f"Invalid syntax (unsupported '{ast_struct['ast_type']}'' Python AST node).",
+            f"Invalid syntax (unsupported '{ast_struct['ast_type']}' Python AST node).",
             ast_struct
         )
 
@@ -128,9 +128,12 @@ class VyperNode:
                 setattr(self, field_name, value)
 
             elif value and field_name in self._only_empty_fields:
+                if isinstance(value, list):
+                    value = value[0]
                 raise SyntaxException(
-                    f'Unsupported non-empty value (valid in Python, but invalid in Vyper) \n'
-                    f' field_name: {field_name}, class: {type(self)} value: {value}'
+                    f"Syntax is valid Python but not valid for Vyper\n"
+                    f"class: {type(self).__name__}, field_name: {field_name}",
+                    value
                 )
 
         # add to children of parent last to ensure an accurate hash is generated

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -17,7 +17,7 @@ from vyper.ast.pre_parser import (
 from vyper.exceptions import (
     CompilerPanic,
     ParserException,
-    PythonSyntaxException,
+    SyntaxException,
 )
 
 
@@ -44,7 +44,7 @@ def parse_to_ast(source_code: str, source_id: int = 0) -> vy_ast.Module:
         py_ast = python_ast.parse(reformatted_code)
     except SyntaxError as e:
         # TODO: Ensure 1-to-1 match of source_code:reformatted_code SyntaxErrors
-        raise PythonSyntaxException(e, source_code) from e
+        raise SyntaxException(str(e), source_code, e.lineno, e.offset) from e
     annotate_python_ast(py_ast, source_code, class_types, source_id)
 
     # Convert to Vyper AST.

--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -13,7 +13,7 @@ import sys
 
 import vyper
 from vyper.exceptions import (
-    ParserException,
+    VyperException,
 )
 from vyper.opcodes import (
     DEFAULT_EVM_VERSION,
@@ -110,7 +110,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
                 evm_version=data.get('evm_version', DEFAULT_EVM_VERSION)
             )['']
             out_dict['ir'] = str(out_dict['ir'])
-        except ParserException as e:
+        except VyperException as e:
             return {
                 'status': 'failed',
                 'message': str(e),

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -62,15 +62,15 @@ class SyntaxException(ParserException):
 
 
 class StructureException(ParserException):
-    """TODO"""
+    """Invalid structure for parsable syntax."""
+
+
+class VersionException(ParserException):
+    """Version string is malformed or incompatible with this compiler version."""
 
 
 class InvalidLiteralException(ParserException):
     """Invalid literal value."""
-
-
-class InvalidTypeException(ParserException):
-    """Invalid type declaration."""
 
 
 class VariableDeclarationException(ParserException):
@@ -85,8 +85,20 @@ class EventDeclarationException(ParserException):
     """Invalid event declaration."""
 
 
+class UndeclaredDefinition(ParserException):
+    """Reference to a definition that has not been declared."""
+
+
+class NamespaceCollsion(ParserException):
+    """Assignment to a name that is already in use."""
+
+
+class InvalidTypeException(ParserException):
+    """Type is invalid for an action."""
+
+
 class TypeMismatchException(ParserException):
-    """TODO"""
+    """Attempt to perform an action with multiple, incompatible types."""
 
 
 class ConstancyViolationException(ParserException):
@@ -94,11 +106,7 @@ class ConstancyViolationException(ParserException):
 
 
 class NonPayableViolationException(ParserException):
-    """Used msg.value in a nonpayable function."""
-
-
-class VersionException(ParserException):
-    """Version string is malform or incompatible with this version of Vyper."""
+    """msg.value in a nonpayable function."""
 
 
 class ArrayIndexException(ParserException):
@@ -109,8 +117,12 @@ class ZeroDivisionException(ParserException):
     """Second argument to a division or modulo operation was zero."""
 
 
+class OverflowException(ParserException):
+    """Numeric value out of range for the given type."""
+
+
 class EvmVersionException(ParserException):
-    """Cannot perform an action based on the active EVM ruleset."""
+    """Invalid action for the active EVM ruleset."""
 
 
 class CompilerPanic(Exception):

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -6,8 +6,13 @@ from vyper.settings import (
 )
 
 
-# Attempts to display the line and column of violating code.
-class ParserException(Exception):
+class VyperException(Exception):
+    """
+    Base Vyper exception class.
+
+    This exception is not raised directly. Other exceptions inherit it in
+    order to display source annotations in the error string.
+    """
     def __init__(self, message='Error Message not found.', item=None):
         self.message = message
         self.lineno = None
@@ -49,7 +54,7 @@ class ParserException(Exception):
         return self.message
 
 
-class SyntaxException(ParserException):
+class SyntaxException(VyperException):
 
     """Invalid syntax."""
 
@@ -61,67 +66,67 @@ class SyntaxException(ParserException):
         super().__init__(message, item)
 
 
-class StructureException(ParserException):
+class StructureException(VyperException):
     """Invalid structure for parsable syntax."""
 
 
-class VersionException(ParserException):
+class VersionException(VyperException):
     """Version string is malformed or incompatible with this compiler version."""
 
 
-class InvalidLiteralException(ParserException):
+class InvalidLiteralException(VyperException):
     """Invalid literal value."""
 
 
-class VariableDeclarationException(ParserException):
+class VariableDeclarationException(VyperException):
     """Invalid variable declaration."""
 
 
-class FunctionDeclarationException(ParserException):
+class FunctionDeclarationException(VyperException):
     """Invalid function declaration."""
 
 
-class EventDeclarationException(ParserException):
+class EventDeclarationException(VyperException):
     """Invalid event declaration."""
 
 
-class UndeclaredDefinition(ParserException):
+class UndeclaredDefinition(VyperException):
     """Reference to a definition that has not been declared."""
 
 
-class NamespaceCollsion(ParserException):
+class NamespaceCollsion(VyperException):
     """Assignment to a name that is already in use."""
 
 
-class InvalidTypeException(ParserException):
+class InvalidTypeException(VyperException):
     """Type is invalid for an action."""
 
 
-class TypeMismatchException(ParserException):
+class TypeMismatchException(VyperException):
     """Attempt to perform an action between multiple objects of incompatible types."""
 
 
-class ConstancyViolationException(ParserException):
+class ConstancyViolationException(VyperException):
     """State-changing action inside a constant function."""
 
 
-class NonPayableViolationException(ParserException):
+class NonPayableViolationException(VyperException):
     """msg.value in a nonpayable function."""
 
 
-class ArrayIndexException(ParserException):
+class ArrayIndexException(VyperException):
     """Array index out of range."""
 
 
-class ZeroDivisionException(ParserException):
+class ZeroDivisionException(VyperException):
     """Second argument to a division or modulo operation was zero."""
 
 
-class OverflowException(ParserException):
+class OverflowException(VyperException):
     """Numeric value out of range for the given type."""
 
 
-class EvmVersionException(ParserException):
+class EvmVersionException(VyperException):
     """Invalid action for the active EVM ruleset."""
 
 
@@ -144,3 +149,7 @@ class JSONError(Exception):
         super().__init__(msg)
         self.lineno = lineno
         self.col_offset = col_offset
+
+
+class ParserException(Exception):
+    """Contract source cannot be parsed."""

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -51,73 +51,77 @@ class ParserException(Exception):
 
 class PythonSyntaxException(ParserException):
     """
-    Conversion from error using ast.parse()
+    Invalid syntax.
+
+    This error is converted from errors raised during ast.parse
     """
     def __init__(self, syntax_error: SyntaxError, source_code: str):
         item = types.SimpleNamespace()  # TODO: Create an actual object for this
         item.lineno = syntax_error.lineno
         item.col_offset = syntax_error.offset
-        item.source_code = source_code
+        item.full_source_code = source_code
         super().__init__(message=f'SyntaxError: {syntax_error.msg}', item=item)
 
 
-class VariableDeclarationException(ParserException):
-    pass
+class SyntaxException(ParserException):
+    """Valid Python syntax, but invalid Vyper syntax."""
 
 
 class StructureException(ParserException):
-    pass
-
-
-class ConstancyViolationException(ParserException):
-    pass
-
-
-class NonPayableViolationException(ParserException):
-    pass
+    """TODO"""
 
 
 class InvalidLiteralException(ParserException):
-    pass
+    """Invalid literal value."""
 
 
 class InvalidTypeException(ParserException):
-    pass
+    """Invalid type declaration."""
 
 
-class TypeMismatchException(ParserException):
-    pass
+class VariableDeclarationException(ParserException):
+    """Invalid variable declaration."""
 
 
 class FunctionDeclarationException(ParserException):
-    pass
+    """Invalid function declaration."""
 
 
 class EventDeclarationException(ParserException):
-    pass
+    """Invalid event declaration."""
+
+
+class TypeMismatchException(ParserException):
+    """TODO"""
+
+
+class ConstancyViolationException(ParserException):
+    """State-changing action inside a constant function."""
+
+
+class NonPayableViolationException(ParserException):
+    """Used msg.value in a nonpayable function."""
 
 
 class VersionException(ParserException):
-    pass
-
-
-class SyntaxException(ParserException):
-    pass
+    """Version string is malform or incompatible with this version of Vyper."""
 
 
 class ArrayIndexException(ParserException):
-    pass
+    """Array index out of range."""
 
 
 class ZeroDivisionException(ParserException):
-    pass
+    """Second argument to a division or modulo operation was zero."""
 
 
 class EvmVersionException(ParserException):
-    pass
+    """Cannot perform an action based on the active EVM ruleset."""
 
 
 class CompilerPanic(Exception):
+
+    """Unexpected error during compilation."""
 
     def __init__(self, message):
         self.message = message
@@ -127,6 +131,8 @@ class CompilerPanic(Exception):
 
 
 class JSONError(Exception):
+
+    """Invalid compiler input JSON."""
 
     def __init__(self, msg, lineno=None, col_offset=None):
         super().__init__(msg)

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -98,7 +98,7 @@ class InvalidTypeException(ParserException):
 
 
 class TypeMismatchException(ParserException):
-    """Attempt to perform an action with multiple, incompatible types."""
+    """Attempt to perform an action between multiple objects of incompatible types."""
 
 
 class ConstancyViolationException(ParserException):

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -49,22 +49,16 @@ class ParserException(Exception):
         return self.message
 
 
-class PythonSyntaxException(ParserException):
-    """
-    Invalid syntax.
-
-    This error is converted from errors raised during ast.parse
-    """
-    def __init__(self, syntax_error: SyntaxError, source_code: str):
-        item = types.SimpleNamespace()  # TODO: Create an actual object for this
-        item.lineno = syntax_error.lineno
-        item.col_offset = syntax_error.offset
-        item.full_source_code = source_code
-        super().__init__(message=f'SyntaxError: {syntax_error.msg}', item=item)
-
-
 class SyntaxException(ParserException):
-    """Valid Python syntax, but invalid Vyper syntax."""
+
+    """Invalid syntax."""
+
+    def __init__(self, message, source_code, lineno, col_offset):
+        item = types.SimpleNamespace()  # TODO: Create an actual object for this
+        item.lineno = lineno
+        item.col_offset = col_offset
+        item.full_source_code = source_code
+        super().__init__(message, item)
 
 
 class StructureException(ParserException):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -4,9 +4,9 @@ from vyper import (
     ast as vy_ast,
 )
 from vyper.exceptions import (
+    CompilerPanic,
     ConstancyViolationException,
     InvalidLiteralException,
-    ParserException,
     StructureException,
     TypeMismatchException,
 )
@@ -1281,7 +1281,7 @@ else:
 
 
 def _clear():
-    raise ParserException(
+    raise CompilerPanic(
         "This function should never be called! `clear()` is currently handled "
         "differently than other functions as it self modifies its input argument "
         "statement. Please see `_clear()` in `stmt.py`"

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -7,7 +7,6 @@ from vyper.exceptions import (
     EvmVersionException,
     InvalidLiteralException,
     NonPayableViolationException,
-    ParserException,
     StructureException,
     TypeMismatchException,
     VariableDeclarationException,
@@ -378,7 +377,9 @@ class Expr(object):
             key = self.expr.value.id + "." + self.expr.attr
             if key == "msg.sender":
                 if self.context.is_private:
-                    raise ParserException("msg.sender not allowed in private functions.", self.expr)
+                    raise StructureException(
+                        "msg.sender not allowed in private functions.", self.expr
+                    )
                 return LLLnode.from_list(['caller'], typ='address', pos=getpos(self.expr))
             elif key == "msg.value":
                 if not self.context.is_payable:
@@ -428,7 +429,7 @@ class Expr(object):
                     )
                 return LLLnode.from_list(['chainid'], typ='uint256', pos=getpos(self.expr))
             else:
-                raise ParserException("Unsupported keyword: " + key, self.expr)
+                raise StructureException("Unsupported keyword: " + key, self.expr)
         # Other variables
         else:
             sub = Expr.parse_variable_location(self.expr.value, self.context)
@@ -507,7 +508,7 @@ class Expr(object):
                     if left.value < 0:
                         val = -val
             else:
-                raise ParserException(
+                raise StructureException(
                     f'Unsupported literal operator: {type(self.expr.op)}',
                     self.expr,
                 )
@@ -709,7 +710,7 @@ class Expr(object):
             else:
                 raise TypeMismatchException('Only whole number exponents are supported', self.expr)
         else:
-            raise ParserException(f"Unsupported binary operator: {self.expr.op}", self.expr)
+            raise StructureException(f"Unsupported binary operator: {self.expr.op}", self.expr)
 
         p = ['seq']
 
@@ -889,7 +890,7 @@ class Expr(object):
                     )
 
                 else:
-                    raise ParserException(
+                    raise StructureException(
                         "Can only compare strings/bytes of length shorter",
                         " than 32 bytes other than equality comparisons",
                         self.expr,
@@ -1173,5 +1174,5 @@ class Expr(object):
     def parse_variable_location(cls, expr, context):
         o = cls(expr, context).lll_node
         if not o.location:
-            raise ParserException("Looking for a variable location, instead got a value", expr)
+            raise StructureException("Looking for a variable location, instead got a value", expr)
         return o

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -5,7 +5,6 @@ from vyper.exceptions import (
     EventDeclarationException,
     FunctionDeclarationException,
     InvalidTypeException,
-    ParserException,
     StructureException,
     VariableDeclarationException,
 )
@@ -368,7 +367,7 @@ class GlobalContext:
         item_attributes = {"public": False}
 
         if len(self._globals) > NONRENTRANT_STORAGE_OFFSET:
-            raise ParserException(
+            raise StructureException(
                 f"Too many globals defined, only {NONRENTRANT_STORAGE_OFFSET} globals are allowed",
                 item,
             )

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -13,7 +13,6 @@ from vyper import (
     ast as vy_ast,
 )
 from vyper.exceptions import (
-    ParserException,
     StructureException,
 )
 import vyper.interfaces
@@ -71,7 +70,7 @@ def abi_type_to_ast(atype, expected_size):
             slice=vy_ast.Index(value=vy_ast.Int(n=expected_size))
         )
     else:
-        raise ParserException(f'Type {atype} not supported by vyper.')
+        raise StructureException(f'Type {atype} not supported by vyper.')
 
 
 # Vyper defines a maximum length for bytes and string types, but Solidity does not.

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -6,7 +6,7 @@ from vyper import (
 )
 from vyper.exceptions import (
     InvalidLiteralException,
-    ParserException,
+    StructureException,
     TypeMismatchException,
 )
 from vyper.functions.signatures import (
@@ -418,7 +418,7 @@ def to_bytes(expr, args, kwargs, context):
 
 def convert(expr, context):
     if len(expr.args) != 2:
-        raise ParserException('The convert function expects two parameters.', expr)
+        raise StructureException('The convert function expects two parameters.', expr)
     if isinstance(expr.args[1], vy_ast.Str):
         warnings.warn(
             "String parameter has been removed (see VIP1026). "
@@ -434,12 +434,12 @@ def convert(expr, context):
     ):
         output_type = expr.args[1].value.id
     else:
-        raise ParserException("Invalid conversion type, use valid Vyper type.", expr)
+        raise StructureException("Invalid conversion type, use valid Vyper type.", expr)
 
     if output_type in CONVERSION_TABLE:
         return CONVERSION_TABLE[output_type](expr, context)
     else:
-        raise ParserException(f"Conversion to {output_type} is invalid.", expr)
+        raise StructureException(f"Conversion to {output_type} is invalid.", expr)
 
 
 CONVERSION_TABLE = {


### PR DESCRIPTION
### What I did
1. Add docstrings for all custom exceptions.
2. Expand some of the more commonly used exceptions into different types that are more specific to what is happening.
3. Rename `ParserException` to `VyperException` and explicitly declare it to be an inherited base exception.
4. Update documentation and tests.

### Motivation
Related to #1869 - I think it's good to have all custom exception types very clear prior to major refactoring. I also think we should have a policy that the compiler never intentionally raises a builtin exception. An end-user receiving a builtin exception should be a clear sign of a bug within the compiler.

I don't intend to change any raise statements throughout the existing code. But I __do__ want to enforce their use in any code we add going forward, specifically in the refactors on the near horizon.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/75921232-35cefc80-5e7a-11ea-97c6-de9d053b9416.png)
