### PR TITLE
AST Round 4

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -8,6 +8,7 @@ from vyper import (
 )
 from vyper.exceptions import (
     StructureException,
+    SyntaxException,
 )
 
 fail_list = [
@@ -148,18 +149,6 @@ def foo() -> int128:
     return self.q
     """,
     """
-b: map(int128, bytes32)
-@public
-def foo():
-    del self.b[0], self.b[1]
-    """,
-    """
-@public
-def foo():
-    b: int128
-    del b
-    """,
-    """
 contract F:
     def foo(): constant
 struct S:
@@ -198,4 +187,26 @@ def double_nonreentrant():
 @pytest.mark.parametrize('bad_code', fail_list)
 def test_invalid_type_exception(bad_code):
     with raises(StructureException):
+        compiler.compile_code(bad_code)
+
+
+del_fail_list = [
+    """
+b: map(int128, bytes32)
+@public
+def foo():
+    del self.b[0], self.b[1]
+    """,
+    """
+@public
+def foo():
+    b: int128
+    del b
+    """,
+]
+
+
+@pytest.mark.parametrize('bad_code', del_fail_list)
+def test_syntax_exception(bad_code):
+    with raises(SyntaxException):
         compiler.compile_code(bad_code)

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -107,6 +107,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         if is_sub and is_num:
             node.operand.n = 0 - node.operand.n
             node.operand.col_offset = node.col_offset
+            node.operand.node_source_code = node.node_source_code
             return node.operand
         else:
             return node

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1,6 +1,10 @@
 import ast as python_ast
+import decimal
 import sys
-import typing
+from typing import (
+    Optional,
+    Union,
+)
 
 from vyper.exceptions import (
     SyntaxException,
@@ -30,8 +34,8 @@ DICT_AST_SKIPLIST = ('full_source_code', 'node_source_code')
 
 
 def get_node(
-    ast_struct: typing.Union[typing.Dict, python_ast.AST],
-    parent: typing.Optional["VyperNode"] = None
+    ast_struct: Union[dict, python_ast.AST],
+    parent: Optional["VyperNode"] = None
 ) -> "VyperNode":
     """
     Converts an AST structure to a vyper AST node.
@@ -119,10 +123,10 @@ class VyperNode:
         fields across different python versions.
     """
     __slots__ = BASE_NODE_ATTRIBUTES
-    _only_empty_fields: typing.Tuple = ()
-    _translated_fields: typing.Dict = {}
+    _only_empty_fields: tuple = ()
+    _translated_fields: dict = {}
 
-    def __init__(self, parent: typing.Optional["VyperNode"] = None, **kwargs: dict):
+    def __init__(self, parent: Optional["VyperNode"] = None, **kwargs: dict):
         """
         AST node initializer method.
 
@@ -190,14 +194,14 @@ class VyperNode:
         return f'{class_repr}:\n{source_annotation}'
 
     @classmethod
-    def get_slots(cls) -> typing.Set:
+    def get_slots(cls) -> set:
         """
         Returns a set of field names for this node.
         """
         slot_fields = [x for i in cls.__mro__ for x in getattr(i, '__slots__', [])]
         return set(i for i in slot_fields if not i.startswith('_'))
 
-    def to_dict(self) -> typing.Dict:
+    def to_dict(self) -> dict:
         """
         Returns the node as a dict. All child nodes are also converted.
         """
@@ -210,7 +214,7 @@ class VyperNode:
                 ast_dict[key] = _to_dict(value)
         return ast_dict
 
-    def get_children(self, filters: typing.Optional[dict] = None) -> list:
+    def get_children(self, filters: Optional[dict] = None) -> list:
         """
         Returns direct childen of this node that match the given filter.
 
@@ -236,7 +240,9 @@ class VyperNode:
             return children
         return [i for i in children if _node_filter(i, filters)]
 
-    def get_all_children(self, filters: typing.Optional[dict] = None, include_self: typing.Optional[bool] = False) -> list:
+    def get_all_children(
+        self, filters: Optional[dict] = None, include_self: Optional[bool] = False
+    ) -> list:
         """
         Returns direct and indirect childen of this node that match the given filter.
 
@@ -268,7 +274,7 @@ class VyperNode:
             children.append(self)
         return _sort_nodes(children)
 
-    def get(self, field_str: str) -> typing.Optional["VyperNode"]:
+    def get(self, field_str: str) -> Optional["VyperNode"]:
         """
         Recursive getter function for node attributes.
 
@@ -374,10 +380,18 @@ class Bytes(Constant):
     __slots__ = ('s', )
     _translated_fields = {'value': 's'}
 
+    @property
+    def value(self):
+        return self.s
+
 
 class Str(Constant):
     __slots__ = ('s', )
     _translated_fields = {'value': 's'}
+
+    @property
+    def value(self):
+        return self.s
 
 
 class Num(Constant):
@@ -390,21 +404,41 @@ class Num(Constant):
 class Int(Num):
     __slots__ = ()
 
+    @property
+    def value(self):
+        return self.n
+
 
 class Decimal(Num):
     __slots__ = ()
+
+    @property
+    def value(self):
+        return decimal.Decimal(self.node_source_code)
 
 
 class Hex(Num):
     __slots__ = ()
 
+    @property
+    def value(self):
+        return self.node_source_code
+
 
 class Binary(Num):
     __slots__ = ()
 
+    @property
+    def value(self):
+        return self.node_source_code
+
 
 class Octal(Num):
     __slots__ = ()
+
+    @property
+    def value(self):
+        return self.node_source_code
 
 
 class Attribute(VyperNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -622,6 +622,7 @@ class ClassDef(VyperNode):
 
 class Raise(VyperNode):
     __slots__ = ('exc', )
+    _only_empty_fields = ('cause', )
 
 
 class Slice(VyperNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -110,15 +110,18 @@ class VyperNode:
 
     Vyper nodes are generated from, and closely resemble, their python counterparts.
 
-    Attributes
-    ----------
+    Object Attributes
+    -----------------
     __slots__ : Tuple
         Allowed field names for the node.
-    _only_empty_fields : Tuple
+    _description : str, optional
+        A human-readable description of the node. Used to give more verbose error
+        messages.
+    _only_empty_fields : Tuple, optional
         Field names that, if present, must be set to None or a SyntaxException is
         raised. This attribute is used to exclude syntax that is valid in python
         but not in vyper.
-    _translated_fields:
+    _translated_fields : Dict, optional
         Field names that should be reassigned if encountered. Used to normalize
         fields across different python versions.
     """
@@ -192,6 +195,10 @@ class VyperNode:
         )
 
         return f'{class_repr}:\n{source_annotation}'
+
+    @property
+    def description(self):
+        return getattr(self, '_description', type(self).__name__)
 
     @classmethod
     def get_slots(cls) -> set:
@@ -472,26 +479,32 @@ class Dict(VyperNode):
 
 class Add(VyperNode):
     __slots__ = ()
+    _description = "addition"
 
 
 class Sub(VyperNode):
     __slots__ = ()
+    _description = "subtraction"
 
 
 class Mult(VyperNode):
     __slots__ = ()
+    _description = "multiplication"
 
 
 class Div(VyperNode):
     __slots__ = ()
+    _description = "division"
 
 
 class Mod(VyperNode):
     __slots__ = ()
+    _description = "modulus"
 
 
 class Pow(VyperNode):
     __slots__ = ()
+    _description = "exponentiation"
 
 
 class In(VyperNode):
@@ -500,26 +513,32 @@ class In(VyperNode):
 
 class Gt(VyperNode):
     __slots__ = ()
+    _description = "greater than"
 
 
 class GtE(VyperNode):
     __slots__ = ()
+    _description = "greater-or-equal"
 
 
 class LtE(VyperNode):
     __slots__ = ()
+    _description = "less-or-equal"
 
 
 class Lt(VyperNode):
     __slots__ = ()
+    _description = "less than"
 
 
 class Eq(VyperNode):
     __slots__ = ()
+    _description = "equality"
 
 
 class NotEq(VyperNode):
     __slots__ = ()
+    _description = "non-equality"
 
 
 class And(VyperNode):
@@ -536,10 +555,12 @@ class Not(VyperNode):
 
 class USub(VyperNode):
     __slots__ = ()
+    _description = "in-place subtraction"
 
 
 class UAdd(VyperNode):
     __slots__ = ()
+    _description = "in-place addition"
 
 
 class Expr(VyperNode):

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -78,7 +78,6 @@ class Stmt(object):
             vy_ast.Break: self.parse_break,
             vy_ast.Continue: self.parse_continue,
             vy_ast.Return: self.parse_return,
-            vy_ast.Delete: self.parse_delete,
             vy_ast.Name: self.parse_name,
             vy_ast.Raise: self.parse_raise,
         }
@@ -963,12 +962,6 @@ class Stmt(object):
 
         else:
             raise TypeMismatch(f"Can't return type {sub.typ}", self.stmt)
-
-    def parse_delete(self):
-        raise StructureException(
-            "Deleting is not supported, use built-in `clear()` function.",
-            self.stmt
-        )
 
     def get_target(self, target):
         # Check if we are doing assignment of an iteration loop.

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -421,11 +421,6 @@ def parse_type(item, location, sigs=None, custom_units=None, custom_structs=None
         return BaseType(base_type, unit, positional)
     # Subscripts
     elif isinstance(item, vy_ast.Subscript):
-        if isinstance(item.slice, vy_ast.Slice):
-            raise InvalidType(
-                "Array / ByteArray access must access a single element, not a slice",
-                item,
-            )
         # Fixed size lists or bytearrays, e.g. num[100]
         is_constant_val = constants.ast_is_constant(item.slice.value)
         if isinstance(item.slice.value, vy_ast.Int) or is_constant_val:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -326,6 +326,9 @@ def annotate_source_code(
 
     :return: A string containing the annotated source code location.
     """
+    if lineno is None:
+        return ""
+
     source_lines = source_code.splitlines(keepends=True)
     if lineno < 1 or lineno > len(source_lines):
         raise ValueError('Line number is out of range')


### PR DESCRIPTION
### What I did
This PR includes a mix of new features and bugfixes related to #1869. I've separated them out to reduce the size of the diff once the main PR is ready for review.

1. Add `UNSUPPORTED_NODE_REASONS` var and remove node types which are disallowed later in compilation.
2. Add `get_children`, `get_all_children`, and `get` methods to `NodeBase`. These are useful for targeted traversal of the AST, see the docstrings for implementation details.
3. Add `value` property to `Num` nodes as a standard way to access the actual value of the node. Eventually I would like to remove `n` and `s` altogether, this is a first step towards that.
4. Add `description` property to nodes. Useful for giving more descriptive error messages.
5. Disallow use of `from ...` syntax in `raise` statements.
6. Fix a bug when attempting to annotate an AST node without a source offset.

### How I did it
See diff.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76559512-c29c3a80-64b8-11ea-8bb9-40e24f703388.png)
