### PR TITLE
fix: adjust test to consider bounds

### DIFF
--- a/tests/ast/nodes/test_evaluate_binop_decimal.py
+++ b/tests/ast/nodes/test_evaluate_binop_decimal.py
@@ -79,7 +79,7 @@ def foo({input_value}) -> decimal:
     try:
         vy_ast.folding.replace_literal_ops(vyper_ast)
         expected = vyper_ast.body[0].value.value
-        is_valid = True
+        is_valid = -2**127 <= expected < 2**127
     except ZeroDivisionException:
         # for division/modulus by 0, expect the contract call to revert
         is_valid = False


### PR DESCRIPTION
### What I did
Fix a hypothesis test issue where the expected value could be out of bounds for `decimal`.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/82075258-0431a780-96ed-11ea-820d-695ad889d5e0.png)
