### PR TITLE
CI updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,6 @@ addopts = -n auto
           --cov=vyper
           # Hypothesis Test Config
           --hypothesis-show-statistics
-          # Pytest Test Config
-          --showlocals
 python_files = test_*.py
 testpaths = tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ passenv =
     CIRCLE_*
     CI_PULL_REQUEST
 commands =
-    core: pytest -m "not fuzzing" {posargs:tests/}
+    core: pytest -m "not fuzzing" --showlocals {posargs:tests/}
 basepython =
     py36: python3.6
     py37: python3.7
@@ -51,7 +51,6 @@ deps =
     recommonmark
 commands =
     sphinx-build {posargs:-E} -b html docs dist/docs -n -q --color
-    sphinx-build -b linkcheck docs dist/docs -n -q --color
 
 [testenv:fuzzing]
 basepython = python3.8


### PR DESCRIPTION
### What I did
1. Move the `--showlocals` flag to `tox.ini` - it's useful information in the CI, but locally it can be overwhelming and there's no flag that can be used to disable it.
2. Remove the external links check in the `docs` build.

### How to verify it
Let the CI do it's thing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/77094471-f7167600-6a25-11ea-8476-2d1c1d932e6a.png)
