### PR TITLE
docs: fix broken link in style guide

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -23,7 +23,7 @@ All code **must** conform to the `PEP 8 style guide <https://www.python.org/dev/
 
     * Maximum line length of 100
 
-We handle code formatting with `black <https://github.com/psf/black>` with the line-length option set to 80. This ensures a consistent style across the project and saves time by not having to be opinionated.
+We handle code formatting with `black <https://github.com/psf/black>`_ with the line-length option set to 80. This ensures a consistent style across the project and saves time by not having to be opinionated.
 
 Naming Conventions
 ------------------


### PR DESCRIPTION
### What I did
Fix the broken link to `black` in the style guide.

### How I did it
`_`

### How to verify it
Read the docs.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/77960381-43489c80-72e9-11ea-84bb-581175d1ab67.png)
