### PR TITLE
Change raw_call kwarg

### DIFF
--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -127,7 +127,7 @@ def set(i: int128, owner: address):
         cdata,
         gas=msg.gas,
         outsize=0,
-        delegate_call=True
+        is_delegate_call=True
     )
     """
 

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -625,7 +625,7 @@ false_value = LLLnode.from_list(0, typ=BaseType('bool', is_literal=True))
     outsize=Optional('num_literal', 0),
     gas=Optional('uint256', 'gas'),
     value=Optional('uint256', zero_value),
-    delegate_call=Optional('bool', false_value),
+    is_delegate_call=Optional('bool', false_value),
 )
 def raw_call(expr, args, kwargs, context):
     to, data = args
@@ -633,7 +633,7 @@ def raw_call(expr, args, kwargs, context):
         kwargs['gas'],
         kwargs['value'],
         kwargs['outsize'],
-        kwargs['delegate_call'],
+        kwargs['is_delegate_call'],
     )
     if delegate_call.typ.is_literal is False:
         raise TypeMismatch(


### PR DESCRIPTION
### What I did
In `raw_call`, change the `delegate_call` kwarg to `is_delegate_call`. It was already listed this way in the documentation.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/78586620-bf446680-784c-11ea-9218-7a0ae1784807.png)
