### PR TITLE
Add license to NatSpec

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -187,6 +187,7 @@ Vyper supports structured documentation for contracts and public functions using
 
     """
     @title A simulator for Bug Bunny, the most famous Rabbit
+    @license MIT
     @author Warned Bros
     @notice You can use this contract for only the most basic simulation
     @dev
@@ -210,16 +211,17 @@ Tags
 
 All tags are optional. The following table explains the purpose of each NatSpec tag and where it may be used:
 
-=========== ======================================== ==================
-Tag         Description                              Context
-=========== ======================================== ==================
-``@title``  Title that describes the contract        contract
-``@author`` Name of the author                       contract, function
-``@notice`` Explain to an end user what this does    contract, function
-``@dev``    Explain to a developer any extra details contract, function
-``@param``  Documents a single parameter             function
-``@return`` Documents one or all return variable(s)  function
-=========== ======================================== ==================
+============ ======================================== ==================
+Tag          Description                              Context
+============ ======================================== ==================
+``@title``   Title that describes the contract        contract
+``@licence`` License of the contract                  contract
+``@author``  Name of the author                       contract, function
+``@notice``  Explain to an end user what this does    contract, function
+``@dev``     Explain to a developer any extra details contract, function
+``@param``   Documents a single parameter             function
+``@return``  Documents one or all return variable(s)  function
+============ ======================================== ==================
 
 Some rules / restrictions:
 
@@ -269,6 +271,7 @@ file should also be produced and should look like this:
 
     {
       "author": "Warned Bros",
+      "license": "MIT",
       "details": "Simply chewing a carrot does not count, carrots must pass the throat to be considered eaten",
       "methods": {
         "doesEat(string,uint256)": {

--- a/vyper/ast/natspec.py
+++ b/vyper/ast/natspec.py
@@ -8,7 +8,7 @@ from vyper.exceptions import NatSpecSyntaxException
 from vyper.parser.global_context import GlobalContext
 from vyper.signatures import sig_utils
 
-SINGLE_FIELDS = ("title", "author", "notice", "dev")
+SINGLE_FIELDS = ("title", "author", "license", "notice", "dev")
 PARAM_FIELDS = ("param", "return")
 USERDOCS_FIELDS = ("notice",)
 
@@ -56,7 +56,8 @@ def parse_natspec(
 
         if sigs:
             args = tuple(i.arg for i in node.args.args)
-            fn_natspec = _parse_docstring(source, docstring, ("title",), args, ret_len)
+            invalid_fields = ("title", "license",)
+            fn_natspec = _parse_docstring(source, docstring, invalid_fields, args, ret_len)
             for s in sigs:
                 if "notice" in fn_natspec:
                     userdoc.setdefault("methods", {})[s] = {


### PR DESCRIPTION
### What I did
Add license tag to NatSpec.

### How I did it
Add the "license" tag in the permitted fields.

### How to verify it
There is a test case.

### Description for the changelog
Add license tag to NatSpec.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
