### PR TITLE
remove old environment vars in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,6 @@ use_parentheses = True
 
 [testenv]
 usedevelop = True
-passenv =
-    COVERALLS_REPO_TOKEN
-    CIRCLECI
-    CIRCLE_*
-    CI_PULL_REQUEST
 commands =
     core: pytest -m "not fuzzing" --showlocals {posargs:tests/}
 basepython =


### PR DESCRIPTION
### What I did
Remove references to circle CI and coveralls environment variables in `tox.ini`

### How to verify it
Check that CI isn't broken.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/80276938-ce585f00-86fc-11ea-899c-83b1ad102506.png)
