### PR TITLE
Adjust constant AST fields

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1,5 +1,4 @@
 import ast as python_ast
-import decimal
 import sys
 from typing import (
     Optional,
@@ -405,72 +404,58 @@ class ClassDef(VyperNode):
 
 class Constant(VyperNode):
     # inherited class for all simple constant node types
-    __slots__ = ()
+    __slots__ = ('value', )
 
 
 class Num(Constant):
     # inherited class for all numeric constant node types
-    __slots__ = ('n', )
-    _translated_fields = {'value': 'n'}
+    __slots__ = ()
     _python_ast_type = "Num"
+    _translated_fields = {'n': 'value'}
+
+    @property
+    def n(self):
+        # TODO phase out use of Num.n and remove this
+        return self.value
 
 
 class Int(Num):
     __slots__ = ()
 
-    @property
-    def value(self):
-        return self.n
-
 
 class Decimal(Num):
     __slots__ = ()
-
-    @property
-    def value(self):
-        return decimal.Decimal(self.node_source_code)
 
 
 class Hex(Num):
     __slots__ = ()
 
-    @property
-    def value(self):
-        return self.node_source_code
-
 
 class Binary(Num):
     __slots__ = ()
-
-    @property
-    def value(self):
-        return self.node_source_code
 
 
 class Octal(Num):
     __slots__ = ()
 
-    @property
-    def value(self):
-        return self.node_source_code
-
 
 class Str(Constant):
-    __slots__ = ('s', )
-    _translated_fields = {'value': 's'}
+    __slots__ = ()
+    _translated_fields = {'s': 'value'}
 
     @property
-    def value(self):
-        return self.s
+    def s(self):
+        # TODO phase out use of Str.s and remove this
+        return self.value
 
 
 class Bytes(Constant):
-    __slots__ = ('s', )
-    _translated_fields = {'value': 's'}
+    __slots__ = ()
+    _translated_fields = {'s': 'value'}
 
     @property
-    def value(self):
-        return self.s
+    def s(self):
+        return self.value
 
 
 class List(VyperNode):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1,3 +1,6 @@
+from decimal import (
+    Decimal,
+)
 import hashlib
 
 from vyper import (
@@ -604,7 +607,7 @@ def as_wei_value(expr, args, kwargs, context):
         )
 
     # Compute the amount of wei and return that value
-    if isinstance(value, (int, float)):
+    if isinstance(value, (int, Decimal)):
         expr_args_0 = expr.args[0]
         # On constant reference fetch value node of constant assignment.
         if context.constants.ast_is_constant(expr.args[0]):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -197,13 +197,13 @@ class Expr(object):
                     self.expr
                 )
             return LLLnode.from_list(
-                self.expr.n,
+                int(self.expr.value, 16),
                 typ=BaseType('address', is_literal=True),
                 pos=getpos(self.expr),
             )
         elif len(orignum) == 66:
             return LLLnode.from_list(
-                self.expr.n,
+                int(self.expr.value, 16),
                 typ=BaseType('bytes32', is_literal=True),
                 pos=getpos(self.expr),
             )
@@ -216,7 +216,7 @@ class Expr(object):
 
     # String literals
     def string(self):
-        bytez, bytez_length = string_to_bytes(self.expr.s)
+        bytez, bytez_length = string_to_bytes(self.expr.value)
         typ = StringType(bytez_length, is_literal=True)
         return self._make_bytelike(typ, bytez, bytez_length)
 
@@ -513,7 +513,7 @@ class Expr(object):
                     self.expr,
                 )
 
-            num = vy_ast.Int(n=val)
+            num = vy_ast.Int(value=val)
             num.full_source_code = self.expr.full_source_code
             num.node_source_code = self.expr.node_source_code
             num.lineno = self.expr.lineno

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -49,9 +49,7 @@ getcontext().prec = 78  # MAX_UINT256 < 1e78
 
 # Get a decimal number as a fraction with denominator multiple of 10
 def get_number_as_fraction(expr, context):
-    context_line = context.origcode.splitlines()[expr.lineno - 1]
-    context_slice = context_line[expr.col_offset:expr.end_col_offset]
-    literal = Decimal(context_slice)
+    literal = Decimal(expr.value)
     sign, digits, exponent = literal.as_tuple()
 
     if exponent < -10:
@@ -70,7 +68,7 @@ def get_number_as_fraction(expr, context):
     # TODO: Would be best to raise >10 decimal place exception here
     #       (unless Decimal is used more widely)
 
-    return context_slice, top, bottom
+    return expr.node_source_code, top, bottom
 
 
 # Copies byte array

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -67,7 +67,7 @@ def abi_type_to_ast(atype, expected_size):
         # expected_size is the maximum length for inputs, minimum length for outputs
         return vy_ast.Subscript(
             value=vy_ast.Name(id=atype),
-            slice=vy_ast.Index(value=vy_ast.Int(n=expected_size))
+            slice=vy_ast.Index(value=vy_ast.Int(value=expected_size))
         )
     else:
         raise StructureException(f'Type {atype} not supported by vyper.')

--- a/vyper/types/convert.py
+++ b/vyper/types/convert.py
@@ -1,3 +1,6 @@
+from decimal import (
+    Decimal,
+)
 import math
 import warnings
 
@@ -73,7 +76,7 @@ def to_int128(expr, args, kwargs, context):
                 typ=BaseType('int128', _unit),
                 pos=getpos(expr)
             )
-        elif isinstance(in_arg, float):
+        elif isinstance(in_arg, Decimal):
             if not SizeLimits.in_bounds('int128', math.trunc(in_arg)):
                 raise InvalidLiteral(f"Number out of range: {math.trunc(in_arg)}")
             return LLLnode.from_list(
@@ -185,7 +188,7 @@ def to_uint256(expr, args, kwargs, context):
                 typ=BaseType('uint256', _unit),
                 pos=getpos(expr)
             )
-        elif isinstance(in_arg, float):
+        elif isinstance(in_arg, Decimal):
             if not SizeLimits.in_bounds('uint256', math.trunc(in_arg)):
                 raise InvalidLiteral(f"Number out of range: {math.trunc(in_arg)}")
             return LLLnode.from_list(


### PR DESCRIPTION
### What I did
Modified the members of `Constant` ast nodes.

1. Values are now always stored at `value`, instead of `n`/`s`. This is a change that Python introduced in version 3.8.
2. `ast.Decimal.value` is set as a `decimal.Decimal` immediately when the node is created.
3. Values for `ast.Hex`, `ast.Binary`, and `ast.Octal` are represented as strings instead of their `int` equivalent.

### How I did it
Mostly it involved modifying `ast/annotation.py` and deleting some now redundant code.

I've also added `n` and `s` `@property` members as `value` aliases, so these attributes are still available. It is the path of less resistance as opposed to changing every reference within the remaining existing code base.  As we refactor many of those references will be removed anyway.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/76975080-7a16ce00-694b-11ea-9090-6fd0106d29c6.png)
