### PR TITLE
Toggle button for day/night mode in docs

### DIFF
--- a/docs/_static/css/dark.css
+++ b/docs/_static/css/dark.css
@@ -52,11 +52,12 @@ em.property {
 .py-meth,
 .rst-content a code {
     color: #aaddff !important;
+    font-weight: normal !important;
 }
 
 .rst-content code {
     color: #eee !important;
-    font-weight: bold !important;
+    font-weight: normal !important;
 }
 
 code.literal {
@@ -84,9 +85,11 @@ pre {
 }
 
 .highlight .go,
-.highlight .nb {
+.highlight .nb,
+.highlight .kn {
     /* text */
     color: #ddd;
+    font-weight: normal;
 }
 
 .highlight .o,

--- a/docs/_static/css/toggle.css
+++ b/docs/_static/css/toggle.css
@@ -1,0 +1,77 @@
+input[type=checkbox] {
+    visibility: hidden;
+    height: 0;
+    width: 0;
+    margin: 0;
+}
+
+.rst-versions .rst-current-version {
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.rst-versions .rst-current-version .fa-book,
+.rst-versions .rst-current-version .fa-v,
+.rst-versions .rst-current-version .fa-caret-down {
+    height: 24px;
+    line-height: 24px;
+    vertical-align: middle;
+}
+
+.rst-versions .rst-current-version .fa-element {
+    width: 80px;
+    text-align: center;
+}
+
+.rst-versions .rst-current-version .fa-book {
+    text-align: left;
+}
+
+.rst-versions .rst-current-version .fa-v {
+    color: #27AE60;
+    text-align: right;
+}
+
+label {
+    margin: 0 auto;
+    display: inline-block;
+    justify-content: center;
+    align-items: right;
+    border-radius: 100px;
+    position: relative;
+    cursor: pointer;
+    text-indent: -9999px;
+    width: 50px;
+    height: 21px;
+    background: #000;
+}
+
+label:after {
+    border-radius: 50%;
+    position: absolute;
+    content: '';
+    background: #fff;
+    width: 15px;
+    height: 15px;
+    top: 3px;
+    left: 3px;
+    transition: ease-in-out 200ms;
+}
+
+input:checked+label {
+    background: #3a7ca8;
+}
+
+input:checked+label:after {
+    left: calc(100% - 5px);
+    transform: translateX(-100%);
+}
+
+html.transition,
+html.transition *,
+html.transition *:before,
+html.transition *:after {
+    transition: ease-in-out 200ms !important;
+    transition-delay: 0 !important;
+}

--- a/docs/_static/js/toggle.js
+++ b/docs/_static/js/toggle.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', function() {
+
+    var checkbox = document.querySelector('input[name=mode]');
+
+    function toggleCssMode(isDay) {
+        var mode = (isDay ? "Day" : "Night");
+        localStorage.setItem("css-mode", mode);
+
+        var darksheet = $('link[href="_static/css/dark.css"]')[0].sheet;
+        darksheet.disabled = isDay;
+    }
+
+    if (localStorage.getItem("css-mode") == "Day") {
+        toggleCssMode(true);
+        checkbox.setAttribute('checked', true);
+    }
+
+    checkbox.addEventListener('change', function() {
+        document.documentElement.classList.add('transition');
+        window.setTimeout(() => {
+            document.documentElement.classList.remove('transition');
+        }, 1000)
+        toggleCssMode(this.checked);
+    })
+
+});

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,0 +1,36 @@
+{# Add rst-badge after rst-versions for small badge style. #}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book fa-element"> RTD </span>
+
+    <span class="fa fa-element">
+    <input class="container_toggle" type="checkbox" id="switch" name="mode">
+    <label for="switch"></label>
+    </span>
+
+    <span class="fa fa-v fa-element"> v: {{ current_version }} <span class="fa fa-caret-down"></span></span>
+
+    </span>
+    <div class="rst-other-versions">
+        <dl>
+            <dt>{{ _('Versions') }}</dt> {% for slug, url in versions %}
+            <dd><a href="{{ url }}">{{ slug }}</a></dd>
+            {% endfor %}
+        </dl>
+        <dl>
+            <dt>{{ _('Downloads') }}</dt> {% for type, url in downloads %}
+            <dd><a href="{{ url }}">{{ type }}</a></dd>
+            {% endfor %}
+        </dl>
+        <dl>
+            {# Translators: The phrase "Read the Docs" is not translated #}
+            <dt>{{ _('On Read the Docs') }}</dt>
+            <dd>
+                <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
+            </dd>
+            <dd>
+                <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
+            </dd>
+        </dl>
+    </div>
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,22 +106,19 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_css_files = ["css/custom.css"]
+html_css_files = ["css/toggle.css", "css/dark.css"]
+
+html_js_files = ["js/toggle.js"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-        'donate.html',
-    ]
-}
+# The default sidebars (for documents that don't match any pattern) are
+# defined by theme itself.  Builtin themes are using these templates by
+# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
+# 'searchbox.html']``.
+#
+# html_sidebars = {}
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
### What I did
Add a toggle button to switch between day and night mode in the docs.  It replaces the "edit on Github" button in the header of each page.

You can see the effect in action by checking out the latest [Brownie docs](https://eth-brownie.readthedocs.io/en/latest/).

### How I did it
Hacky copy-pasta and a lot of trial and error.

### How to verify it
Build and read the docs.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/79049910-7d923200-7c37-11ea-825a-f11b9ad7849e.png)
