### PR TITLE
refactor: change value to _value in example contracts

### DIFF
--- a/examples/auctions/blind_auction.vy
+++ b/examples/auctions/blind_auction.vy
@@ -74,9 +74,9 @@ def bid(_blindedBid: bytes32):
 
 # Returns a boolean value, `True` if bid placed successfully, `False` otherwise.
 @private
-def placeBid(bidder: address, value: uint256) -> bool:
+def placeBid(bidder: address, _value: uint256) -> bool:
     # If bid is less than highest bid, bid fails
-    if (value <= self.highestBid):
+    if (_value <= self.highestBid):
         return False
 
     # Refund the previously highest bidder
@@ -84,7 +84,7 @@ def placeBid(bidder: address, value: uint256) -> bool:
         self.pendingReturns[self.highestBidder] += self.highestBid
 
     # Place bid successfully and update auction state
-    self.highestBid = value
+    self.highestBid = _value
     self.highestBidder = bidder
 
     return True

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -117,7 +117,7 @@ def balanceOf(_owner: address) -> uint256:
 @constant
 def ownerOf(_tokenId: uint256) -> address:
     """
-    @dev Returns the address of the owner of the NFT. 
+    @dev Returns the address of the owner of the NFT.
          Throws if `_tokenId` is not a valid NFT.
     @param _tokenId The identifier for an NFT.
     """
@@ -160,7 +160,7 @@ def _isApprovedOrOwner(_spender: address, _tokenId: uint256) -> bool:
     @dev Returns whether the given spender can transfer a given token ID
     @param spender address of the spender to query
     @param tokenId uint256 ID of the token to be transferred
-    @return bool whether the msg.sender is approved for the given token ID, 
+    @return bool whether the msg.sender is approved for the given token ID,
         is an operator of the owner, or is the owner of the token
     """
     owner: address = self.idToOwner[_tokenId]
@@ -214,7 +214,7 @@ def _clearApproval(_owner: address, _tokenId: uint256):
 @private
 def _transferFrom(_from: address, _to: address, _tokenId: uint256, _sender: address):
     """
-    @dev Exeute transfer of a NFT. 
+    @dev Exeute transfer of a NFT.
          Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
          address for this NFT. (NOTE: `msg.sender` not allowed in private function so pass `_sender`.)
          Throws if `_to` is the zero address.
@@ -259,7 +259,7 @@ def safeTransferFrom(
         _from: address,
         _to: address,
         _tokenId: uint256,
-        _data: bytes[1024]=""
+        _data: bytes[1024]=b""
     ):
     """
     @dev Transfers the ownership of an NFT from one address to another address.
@@ -286,7 +286,7 @@ def safeTransferFrom(
 @public
 def approve(_approved: address, _tokenId: uint256):
     """
-    @dev Set or reaffirm the approved address for an NFT. The zero address indicates there is no approved address. 
+    @dev Set or reaffirm the approved address for an NFT. The zero address indicates there is no approved address.
          Throws unless `msg.sender` is the current NFT owner, or an authorized operator of the current owner.
          Throws if `_tokenId` is not a valid NFT. (NOTE: This is not written the EIP)
          Throws if `_approved` is the current owner. (NOTE: This is not written the EIP)

--- a/examples/wallet/wallet.vy
+++ b/examples/wallet/wallet.vy
@@ -25,9 +25,9 @@ def testEcrecover(h: bytes32, v:uint256, r:uint256, s:uint256) -> address:
 # `@payable` allows functions to receive ether
 @public
 @payable
-def approve(_seq: int128, to: address, value: uint256, data: bytes[4096], sigdata: uint256[3][5]) -> bytes[4096]:
+def approve(_seq: int128, to: address, _value: uint256, data: bytes[4096], sigdata: uint256[3][5]) -> bytes[4096]:
     # Throws if the value sent to the contract is less than the sum of the value to be sent
-    assert msg.value >= value
+    assert msg.value >= _value
     # Every time the number of approvals starts at 0 (multiple signatures can be added through the sigdata argument)
     approvals: int128 = 0
     # Starts by combining:
@@ -36,7 +36,7 @@ def approve(_seq: int128, to: address, value: uint256, data: bytes[4096], sigdat
     # 3) The value in wei that will be sent with this transaction.
     # 4) The data to be sent with this transaction (usually data is used to deploy contracts or to call functions on contracts, but you can put whatever you want in it).
     # Takes the keccak256 hash of the combination
-    h: bytes32 = keccak256(concat(convert(_seq, bytes32), convert(to, bytes32), convert(value, bytes32), data))
+    h: bytes32 = keccak256(concat(convert(_seq, bytes32), convert(to, bytes32), convert(_value, bytes32), data))
     # Then we combine the Ethereum Signed message with our previous hash
     # Owners will have to sign the below message
     h2: bytes32 = keccak256(concat(b"\x19Ethereum Signed Message:\n32", h))
@@ -56,7 +56,7 @@ def approve(_seq: int128, to: address, value: uint256, data: bytes[4096], sigdat
     # Increase the number of approved transactions by 1
     self.seq += 1
     # Use raw_call to send the transaction
-    return raw_call(to, data, outsize=4096, gas=3000000, value=value)
+    return raw_call(to, data, outsize=4096, gas=3000000, value=_value)
 
 
 @public


### PR DESCRIPTION
### What I did
Update example contracts to use `_value` instead of `_value` per #1877 

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/78583155-7b9b2e00-7847-11ea-85fd-64dc363142e1.png)
