### PR TITLE
Move docstring out of body in FunctionDef AST

### DIFF
--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -271,8 +271,9 @@ def sum(a: int128, b: int128) -> int128:
 must_fail('''
 @public
 def a():
-    "Test"
-''', InvalidLiteralException)
+    "Behold me mortal, for I am a DOCSTRING!"
+    "Alas, I am but a mere string."
+''', StructureException)
 
 must_fail('''
 struct StructX:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -227,7 +227,18 @@ class Tuple(VyperNode):
 
 
 class FunctionDef(VyperNode):
-    __slots__ = ('args', 'body', 'returns', 'name', 'decorator_list', 'pos')
+    __slots__ = ('args', 'body', 'returns', 'name', 'decorator_list', 'pos', 'doc_string')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if (
+            kwargs.get('body') and
+            isinstance(self.body[0], Expr) and
+            isinstance(self.body[0].value, Str)
+        ):
+            # if the first body item is a docstring, move it into it's own field
+            self.doc_string = self.body[0].value.s
+            del self.body[0]
 
 
 class arguments(VyperNode):

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -79,7 +79,6 @@ class Stmt(object):
             vy_ast.Continue: self.parse_continue,
             vy_ast.Return: self.parse_return,
             vy_ast.Delete: self.parse_delete,
-            vy_ast.Str: self.parse_docblock,  # docblock
             vy_ast.Name: self.parse_name,
             vy_ast.Raise: self.parse_raise,
         }
@@ -87,7 +86,7 @@ class Stmt(object):
         if stmt_type in self.stmt_table:
             self.lll_node = self.stmt_table[stmt_type]()
         else:
-            raise StructureException(f"Unsupported statement type: {type(stmt)}", stmt)
+            raise StructureException(f"Unsupported statement type: {type(stmt).__name__}", stmt)
 
     def expr(self):
         return Stmt(self.stmt.value, self.context).lll_node
@@ -1005,11 +1004,6 @@ class Stmt(object):
         target = Expr.parse_variable_location(target, self.context)
         constancy_checks(target, self.context, self.stmt)
         return target
-
-    def parse_docblock(self):
-        if '"""' not in self.context.origcode.splitlines()[self.stmt.lineno - 1]:
-            raise InvalidLiteralException('Only valid """ docblocks allowed', self.stmt)
-        return LLLnode.from_list('pass', typ=None, pos=getpos(self.stmt))
 
 
 # Parse a statement (usually one line of code but not always)


### PR DESCRIPTION
### What I did
Store function docstrings in the `doc_string` field of the related AST node.

### How I did it
1. `vyper/ast/nodes.py` - When `FunctionDef.body[0]` is an `Expr` containing a `Str`, remove the `Expr` from `body` and add `Str.s` to `FunctionDef.doc_string`.
2. `vyper/parser/expr.py` - remove logic for `Str` - the only use it had was to raise if a value _wasn't_ a docstring.

### How to verify it
Run the tests. I updated a test case that was failing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76106781-02fb4480-5ff1-11ea-8f1e-c2af1dbf460d.png)
