### PR TITLE
chore: allow actions to run on every branch and PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches:
-      - master
-
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
### What I did
Allow Github Actions to run on every branch and pull request.

This is useful because it also means actions will run on branches of forked repos.  Less time waiting for the CI to finish on pull requests, more information for contributors as they work.

### How I did it
Modify the actions yaml.

### How to verify it
Watch actions in..  action?

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/80248345-c65ad980-8680-11ea-9866-365278d55805.png)
