### PR TITLE
Docs: Updated exception names

### DIFF
--- a/docs/compiler-exceptions.rst
+++ b/docs/compiler-exceptions.rst
@@ -38,7 +38,7 @@ of the error within the code:
 
     Raises when an event declaration is invalid.
 
-.. py:exception:: EMVVersionException
+.. py:exception:: EvmVersionException
 
     Raises when a contract contains an action that cannot be performed with the active EVM ruleset.
 
@@ -104,7 +104,7 @@ of the error within the code:
 
     .. code-block:: python
 
-        vyper.exceptions.InvalidTypeException: line 28:15 Invalid base type: addres
+        vyper.exceptions.InvalidType: line 28:15 Invalid base type: addres
                  27 bids: map(address, Bid[128])
             ---> 28 bidCounts: map(addres, int128)
             -----------------------^
@@ -175,7 +175,7 @@ of the error within the code:
 
     .. code-block:: bash
 
-        vyper.exceptions.TypeMismatchException: line 4:4 Invalid type, expected: bytes32
+        vyper.exceptions.TypeMismatch: line 4:4 Invalid type, expected: bytes32
              3     a: uint256 = 1
         ---> 4     b: bytes32 = a
         -----------^

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -236,8 +236,8 @@ The following example describes the output format of ``vyper-json``. Comments ar
                 "lineno": 5,
                 "col_offset": 11
             },
-            // Mandatory: Exception type, such as "JSONError", "KeyError", "StructureException", etc.
-            "type": "TypeMismatchException",
+            // Mandatory: Exception type, such as "JSONError", "StructureException", etc.
+            "type": "TypeMismatch",
             // Mandatory: Component where the error originated, such as "json", "compiler", "vyper", etc.
             "component": "compiler",
             // Mandatory ("error" or "warning")


### PR DESCRIPTION
### What I did

Updated the names of exceptions in the docs
Resolves #1924  

### How I did it

EMVVersionException changed to EvmVersionException
InvalidTypeException changed to InvalidType
TypeMismatchException changed to TypeMismatch

KeyError was removed since it was replaced by JSONError

### How to verify it

Read the docs