### PR TITLE
Exception modifications

### DIFF
--- a/tests/compiler/test_pre_parser.py
+++ b/tests/compiler/test_pre_parser.py
@@ -3,7 +3,7 @@ from pytest import (
 )
 
 from vyper.exceptions import (
-    StructureException,
+    SyntaxException,
 )
 
 
@@ -14,7 +14,7 @@ def test() -> int128:
     return a + b
     """
 
-    with raises(StructureException):
+    with raises(SyntaxException):
         get_contract(code)
 
 
@@ -111,5 +111,5 @@ def foo():
     convert(
     """
 
-    with raises(StructureException):
+    with raises(SyntaxException):
         get_contract(code)

--- a/tests/parser/syntax/test_rlplist.py
+++ b/tests/parser/syntax/test_rlplist.py
@@ -7,7 +7,7 @@ from vyper import (
     compiler,
 )
 from vyper.exceptions import (
-    StructureException,
+    SyntaxException,
     TypeMismatch,
 )
 
@@ -35,7 +35,7 @@ def foo() -> bytes[500]:
 def foo() -> bytes[500]:
     x: int128 = 1
     return RLPList(convert('\xe0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', bytes[64])4])4]))
-    """, StructureException),
+    """, SyntaxException),
     """
 @public
 def foo() -> bytes[500]:

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from vyper.exceptions import (
-    StructureException,
+    SyntaxException,
     VersionException,
 )
 from vyper.typing import (
@@ -112,9 +112,11 @@ def pre_parse(code: str) -> Tuple[ClassTypes, str]:
                 validate_version_pragma(string[1:], start)
 
             if typ == NAME and string == "class" and start[1] == 0:
-                raise StructureException(
+                raise SyntaxException(
                     "The `class` keyword is not allowed. Perhaps you meant `contract` or `struct`?",
-                    start,
+                    code,
+                    start[0],
+                    start[1]
                 )
 
             # Make note of contract or struct name along with the type keyword
@@ -130,10 +132,9 @@ def pre_parse(code: str) -> Tuple[ClassTypes, str]:
                 previous_keyword = string
 
             if (typ, string) == (OP, ";"):
-                raise StructureException("Semi-colon statements not allowed.", start)
-
+                raise SyntaxException("Semi-colon statements not allowed", code, start[0], start[1])
             result.extend(toks)
     except TokenError as e:
-        raise StructureException(e.args[0], e.args[1]) from e
+        raise SyntaxException(e.args[0], code, e.args[1][0], e.args[1][1]) from e
 
     return class_types, untokenize(result).decode('utf-8')


### PR DESCRIPTION
### What I did
1. Add `VyperException.with_annotation` method, for raising exception from a specific ast node. My envisioned use:

```python
try:
    do_thing_with_a_node(node)
except VyperException as exc:
    raise exc.with_annotation(node)
```
2. In `vyper/ast/pre_parser.py`, raise `SyntaxException` rather than `StructureException`.
3. Add docstrings to `VyperException`.


### How I did it
See above, see diff.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/77053081-396c9280-69e7-11ea-910e-c79c17a69c57.png)
