### PR TITLE
Update ERC721.py

### DIFF
--- a/vyper/interfaces/ERC721.py
+++ b/vyper/interfaces/ERC721.py
@@ -37,7 +37,7 @@ def transferFrom(_from: address, _to: address, _tokenId: uint256):
     pass
 
 @public
-def safeTransferFrom(_from: address, _to: address, _tokenId: uint256, _data: bytes[1024]):
+def safeTransferFrom(_from: address, _to: address, _tokenId: uint256):
     pass
 
 @public


### PR DESCRIPTION
Duplicate safeTransferFrom method signatures corrected.

### What I did
The method signatures were the same for both safeTransferFrom methods. I changed one to being with no data. 
