### PR TITLE
Refactor generation of GlobalContext

### DIFF
--- a/tests/ast/test_natspec.py
+++ b/tests/ast/test_natspec.py
@@ -7,6 +7,9 @@ from vyper.ast import (
 from vyper.exceptions import (
     NatSpecSyntaxException,
 )
+from vyper.parser.global_context import (
+    GlobalContext,
+)
 
 test_code = """
 '''
@@ -61,7 +64,8 @@ expected_devdoc = {
 
 def test_documentation_example_output():
     vyper_ast = parse_to_ast(test_code)
-    userdoc, devdoc = parse_natspec(vyper_ast)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
+    userdoc, devdoc = parse_natspec(vyper_ast, global_ctx)
 
     assert userdoc == expected_userdoc
     assert devdoc == expected_devdoc
@@ -81,7 +85,8 @@ def foo():
     """
 
     vyper_ast = parse_to_ast(code)
-    userdoc, devdoc = parse_natspec(vyper_ast)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
+    userdoc, devdoc = parse_natspec(vyper_ast, global_ctx)
 
     assert userdoc == {
         "methods": {"foo()": {"notice": "This one too!"}},
@@ -109,7 +114,8 @@ We don't mind!
                 '''
 """
     vyper_ast = parse_to_ast(code)
-    _, devdoc = parse_natspec(vyper_ast)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
+    _, devdoc = parse_natspec(vyper_ast, global_ctx)
 
     assert devdoc == {
         "author": "Mr No-linter",
@@ -130,7 +136,8 @@ def foo(bar: int128, baz: uint256, potato: bytes32):
     """
 
     vyper_ast = parse_to_ast(code)
-    _, devdoc = parse_natspec(vyper_ast)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
+    _, devdoc = parse_natspec(vyper_ast, global_ctx)
 
     assert devdoc == {
         "methods": {
@@ -154,7 +161,8 @@ def foo(bar: int128, baz: uint256) -> (int128, uint256):
     """
 
     vyper_ast = parse_to_ast(code)
-    _, devdoc = parse_natspec(vyper_ast)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
+    _, devdoc = parse_natspec(vyper_ast, global_ctx)
 
     assert devdoc == {
         "methods": {
@@ -179,7 +187,8 @@ def notfoo(bar: int128, baz: uint256):
     """
 
     vyper_ast = parse_to_ast(code)
-    _, devdoc = parse_natspec(vyper_ast)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
+    _, devdoc = parse_natspec(vyper_ast, global_ctx)
 
     assert devdoc["methods"] == {
         "foo(int128,uint256)": {"details": "I will be parsed."}
@@ -198,10 +207,11 @@ def foo():
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(
         NatSpecSyntaxException, match="NatSpec docstring opens with untagged comment"
     ):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 empty_field_cases = [
@@ -232,8 +242,9 @@ def foo():
     pass
     """
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="No description given for tag '@notice'"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_unknown_field():
@@ -248,8 +259,9 @@ def foo():
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="Unknown NatSpec field '@thing'"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_invalid_field():
@@ -261,8 +273,9 @@ def foo():
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="'@title' is not a valid field"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_duplicate_fields():
@@ -277,8 +290,9 @@ def foo():
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="Duplicate NatSpec field '@notice'"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_duplicate_param():
@@ -293,10 +307,11 @@ def foo(bar: int128, baz: uint256):
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(
         NatSpecSyntaxException, match="Parameter 'bar' documented more than once"
     ):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_unknown_param():
@@ -308,8 +323,9 @@ def foo(bar: int128, baz: uint256):
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="Method has no parameter 'hotdog'"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 empty_field_cases = [
@@ -340,8 +356,9 @@ def foo(a: int128):
     pass
     """
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="No description given for parameter 'a'"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_too_many_returns_no_return_type():
@@ -353,8 +370,9 @@ def foo():
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(NatSpecSyntaxException, match="Method does not return any values"):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_too_many_returns_single_return_type():
@@ -369,11 +387,12 @@ def foo() -> int128:
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(
         NatSpecSyntaxException,
         match="Number of documented return values exceeds actual number",
     ):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)
 
 
 def test_too_many_returns_tuple_return_type():
@@ -389,8 +408,9 @@ def foo() -> (int128,uint256):
     """
 
     vyper_ast = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast)
     with pytest.raises(
         NatSpecSyntaxException,
         match="Number of documented return values exceeds actual number",
     ):
-        parse_natspec(vyper_ast)
+        parse_natspec(vyper_ast, global_ctx)

--- a/vyper/ast/natspec.py
+++ b/vyper/ast/natspec.py
@@ -20,9 +20,6 @@ from vyper.parser.global_context import (
 from vyper.signatures import (
     sig_utils,
 )
-from vyper.typing import (
-    InterfaceImports,
-)
 
 SINGLE_FIELDS = ("title", "author", "notice", "dev")
 PARAM_FIELDS = ("param", "return")
@@ -31,7 +28,7 @@ USERDOCS_FIELDS = ("notice",)
 
 def parse_natspec(
     vyper_ast: vy_ast.Module,
-    interface_codes: Optional[InterfaceImports] = None,
+    global_ctx: GlobalContext,
 ) -> Tuple[dict, dict]:
     """
     Parses NatSpec documentation from a contract.
@@ -53,8 +50,6 @@ def parse_natspec(
     """
     userdoc, devdoc = {}, {}
     source: str = vyper_ast.full_source_code
-
-    global_ctx = GlobalContext.get_global_context(vyper_ast, interface_codes)
 
     docstring = vyper_ast.get("doc_string.value")
     if docstring:

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -92,10 +92,14 @@ def gas_estimate(origcode, *args, **kwargs):
     return o
 
 
-def mk_full_signature(code, *args, **kwargs):
-    abi = sig_utils.mk_full_signature(parse_to_ast(code), *args, **kwargs)
+def mk_full_signature(source_code, *args, **kwargs):
+    vyper_ast_node = parse_to_ast(source_code)
+    global_ctx = GlobalContext.get_global_context(
+        vyper_ast_node, interface_codes=kwargs.get('interface_codes')
+    )
+    abi = sig_utils.mk_full_signature(global_ctx)
     # Add gas estimates for each function to ABI
-    gas_estimates = gas_estimate(code, *args, **kwargs)
+    gas_estimates = gas_estimate(source_code, *args, **kwargs)
     for func in abi:
         try:
             func_signature = func['name']
@@ -257,15 +261,21 @@ def _mk_source_map_output(code, contract_name, interface_codes, source_id):
 
 
 def _mk_method_identifiers_output(code, contract_name, interface_codes, source_id):
-    return sig_utils.mk_method_identifiers(code, interface_codes=interface_codes)
+    vyper_ast_node = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
+    return sig_utils.mk_method_identifiers(global_ctx)
 
 
 def _mk_interface_output(code, contract_name, interface_codes, source_id):
-    return extract_interface_str(code, contract_name, interface_codes=interface_codes)
+    vyper_ast_node = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
+    return extract_interface_str(global_ctx)
 
 
 def _mk_external_interface_output(code, contract_name, interface_codes, source_id):
-    return extract_external_interface(code, contract_name, interface_codes=interface_codes)
+    vyper_ast_node = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
+    return extract_external_interface(global_ctx, contract_name)
 
 
 def _mk_opcodes(code, contract_name, interface_codes, source_id):

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -29,6 +29,9 @@ from vyper.opcodes import (
 from vyper.parser import (
     parser,
 )
+from vyper.parser.global_context import (
+    GlobalContext,
+)
 from vyper.signatures import (
     sig_utils,
 )
@@ -45,12 +48,12 @@ from vyper.typing import (
 )
 
 
-def __compile(code, interface_codes=None, *args, **kwargs):
-    ast = parse_to_ast(code)
+def __compile(source_code, interface_codes=None, *args, **kwargs):
+    vyper_ast_node = parse_to_ast(source_code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
     lll = parser.parse_tree_to_lll(
-        ast,
-        code,
-        interface_codes=interface_codes,
+        source_code,
+        global_ctx,
         runtime_only=kwargs.get('bytecode_runtime', False)
     )
     opt_lll = optimizer.optimize(lll)

--- a/vyper/compiler.py
+++ b/vyper/compiler.py
@@ -295,14 +295,16 @@ def _mk_ast_dict(code, contract_name, interface_codes, source_id):
 
 
 def _mk_userdoc(code, contract_name, interface_codes, source_id):
-    vyper_ast = parse_to_ast(code)
-    userdoc, devdoc = parse_natspec(vyper_ast, interface_codes)
+    vyper_ast_node = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
+    userdoc, devdoc = parse_natspec(vyper_ast_node, global_ctx)
     return userdoc
 
 
 def _mk_devdoc(code, contract_name, interface_codes, source_id):
-    vyper_ast = parse_to_ast(code)
-    userdoc, devdoc = parse_natspec(vyper_ast, interface_codes)
+    vyper_ast_node = parse_to_ast(code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
+    userdoc, devdoc = parse_natspec(vyper_ast_node, global_ctx)
     return devdoc
 
 

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -163,12 +163,10 @@ def parse_other_functions(o,
 
 # Main python parse tree => LLL method
 def parse_tree_to_lll(
-    vyper_ast_node: vy_ast.Module,
     source_code: str,
+    global_ctx: GlobalContext,
     runtime_only: bool = False,
-    interface_codes: Optional[InterfaceImports] = None
 ) -> LLLnode:
-    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
     _names_def = [_def.name for _def in global_ctx._defs]
     # Checks for duplicate function names
     if len(set(_names_def)) < len(_names_def):
@@ -237,6 +235,9 @@ def parse_to_lll(
     interface_codes: Optional[InterfaceImports] = None
 ) -> LLLnode:
     vyper_ast_node = vy_ast.parse_to_ast(source_code)
+    global_ctx = GlobalContext.get_global_context(vyper_ast_node, interface_codes=interface_codes)
     return parse_tree_to_lll(
-        vyper_ast_node, source_code, runtime_only=runtime_only, interface_codes=interface_codes
+        source_code,
+        global_ctx,
+        runtime_only=runtime_only,
     )

--- a/vyper/signatures/sig_utils.py
+++ b/vyper/signatures/sig_utils.py
@@ -1,11 +1,5 @@
 import copy
 
-from vyper.ast import (
-    parse_to_ast,
-)
-from vyper.parser.global_context import (
-    GlobalContext,
-)
 from vyper.signatures.event_signature import (
     EventSignature,
 )
@@ -64,14 +58,13 @@ def _default_sig_formatter(sig):
 
 
 # Get ABI signature
-def mk_full_signature(code, sig_formatter=None, interface_codes=None):
+def mk_full_signature(global_ctx, sig_formatter=None):
 
     if sig_formatter is None:
         # Use default JSON style output.
         sig_formatter = _default_sig_formatter
 
     o = []
-    global_ctx = GlobalContext.get_global_context(code, interface_codes=interface_codes)
 
     # Produce event signatues.
     for code in global_ctx._events:
@@ -93,12 +86,8 @@ def mk_full_signature(code, sig_formatter=None, interface_codes=None):
     return o
 
 
-def mk_method_identifiers(source_str, interface_codes=None):
+def mk_method_identifiers(global_ctx):
     identifiers = {}
-    global_ctx = GlobalContext.get_global_context(
-        parse_to_ast(source_str),
-        interface_codes=interface_codes,
-    )
 
     for code in global_ctx._defs:
         identifiers.update(mk_single_method_identifier(code, global_ctx))


### PR DESCRIPTION

_(This PR requires and is built on top of #1960)_
### What I did
Refactor methods for LLL, natspec and interface generation.

Each of these functions requires either the source code or AST as an input, in order to generate a `GlobalContext` object. I've modified them so that they now receive `GlobalContext` as an input.  This way we can make the core logic in `vyper/compiler.py` more linear.

### How I did it
* In several methods, modified the input arguments from `code` or `ast` to `global_ctx`.
* Adjusted `vyper/compiler.py` to generate `global_ctx` prior to calling each of these methods.

The only place that a `GlobalContext` is generated now, outside of `compiler.py`, is when handling interfaces.  I think it will be possible to refactor this out as well, but I didn't want to do too much in a single PR.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/81485488-88ec7380-925e-11ea-97bd-1b6cc6702e87.png)
