### PR TITLE
Fix memory length generated by assert_reason

### DIFF
--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -1,6 +1,6 @@
 import pytest
-from eth_tester.exceptions import TransactionFailed
 from eth_abi import decode_single
+from eth_tester.exceptions import TransactionFailed
 
 from vyper.exceptions import ConstancyViolation, StructureException
 

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -399,7 +399,7 @@ class Stmt(object):
                     'assert_reason',
                     test_expr,
                     int(sig_placeholder + 28),
-                    int(4 + 32 + get_size_of_type(reason_str_type) * 32),
+                    int(4 + get_size_of_type(reason_str_type) * 32),
                     ],
                 ]
         return LLLnode.from_list(assert_reason, typ=None, pos=getpos(self.stmt))


### PR DESCRIPTION
Fixes #1981

### Description of issue

Code generation for `assert_reason` generates incorrect length for revert string which leads to [issues with revert reason decoding](https://etherscan.io/tx/0xa0f0aa5fc4f56771a0b49ff66c752bcad2a32844ec4b173337086d6610571d65).

### How I fixed it

Fixed length of memory passed to revert opcode generated by assert_reason.

### How to verify it

Check that [assert tests](https://github.com/vyperlang/vyper/blob/master/tests/parser/features/test_assert.py) are still passing.

### Description for the changelog

Removed 32 bytes of junk at the end of revert reasons.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/06/80/4c/06804c0b50a140538c23334793077588.jpg)
