### PR TITLE
add semantic_version to isort known_third_party

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ exclude =
 [isort]
 force_grid_wrap = 0
 include_trailing_comma = True
-known_third_party = hypothesis,lark,pytest,web3,eth_*,rlp
+known_third_party = hypothesis,lark,pytest,semantic_version,web3,eth_*,rlp
 known_first_party = vyper
 multi_line_output = 3
 use_parentheses = True


### PR DESCRIPTION
### What I did
Add `semantic_version` as a known 3rd party library in `isort` config. This was causing me issues locally.