### PR TITLE
Optimize precompiles to use STATICCALL

### DIFF
--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -316,10 +316,9 @@ def _keccak256(expr, args, kwargs, context):
 def _make_sha256_call(inp_start, inp_len, out_start, out_len):
     return [
         'assert', [
-            'call',
+            'staticcall',
             ['gas'],  # gas
             SHA256_ADDRESS,  # address
-            0,  # value
             inp_start,
             inp_len,
             out_start,
@@ -435,7 +434,9 @@ def ecrecover(expr, args, kwargs, context):
         ['mstore', ['add', placeholder_node, 32], args[1]],
         ['mstore', ['add', placeholder_node, 64], args[2]],
         ['mstore', ['add', placeholder_node, 96], args[3]],
-        ['pop', ['call', ['gas'], 1, 0, placeholder_node, 128, MemoryPositions.FREE_VAR_SPACE, 32]],
+        ['pop', [
+            'staticcall', ['gas'], 1, placeholder_node, 128, MemoryPositions.FREE_VAR_SPACE, 32
+        ]],
         ['mload', MemoryPositions.FREE_VAR_SPACE],
     ], typ=BaseType('address'), pos=getpos(expr))
 
@@ -456,7 +457,7 @@ def ecadd(expr, args, kwargs, context):
         ['mstore', ['add', placeholder_node, 32], avo(args[0], 1, pos)],
         ['mstore', ['add', placeholder_node, 64], avo(args[1], 0, pos)],
         ['mstore', ['add', placeholder_node, 96], avo(args[1], 1, pos)],
-        ['assert', ['call', ['gas'], 6, 0, placeholder_node, 128, placeholder_node, 64]],
+        ['assert', ['staticcall', ['gas'], 6, placeholder_node, 128, placeholder_node, 64]],
         placeholder_node,
     ], typ=ListType(BaseType('uint256'), 2), pos=getpos(expr), location='memory')
     return o
@@ -473,7 +474,7 @@ def ecmul(expr, args, kwargs, context):
         ['mstore', placeholder_node, avo(args[0], 0, pos)],
         ['mstore', ['add', placeholder_node, 32], avo(args[0], 1, pos)],
         ['mstore', ['add', placeholder_node, 64], args[1]],
-        ['assert', ['call', ['gas'], 7, 0, placeholder_node, 96, placeholder_node, 64]],
+        ['assert', ['staticcall', ['gas'], 7, placeholder_node, 96, placeholder_node, 64]],
         placeholder_node,
     ], typ=ListType(BaseType('uint256'), 2), pos=pos, location='memory')
     return o


### PR DESCRIPTION
fixes: #1929

### What I did
Our precompiled calls were using `CALL` instead of `STATICCALL`, overpaying by 660 gas per call. This change switches out how the call is made to cost less gas. No changes required for testing.

### Description for the changelog
Optimize precompiles to use `STATICCALL`

### Cute Animal Picture
![cute aardvark](http://www.somepets.com/wp-content/uploads/2013/01/small_pets_3.jpg)