### PR TITLE
Valid Assignment: Check that value being assigned in not None

### DIFF
--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -261,6 +261,7 @@ def foo():
             TypeMismatch
         )
 
+
 def test_invalid_nonetype_assignment(assert_compile_failed, get_contract_with_gas_estimation):
     code = """
 @private

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -260,3 +260,17 @@ def foo():
             lambda: get_contract_with_gas_estimation(contract),
             TypeMismatch
         )
+
+def test_invalid_nonetype_assignment(assert_compile_failed, get_contract_with_gas_estimation):
+    code = """
+@private
+def bar():
+    pass
+
+@public
+def foo():
+    ret : bool = self.bar()
+"""
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(code), TypeMismatch
+    )

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -132,6 +132,11 @@ class Stmt(object):
                     f'Invalid type, expected: {self.stmt.annotation.value.id},'
                     f' got: {sub.typ}', self.stmt
                 )
+        elif sub.typ is None:
+            #Check that the object to be assigned is not of NoneType
+            raise TypeMismatch(
+                f"Invalid type, expected {self.stmt.annotation.id}", self.stmt
+            )
         elif isinstance(sub.typ, StructType):
             # This needs to get more sophisticated in the presence of
             # foreign structs.

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -133,7 +133,7 @@ class Stmt(object):
                     f' got: {sub.typ}', self.stmt
                 )
         elif sub.typ is None:
-            #Check that the object to be assigned is not of NoneType
+            # Check that the object to be assigned is not of NoneType
             raise TypeMismatch(
                 f"Invalid type, expected {self.stmt.annotation.id}", self.stmt
             )


### PR DESCRIPTION
### What I did

Checked that during assignment the value being assigned is not None
In Vyper, there is no null option like most programming languages have so I assumed that any valid assignment should not be assigning a None value.

Added a test for the same where the returned NoneType value is being assigned to a variable

Resolves #1862 
Resolves #1821 

### How I did it

Raised a `TypeMismatch` Exception when a NoneType is being assigned.


### How to verify it

Run the test

### Description for the changelog

Check for `NoneType` assignment is added to `vyper/parser/stmt.py`
`test_invalid_nonetype_assignment` added in `tests/parser/features/test_assignment.py`
