### PR TITLE
Allow STATICCALL using raw_call

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -144,7 +144,7 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
 
         The amount to send is always specified in ``wei``.
 
-.. py:function:: raw_call(to: address, data: bytes, outsize: int = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False) -> bytes[outsize]
+.. py:function:: raw_call(to: address, data: bytes, outsize: int = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False, is_static_call: bool = False) -> bytes[outsize]
 
     Calls to the specified Ethereum address.
 
@@ -154,6 +154,7 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
     * ``gas``: The amount of gas to attach to the call. If not set, all remainaing gas is forwarded.
     * ``value``: The wei value to send to the address (Optional, default ``0``)
     * ``is_delegate_call``: If ``True``, the call will be sent as ``DELEGATECALL`` (Optional, default ``False``)
+    * ``is_static_call``: If ``True``, the call will be sent as ``STATICCALL`` (Optional, default ``False``)
 
     Returns the data returned by the call as a ``bytes`` list, with ``outsize`` as the max length.
 


### PR DESCRIPTION
### What I did
Add `is_static_call` kwarg to `raw_call` as a way to perform a `STATICCALL`.

Closes #1971

### How I did it
Minor tweaks to the `RawCall.build_LLL` logic in `vyper/functions/functions.py`:

* use of `is_static_call` and `is_delegate_call` together raises
* `raw_call` may now be used in `@constant` functions, ONLY when `is_static_call=True`. If the kwarg is omitted, the exception message suggests it's use to the user.

### How to verify it
Run the tests. I added a few cases to verify that it works.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/82024253-8e9fea00-96a0-11ea-9a64-a644aee6eeba.png)
