### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -171,9 +171,9 @@ Bitwise Operators
 Operator              Description
 ===================== =============
 ``bitwise_and(x, y)`` AND
-``bitwise_not(x, y)`` NOT
 ``bitwise_or(x, y)``  OR
 ``bitwise_xor(x, y)`` XOR
+``bitwise_not(x)``    NOT
 ``shift(x, _shift)``  Bitwise Shift
 ===================== =============
 


### PR DESCRIPTION
### What I did
Fix a typo in the documentation. `bitwise_not` expects one argument, not two.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76147759-107c0180-60b9-11ea-921c-b1f4a9221f43.png)
