### PR TITLE
Remove some reserved keywords

### DIFF
--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -155,7 +155,7 @@ RESERVED_KEYWORDS = {
     # control flow
     'if', 'for', 'while', 'until', 'pass', 'def',
     # EVM operations
-    'send', 'selfdestruct', 'assert', 'raise',
+    'send', 'selfdestruct', 'assert', 'raise', 'throw',
     # special functions (no name mangling)
     'init', '_init_', '___init___', '____init____',
     'default', '_default_', '___default___', '____default____',

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -155,12 +155,10 @@ RESERVED_KEYWORDS = {
     # control flow
     'if', 'for', 'while', 'until', 'pass', 'def',
     # EVM operations
-    'push', 'dup', 'swap', 'send', 'call',
-    'selfdestruct', 'assert', 'stop', 'throw',
-    'raise', 'init', 'default',
-    # special function (name mangling)
-    '_init_', '___init___', '____init____',
-    '_default_', '___default___', '____default____',
+    'send', 'selfdestruct', 'assert', 'raise',
+    # special functions (no name mangling)
+    'init', '_init_', '___init___', '____init____',
+    'default', '_default_', '___default___', '____default____',
     # environment variables
     'block', 'msg', 'tx', 'chain', 'chainid',
     'blockhash', 'timestamp', 'timedelta',


### PR DESCRIPTION
fixes: #1938

### What I Did
There's no reason for certain LLL keywords to be reserved for use with Vyper syntax

I removed:
`push`, `dup`, `swap`, `call`, `stop`

### Cute Animal Picture
![cute gecko](https://www.nationalgeographic.com/content/dam/news/2016/01/06/tokay_gecko/01_tokay-gecko.ngsversion.1452103200406.adapt.1900.1.jpg)