### PR TITLE
Ast modifications

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -134,11 +134,6 @@ def foo():
     x = concat(b"")
     """,
     """
-@public
-def foo():
-    x = y = 3
-    """,
-    """
 def foo() -> int128:
     q:int128 = 111
     return q

--- a/tests/parser/exceptions/test_syntax_exception.py
+++ b/tests/parser/exceptions/test_syntax_exception.py
@@ -54,7 +54,12 @@ def test() -> uint256:
     else:
       return 1
     return 1
+    """,
     """
+@public
+def foo():
+    x = y = 3
+    """,
 ]
 
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -554,7 +554,16 @@ class Or(VyperNode):
 
 
 class Compare(VyperNode):
-    __slots__ = ('comparators', 'ops', 'left', 'right')
+    __slots__ = ('op', 'left', 'right')
+
+    def __init__(self, *args, **kwargs):
+        if len(kwargs['ops']) > 1 or len(kwargs['comparators']) > 1:
+            err_args = (kwargs['full_source_code'], kwargs['lineno'], kwargs['col_offset'])
+            raise SyntaxException("Cannot have a comparison with more than two elements", err_args)
+
+        kwargs['op'] = kwargs.pop('ops')[0]
+        kwargs['right'] = kwargs.pop('comparators')[0]
+        super().__init__(*args, **kwargs)
 
 
 class Eq(VyperNode):
@@ -618,6 +627,7 @@ class Assign(VyperNode):
         if len(kwargs['targets']) > 1:
             err_args = (kwargs['full_source_code'], kwargs['lineno'], kwargs['col_offset'])
             raise SyntaxException("Assignment statement must have one target", *err_args)
+
         kwargs['target'] = kwargs.pop('targets')[0]
         super().__init__(*args, **kwargs)
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -612,7 +612,14 @@ class Index(VyperNode):
 
 
 class Assign(VyperNode):
-    __slots__ = ('targets', 'value')
+    __slots__ = ('target', 'value')
+
+    def __init__(self, *args, **kwargs):
+        if len(kwargs['targets']) > 1:
+            err_args = (kwargs['full_source_code'], kwargs['lineno'], kwargs['col_offset'])
+            raise SyntaxException("Assignment statement must have one target", *err_args)
+        kwargs['target'] = kwargs.pop('targets')[0]
+        super().__init__(*args, **kwargs)
 
 
 class AnnAssign(VyperNode):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -738,7 +738,7 @@ class Expr(object):
 
     def build_in_comparator(self):
         left = Expr(self.expr.left, self.context).lll_node
-        right = Expr(self.expr.comparators[0], self.context).lll_node
+        right = Expr(self.expr.right, self.context).lll_node
 
         if left.typ != right.typ.subtype:
             raise TypeMismatch(
@@ -827,7 +827,7 @@ class Expr(object):
 
     def compare(self):
         left = Expr.parse_value_expr(self.expr.left, self.context)
-        right = Expr.parse_value_expr(self.expr.comparators[0], self.context)
+        right = Expr.parse_value_expr(self.expr.right, self.context)
 
         if isinstance(right.typ, NullType):
             raise InvalidLiteral(
@@ -839,7 +839,7 @@ class Expr(object):
             # TODO: Can this if branch be removed ^
             pass
 
-        elif isinstance(self.expr.ops[0], vy_ast.In) and isinstance(right.typ, ListType):
+        elif isinstance(self.expr.op, vy_ast.In) and isinstance(right.typ, ListType):
             if left.typ != right.typ.subtype:
                 raise TypeMismatch(
                     "Can't use IN comparison with different types!",
@@ -850,22 +850,17 @@ class Expr(object):
             if not are_units_compatible(left.typ, right.typ) and not are_units_compatible(right.typ, left.typ):  # noqa: E501
                 raise TypeMismatch("Can't compare values with different units!", self.expr)
 
-        if len(self.expr.ops) != 1:
-            raise StructureException(
-                "Cannot have a comparison with more than two elements",
-                self.expr,
-            )
-        if isinstance(self.expr.ops[0], vy_ast.Gt):
+        if isinstance(self.expr.op, vy_ast.Gt):
             op = 'sgt'
-        elif isinstance(self.expr.ops[0], vy_ast.GtE):
+        elif isinstance(self.expr.op, vy_ast.GtE):
             op = 'sge'
-        elif isinstance(self.expr.ops[0], vy_ast.LtE):
+        elif isinstance(self.expr.op, vy_ast.LtE):
             op = 'sle'
-        elif isinstance(self.expr.ops[0], vy_ast.Lt):
+        elif isinstance(self.expr.op, vy_ast.Lt):
             op = 'slt'
-        elif isinstance(self.expr.ops[0], vy_ast.Eq):
+        elif isinstance(self.expr.op, vy_ast.Eq):
             op = 'eq'
-        elif isinstance(self.expr.ops[0], vy_ast.NotEq):
+        elif isinstance(self.expr.op, vy_ast.NotEq):
             op = 'ne'
         else:
             raise Exception("Unsupported comparison operator")
@@ -873,7 +868,7 @@ class Expr(object):
         # Compare (limited to 32) byte arrays.
         if isinstance(left.typ, ByteArrayLike) and isinstance(right.typ, ByteArrayLike):
             left = Expr(self.expr.left, self.context).lll_node
-            right = Expr(self.expr.comparators[0], self.context).lll_node
+            right = Expr(self.expr.right, self.context).lll_node
 
             length_mismatch = (left.typ.maxlen != right.typ.maxlen)
             left_over_32 = left.typ.maxlen > 32

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -260,8 +260,6 @@ class Stmt(object):
 
     def assign(self):
         # Assignment (e.g. x[4] = y)
-        if len(self.stmt.targets) != 1:
-            raise StructureException("Assignment statement must have one target", self.stmt)
 
         with self.context.assignment_scope():
             sub = Expr(self.stmt.value, self.context).lll_node
@@ -282,27 +280,27 @@ class Stmt(object):
 
             # Determine if it's an RLPList assignment.
             if is_valid_rlp_list_assign:
-                pos = self.context.new_variable(self.stmt.targets[0].id, sub.typ)
+                pos = self.context.new_variable(self.stmt.target.id, sub.typ)
                 variable_loc = LLLnode.from_list(
                     pos,
                     typ=sub.typ,
                     location='memory',
                     pos=getpos(self.stmt),
-                    annotation=self.stmt.targets[0].id,
+                    annotation=self.stmt.target.id,
                 )
                 o = make_setter(variable_loc, sub, 'memory', pos=getpos(self.stmt))
             else:
                 # Error check when assigning to declared variable
-                if isinstance(self.stmt.targets[0], vy_ast.Name):
+                if isinstance(self.stmt.target, vy_ast.Name):
                     # Do not allow assignment to undefined variables without annotation
-                    if self.stmt.targets[0].id not in self.context.vars:
+                    if self.stmt.target.id not in self.context.vars:
                         raise VariableDeclarationException("Variable type not defined", self.stmt)
 
                     # Check against implicit conversion
-                    self._check_implicit_conversion(self.stmt.targets[0].id, sub)
+                    self._check_implicit_conversion(self.stmt.target.id, sub)
 
                 is_valid_tuple_assign = (
-                    isinstance(self.stmt.targets[0], vy_ast.Tuple)
+                    isinstance(self.stmt.target, vy_ast.Tuple)
                 ) and isinstance(self.stmt.value, vy_ast.Tuple)
 
                 # Do no allow tuple-to-tuple assignment
@@ -313,7 +311,7 @@ class Stmt(object):
                     )
 
                 # Checks to see if assignment is valid
-                target = self.get_target(self.stmt.targets[0])
+                target = self.get_target(self.stmt.target)
                 if isinstance(target.typ, ContractType) and not isinstance(sub.typ, ContractType):
                     raise TypeMismatch(
                         'Contract assignment expects casted address: '

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -165,7 +165,7 @@ class Stmt(object):
 
     def _check_rhs_var_assn_recur(self, val):
         names = ()
-        if isinstance(val, vy_ast.BinOp):
+        if isinstance(val, (vy_ast.BinOp, vy_ast.Compare)):
             right_node = val.right
             left_node = val.left
             names = names + self._check_rhs_var_assn_recur(right_node)
@@ -176,11 +176,6 @@ class Stmt(object):
         elif isinstance(val, vy_ast.BoolOp):
             for bool_val in val.values:
                 names = names + self._check_rhs_var_assn_recur(bool_val)
-        elif isinstance(val, vy_ast.Compare):
-            compare_left = val.left
-            names = names + self._check_rhs_var_assn_recur(compare_left)
-            for compr in val.comparators:
-                names = names + self._check_rhs_var_assn_recur(compr)
         elif isinstance(val, vy_ast.Name):
             name = val.id
             names = names + (name, )


### PR DESCRIPTION
### What I did
Simplify the structure of `Compare` and `Assign` nodes.

### How I did it
1. Python comparisons allow more than 2 comparators:  `x < y < z`. Because of this, `Compare` has a rather complex structure. Since Vyper only allows `x < y`, I've changed the `Compare` structure to be identical to `BinOp`.  Members are now `left`, `op`, `right`.
2. Python allows multiple targets for assignment: `a = b = 42`. Vyper does not.  To standardize `AnnAssign` with `Assign`/`AugAssign`, I've converted the `AnnAssign.targets` list member into a single `AnnAssign.target`.

Both of these changes occur in the respective `__init__` methods for the nodes and raise `SyntaxException` if syntax is valid python but not valid vyper.  This is the only user-facing change - prior to this PR these situations would raise `StructureException`.

### How to verify it
Run tests. I've updated where needed.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76767794-97b12f80-67b3-11ea-9487-9b2213a3b34f.png)
