### PR TITLE
only allow ascii literals in byte arrays

### DIFF
--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -32,8 +32,8 @@ def fourbytes_to_int(inp):
 def string_to_bytes(str):
     bytez = b''
     for c in str:
-        if ord(c) >= 256:
-            raise InvalidLiteral(f"Cannot insert special character {c} into byte array")
+        if ord(c) >= 128:
+            raise InvalidLiteral(f"Cannot insert non-ASCII literal '{c}' into byte array")
         bytez += bytes([ord(c)])
     bytez_length = len(bytez)
     return bytez, bytez_length


### PR DESCRIPTION
### What I did
Fix #1805 

### How I did it
Change the check for `>=256` to `>=128`

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/77425718-99e73f80-6dec-11ea-81e2-54aade43b6ed.png)
