### PR TITLE
Folding builtins

### DIFF
--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -189,3 +189,26 @@ def test_replace_userdefined_constant_no(source):
     folding.replace_user_defined_constants(folded_ast)
 
     assert vy_ast.compare_nodes(unmodified_ast, folded_ast)
+
+
+builtin_folding_functions = [("ceil(4.2)", "5"), ("floor(4.2)", "4")]
+
+builtin_folding_sources = [
+    "{}",
+    "foo = {}",
+    "foo = [{0}, {0}]",
+    "def foo(): {}",
+    "def foo(): return {}",
+    "def foo(bar: {}): pass",
+]
+
+
+@pytest.mark.parametrize("source", builtin_folding_sources)
+@pytest.mark.parametrize("original,result", builtin_folding_functions)
+def test_replace_builtins(source, original, result):
+    original_ast = vy_ast.parse_to_ast(source.format(original))
+    target_ast = vy_ast.parse_to_ast(source.format(result))
+
+    folding.replace_builtin_functions(original_ast)
+
+    assert vy_ast.compare_nodes(original_ast, target_ast)

--- a/tests/functions/folding/test_fold_floor_ceil.py
+++ b/tests/functions/folding/test_fold_floor_ceil.py
@@ -1,0 +1,68 @@
+from decimal import (
+    Decimal,
+)
+
+from hypothesis import (
+    example,
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+st_decimals = st.decimals(
+    min_value=-2 ** 32,
+    max_value=2 ** 32,
+    allow_nan=False,
+    allow_infinity=False,
+    places=10,
+)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(value=st_decimals)
+@example(value=Decimal("0.9999999999"))
+@example(value=Decimal("0.0000000001"))
+@example(value=Decimal("-0.9999999999"))
+@example(value=Decimal("-0.0000000001"))
+def test_fold_ceil(get_contract, assert_tx_failed, value):
+    source = f"""
+@public
+def foo(a: decimal) -> int128:
+    return ceil(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"ceil({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.Ceil().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(value=st_decimals)
+@example(value=Decimal("0.9999999999"))
+@example(value=Decimal("0.0000000001"))
+@example(value=Decimal("-0.9999999999"))
+@example(value=Decimal("-0.0000000001"))
+def test_fold_floor(get_contract, assert_tx_failed, value):
+    source = f"""
+@public
+def foo(a: decimal) -> int128:
+    return floor(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"floor({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.Floor().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value

--- a/vyper/ast/__init__.py
+++ b/vyper/ast/__init__.py
@@ -3,6 +3,7 @@ import sys
 from . import (  # noqa: F401
     folding,
     nodes,
+    validation,
 )
 from .nodes import (  # noqa: F401
     compare_nodes,

--- a/vyper/ast/validation.py
+++ b/vyper/ast/validation.py
@@ -1,0 +1,77 @@
+from typing import (
+    Optional,
+    Union,
+)
+
+from vyper.ast import (
+    nodes as vy_ast,
+)
+from vyper.exceptions import (
+    ArgumentException,
+    CompilerPanic,
+    StructureException,
+)
+
+
+def validate_call_args(
+    node: vy_ast.Call, arg_count: Union[int, tuple], kwargs: Optional[list] = None
+) -> None:
+    """
+    Validate positional and keyword arguments of a Call node.
+
+    This function does not handle type checking of arguments, it only checks
+    correctness of the number of arguments given and keyword names.
+
+    Arguments
+    ---------
+    node : Call
+        Vyper ast Call node to be validated.
+    arg_count : int | tuple
+        The required number of positional arguments. When given as a tuple the
+        value is interpreted as the minimum and maximum number of arguments.
+    kwargs : list, optional
+        A list of valid keyword arguments. When arg_count is a tuple and the
+        number of positional arguments exceeds the minimum, the excess values are
+        considered to fill the first values on this list.
+
+    Returns
+    -------
+        None. Raises an exception when the arguments are invalid.
+    """
+    if kwargs is None:
+        kwargs = []
+    if not isinstance(node, vy_ast.Call):
+        raise StructureException("Expected Call", node)
+    if not isinstance(arg_count, (int, tuple)):
+        raise CompilerPanic(f"Invalid type for arg_count: {type(arg_count).__name__}")
+
+    if isinstance(arg_count, int) and len(node.args) != arg_count:
+        raise ArgumentException(
+            f"Invalid argument count: expected {arg_count}, got {len(node.args)}", node
+        )
+    elif (
+        isinstance(arg_count, tuple)
+        and not arg_count[0] <= len(node.args) <= arg_count[1]
+    ):
+        raise ArgumentException(
+            f"Invalid argument count: expected between "
+            f"{arg_count[0]} and {arg_count[1]}, got {len(node.args)}",
+            node,
+        )
+
+    if not kwargs and node.keywords:
+        raise ArgumentException(
+            "Keyword arguments are not accepted here", node.keywords[0]
+        )
+    for key in node.keywords:
+        if key.arg is None:
+            raise StructureException("Use of **kwargs is not supported", key.value)
+        if key.arg not in kwargs:
+            raise ArgumentException(f"Invalid keyword argument '{key.arg}'", key)
+        if (
+            isinstance(arg_count, tuple)
+            and kwargs.index(key.arg) < len(node.args) - arg_count[0]
+        ):
+            raise ArgumentException(
+                f"'{key.arg}' was given as a positional argument", key
+            )

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -2,13 +2,18 @@ from decimal import (
     Decimal,
 )
 import hashlib
+import math
 
 from vyper import (
     ast as vy_ast,
 )
+from vyper.ast.validation import (
+    validate_call_args,
+)
 from vyper.exceptions import (
     ConstancyViolation,
     InvalidLiteral,
+    InvalidType,
     StructureException,
     TypeMismatch,
 )
@@ -84,6 +89,14 @@ class Floor:
     _id = "floor"
     _inputs = [("value", "decimal")]
     _return_type = "int128"
+
+    def evaluate(self, node):
+        validate_call_args(node, 1)
+        if not isinstance(node.args[0], vy_ast.Decimal):
+            raise InvalidType("Call cannot be folded", node)
+
+        value = math.floor(node.args[0].value)
+        return vy_ast.Int.from_node(node, value=value)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -118,6 +118,14 @@ class Ceil:
     _inputs = [("value", "decimal")]
     _return_type = "int128"
 
+    def evaluate(self, node):
+        validate_call_args(node, 1)
+        if not isinstance(node.args[0], vy_ast.Decimal):
+            raise InvalidType("Call cannot be folded", node)
+
+        value = math.ceil(node.args[0].value)
+        return vy_ast.Int.from_node(node, value=value)
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(


### PR DESCRIPTION
### What I did
Add folding logic for `floor` and `ceil` builtin functions.

### How I did it
* add `ast/validation.py` which contains the `validate_call_args` method. This method checks the number of arguments used in a function call, and the key names for keyword arguments.
* in `functions/functions.py`, add an `evaluate` method to the classes for `floor` and `ceil`. This method accepts a `Call` node and returns an `Int` node when the value can be folded.
* add property-based tests to verify that the folded output is equivalent to the unfolded output.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/80398413-a289d480-88c8-11ea-9948-8861909331a7.png)
