### PR TITLE
Add Publishing Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish
+
+on:
+  release:
+    types: [released]
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+
+    - name: Publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: twine upload dist/*


### PR DESCRIPTION
### What I did
Added an action that triggers whenever a new tag is created (via new release)

How this should work is that when a tag is pushed (or created through "Releases"), this should get triggered and make a release to PyPI with the latest tag

### Cute Animal Picture
![grimace](https://i.pinimg.com/originals/66/0c/09/660c097493cd5244cc919f978d5a4522.jpg)