### PR TITLE
Validate constants

### DIFF
--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -6,16 +6,6 @@ from vyper.exceptions import InvalidLiteral
 
 fail_list = [
     """
-@public
-def foo():
-    x: int128 = -170141183460469231731687303715884105729 # -2**127 - 1
-    """,
-    """
-@public
-def foo():
-    x: decimal = -170141183460469231731687303715884105728.0000000001
-    """,
-    """
 b: decimal
 @public
 def foo():
@@ -30,11 +20,6 @@ def foo():
 @public
 def foo():
     send(0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae, 5)
-    """,
-    """
-@public
-def foo():
-    x: uint256 = convert(821649876217461872458712528745872158745214187264875632587324658732648753245328764872135671285218762145, uint256)  # noqa: E501
     """,
     """
 @public
@@ -59,6 +44,51 @@ def overflow() -> uint256:
 def overflow2() -> uint256:
     a: uint256 = 2**256
     return a
+    """,
+    """
+@public
+def foo():
+    x: address = create_forwarder_to(0x123456789012345678901234567890123456789)
+    """,
+    """
+@public
+def foo():
+    x: bytes[4] = raw_call(0x123456789012345678901234567890123456789, "cow", max_outsize=4)
+    """,
+    """
+@public
+def foo():
+    x: string[100] = "these bytes are nо gооd because the o's are from the Russian alphabet"
+    """,
+    """
+@public
+def foo():
+    x: string[100] = "这个傻老外不懂中文"
+    """,
+    """
+@public
+def foo():
+    x: address = 0x12345678901234567890123456789012345678901
+    """,
+    """
+@public
+def foo():
+    x: address = 0x01234567890123456789012345678901234567890
+    """,
+    """
+@public
+def foo():
+    x: address = 0x123456789012345678901234567890123456789
+    """,
+    """
+@public
+def foo():
+    a: bytes[100] = "ѓtest"
+    """,
+    """
+@public
+def foo():
+    a: bytes32 = keccak256("ѓtest")
     """,
 ]
 

--- a/tests/parser/exceptions/test_overflow_exception.py
+++ b/tests/parser/exceptions/test_overflow_exception.py
@@ -1,0 +1,29 @@
+import pytest
+from pytest import raises
+
+from vyper import compiler
+from vyper.exceptions import OverflowException
+
+fail_list = [
+    """
+@public
+def foo():
+    x: int128 = -170141183460469231731687303715884105729 # -2**127 - 1
+    """,
+    """
+@public
+def foo():
+    x: decimal = -170141183460469231731687303715884105728.0000000001
+    """,
+    """
+@public
+def foo():
+    x: uint256 = convert(821649876217461872458712528745872158745214187264875632587324658732648753245328764872135671285218762145, uint256)  # noqa: E501
+    """,
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_invalid_literal_exception(bad_code):
+    with raises(OverflowException):
+        compiler.compile_code(bad_code)

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -56,12 +56,6 @@ def foo() -> int128:
     pass
     """,
     """
-bar: int128[3]
-@public
-def foo():
-    self.bar = []
-    """,
-    """
 @public
 def foo():
     x: bytes[4] = raw_call(0x1234567890123456789012345678901234567890, max_outsize=4)
@@ -85,11 +79,6 @@ def foo():
     """,
     """
 x: public()
-    """,
-    """
-@public
-def foo():
-    raw_log([], b"cow", "dog")
     """,
     """
 @public
@@ -160,7 +149,18 @@ s: S = S()
 @nonreentrant("C")
 def double_nonreentrant():
     pass
+    """,
     """
+bar: int128[3]
+@public
+def foo():
+    self.bar = []
+    """,
+    """
+@public
+def foo():
+    raw_log([], b"cow", "dog")
+    """,
 ]
 
 

--- a/tests/parser/exceptions/test_syntax_exception.py
+++ b/tests/parser/exceptions/test_syntax_exception.py
@@ -51,51 +51,6 @@ def test() -> uint256:
 def foo():
     x = y = 3
     """,
-    """
-@public
-def foo():
-    x: address = create_forwarder_to(0x123456789012345678901234567890123456789)
-    """,
-    """
-@public
-def foo():
-    x: bytes[4] = raw_call(0x123456789012345678901234567890123456789, "cow", max_outsize=4)
-    """,
-    """
-@public
-def foo():
-    x: string[100] = "these bytes are nо gооd because the o's are from the Russian alphabet"
-    """,
-    """
-@public
-def foo():
-    x: string[100] = "这个傻老外不懂中文"
-    """,
-    """
-@public
-def foo():
-    x: address = 0x12345678901234567890123456789012345678901
-    """,
-    """
-@public
-def foo():
-    x: address = 0x01234567890123456789012345678901234567890
-    """,
-    """
-@public
-def foo():
-    x: address = 0x123456789012345678901234567890123456789
-    """,
-    """
-@public
-def foo():
-    a: bytes[100] = "ѓtest"
-    """,
-    """
-@public
-def foo():
-    a: bytes32 = keccak256("ѓtest")
-    """,
 ]
 
 

--- a/tests/parser/functions/test_convert_to_int128.py
+++ b/tests/parser/functions/test_convert_to_int128.py
@@ -1,4 +1,4 @@
-from vyper.exceptions import InvalidLiteral, TypeMismatch
+from vyper.exceptions import InvalidLiteral, OverflowException, TypeMismatch
 from vyper.utils import SizeLimits
 
 
@@ -261,7 +261,7 @@ def foo() -> int128:
 
     assert_compile_failed(
         lambda: get_contract_with_gas_estimation(code),
-        InvalidLiteral
+        OverflowException,
     )
 
 

--- a/vyper/ast/validation.py
+++ b/vyper/ast/validation.py
@@ -70,3 +70,20 @@ def validate_call_args(
             raise ArgumentException(
                 f"'{key.arg}' was given as a positional argument", key
             )
+
+
+def validate_literal_nodes(vyper_module: vy_ast.Module) -> None:
+    """
+    Individually validate Vyper AST nodes.
+
+    Calls the `validate` method of each node to verify that literal nodes
+    do not contain invalid values.
+
+    Arguments
+    ---------
+    vyper_module : vy_ast.Module
+        Top level Vyper AST node.
+    """
+    for node in vyper_module.get_descendants():
+        if hasattr(node, "validate"):
+            node.validate()

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -76,6 +76,8 @@ class CompilerData:
 
     @property
     def vyper_module_folded(self) -> vy_ast.Module:
+        vy_ast.validation.validate_literal_nodes(self.vyper_module)
+
         if not hasattr(self, "_vyper_module_folded"):
             self._vyper_module_folded = generate_folded_ast(self.vyper_module)
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -73,7 +73,8 @@ GAS_IDENTITY = 15
 GAS_IDENTITYWORD = 3
 
 # A decimal value can store multiples of 1/DECIMAL_DIVISOR
-DECIMAL_DIVISOR = 10000000000
+MAX_DECIMAL_PLACES = 10
+DECIMAL_DIVISOR = 10 ** MAX_DECIMAL_PLACES
 
 
 # Number of bytes in memory used for system purposes, not for variables


### PR DESCRIPTION
### What I did
Validate constant values prior to folding.

### How I did it
Add a `validate` method to some AST nodes that raises if the node's value cannot be typed. This is useful for ensuring descriptive exceptions for e.g. numeric bounds issues, without having to duplicate code.

The `validate` methods are called from `ast.validate.validate_literal_nodes`, which runs after AST generation and prior to constant folding.

This PR results in the some dead code in `functions/functions.py` and `parser/**.py`.  I intend to handle that as part of the larger coming soon:tm: type-checker PR.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/83069110-68078900-a07a-11ea-9f51-f8f74490df46.png)
