### PR TITLE
Modifications to raw_call arguments

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -179,18 +179,20 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
 
         The amount to send is always specified in ``wei``.
 
-.. py:function:: raw_call(to: address, data: bytes, outsize: int, gas: uint256, value: uint256(wei) = 0, is_delegate_call: bool = False) -> bytes[outsize]
+.. py:function:: raw_call(to: address, data: bytes, outsize: int = 0, gas: uint256 = gasLeft, value: uint256(wei) = 0, is_delegate_call: bool = False) -> bytes[outsize]
 
     Calls to the specified Ethereum address.
 
     * ``to``: Destination address to call to
     * ``data``: Data to send to the destination address
-    * ``outsize``: Maximum length of the bytes array returned from the call
-    * ``gas``: Amount of gas to atttach to the call
+    * ``outsize``: Maximum length of the bytes array returned from the call. If the returned call data exceeds this length, only this number of bytes is returned.
+    * ``gas``: The amount of gas to attach to the call. If not set, all remainaing gas is forwarded.
     * ``value``: The wei value to send to the address (Optional, default ``0``)
     * ``is_delegate_call``: If ``True``, the call will be sent as ``DELEGATECALL`` (Optional, default ``False``)
 
     Returns the data returned by the call as a ``bytes`` list, with ``outsize`` as the max length.
+
+    Returns ``None`` if ``outsize`` is omitted or set to ``0``.
 
 .. py:function:: selfdestruct(to: address) -> None
 

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -76,27 +76,24 @@ def foo():
     """
 @public
 def foo():
-    x = raw_call(0x1234567890123456789012345678901234567890, b"cow")
+    x: bytes[4] = raw_call(0x1234567890123456789012345678901234567890, outsize=4)
     """,
     """
 @public
 def foo():
-    x = raw_call(0x1234567890123456789012345678901234567890, outsize=4)
+    x: bytes[4] = create_forwarder_to(0x1234567890123456789012345678901234567890, b"cow")
     """,
     """
 @public
 def foo():
-    x = create_forwarder_to(0x1234567890123456789012345678901234567890, b"cow")
+    x: bytes[4] = raw_call(
+        0x1234567890123456789012345678901234567890, b"cow", gas=111111, outsize=4, moose=9
+    )
     """,
     """
 @public
 def foo():
-    x = raw_call(0x1234567890123456789012345678901234567890, b"cow", gas=111111, outsize=4, moose=9)
-    """,
-    """
-@public
-def foo():
-    x = create_forwarder_to(0x1234567890123456789012345678901234567890, outsize=4)
+    x: bytes[4] = create_forwarder_to(0x1234567890123456789012345678901234567890, outsize=4)
     """,
     """
 x: public()

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -26,7 +26,13 @@ def foo():
 @public
 def foo():
     raw_log([], 0x1234567890123456789012345678901234567890)
+    """,
     """
+@public
+def foo():
+    # fails because raw_call without outsize does not return a value
+    x: bytes[9] = raw_call(0x1234567890123456789012345678901234567890, b"cow")
+    """,
 ]
 
 
@@ -73,7 +79,12 @@ def foo():
         gas=595757,
         value=9
     )
+    """,
     """
+@public
+def foo():
+    raw_call(0x1234567890123456789012345678901234567890, b"cow")
+    """,
 ]
 
 


### PR DESCRIPTION
### What I did
1. Make `gas` and `outsize` into optional kwargs in `raw_call`.
2. When `outsize` is `0`, do not return a value.
3. When `gas` is not given, forward all available gas.

Closes #1890 

### How I did it
Modifications to `vyper/functions/functions.py` - I refactored / optimized the LLL a bit, if `outsize` is 0, the return value isn't copied to memory. I added comments, hopefully it's clear enough.

### How to verify it
Run tests. I added a few new cases, mostly around `gas`.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76877975-93f1db80-688d-11ea-9e0a-004b8a7d822a.png)
