### PR TITLE
Remove misleading comments

### DIFF
--- a/vyper/parser/arg_clamps.py
+++ b/vyper/parser/arg_clamps.py
@@ -65,11 +65,9 @@ def make_arg_clamper(datapos, mempos, typ, is_init=False):
             subtype_size = get_size_of_type(typ.subtype)
             i_incr = subtype_size * 32
 
-            # for i in range(typ.count):
             mem_to = subtype_size * 32 * (typ.count - 1)
             loop_label = f"_check_list_loop_{str(uuid.uuid4())}"
 
-            # use LOOP_FREE_INDEX to store i
             offset = 288
             o = [['mstore', offset, 0],  # init loop
                  ['label', loop_label],


### PR DESCRIPTION
### What I did
Remove misleading comments, as they were added during #1488, and do not reflect the code's operation.

### How I did it
Hit delete.

### Description for the changelog
Remove misleading comments.