### PR TITLE
Folding for builtin and user-defined constants

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -62,6 +62,7 @@ The following conventions **should** be used when naming functions or methods. C
     * ``build_``: For creation of a new object that is derived from some other data.
     * ``set_``: For adding a new value or modifying an existing one within an object.
     * ``add_``: For adding a new attribute or other value to an object. Raises an exception if the value already exists.
+    * ``replace_``: For mutating an object. Should return ``None`` on success or raise an exception if something is wrong.
     * ``compare_``: For comparing values. Returns ``True`` or ``False``, does not raise an exception.
     * ``validate_``: Returns ``None`` or raises an exception if something is wrong.
     * ``from_``: For class methods that instantiate an object based on the given input data.

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -1,3 +1,6 @@
+from decimal import (
+    Decimal,
+)
 from typing import (
     Union,
 )
@@ -9,6 +12,16 @@ from vyper.exceptions import (
     InvalidType,
 )
 
+BUILTIN_CONSTANTS = {
+    "EMPTY_BYTES32": (vy_ast.Hex, "0x0000000000000000000000000000000000000000000000000000000000000000"),  # NOQA: E501
+    "ZERO_ADDRESS": (vy_ast.Hex, "0x0000000000000000000000000000000000000000"),
+    "MAX_INT128": (vy_ast.Int, 2 ** 127 - 1),
+    "MIN_INT128": (vy_ast.Int, -(2 ** 127)),
+    "MAX_DECIMAL": (vy_ast.Decimal, Decimal(2 ** 127 - 1)),
+    "MIN_DECIMAL": (vy_ast.Decimal, Decimal(-(2 ** 127))),
+    "MAX_UINT256": (vy_ast.Int, 2 ** 256 - 1),
+}
+
 
 def fold(vyper_ast_node: vy_ast.Module) -> None:
     """
@@ -19,6 +32,8 @@ def fold(vyper_ast_node: vy_ast.Module) -> None:
     vyper_ast_node : Module
         Top-level Vyper AST node.
     """
+    replace_builtin_constants(vyper_ast_node)
+
     changed_nodes = 1
     while changed_nodes:
         changed_nodes = 0
@@ -73,6 +88,19 @@ def replace_subscripts(vyper_ast_node: vy_ast.Module) -> int:
         vyper_ast_node.replace_in_tree(node, new_node)
 
     return changed_nodes
+
+
+def replace_builtin_constants(vyper_ast_node: vy_ast.Module) -> None:
+    """
+    Replace references to builtin constants with their literal values.
+
+    Arguments
+    ---------
+    vyper_ast_node : Module
+        Top-level Vyper AST node.
+    """
+    for name, (node, value) in BUILTIN_CONSTANTS.items():
+        replace_constant(vyper_ast_node, name, node(value=value))
 
 
 def _replace(old_node, new_node):


### PR DESCRIPTION
### What I did
Add folding logic for builtin and user-defined constants.

### How I did it
The core functionality was added in #1912 as `ast.folding.replace_constant`. This PR adds two methods, `replace_builtin_constants` and `replace_user_defined_constants` that make use of this functionality.

### How to verify it
Run the tests.  I expanded on the test cases in `tests/ast/test_folding.py`.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/80235988-80dfe180-866b-11ea-94d9-249c6dc13d9e.png)
