### PR TITLE
Folding builtins

### DIFF
--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -189,3 +189,26 @@ def test_replace_userdefined_constant_no(source):
     folding.replace_user_defined_constants(folded_ast)
 
     assert vy_ast.compare_nodes(unmodified_ast, folded_ast)
+
+
+builtin_folding_functions = [("ceil(4.2)", "5"), ("floor(4.2)", "4")]
+
+builtin_folding_sources = [
+    "{}",
+    "foo = {}",
+    "foo = [{0}, {0}]",
+    "def foo(): {}",
+    "def foo(): return {}",
+    "def foo(bar: {}): pass",
+]
+
+
+@pytest.mark.parametrize("source", builtin_folding_sources)
+@pytest.mark.parametrize("original,result", builtin_folding_functions)
+def test_replace_builtins(source, original, result):
+    original_ast = vy_ast.parse_to_ast(source.format(original))
+    target_ast = vy_ast.parse_to_ast(source.format(result))
+
+    folding.replace_builtin_functions(original_ast)
+
+    assert vy_ast.compare_nodes(original_ast, target_ast)

--- a/tests/functions/folding/test_addmod_mulmod.py
+++ b/tests/functions/folding/test_addmod_mulmod.py
@@ -1,0 +1,35 @@
+from hypothesis import (
+    assume,
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+st_uint256 = st.integers(min_value=0, max_value=2 ** 256 - 1)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(a=st_uint256, b=st_uint256, c=st_uint256)
+@pytest.mark.parametrize('fn_name', ['uint256_addmod', 'uint256_mulmod'])
+def test_modmath(get_contract, a, b, c, fn_name):
+    assume(c > 0)
+
+    source = f"""
+@public
+def foo(a: uint256, b: uint256, c: uint256) -> uint256:
+    return {fn_name}(a, b, c)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({a}, {b}, {c})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(a, b, c) == new_node.value

--- a/tests/functions/folding/test_bitwise.py
+++ b/tests/functions/folding/test_bitwise.py
@@ -1,0 +1,71 @@
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+st_uint256 = st.integers(min_value=0, max_value=2 ** 256 - 1)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(a=st_uint256, b=st_uint256)
+@pytest.mark.parametrize('fn_name', ['bitwise_and', 'bitwise_or', 'bitwise_xor'])
+def test_bitwise(get_contract, a, b, fn_name):
+
+    source = f"""
+@public
+def foo(a: uint256, b: uint256) -> uint256:
+    return {fn_name}(a, b)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({a}, {b})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(a, b) == new_node.value
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(value=st_uint256)
+def test_bitwise_not(get_contract, value):
+
+    source = f"""
+@public
+def foo(a: uint256) -> uint256:
+    return bitwise_not(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"bitwise_not({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.BitwiseNot().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(value=st_uint256, steps=st.integers(min_value=-256, max_value=256))
+def test_shift(get_contract, value, steps):
+
+    source = f"""
+@public
+def foo(a: uint256, b: int128) -> uint256:
+    return shift(a, b)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"shift({value}, {steps})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.Shift().evaluate(old_node)
+
+    assert contract.foo(value, steps) == new_node.value

--- a/tests/functions/folding/test_floor_ceil.py
+++ b/tests/functions/folding/test_floor_ceil.py
@@ -1,0 +1,47 @@
+from decimal import (
+    Decimal,
+)
+
+from hypothesis import (
+    example,
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+st_decimals = st.decimals(
+    min_value=-(2 ** 32),
+    max_value=2 ** 32,
+    allow_nan=False,
+    allow_infinity=False,
+    places=10,
+)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(value=st_decimals)
+@example(value=Decimal("0.9999999999"))
+@example(value=Decimal("0.0000000001"))
+@example(value=Decimal("-0.9999999999"))
+@example(value=Decimal("-0.0000000001"))
+@pytest.mark.parametrize("fn_name", ["floor", "ceil"])
+def test_floor_ceil(get_contract, value, fn_name):
+    source = f"""
+@public
+def foo(a: decimal) -> int128:
+    return {fn_name}(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value

--- a/tests/functions/folding/test_fold_as_wei_value.py
+++ b/tests/functions/folding/test_fold_as_wei_value.py
@@ -1,0 +1,60 @@
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+denoms = [x for k in vy_fn.AsWeiValue.wei_denoms.keys() for x in k]
+
+
+st_decimals = st.decimals(
+    min_value=0,
+    max_value=2 ** 32,
+    allow_nan=False,
+    allow_infinity=False,
+    places=10,
+)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=10, deadline=1000)
+@given(value=st_decimals)
+@pytest.mark.parametrize('denom', denoms)
+def test_decimal(get_contract, value, denom):
+    source = f"""
+@public
+def foo(a: decimal) -> uint256:
+    return as_wei_value(a, '{denom}')
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"as_wei_value({value:.10f}, '{denom}')")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.AsWeiValue().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=10, deadline=1000)
+@given(value=st.integers(min_value=0, max_value=2 ** 128))
+@pytest.mark.parametrize('denom', denoms)
+def test_integer(get_contract, value, denom):
+    source = f"""
+@public
+def foo(a: uint256) -> uint256:
+    return as_wei_value(a, '{denom}')
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"as_wei_value({value}, '{denom}')")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.AsWeiValue().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value

--- a/tests/functions/folding/test_keccak_sha.py
+++ b/tests/functions/folding/test_keccak_sha.py
@@ -1,0 +1,73 @@
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&()*+,-./:;<=>?@[]^_`{|}~'  # NOQA: E501
+
+
+@pytest.mark.fuzzing
+@given(value=st.text(alphabet=alphabet, min_size=0, max_size=100))
+@settings(max_examples=50, deadline=1000)
+@pytest.mark.parametrize('fn_name', ['keccak256', 'sha256'])
+def test_string(get_contract, value, fn_name):
+
+    source = f"""
+@public
+def foo(a: string[100]) -> bytes32:
+    return {fn_name}(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}('''{value}''')")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value
+
+
+@pytest.mark.fuzzing
+@given(value=st.binary(min_size=0, max_size=100))
+@settings(max_examples=50, deadline=1000)
+@pytest.mark.parametrize('fn_name', ['keccak256', 'sha256'])
+def test_bytes(get_contract, value, fn_name):
+    source = f"""
+@public
+def foo(a: bytes[100]) -> bytes32:
+    return {fn_name}(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value
+
+
+@pytest.mark.fuzzing
+@given(value=st.binary(min_size=1, max_size=100))
+@settings(max_examples=50, deadline=1000)
+@pytest.mark.parametrize('fn_name', ['keccak256', 'sha256'])
+def test_hex(get_contract, value, fn_name):
+    source = f"""
+@public
+def foo(a: bytes[100]) -> bytes32:
+    return {fn_name}(a)
+    """
+    contract = get_contract(source)
+
+    value = f"0x{value.hex()}"
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value

--- a/tests/functions/folding/test_len.py
+++ b/tests/functions/folding/test_len.py
@@ -1,0 +1,60 @@
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+
+@pytest.mark.parametrize("length", [0, 1, 32, 33, 64, 65, 1024])
+def test_len_string(get_contract, length):
+    source = f"""
+@public
+def foo(a: string[1024]) -> int128:
+    return len(a)
+    """
+    contract = get_contract(source)
+
+    value = "a" * length
+
+    vyper_ast = vy_ast.parse_to_ast(f"len('{value}')")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.Len().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value
+
+
+@pytest.mark.parametrize("length", [0, 1, 32, 33, 64, 65, 1024])
+def test_len_bytes(get_contract, length):
+    source = f"""
+@public
+def foo(a: bytes[1024]) -> int128:
+    return len(a)
+    """
+    contract = get_contract(source)
+
+    value = "a" * length
+
+    vyper_ast = vy_ast.parse_to_ast(f"len(b'{value}')")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.Len().evaluate(old_node)
+
+    assert contract.foo(value.encode()) == new_node.value
+
+
+@pytest.mark.parametrize("length", [1, 32, 33, 64, 65, 1024])
+def test_len_hex(get_contract, length):
+    source = f"""
+@public
+def foo(a: bytes[1024]) -> int128:
+    return len(a)
+    """
+    contract = get_contract(source)
+
+    value = f"0x{'00' * length}"
+
+    vyper_ast = vy_ast.parse_to_ast(f"len({value})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.Len().evaluate(old_node)
+
+    assert contract.foo(value) == new_node.value

--- a/tests/functions/folding/test_min_max.py
+++ b/tests/functions/folding/test_min_max.py
@@ -1,0 +1,78 @@
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+import pytest
+
+from vyper import (
+    ast as vy_ast,
+    functions as vy_fn,
+)
+
+st_decimals = st.decimals(
+    min_value=-2 ** 32,
+    max_value=2 ** 32,
+    allow_nan=False,
+    allow_infinity=False,
+    places=10,
+)
+st_int128 = st.integers(min_value=-2**127, max_value=2**127-1)
+st_uint256 = st.integers(min_value=0, max_value=2**256-1)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(left=st_decimals, right=st_decimals)
+@pytest.mark.parametrize("fn_name", ["min", "max"])
+def test_decimal(get_contract, left, right, fn_name):
+    source = f"""
+@public
+def foo(a: decimal, b: decimal) -> decimal:
+    return {fn_name}(a, b)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({left}, {right})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(left, right) == new_node.value
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(left=st_int128, right=st_int128)
+@pytest.mark.parametrize("fn_name", ["min", "max"])
+def test_int128(get_contract, left, right, fn_name):
+    source = f"""
+@public
+def foo(a: int128, b: int128) -> int128:
+    return {fn_name}(a, b)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({left}, {right})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(left, right) == new_node.value
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(left=st_uint256, right=st_uint256)
+@pytest.mark.parametrize("fn_name", ["min", "max"])
+def test_min_uint256(get_contract, left, right, fn_name):
+    source = f"""
+@public
+def foo(a: uint256, b: uint256) -> uint256:
+    return {fn_name}(a, b)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"{fn_name}({left}, {right})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE[fn_name].evaluate(old_node)
+
+    assert contract.foo(left, right) == new_node.value

--- a/vyper/ast/__init__.py
+++ b/vyper/ast/__init__.py
@@ -3,6 +3,7 @@ import sys
 from . import (  # noqa: F401
     folding,
     nodes,
+    validation,
 )
 from .nodes import (  # noqa: F401
     compare_nodes,

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -11,6 +11,9 @@ from vyper.ast import (
 from vyper.exceptions import (
     UnfoldableNode,
 )
+from vyper.functions import (
+    DISPATCH_TABLE,
+)
 
 BUILTIN_CONSTANTS = {
     "EMPTY_BYTES32": (vy_ast.Hex, "0x0000000000000000000000000000000000000000000000000000000000000000"),  # NOQA: E501
@@ -40,6 +43,7 @@ def fold(vyper_ast_node: vy_ast.Module) -> None:
         changed_nodes = 0
         changed_nodes += replace_literal_ops(vyper_ast_node)
         changed_nodes += replace_subscripts(vyper_ast_node)
+        changed_nodes += replace_builtin_functions(vyper_ast_node)
 
 
 def replace_literal_ops(vyper_ast_node: vy_ast.Module) -> int:
@@ -82,6 +86,37 @@ def replace_subscripts(vyper_ast_node: vy_ast.Module) -> int:
     for node in vyper_ast_node.get_descendants(vy_ast.Subscript, reverse=True):
         try:
             new_node = node.evaluate()
+        except UnfoldableNode:
+            continue
+
+        changed_nodes += 1
+        vyper_ast_node.replace_in_tree(node, new_node)
+
+    return changed_nodes
+
+
+def replace_builtin_functions(vyper_ast_node: vy_ast.Module) -> int:
+    """
+    Find and evaluate builtin function calls within the Vyper AST, replacing
+    them with Constant nodes where possible.
+
+    Arguments
+    ---------
+    vyper_ast_node : Module
+        Top-level Vyper AST node.
+    """
+    changed_nodes = 0
+
+    for node in vyper_ast_node.get_descendants(vy_ast.Call, reverse=True):
+        if not isinstance(node.func, vy_ast.Name):
+            continue
+
+        name = node.func.id
+        func = DISPATCH_TABLE.get(name)
+        if func is None or not hasattr(func, 'evaluate'):
+            continue
+        try:
+            new_node = func.evaluate(node)  # type: ignore
         except UnfoldableNode:
             continue
 

--- a/vyper/ast/validation.py
+++ b/vyper/ast/validation.py
@@ -1,0 +1,77 @@
+from typing import (
+    Optional,
+    Union,
+)
+
+from vyper.ast import (
+    nodes as vy_ast,
+)
+from vyper.exceptions import (
+    ArgumentException,
+    CompilerPanic,
+    StructureException,
+)
+
+
+def validate_call_args(
+    node: vy_ast.Call, arg_count: Union[int, tuple], kwargs: Optional[list] = None
+) -> None:
+    """
+    Validate positional and keyword arguments of a Call node.
+
+    This function does not handle type checking of arguments, it only checks
+    correctness of the number of arguments given and keyword names.
+
+    Arguments
+    ---------
+    node : Call
+        Vyper ast Call node to be validated.
+    arg_count : int | tuple
+        The required number of positional arguments. When given as a tuple the
+        value is interpreted as the minimum and maximum number of arguments.
+    kwargs : list, optional
+        A list of valid keyword arguments. When arg_count is a tuple and the
+        number of positional arguments exceeds the minimum, the excess values are
+        considered to fill the first values on this list.
+
+    Returns
+    -------
+        None. Raises an exception when the arguments are invalid.
+    """
+    if kwargs is None:
+        kwargs = []
+    if not isinstance(node, vy_ast.Call):
+        raise StructureException("Expected Call", node)
+    if not isinstance(arg_count, (int, tuple)):
+        raise CompilerPanic(f"Invalid type for arg_count: {type(arg_count).__name__}")
+
+    if isinstance(arg_count, int) and len(node.args) != arg_count:
+        raise ArgumentException(
+            f"Invalid argument count: expected {arg_count}, got {len(node.args)}", node
+        )
+    elif (
+        isinstance(arg_count, tuple)
+        and not arg_count[0] <= len(node.args) <= arg_count[1]
+    ):
+        raise ArgumentException(
+            f"Invalid argument count: expected between "
+            f"{arg_count[0]} and {arg_count[1]}, got {len(node.args)}",
+            node,
+        )
+
+    if not kwargs and node.keywords:
+        raise ArgumentException(
+            "Keyword arguments are not accepted here", node.keywords[0]
+        )
+    for key in node.keywords:
+        if key.arg is None:
+            raise StructureException("Use of **kwargs is not supported", key.value)
+        if key.arg not in kwargs:
+            raise ArgumentException(f"Invalid keyword argument '{key.arg}'", key)
+        if (
+            isinstance(arg_count, tuple)
+            and kwargs.index(key.arg) < len(node.args) - arg_count[0]
+        ):
+            raise ArgumentException(
+                f"'{key.arg}' was given as a positional argument", key
+            )

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -206,7 +206,7 @@ class VyperInternalException(Exception):
     Internal exceptions are raised as a means of passing information between
     compiler processes. They should never be exposed to the user.
     """
-    def __init__(self, message):
+    def __init__(self, message=""):
         self.message = message
 
     def __str__(self):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -383,8 +383,19 @@ class Keccak256:
     _return_type = "bytes32"
 
     def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
+        validate_call_args(node, 1)
+        if isinstance(node.args[0], vy_ast.Bytes):
+            value = node.args[0].value
+        elif isinstance(node.args[0], vy_ast.Str):
+            value = node.args[0].value.encode()
+        elif isinstance(node.args[0], vy_ast.Hex):
+            length = len(node.args[0].value) // 2 - 1
+            value = int(node.args[0].value, 16).to_bytes(length, "big")
+        else:
+            raise UnfoldableNode
+
+        hash_ = keccak256(value)
+        return vy_ast.Bytes.from_node(node, value=hash_)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -411,9 +422,21 @@ class Sha256:
     _inputs = [("value", ('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))]
     _return_type = "bytes32"
 
+    # TODO once active, remove the literal input logic from build_LLL
     def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
+        validate_call_args(node, 1)
+        if isinstance(node.args[0], vy_ast.Bytes):
+            value = node.args[0].value
+        elif isinstance(node.args[0], vy_ast.Str):
+            value = node.args[0].value.encode()
+        elif isinstance(node.args[0], vy_ast.Hex):
+            length = len(node.args[0].value) // 2 - 1
+            value = int(node.args[0].value, 16).to_bytes(length, "big")
+        else:
+            raise UnfoldableNode
+
+        hash_ = hashlib.sha256(value).digest()
+        return vy_ast.Bytes.from_node(node, value=hash_)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -150,10 +150,6 @@ class Convert:
     def build_LLL(self, expr, context):
         return convert(expr, context)
 
-    def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
-
 
 class Slice:
 
@@ -245,7 +241,6 @@ class Len:
     _inputs = [("b", ("bytes", "string"))]
     _return_type = "int128"
 
-    # TODO unit tests
     def evaluate(self, node):
         validate_call_args(node, 1)
         arg = node.args[0]
@@ -521,8 +516,7 @@ class MethodID:
     _id = "method_id"
     _inputs = [("method", "str_literal"), ("type", "name_literal")]
 
-    # TODO tests
-    # once this is plugged in, build_LLL can be removed as this method should always be foldable
+    # TODO once this is plugged in, build_LLL can be removed as this method is always foldable
     def evaluate(self, node):
         validate_call_args(node, 2)
         if not isinstance(node.args[0], vy_ast.Str):
@@ -744,7 +738,6 @@ class AsWeiValue:
         ("kether", "grand"): 10**21,
     }
 
-    # TODO test
     def evaluate(self, node):
         validate_call_args(node, 2)
         if not isinstance(node.args[1], vy_ast.Str):
@@ -1150,7 +1143,6 @@ class _AddMulMod:
     _inputs = [("a", "uint256"), ("b", "uint256"), ("c", "uint256")]
     _return_type = "uint256"
 
-    # TODO test
     def evaluate(self, node):
         validate_call_args(node, 3)
         for arg in node.args:
@@ -1335,10 +1327,6 @@ class Sqrt:
     _inputs = [("d", "decimal")]
     _return_type = "decimal"
 
-    def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
-
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         from vyper.functions.utils import (
@@ -1402,10 +1390,6 @@ class Empty:
 
     _id = "empty"
     _inputs = [("typename", "*")]
-
-    def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -238,6 +238,19 @@ class Len:
     _inputs = [("b", ("bytes", "string"))]
     _return_type = "int128"
 
+    def evaluate(self, node):
+        validate_call_args(node, 1)
+        arg = node.args[0]
+        if isinstance(arg, (vy_ast.Str, vy_ast.Bytes)):
+            length = len(arg.value)
+        elif isinstance(arg, vy_ast.Hex):
+            # 2 characters represent 1 byte and we subtract 1 to ignore the leading `0x`
+            length = len(arg.value) // 2 - 1
+        else:
+            raise UnfoldableNode
+
+        return vy_ast.Int.from_node(node, value=length)
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return get_length(args[0])

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -975,29 +975,21 @@ class BitwiseAnd:
     _return_type = "uint256"
 
     def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
+        validate_call_args(node, 2)
+        for arg in node.args:
+            if not isinstance(arg, vy_ast.Num):
+                raise UnfoldableNode
+            if arg.value < 0 or arg.value >= 2**256:
+                raise InvalidLiteral("Value out of range for uint256", arg)
+
+        value = node.args[0].value & node.args[1].value
+        return vy_ast.Int.from_node(node, value=value)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(
             ['and', args[0], args[1]], typ=BaseType('uint256'), pos=getpos(expr)
         )
-
-
-class BitwiseNot:
-
-    _id = "bitwise_not"
-    _inputs = [("x", "uint256")]
-    _return_type = "uint256"
-
-    def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
-
-    @validate_inputs
-    def build_LLL(self, expr, args, kwargs, context):
-        return LLLnode.from_list(['not', args[0]], typ=BaseType('uint256'), pos=getpos(expr))
 
 
 class BitwiseOr:
@@ -1007,8 +999,15 @@ class BitwiseOr:
     _return_type = "uint256"
 
     def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
+        validate_call_args(node, 2)
+        for arg in node.args:
+            if not isinstance(arg, vy_ast.Num):
+                raise UnfoldableNode
+            if arg.value < 0 or arg.value >= 2**256:
+                raise InvalidLiteral("Value out of range for uint256", arg)
+
+        value = node.args[0].value | node.args[1].value
+        return vy_ast.Int.from_node(node, value=value)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -1024,14 +1023,44 @@ class BitwiseXor:
     _return_type = "uint256"
 
     def evaluate(self, node):
-        # TODO
-        raise UnfoldableNode
+        validate_call_args(node, 2)
+        for arg in node.args:
+            if not isinstance(arg, vy_ast.Num):
+                raise UnfoldableNode
+            if arg.value < 0 or arg.value >= 2**256:
+                raise InvalidLiteral("Value out of range for uint256", arg)
+
+        value = node.args[0].value ^ node.args[1].value
+        return vy_ast.Int.from_node(node, value=value)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(
             ['xor', args[0], args[1]], typ=BaseType('uint256'), pos=getpos(expr)
         )
+
+
+class BitwiseNot:
+
+    _id = "bitwise_not"
+    _inputs = [("x", "uint256")]
+    _return_type = "uint256"
+
+    def evaluate(self, node):
+        validate_call_args(node, 1)
+        if not isinstance(node.args[0], vy_ast.Num):
+            raise UnfoldableNode
+
+        value = node.args[0].value
+        if value < 0 or value >= 2**256:
+            raise InvalidLiteral("Value out of range for uint256", node.args[0])
+
+        value = (2**256-1) - value
+        return vy_ast.Int.from_node(node, value=value)
+
+    @validate_inputs
+    def build_LLL(self, expr, args, kwargs, context):
+        return LLLnode.from_list(['not', args[0]], typ=BaseType('uint256'), pos=getpos(expr))
 
 
 class _AddMulMod:

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -2,15 +2,20 @@ from decimal import (
     Decimal,
 )
 import hashlib
+import math
 
 from vyper import (
     ast as vy_ast,
+)
+from vyper.ast.validation import (
+    validate_call_args,
 )
 from vyper.exceptions import (
     ConstancyViolation,
     InvalidLiteral,
     StructureException,
     TypeMismatch,
+    UnfoldableNode,
 )
 from vyper.functions.convert import (
     convert,
@@ -85,6 +90,14 @@ class Floor:
     _inputs = [("value", "decimal")]
     _return_type = "int128"
 
+    def evaluate(self, node):
+        validate_call_args(node, 1)
+        if not isinstance(node.args[0], vy_ast.Decimal):
+            raise UnfoldableNode
+
+        value = math.floor(node.args[0].value)
+        return vy_ast.Int.from_node(node, value=value)
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(
@@ -104,6 +117,14 @@ class Ceil:
     _id = "ceil"
     _inputs = [("value", "decimal")]
     _return_type = "int128"
+
+    def evaluate(self, node):
+        validate_call_args(node, 1)
+        if not isinstance(node.args[0], vy_ast.Decimal):
+            raise UnfoldableNode
+
+        value = math.ceil(node.args[0].value)
+        return vy_ast.Int.from_node(node, value=value)
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -147,6 +147,10 @@ class Convert:
     def build_LLL(self, expr, context):
         return convert(expr, context)
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
 
 class Slice:
 
@@ -238,6 +242,7 @@ class Len:
     _inputs = [("b", ("bytes", "string"))]
     _return_type = "int128"
 
+    # TODO unit tests
     def evaluate(self, node):
         validate_call_args(node, 1)
         arg = node.args[0]
@@ -374,6 +379,10 @@ class Keccak256:
     _inputs = [("value", ('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))]
     _return_type = "bytes32"
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return keccak256_helper(expr, args, kwargs, context)
@@ -398,6 +407,10 @@ class Sha256:
     _id = "sha256"
     _inputs = [("value", ('bytes_literal', 'str_literal', 'bytes', 'string', 'bytes32'))]
     _return_type = "bytes32"
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -481,6 +494,10 @@ class MethodID:
 
     _id = "method_id"
     _inputs = [("method", "str_literal"), ("type", "name_literal")]
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -678,6 +695,10 @@ class AsWeiValue:
         ("ether", ): 10**18,
         ("kether", "grand"): 10**21,
     }
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -910,6 +931,10 @@ class BitwiseAnd:
     _inputs = [("x", "uint256"), ("y", "uint256")]
     _return_type = "uint256"
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(
@@ -923,6 +948,10 @@ class BitwiseNot:
     _inputs = [("x", "uint256")]
     _return_type = "uint256"
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(['not', args[0]], typ=BaseType('uint256'), pos=getpos(expr))
@@ -933,6 +962,10 @@ class BitwiseOr:
     _id = "bitwise_or"
     _inputs = [("x", "uint256"), ("y", "uint256")]
     _return_type = "uint256"
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -947,6 +980,10 @@ class BitwiseXor:
     _inputs = [("x", "uint256"), ("y", "uint256")]
     _return_type = "uint256"
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(
@@ -959,6 +996,10 @@ class AddMod:
     _id = "uint256_addmod"
     _inputs = [("a", "uint256"), ("b", "uint256"), ("c", "uint256")]
     _return_type = "uint256"
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -979,6 +1020,10 @@ class MulMod:
     _inputs = [("a", "uint256"), ("b", "uint256"), ("c", "uint256")]
     _return_type = "uint256"
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return LLLnode.from_list(
@@ -997,6 +1042,10 @@ class Shift:
     _id = "shift"
     _inputs = [("x", "uint256"), ("_shift", "int128")]
     _return_type = "uint256"
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -1114,6 +1163,10 @@ class Min:
     _id = "min"
     _inputs = [("a", ('int128', 'decimal', 'uint256')), ("b", ('int128', 'decimal', 'uint256'))]
 
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
+
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
         return minmax(expr, args, kwargs, context, 'gt')
@@ -1123,6 +1176,10 @@ class Max:
 
     _id = "max"
     _inputs = [("a", ('int128', 'decimal', 'uint256')), ("b", ('int128', 'decimal', 'uint256'))]
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -1168,6 +1225,10 @@ class Sqrt:
     _id = "sqrt"
     _inputs = [("d", "decimal")]
     _return_type = "decimal"
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):
@@ -1232,6 +1293,10 @@ class Empty:
 
     _id = "empty"
     _inputs = [("typename", "*")]
+
+    def evaluate(self, node):
+        # TODO
+        raise UnfoldableNode
 
     @validate_inputs
     def build_LLL(self, expr, args, kwargs, context):


### PR DESCRIPTION
### What I did
Add constant folding logic for builtin functions.

### How I did it
* folding logic is found in the `evaluate` method of each class in `vyper/functions/functions.py`
* the high level execution is handled via `replace_builtin_functions` in `vyper/ast/folding.py`
* test cases are in `tests/functions/folding/`

The only folding implementation I'm not testing is `method_id`. This function should _always_ fold, so verifying the result of folding vs not-folding seems redundant. Once we add folding into the compiler process we can update the existing test cases around this function.

### Next Steps
Things to do next that are outside the scope of this PR.

* add documentation
    * updates to "Types" and "Builtin functions" within RTD
    * add docstrings to classes in `vyper/functions/functions.py`
    * add `README.md` to `vyper/functions`
* plug folding logic into main compiler process
* refactor out now-redundant code

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/81297166-ee383d00-9083-11ea-9e32-9f3f36849f04.png)
