### PR TITLE
remove vyper.online references in docs

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -76,15 +76,6 @@ See :ref:`searching_for_imports` for more information on Vyper's import system.
 Online Compilers
 ================
 
-Vyper Online Compiler
----------------------
-
-`Vyper Online Compiler <https://vyper.online/>`_ is an online compiler which lets you experiment with the language without having to install Vyper. It allows you to compile to ``bytecode`` as well as ``LLL``.
-
-.. note::
-
-    While the vyper version of the online compiler is updated on a regular basis it might be a bit behind the latest version found in the master branch of the repository.
-
 Remix IDE
 ---------
 

--- a/docs/installing-vyper.rst
+++ b/docs/installing-vyper.rst
@@ -10,8 +10,10 @@ Take a deep breath, follow the instructions, and please
 any errors.
 
 .. note::
-   The easiest way to try out the language, experiment with examples, and compile code to ``bytecode``
-   or ``LLL`` is to use the online compiler at https://vyper.online/.
+
+    The easiest way to try out the language, experiment with examples, and
+    compile code to ``bytecode`` or ``LLL`` is to use the
+    `Remix online compiler <https://remix.ethereum.org>`_.
 
 Prerequisites
 *************


### PR DESCRIPTION
### What I did
Remove https://vyper.online/ from the docs.

### How I did it
With the delete key.

### How to verify it
Read the docs.  More importantly, see that the docs CI build passes.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76854325-4ca52400-6868-11ea-9280-d491d3655334.png)
