### PR TITLE
Remove .hypothesis/ via make target clean-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ clean-test:
 	@rm -fr coverage.xml
 	@rm -fr .coverage
 	@rm -fr .eggs/
+	@rm -fr .hypothesis/
 	@rm -fr .pytest_cache/
 
 


### PR DESCRIPTION
### What I did
Added the removal of `.hypothesis/` in `make` target `clean-test`.

### How to verify it
To quickly check, you can run this command:
```shell
$ mkdir -p .hypothesis && ls -al .hypothesis && make clean-test && ls -al .hypothesis
```
the output should be similar to:
```shell
drwxr-xr-x  2 orange orange 4096 May  1 06:45 .
drwxr-xr-x 14 orange orange 4096 May  1 06:45 ..
Cleaning test files...
ls: cannot access '.hypothesis': No such file or directory
```
where `orange` is your user id and group id (`id -un` and `id -gn`).

Alternatively, instead of running the above command:  
* Check that the `.hypothesis` directory is there. If not create it or run a test, which will create the directory.
* Run `make clean` or `make clean-test` to be more precise.
* Check that the `.hypothesis` directory is no longer there.

### Description for the changelog
Running `make clean-test`, and other targets that invoke it such as `make clean` now removes the directory `.hypothesis`.
