### PR TITLE
Remove dead code, round 1

### DIFF
--- a/vyper/context/validation/utils.py
+++ b/vyper/context/validation/utils.py
@@ -21,6 +21,7 @@ from vyper.exceptions import (
     UndeclaredDefinition,
     UnknownAttribute,
     VyperException,
+    ZeroDivisionException,
 )
 
 
@@ -100,6 +101,14 @@ class _ExprTypeChecker:
     def types_from_BinOp(self, node):
         # binary operation: `x + y`
         types_list = get_common_types(node.left, node.right)
+
+        if (
+            isinstance(node.op, (vy_ast.Div, vy_ast.Mod))
+            and isinstance(node.right, vy_ast.Num)
+            and not node.right.value
+        ):
+            raise ZeroDivisionException(f"{node.op.description} by zero", node)
+
         return _validate_op(node, types_list, "validate_numeric_op")
 
     def types_from_BoolOp(self, node):

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -256,3 +256,7 @@ class UnexpectedValue(VyperInternalException):
 
 class UnfoldableNode(VyperInternalException):
     """Constant folding logic cannot be applied to an AST node."""
+
+
+class TypeCheckFailure(VyperInternalException):
+    """An issue was not caught during type checking that should have been."""

--- a/vyper/functions/signatures.py
+++ b/vyper/functions/signatures.py
@@ -27,8 +27,6 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
             expected_arg = expected_arg._id
 
         if expected_arg == 'num_literal':
-            if context.constants.is_constant_of_base_type(arg, ('uint256', 'int128')):
-                return context.constants.get_constant(arg.id, None).value
             if isinstance(arg, (vy_ast.Int, vy_ast.Decimal)):
                 return arg.n
         elif expected_arg == 'str_literal':

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -1,7 +1,7 @@
 import contextlib
 import enum
 
-from vyper.exceptions import VariableDeclarationException
+from vyper.exceptions import CompilerPanic, TypeCheckFailure
 from vyper.signatures.function_signature import VariableRecord
 from vyper.types import get_size_of_type
 from vyper.utils import check_valid_varname
@@ -130,7 +130,7 @@ class Context:
             )
             # Local context duplicate context check.
             if any((name in self.vars, name in self.globals, name in self.constants)):
-                raise VariableDeclarationException(f"Duplicate variable name: {name}", name)
+                raise TypeCheckFailure(f"Duplicate variable name: {name}")
         return True
 
     def _mangle(self, name):
@@ -180,4 +180,4 @@ class Context:
             return 'a range expression'
         elif self.constancy == Constancy.Constant:
             return 'a constant function'
-        raise ValueError(f'Compiler error: unknown constancy in pp_constancy: {self.constancy}')
+        raise CompilerPanic(f"unknown constancy in pp_constancy: {self.constancy}")

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -241,8 +241,6 @@ class Expr(object):
                 [obj],
                 typ=BaseType(typ, is_literal=True),
                 pos=getpos(self.expr))
-        elif self.context.constants.ast_is_constant(self.expr):
-            return self.context.constants.get_constant(self.expr.id, self.context)
         else:
             raise VariableDeclarationException(f"Undeclared variable: {self.expr.id}", self.expr)
 

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -1,14 +1,9 @@
-import warnings
-
 from vyper import ast as vy_ast
 from vyper.exceptions import (
     EvmVersionException,
-    InvalidLiteral,
-    NonPayableViolation,
     StructureException,
+    TypeCheckFailure,
     TypeMismatch,
-    VariableDeclarationException,
-    ZeroDivisionException,
 )
 from vyper.opcodes import version_check
 from vyper.parser import external_call, self_call
@@ -72,41 +67,27 @@ def get_min_val_for_type(typ: str) -> int:
     return min_val
 
 
-class Expr(object):
+class Expr:
     # TODO: Once other refactors are made reevaluate all inline imports
-    def __init__(self, expr, context):
-        self.expr = expr
+
+    def __init__(self, node, context):
+        self.expr = node
         self.context = context
-        self.expr_table = {
-            LLLnode: self.get_expr,
-            vy_ast.Int: self.integer,
-            vy_ast.Decimal: self.decimal,
-            vy_ast.Hex: self.hexstring,
-            vy_ast.Str: self.string,
-            vy_ast.NameConstant: self.constants,
-            vy_ast.Name: self.variables,
-            vy_ast.Attribute: self.attribute,
-            vy_ast.Subscript: self.subscript,
-            vy_ast.BinOp: self.arithmetic,
-            vy_ast.Compare: self.compare,
-            vy_ast.BoolOp: self.boolean_operations,
-            vy_ast.UnaryOp: self.unary_operations,
-            vy_ast.Call: self.call,
-            vy_ast.List: self.list_literals,
-            vy_ast.Tuple: self.tuple_literals,
-            vy_ast.Dict: self.dict_fail,
-            vy_ast.Bytes: self.bytes,
-        }
-        expr_type = self.expr.__class__
-        if expr_type in self.expr_table:
-            self.lll_node = self.expr_table[expr_type]()
-        else:
-            raise Exception("Unsupported operator.", self.expr)
 
-    def get_expr(self):
-        return self.expr
+        if isinstance(node, LLLnode):
+            # TODO this seems bad
+            self.lll_node = node
+            return
 
-    def integer(self):
+        fn = getattr(self, f"parse_{type(node).__name__}", None)
+        if fn is None:
+            raise TypeCheckFailure(f"Invalid statement node: {type(node).__name__}")
+
+        self.lll_node = fn()
+        if self.lll_node is None:
+            raise TypeCheckFailure(f"{type(node).__name__} node did not produce LLL")
+
+    def parse_Int(self):
         # Literal (mostly likely) becomes int128
         if SizeLimits.in_bounds('int128', self.expr.n) or self.expr.n < 0:
             return LLLnode.from_list(
@@ -122,32 +103,21 @@ class Expr(object):
                 pos=getpos(self.expr),
             )
 
-    def decimal(self):
+    def parse_Decimal(self):
         numstring, num, den = get_number_as_fraction(self.expr, self.context)
-        # if not SizeLimits.in_bounds('decimal', num // den):
-        # if not SizeLimits.MINDECIMAL * den <= num <= SizeLimits.MAXDECIMAL * den:
         if not (SizeLimits.MINNUM * den <= num <= SizeLimits.MAXNUM * den):
-            raise InvalidLiteral("Number out of range: " + numstring, self.expr)
+            return
         if DECIMAL_DIVISOR % den:
-            raise InvalidLiteral(
-                "Type 'decimal' has maximum 10 decimal places",
-                self.expr
-            )
+            return
         return LLLnode.from_list(
             num * DECIMAL_DIVISOR // den,
             typ=BaseType('decimal', is_literal=True),
             pos=getpos(self.expr),
         )
 
-    def hexstring(self):
+    def parse_Hex(self):
         orignum = self.expr.value
-        if len(orignum) == 42:
-            if checksum_encode(orignum) != orignum:
-                raise InvalidLiteral(
-                    "Address checksum mismatch. If you are sure this is the "
-                    f"right address, the correct checksummed form is: {checksum_encode(orignum)}",
-                    self.expr
-                )
+        if len(orignum) == 42 and checksum_encode(orignum) == orignum:
             return LLLnode.from_list(
                 int(self.expr.value, 16),
                 typ=BaseType('address', is_literal=True),
@@ -159,21 +129,15 @@ class Expr(object):
                 typ=BaseType('bytes32', is_literal=True),
                 pos=getpos(self.expr),
             )
-        else:
-            raise InvalidLiteral(
-                f"Cannot read 0x value with length {len(orignum)}. Expecting 42 (address "
-                "incl 0x) or 66 (bytes32 incl 0x)",
-                self.expr
-            )
 
     # String literals
-    def string(self):
+    def parse_Str(self):
         bytez, bytez_length = string_to_bytes(self.expr.value)
         typ = StringType(bytez_length, is_literal=True)
         return self._make_bytelike(typ, bytez, bytez_length)
 
     # Byte literals
-    def bytes(self):
+    def parse_Bytes(self):
         bytez = self.expr.s
         bytez_length = len(self.expr.s)
         typ = ByteArrayType(bytez_length, is_literal=True)
@@ -198,7 +162,7 @@ class Expr(object):
         )
 
     # True, False, None constants
-    def constants(self):
+    def parse_NameConstant(self):
         if self.expr.value is True:
             return LLLnode.from_list(
                 1,
@@ -211,16 +175,9 @@ class Expr(object):
                 typ=BaseType('bool', is_literal=True),
                 pos=getpos(self.expr),
             )
-        elif self.expr.value is None:
-            # block None
-            raise InvalidLiteral(
-                    'None is not allowed in vyper'
-                    '(use a default value or built-in `empty()`')
-        else:
-            raise Exception(f"Unknown name constant: {self.expr.value.value}")
 
     # Variable names
-    def variables(self):
+    def parse_Name(self):
 
         if self.expr.id == 'self':
             return LLLnode.from_list(['address'], typ='address', pos=getpos(self.expr))
@@ -241,79 +198,60 @@ class Expr(object):
                 [obj],
                 typ=BaseType(typ, is_literal=True),
                 pos=getpos(self.expr))
-        else:
-            raise VariableDeclarationException(f"Undeclared variable: {self.expr.id}", self.expr)
 
     # x.y or x[5]
-    def attribute(self):
+    def parse_Attribute(self):
         # x.balance: balance of address x
         if self.expr.attr == 'balance':
             addr = Expr.parse_value_expr(self.expr.value, self.context)
-            if not is_base_type(addr.typ, 'address'):
-                raise TypeMismatch(
-                    "Type mismatch: balance keyword expects an address as input",
-                    self.expr
+            if is_base_type(addr.typ, 'address'):
+                if (
+                    isinstance(self.expr.value, vy_ast.Name) and
+                    self.expr.value.id == "self" and
+                    version_check(begin="istanbul")
+                ):
+                    seq = ['selfbalance']
+                else:
+                    seq = ['balance', addr]
+                return LLLnode.from_list(
+                    seq,
+                    typ=BaseType('uint256'),
+                    location=None,
+                    pos=getpos(self.expr),
                 )
-            if (
-                isinstance(self.expr.value, vy_ast.Name) and
-                self.expr.value.id == "self" and
-                version_check(begin="istanbul")
-            ):
-                seq = ['selfbalance']
-            else:
-                seq = ['balance', addr]
-            return LLLnode.from_list(
-                seq,
-                typ=BaseType('uint256'),
-                location=None,
-                pos=getpos(self.expr),
-            )
         # x.codesize: codesize of address x
         elif self.expr.attr == 'codesize' or self.expr.attr == 'is_contract':
             addr = Expr.parse_value_expr(self.expr.value, self.context)
-            if not is_base_type(addr.typ, 'address'):
-                raise TypeMismatch(
-                    "Type mismatch: codesize keyword expects an address as input",
-                    self.expr,
+            if is_base_type(addr.typ, 'address'):
+                if self.expr.attr == 'codesize':
+                    eval_code = ['extcodesize', addr]
+                    output_type = 'int128'
+                else:
+                    eval_code = ['gt', ['extcodesize', addr], 0]
+                    output_type = 'bool'
+                return LLLnode.from_list(
+                    eval_code,
+                    typ=BaseType(output_type),
+                    location=None,
+                    pos=getpos(self.expr),
                 )
-            if self.expr.attr == 'codesize':
-                eval_code = ['extcodesize', addr]
-                output_type = 'int128'
-            else:
-                eval_code = ['gt', ['extcodesize', addr], 0]
-                output_type = 'bool'
-            return LLLnode.from_list(
-                eval_code,
-                typ=BaseType(output_type),
-                location=None,
-                pos=getpos(self.expr),
-            )
         # x.codehash: keccak of address x
         elif self.expr.attr == 'codehash':
             addr = Expr.parse_value_expr(self.expr.value, self.context)
-            if not is_base_type(addr.typ, 'address'):
-                raise TypeMismatch(
-                    "codehash keyword expects an address as input",
-                    self.expr,
-                )
             if not version_check(begin="constantinople"):
                 raise EvmVersionException(
                     "address.codehash is unavailable prior to constantinople ruleset",
                     self.expr
                 )
-            return LLLnode.from_list(
-                ['extcodehash', addr],
-                typ=BaseType('bytes32'),
-                location=None,
-                pos=getpos(self.expr)
-            )
+            if is_base_type(addr.typ, 'address'):
+                return LLLnode.from_list(
+                    ['extcodehash', addr],
+                    typ=BaseType('bytes32'),
+                    location=None,
+                    pos=getpos(self.expr)
+                )
         # self.x: global attribute
         elif isinstance(self.expr.value, vy_ast.Name) and self.expr.value.id == "self":
-            if self.expr.attr not in self.context.globals:
-                raise VariableDeclarationException(
-                    "Persistent variable undeclared: " + self.expr.attr,
-                    self.expr,
-                )
             var = self.context.globals[self.expr.attr]
             return LLLnode.from_list(
                 var.pos,
@@ -327,18 +265,10 @@ class Expr(object):
             isinstance(self.expr.value, vy_ast.Name) and
             self.expr.value.id in ENVIRONMENT_VARIABLES
         ):
-            key = self.expr.value.id + "." + self.expr.attr
-            if key == "msg.sender":
-                if self.context.is_private:
-                    raise StructureException(
-                        "msg.sender not allowed in private functions.", self.expr
-                    )
+            key = f"{self.expr.value.id}.{self.expr.attr}"
+            if key == "msg.sender" and not self.context.is_private:
                 return LLLnode.from_list(['caller'], typ='address', pos=getpos(self.expr))
-            elif key == "msg.value":
-                if not self.context.is_payable:
-                    raise NonPayableViolation(
-                        "Cannot use msg.value in a non-payable function", self.expr,
-                    )
+            elif key == "msg.value" and self.context.is_payable:
                 return LLLnode.from_list(
                     ['callvalue'],
                     typ=BaseType('uint256'),
@@ -381,56 +311,35 @@ class Expr(object):
                         self.expr
                     )
                 return LLLnode.from_list(['chainid'], typ='uint256', pos=getpos(self.expr))
-            else:
-                raise StructureException("Unsupported keyword: " + key, self.expr)
         # Other variables
         else:
             sub = Expr.parse_variable_location(self.expr.value, self.context)
             # contract type
             if isinstance(sub.typ, ContractType):
                 return sub
-            if not isinstance(sub.typ, StructType):
-                raise TypeMismatch(
-                    "Type mismatch: member variable access not expected",
-                    self.expr.value,
-                )
-            attrs = list(sub.typ.members.keys())
-            if self.expr.attr not in attrs:
-                raise TypeMismatch(
-                    f"Member {self.expr.attr} not found. Only the following available: "
-                    f"{' '.join(attrs)}",
-                    self.expr,
-                )
-            return add_variable_offset(sub, self.expr.attr, pos=getpos(self.expr))
+            if isinstance(sub.typ, StructType) and self.expr.attr in sub.typ.members:
+                return add_variable_offset(sub, self.expr.attr, pos=getpos(self.expr))
 
-    def subscript(self):
+    def parse_Subscript(self):
         sub = Expr.parse_variable_location(self.expr.value, self.context)
         if isinstance(sub.typ, (MappingType, ListType)):
-            if not isinstance(self.expr.slice, vy_ast.Index):
-                raise StructureException(
-                    "Array access must access a single element, not a slice",
-                    self.expr,
-                )
             index = Expr.parse_value_expr(self.expr.slice.value, self.context)
         elif isinstance(sub.typ, TupleType):
-            if not isinstance(self.expr.slice.value, vy_ast.Int) or self.expr.slice.value.n < 0 or self.expr.slice.value.n >= len(sub.typ.members):  # noqa: E501
-                raise TypeMismatch("Tuple index invalid", self.expr.slice.value)
             index = self.expr.slice.value.n
+            if not 0 <= index < len(sub.typ.members):
+                return
         else:
-            raise TypeMismatch("Bad subscript attempt", self.expr.value)
-        o = add_variable_offset(sub, index, pos=getpos(self.expr))
-        o.mutable = sub.mutable
-        return o
+            return
+        lll_node = add_variable_offset(sub, index, pos=getpos(self.expr))
+        lll_node.mutable = sub.mutable
+        return lll_node
 
-    def arithmetic(self):
+    def parse_BinOp(self):
         left = Expr.parse_value_expr(self.expr.left, self.context)
         right = Expr.parse_value_expr(self.expr.right, self.context)
 
         if not is_numeric_type(left.typ) or not is_numeric_type(right.typ):
-            raise TypeMismatch(
-                f"Unsupported types for arithmetic op: {left.typ} {right.typ}",
-                self.expr,
-            )
+            return
 
         arithmetic_pair = {left.typ.typ, right.typ.typ}
         pos = getpos(self.expr)
@@ -454,19 +363,14 @@ class Expr(object):
                 )
 
         if left.typ.typ == "decimal" and isinstance(self.expr.op, vy_ast.Pow):
-            raise TypeMismatch(
-                "Cannot perform exponentiation on decimal values.",
-                self.expr,
-            )
+            return
 
         # Only allow explicit conversions to occur.
         if left.typ.typ != right.typ.typ:
-            raise TypeMismatch(
-                f"Cannot implicitly convert {left.typ.typ} to {right.typ.typ}.",
-                self.expr,
-            )
+            return
 
         ltyp, rtyp = left.typ.typ, right.typ.typ
+        arith = None
         if isinstance(self.expr.op, (vy_ast.Add, vy_ast.Sub)):
             new_typ = BaseType(ltyp)
             op = 'add' if isinstance(self.expr.op, vy_ast.Add) else 'sub'
@@ -485,9 +389,6 @@ class Expr(object):
 
             elif ltyp == rtyp:
                 arith = [op, 'l', 'r']
-
-            else:
-                raise Exception(f"Unsupported Operation '{op}({ltyp}, {rtyp})'")
 
         elif isinstance(self.expr.op, vy_ast.Mult):
             new_typ = BaseType(ltyp)
@@ -513,12 +414,10 @@ class Expr(object):
                                      ['eq', ['sdiv', 'ans', 'l'], 'r'],
                                      ['iszero', 'l']]],
                              ['sdiv', 'ans', DECIMAL_DIVISOR]]]
-            else:
-                raise Exception(f"Unsupported Operation 'mul({ltyp}, {rtyp})'")
 
         elif isinstance(self.expr.op, vy_ast.Div):
             if right.typ.is_literal and right.value == 0:
-                raise ZeroDivisionException("Cannot divide by 0.", self.expr)
+                return
 
             new_typ = BaseType(ltyp)
             if ltyp == rtyp == 'uint256':
@@ -533,12 +432,9 @@ class Expr(object):
                          ['mul', 'l', DECIMAL_DIVISOR],
                          ['clamp_nonzero', 'r']]
 
-            else:
-                raise Exception(f"Unsupported Operation 'div({ltyp}, {rtyp})'")
-
         elif isinstance(self.expr.op, vy_ast.Mod):
             if right.typ.is_literal and right.value == 0:
-                raise ZeroDivisionException("Cannot calculate modulus of 0.", self.expr)
+                return
 
             new_typ = BaseType(ltyp)
 
@@ -548,14 +444,9 @@ class Expr(object):
                 # TODO should this be regular mod
                 arith = ['smod', 'l', ['clamp_nonzero', 'r']]
 
-            else:
-                raise Exception(f"Unsupported Operation 'mod({ltyp}, {rtyp})'")
         elif isinstance(self.expr.op, vy_ast.Pow):
             if ltyp != 'int128' and ltyp != 'uint256' and isinstance(self.expr.right, vy_ast.Name):
-                raise TypeMismatch(
-                    "Cannot use dynamic values as exponents, for unit base types",
-                    self.expr,
-                )
+                return
             new_typ = BaseType(ltyp)
 
             if ltyp == rtyp == 'uint256':
@@ -570,13 +461,10 @@ class Expr(object):
             elif ltyp == rtyp == 'int128':
                 arith = ['exp', 'l', 'r']
 
-            else:
-                raise TypeMismatch('Only whole number exponents are supported', self.expr)
-        else:
-            raise StructureException(f"Unsupported binary operator: {self.expr.op}", self.expr)
+        if arith is None:
+            return
 
         p = ['seq']
-
         if new_typ.typ == 'int128':
             p.append([
                 'clamp',
@@ -594,7 +482,7 @@ class Expr(object):
         elif new_typ.typ == 'uint256':
             p.append(arith)
         else:
-            raise Exception(f"{arith} {new_typ}")
+            return
 
         p = ['with', 'l', left, ['with', 'r', right, p]]
         return LLLnode.from_list(p, typ=new_typ, pos=pos)
@@ -602,12 +490,6 @@ class Expr(object):
     def build_in_comparator(self):
         left = Expr(self.expr.left, self.context).lll_node
         right = Expr(self.expr.right, self.context).lll_node
-
-        if left.typ != right.typ.subtype:
-            raise TypeMismatch(
-                f"{left.typ} cannot be in a list of {right.typ.subtype}",
-                self.expr,
-            )
 
         result_placeholder = self.context.new_placeholder(BaseType('bool'))
         setter = []
@@ -666,14 +548,14 @@ class Expr(object):
             compare_sequence = ['seq'] + for_loop_sequence
 
         # Compare the result of the repeat loop to 1, to know if a match was found.
-        o = LLLnode.from_list([
+        lll_node = LLLnode.from_list([
             'eq', 1,
             compare_sequence],
             typ='bool',
             annotation="in comporator"
         )
 
-        return o
+        return lll_node
 
     @staticmethod
     def _signed_to_unsigned_comparision_op(op):
@@ -688,15 +570,12 @@ class Expr(object):
         else:
             return op
 
-    def compare(self):
+    def parse_Compare(self):
         left = Expr.parse_value_expr(self.expr.left, self.context)
         right = Expr.parse_value_expr(self.expr.right, self.context)
 
         if right.value is None:
-            raise InvalidLiteral(
-                'Comparison to None is not allowed, compare against a default value.',
-                self.expr,
-            )
+            return
 
         if isinstance(left.typ, ByteArrayLike) and isinstance(right.typ, ByteArrayLike):
             # TODO: Can this if branch be removed ^
@@ -704,10 +583,7 @@ class Expr(object):
 
         elif isinstance(self.expr.op, vy_ast.In) and isinstance(right.typ, ListType):
             if left.typ != right.typ.subtype:
-                raise TypeMismatch(
-                    "Can't use IN comparison with different types!",
-                    self.expr,
-                )
+                return
             return self.build_in_comparator()
 
         if isinstance(self.expr.op, vy_ast.Gt):
@@ -723,7 +599,7 @@ class Expr(object):
         elif isinstance(self.expr.op, vy_ast.NotEq):
             op = 'ne'
         else:
-            raise Exception("Unsupported comparison operator")
+            return
 
         # Compare (limited to 32) byte arrays.
         if isinstance(left.typ, ByteArrayLike) and isinstance(right.typ, ByteArrayLike):
@@ -745,11 +621,7 @@ class Expr(object):
                     )
 
                 else:
-                    raise StructureException(
-                        "Can only compare strings/bytes of length shorter",
-                        " than 32 bytes other than equality comparisons",
-                        self.expr,
-                    )
+                    return
 
             else:
                 def load_bytearray(side):
@@ -767,7 +639,7 @@ class Expr(object):
         # Compare other types.
         if not is_numeric_type(left.typ) or not is_numeric_type(right.typ):
             if op not in ('eq', 'ne'):
-                raise TypeMismatch("Invalid type for comparison op", self.expr)
+                return
         left_type, right_type = left.typ.typ, right.typ.typ
 
         # Special Case: comparison of a literal integer. If in valid range allow it to be compared.
@@ -786,20 +658,12 @@ class Expr(object):
         elif {left_type, right_type} == {'uint256', 'uint256'}:
             op = self._signed_to_unsigned_comparision_op(op)
         elif (left_type in ('decimal', 'int128') or right_type in ('decimal', 'int128')) and left_type != right_type:  # noqa: E501
-            raise TypeMismatch(
-                f'Implicit conversion from {left_type} to {right_type} disallowed, please convert.',
-                self.expr,
-            )
+            return
 
         if left_type == right_type:
             return LLLnode.from_list([op, left, right], typ='bool', pos=getpos(self.expr))
-        else:
-            raise TypeMismatch(
-                f"Unsupported types for comparison: {left_type} {right_type}",
-                self.expr,
-            )
 
-    def boolean_operations(self):
+    def parse_BoolOp(self):
         # Iterate through values
         for value in self.expr.values:
             # Check for calls at assignment
@@ -812,12 +676,7 @@ class Expr(object):
             # Check for boolean operations with non-boolean inputs
             _expr = Expr.parse_value_expr(value, self.context)
             if not is_base_type(_expr.typ, 'bool'):
-                raise TypeMismatch(
-                    "Boolean operations can only be between booleans!",
-                    self.expr,
-                )
-
-            # TODO: Handle special case of literals and simplify at compile time
+                return
 
         # Check for valid ops
         if isinstance(self.expr.op, vy_ast.And):
@@ -825,13 +684,11 @@ class Expr(object):
         elif isinstance(self.expr.op, vy_ast.Or):
             op = 'or'
         else:
-            raise Exception("Unsupported bool op: " + self.expr.op)
+            return
 
         # Handle different numbers of inputs
         count = len(self.expr.values)
-        if count < 2:
-            raise StructureException("Expected at least two arguments for a bool op", self.expr)
-        elif count == 2:
+        if count == 2:
             left = Expr.parse_value_expr(self.expr.values[0], self.context)
             right = Expr.parse_value_expr(self.expr.values[1], self.context)
             return LLLnode.from_list([op, left, right], typ='bool', pos=getpos(self.expr))
@@ -849,33 +706,20 @@ class Expr(object):
             return LLLnode.from_list(p, typ='bool', pos=getpos(self.expr))
 
     # Unary operations (only "not" supported)
-    def unary_operations(self):
+    def parse_UnaryOp(self):
         operand = Expr.parse_value_expr(self.expr.operand, self.context)
         if isinstance(self.expr.op, vy_ast.Not):
             if isinstance(operand.typ, BaseType) and operand.typ.typ == 'bool':
                 return LLLnode.from_list(["iszero", operand], typ='bool', pos=getpos(self.expr))
-            else:
-                raise TypeMismatch(
-                    f"Only bool is supported for not operation, {operand.typ} supplied.",
-                    self.expr,
-                )
-        elif isinstance(self.expr.op, vy_ast.USub):
-            if not is_numeric_type(operand.typ):
-                raise TypeMismatch(
-                    f"Unsupported type for negation: {operand.typ}",
-                    self.expr,
-                )
-
+        elif isinstance(self.expr.op, vy_ast.USub) and is_numeric_type(operand.typ):
             # Clamp on minimum integer value as we cannot negate that value
             # (all other integer values are fine)
             min_int_val = get_min_val_for_type(operand.typ.typ)
             return LLLnode.from_list(
-                    ["sub", 0, ["clampgt", operand, min_int_val]],
-                    typ=operand.typ,
-                    pos=getpos(self.expr)
-                )
-        else:
-            raise StructureException("Only the 'not' or 'neg' unary operators are supported")
+                ["sub", 0, ["clampgt", operand, min_int_val]],
+                typ=operand.typ,
+                pos=getpos(self.expr)
+            )
 
     def _is_valid_contract_assign(self):
         if self.expr.args and len(self.expr.args) == 1:
@@ -885,7 +729,7 @@ class Expr(object):
         return False, None
 
     # Function calls
-    def call(self):
+    def parse_Call(self):
         from vyper.functions import (
             DISPATCH_TABLE,
         )
@@ -899,19 +743,8 @@ class Expr(object):
             # Struct constructors do not need `self` prefix.
             elif function_name in self.context.structs:
                 args = self.expr.args
-                if len(args) != 1:
-                    raise StructureException(
-                        "Struct constructor is called with one argument only",
-                        self.expr,
-                    )
-
-                arg = args[0]
-                if not isinstance(arg, vy_ast.Dict):
-                    raise TypeMismatch(
-                        "Struct can only be constructed with a dict",
-                        self.expr,
-                    )
-                return Expr.struct_literals(arg, function_name, self.context)
+                if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
+                    return Expr.struct_literals(args[0], function_name, self.context)
 
             # Contract assignment. Bar(<address>).
             elif function_name in self.context.sigs:
@@ -919,32 +752,21 @@ class Expr(object):
                 if ret is True:
                     arg_lll.typ = ContractType(function_name)  # Cast to Correct contract type.
                     return arg_lll
-                else:
-                    raise TypeMismatch(
-                        "ContractType definition expects one address argument.",
-                        self.expr,
-                    )
-            else:
-                err_msg = f"Not a top-level function: {function_name}"
-                if function_name in [x.split('(')[0] for x, _ in self.context.sigs['self'].items()]:
-                    err_msg += f". Did you mean self.{function_name}?"
-                raise StructureException(err_msg, self.expr)
         elif isinstance(self.expr.func, vy_ast.Attribute) and isinstance(self.expr.func.value, vy_ast.Name) and self.expr.func.value.id == "self":  # noqa: E501
             return self_call.make_call(self.expr, self.context)
         else:
             return external_call.make_external_call(self.expr, self.context)
 
-    def list_literals(self):
-
+    def parse_List(self):
         if not len(self.expr.elements):
-            raise StructureException("List must have elements", self.expr)
+            return
 
         def get_out_type(lll_node):
             if isinstance(lll_node, ListType):
                 return get_out_type(lll_node.subtype)
             return lll_node.typ
 
-        o = []
+        lll_node = []
         previous_type = None
         out_type = None
 
@@ -954,25 +776,17 @@ class Expr(object):
                 out_type = current_lll_node.typ
 
             current_type = get_out_type(current_lll_node)
-            if len(o) > 0 and previous_type != current_type:
+            if len(lll_node) > 0 and previous_type != current_type:
                 raise TypeMismatch("Lists may only contain one type", self.expr)
             else:
-                o.append(current_lll_node)
+                lll_node.append(current_lll_node)
                 previous_type = current_type
 
         return LLLnode.from_list(
-            ["multi"] + o,
-            typ=ListType(out_type, len(o)),
+            ["multi"] + lll_node,
+            typ=ListType(out_type, len(lll_node)),
             pos=getpos(self.expr),
         )
-
-    def dict_fail(self):
-        warnings.warn(
-            "Anonymous structs have been removed in"
-            " favor of named structs, see VIP300",
-            DeprecationWarning
-        )
-        raise InvalidLiteral("Invalid literal.", self.expr)
 
     @staticmethod
     def struct_literals(expr, name, context):
@@ -980,10 +794,7 @@ class Expr(object):
         member_typs = {}
         for key, value in zip(expr.keys, expr.values):
             if not isinstance(key, vy_ast.Name):
-                raise TypeMismatch(
-                    f"Invalid member variable for struct: {getattr(key, 'id', '')}",
-                    key,
-                )
+                return
             check_valid_varname(
                 key.id,
                 context.structs,
@@ -991,7 +802,7 @@ class Expr(object):
                 "Invalid member variable for struct",
             )
             if key.id in member_subs:
-                raise TypeMismatch("Member variable duplicated: " + key.id, key)
+                return
             sub = Expr(value, context).lll_node
             member_subs[key.id] = sub
             member_typs[key.id] = sub.typ
@@ -1001,14 +812,14 @@ class Expr(object):
             pos=getpos(expr),
         )
 
-    def tuple_literals(self):
+    def parse_Tuple(self):
         if not len(self.expr.elements):
-            raise StructureException("Tuple must have elements", self.expr)
-        o = []
-        for elt in self.expr.elements:
-            o.append(Expr(elt, self.context).lll_node)
-        typ = TupleType([x.typ for x in o], is_literal=True)
-        return LLLnode.from_list(["multi"] + o, typ=typ, pos=getpos(self.expr))
+            return
+        lll_node = []
+        for node in self.expr.elements:
+            lll_node.append(Expr(node, self.context).lll_node)
+        typ = TupleType([x.typ for x in lll_node], is_literal=True)
+        return LLLnode.from_list(["multi"] + lll_node, typ=typ, pos=getpos(self.expr))
 
     # Parse an expression that results in a value
     @classmethod

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -329,23 +329,6 @@ class GlobalContext:
             )
         return True
 
-    def add_constant(self, item):
-        args = item.annotation.args
-        if not item.value:
-            raise StructureException('Constants must express a value!', item)
-
-        is_valid_struct = (
-            len(args) == 1 and
-            isinstance(args[0], (vy_ast.Subscript, vy_ast.Name, vy_ast.Call))
-        ) and item.target
-
-        if is_valid_struct:
-            c_name = item.target.id
-            if self.is_valid_varname(c_name, item):
-                self._constants[c_name] = self.unroll_constant(item)
-        else:
-            raise StructureException('Incorrectly formatted struct', item)
-
     @staticmethod
     def get_call_func_name(item):
         if isinstance(item.annotation, vy_ast.Call) and \

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -1,16 +1,13 @@
 from vyper import ast as vy_ast
 from vyper.codegen.return_ import gen_tuple_return, make_return_stmt
 from vyper.exceptions import (
-    CompilerPanic,
     ConstancyViolation,
-    EventDeclarationException,
-    InvalidLiteral,
     StructureException,
-    TypeMismatch,
-    VariableDeclarationException,
+    TypeCheckFailure,
 )
 from vyper.functions import DISPATCH_TABLE, STMT_DISPATCH_TABLE
 from vyper.parser import external_call, self_call
+from vyper.parser.context import Context
 from vyper.parser.events import pack_logging_data, pack_logging_topics
 from vyper.parser.expr import Expr
 from vyper.parser.parser_utils import (
@@ -26,7 +23,6 @@ from vyper.types import (
     BaseType,
     ByteArrayLike,
     ByteArrayType,
-    ContractType,
     ListType,
     NodeType,
     StructType,
@@ -38,69 +34,36 @@ from vyper.types import (
 from vyper.utils import SizeLimits, bytes_to_int, fourbytes_to_int, keccak256
 
 
-class Stmt(object):
-    # TODO: Once other refactors are made reevaluate all inline imports
-    def __init__(self, stmt, context):
-        self.stmt = stmt
-        self.context = context
-        self.stmt_table = {
-            vy_ast.Expr: self.expr,
-            vy_ast.Pass: self.parse_pass,
-            vy_ast.AnnAssign: self.ann_assign,
-            vy_ast.Assign: self.assign,
-            vy_ast.If: self.parse_if,
-            vy_ast.Call: self.call,
-            vy_ast.Assert: self.parse_assert,
-            vy_ast.For: self.parse_for,
-            vy_ast.AugAssign: self.aug_assign,
-            vy_ast.Break: self.parse_break,
-            vy_ast.Continue: self.parse_continue,
-            vy_ast.Return: self.parse_return,
-            vy_ast.Name: self.parse_name,
-            vy_ast.Raise: self.parse_raise,
-        }
-        stmt_type = self.stmt.__class__
-        if stmt_type in self.stmt_table:
-            self.lll_node = self.stmt_table[stmt_type]()
-        else:
-            raise StructureException(f"Unsupported statement type: {type(stmt).__name__}", stmt)
+class Stmt:
 
-    def expr(self):
+    def __init__(self, node: vy_ast.VyperNode, context: Context) -> None:
+        self.stmt = node
+        self.context = context
+        fn = getattr(self, f"parse_{type(node).__name__}", None)
+        if fn is None:
+            raise TypeCheckFailure(f"Invalid statement node: {type(node).__name__}")
+
+        self.lll_node = fn()
+        if self.lll_node is None:
+            raise TypeCheckFailure("Statement node did not produce LLL")
+
+    def parse_Expr(self):
         return Stmt(self.stmt.value, self.context).lll_node
 
-    def parse_pass(self):
+    def parse_Pass(self):
         return LLLnode.from_list('pass', typ=None, pos=getpos(self.stmt))
 
-    def parse_name(self):
+    def parse_Name(self):
         if self.stmt.id == "vdb":
             return LLLnode('debugger', typ=None, pos=getpos(self.stmt))
         else:
             raise StructureException(f"Unsupported statement type: {type(self.stmt)}", self.stmt)
 
-    def parse_raise(self):
-        if self.stmt.exc is None:
-            raise StructureException('Raise must have a reason', self.stmt)
-        return self._assert_reason(0, self.stmt.exc)
+    def parse_Raise(self):
+        if self.stmt.exc:
+            return self._assert_reason(0, self.stmt.exc)
 
-    def _check_rhs_var_assn_recur(self, val):
-        names = ()
-        if isinstance(val, (vy_ast.BinOp, vy_ast.Compare)):
-            right_node = val.right
-            left_node = val.left
-            names = names + self._check_rhs_var_assn_recur(right_node)
-            names = names + self._check_rhs_var_assn_recur(left_node)
-        elif isinstance(val, vy_ast.UnaryOp):
-            operand_node = val.operand
-            names = names + self._check_rhs_var_assn_recur(operand_node)
-        elif isinstance(val, vy_ast.BoolOp):
-            for bool_val in val.values:
-                names = names + self._check_rhs_var_assn_recur(bool_val)
-        elif isinstance(val, vy_ast.Name):
-            name = val.id
-            names = names + (name, )
-        return names
-
-    def ann_assign(self):
+    def parse_AnnAssign(self):
         with self.context.assignment_scope():
             typ = parse_type(
                 self.stmt.annotation,
@@ -108,17 +71,10 @@ class Stmt(object):
                 custom_structs=self.context.structs,
                 constants=self.context.constants,
             )
-            if isinstance(self.stmt.target, vy_ast.Attribute):
-                raise TypeMismatch(
-                    f'May not set type for field {self.stmt.target.attr}',
-                    self.stmt,
-                )
             varname = self.stmt.target.id
             pos = self.context.new_variable(varname, typ)
             if self.stmt.value is None:
-                raise StructureException(
-                    'New variables must be initialized explicitly',
-                    self.stmt)
+                return
 
             sub = Expr(self.stmt.value, self.context).lll_node
 
@@ -144,55 +100,20 @@ class Stmt(object):
                 location='memory',
                 pos=getpos(self.stmt),
             )
-            o = make_setter(variable_loc, sub, 'memory', pos=getpos(self.stmt))
+            lll_node = make_setter(variable_loc, sub, 'memory', pos=getpos(self.stmt))
 
-            return o
+            return lll_node
 
-    def assign(self):
+    def parse_Assign(self):
         # Assignment (e.g. x[4] = y)
-
         with self.context.assignment_scope():
             sub = Expr(self.stmt.value, self.context).lll_node
+            target = self._get_target(self.stmt.target)
+            lll_node = make_setter(target, sub, target.location, pos=getpos(self.stmt))
+            lll_node.pos = getpos(self.stmt)
+        return lll_node
 
-            # Error check when assigning to declared variable
-            if isinstance(self.stmt.target, vy_ast.Name):
-                # Do not allow assignment to undefined variables without annotation
-                if self.stmt.target.id not in self.context.vars:
-                    raise VariableDeclarationException("Variable type not defined", self.stmt)
-
-            is_valid_tuple_assign = (
-                isinstance(self.stmt.target, vy_ast.Tuple)
-            ) and isinstance(self.stmt.value, vy_ast.Tuple)
-
-            # Do no allow tuple-to-tuple assignment
-            if is_valid_tuple_assign:
-                raise VariableDeclarationException(
-                    "Tuple to tuple assignment not supported",
-                    self.stmt,
-                )
-
-            # Checks to see if assignment is valid
-            target = self.get_target(self.stmt.target)
-            if isinstance(target.typ, ContractType) and not isinstance(sub.typ, ContractType):
-                raise TypeMismatch(
-                    'Contract assignment expects casted address: '
-                    f'{target.typ}(<address_var>)',
-                    self.stmt
-                )
-            o = make_setter(target, sub, target.location, pos=getpos(self.stmt))
-
-            o.pos = getpos(self.stmt)
-
-        return o
-
-    def is_bool_expr(self, test_expr):
-        if not isinstance(test_expr.typ, BaseType):
-            return False
-        if not test_expr.typ.typ == 'bool':
-            return False
-        return True
-
-    def parse_if(self):
+    def parse_If(self):
         if self.stmt.orelse:
             block_scope_id = id(self.stmt.orelse)
             with self.context.make_blockscope(block_scope_id):
@@ -203,18 +124,12 @@ class Stmt(object):
         block_scope_id = id(self.stmt)
         with self.context.make_blockscope(block_scope_id):
             test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
-
-            if not self.is_bool_expr(test_expr):
-                raise TypeMismatch('Only boolean expressions allowed', self.stmt.test)
             body = ['if', test_expr,
                     parse_body(self.stmt.body, self.context)] + add_on
-            o = LLLnode.from_list(
-                body,
-                typ=None, pos=getpos(self.stmt)
-            )
-        return o
+            lll_node = LLLnode.from_list(body, typ=None, pos=getpos(self.stmt))
+        return lll_node
 
-    def call(self):
+    def parse_Call(self):
         is_self_function = (
             isinstance(self.stmt.func, vy_ast.Attribute)
         ) and isinstance(self.stmt.func.value, vy_ast.Name) and self.stmt.func.value.id == "self"
@@ -233,21 +148,11 @@ class Stmt(object):
                     self.stmt,
                 )
             else:
-                raise StructureException(
-                    f"Unknown function: '{self.stmt.func.id}'.",
-                    self.stmt,
-                )
+                return
         elif is_self_function:
             return self_call.make_call(self.stmt, self.context)
         elif is_log_call:
-            if self.stmt.func.attr not in self.context.sigs['self']:
-                raise EventDeclarationException(f"Event not declared yet: {self.stmt.func.attr}")
             event = self.context.sigs['self'][self.stmt.func.attr]
-            if len(event.indexed_list) != len(self.stmt.args):
-                raise EventDeclarationException(
-                    f"{event.name} received {len(self.stmt.args)} arguments but "
-                    f"expected {len(event.indexed_list)}"
-                )
             expected_topics, topics = [], []
             expected_data, data = [], []
             for pos, is_indexed in enumerate(event.indexed_list):
@@ -285,20 +190,10 @@ class Stmt(object):
         else:
             return external_call.make_external_call(self.stmt, self.context)
 
-    @staticmethod
-    def _assert_unreachable(test_expr, msg):
-        return LLLnode.from_list(['assert_unreachable', test_expr], typ=None, pos=getpos(msg))
-
     def _assert_reason(self, test_expr, msg):
         if isinstance(msg, vy_ast.Name) and msg.id == 'UNREACHABLE':
-            return self._assert_unreachable(test_expr, msg)
+            return LLLnode.from_list(['assert_unreachable', test_expr], typ=None, pos=getpos(msg))
 
-        if not isinstance(msg, vy_ast.Str):
-            raise StructureException(
-                'Reason parameter of assert needs to be a literal string '
-                '(or UNREACHABLE constant).',
-                msg
-            )
         if len(msg.s.strip()) == 0:
             raise StructureException(
                 'Empty reason string not allowed.', self.stmt
@@ -323,13 +218,10 @@ class Stmt(object):
                 ]
         return LLLnode.from_list(assert_reason, typ=None, pos=getpos(self.stmt))
 
-    def parse_assert(self):
-
+    def parse_Assert(self):
         with self.context.assertion_scope():
             test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
 
-        if not self.is_bool_expr(test_expr):
-            raise TypeMismatch('Only boolean expressions allowed', self.stmt.test)
         if self.stmt.msg:
             return self._assert_reason(test_expr, self.stmt.msg)
         else:
@@ -356,27 +248,20 @@ class Stmt(object):
         _, arg_expr = self._check_valid_range_constant(arg_ast_node)
         return arg_expr.value
 
-    def parse_for(self):
+    def parse_For(self):
         # Type 0 for, e.g. for i in list(): ...
         if self._is_list_iter():
-            return self.parse_for_list()
+            return self._parse_for_list()
 
         if not isinstance(self.stmt.iter, vy_ast.Call):
             if isinstance(self.stmt.iter, vy_ast.Subscript):
                 raise StructureException("Cannot iterate over a nested list", self.stmt.iter)
-            raise StructureException(
-                f"Cannot iterate over '{type(self.stmt.iter).__name__}' object",
-                self.stmt.iter
-            )
-        if getattr(self.stmt.iter.func, 'id', None) != "range":
-            raise StructureException(
-                "Non-literals cannot be used as loop range", self.stmt.iter.func
-            )
-        if len(self.stmt.iter.args) not in {1, 2}:
-            raise StructureException(
-                f"Range expects between 1 and 2 arguments, got {len(self.stmt.iter.args)}",
-                self.stmt.iter.func
-            )
+            return
+
+        if self.stmt.get('iter.func.id') != "range":
+            return
+        if not 0 < len(self.stmt.iter.args) < 3:
+            return
 
         block_scope_id = id(self.stmt)
         with self.context.make_blockscope(block_scope_id):
@@ -400,25 +285,6 @@ class Stmt(object):
             # Type 3 for, e.g. for i in range(x, x + 10): ...
             else:
                 arg1 = self.stmt.iter.args[1]
-                if not isinstance(arg1, vy_ast.BinOp) or not isinstance(arg1.op, vy_ast.Add):
-                    raise StructureException(
-                        (
-                            "Two-arg for statements must be of the form `for i "
-                            "in range(start, start + rounds): ...`"
-                        ),
-                        arg1,
-                    )
-
-                if not vy_ast.compare_nodes(arg0, arg1.left):
-                    raise StructureException(
-                        (
-                            "Two-arg for statements of the form `for i in "
-                            "range(x, x + y): ...` must have x identical in both "
-                            f"places: {vy_ast.ast_to_dict(arg0)} {vy_ast.ast_to_dict(arg1.left)}"
-                        ),
-                        self.stmt.iter,
-                    )
-
                 rounds = self._get_range_const_value(arg1.right)
                 start = Expr.parse_value_expr(arg0, self.context)
 
@@ -433,7 +299,7 @@ class Stmt(object):
             varname = self.stmt.target.id
             pos = self.context.new_variable(varname, BaseType('int128'), pos=getpos(self.stmt))
             self.context.forvars[varname] = True
-            o = LLLnode.from_list(
+            lll_node = LLLnode.from_list(
                 ['repeat', pos, start, rounds, parse_body(self.stmt.body, self.context)],
                 typ=None,
                 pos=getpos(self.stmt),
@@ -441,7 +307,7 @@ class Stmt(object):
             del self.context.vars[varname]
             del self.context.forvars[varname]
 
-        return o
+        return lll_node
 
     def _is_list_iter(self):
         """
@@ -465,7 +331,7 @@ class Stmt(object):
 
         return False
 
-    def parse_for_list(self):
+    def _parse_for_list(self):
         with self.context.range_scope():
             iter_list_node = Expr(self.stmt.iter, self.context).lll_node
         if not isinstance(iter_list_node.typ.subtype, BaseType):  # Sanity check on list subtype.
@@ -500,9 +366,7 @@ class Stmt(object):
                 elif iter_var.location == 'memory':
                     fetcher = 'mload'
                 else:
-                    raise CompilerPanic(
-                        f'List iteration only supported on in-memory types {self.expr}',
-                    )
+                    return
                 body = [
                     'seq',
                     [
@@ -512,7 +376,7 @@ class Stmt(object):
                     ],
                     parse_body(self.stmt.body, self.context)
                 ]
-                o = LLLnode.from_list(
+                lll_node = LLLnode.from_list(
                     ['repeat', i_pos, 0, iter_var.size, body], typ=None, pos=getpos(self.stmt)
                 )
 
@@ -531,7 +395,7 @@ class Stmt(object):
                 ['mstore', value_pos, ['mload', ['add', tmp_list, ['mul', ['mload', i_pos], 32]]]],
                 parse_body(self.stmt.body, self.context)
             ]
-            o = LLLnode.from_list(
+            lll_node = LLLnode.from_list(
                 ['seq',
                     setter,
                     ['repeat', i_pos, 0, count, body]], typ=None, pos=getpos(self.stmt)
@@ -553,7 +417,7 @@ class Stmt(object):
                     ],
                     parse_body(self.stmt.body, self.context),
                 ]
-                o = LLLnode.from_list(
+                lll_node = LLLnode.from_list(
                     ['seq',
                         ['repeat', i_pos, 0, count, body]], typ=None, pos=getpos(self.stmt)
                 )
@@ -564,21 +428,15 @@ class Stmt(object):
         # of operations.
         del self.context.vars[self.context._mangle(i_pos_raw_name)]
         del self.context.forvars[varname]
-        return o
+        return lll_node
 
-    def aug_assign(self):
-        target = self.get_target(self.stmt.target)
+    def parse_AugAssign(self):
+        target = self._get_target(self.stmt.target)
         sub = Expr.parse_value_expr(self.stmt.value, self.context)
-        if not isinstance(
-            self.stmt.op, (vy_ast.Add, vy_ast.Sub, vy_ast.Mult, vy_ast.Div, vy_ast.Mod)
-        ):
-            raise StructureException("Unsupported operator for augassign", self.stmt)
         if not isinstance(target.typ, BaseType):
-            raise TypeMismatch(
-                "Can only use aug-assign operators with simple types!", self.stmt.target
-            )
+            return
         if target.location == 'storage':
-            o = Expr.parse_value_expr(
+            lll_node = Expr.parse_value_expr(
                 vy_ast.BinOp(
                     left=LLLnode.from_list(['sload', '_stloc'], typ=target.typ, pos=target.pos),
                     right=sub,
@@ -594,11 +452,11 @@ class Stmt(object):
                 'with', '_stloc', target, [
                     'sstore',
                     '_stloc',
-                    base_type_conversion(o, o.typ, target.typ, pos=getpos(self.stmt)),
+                    base_type_conversion(lll_node, lll_node.typ, target.typ, pos=getpos(self.stmt)),
                 ],
             ], typ=None, pos=getpos(self.stmt))
         elif target.location == 'memory':
-            o = Expr.parse_value_expr(
+            lll_node = Expr.parse_value_expr(
                 vy_ast.BinOp(
                     left=LLLnode.from_list(['mload', '_mloc'], typ=target.typ, pos=target.pos),
                     right=sub,
@@ -614,28 +472,26 @@ class Stmt(object):
                 'with', '_mloc', target, [
                     'mstore',
                     '_mloc',
-                    base_type_conversion(o, o.typ, target.typ, pos=getpos(self.stmt)),
+                    base_type_conversion(lll_node, lll_node.typ, target.typ, pos=getpos(self.stmt)),
                 ],
             ], typ=None, pos=getpos(self.stmt))
 
-    def parse_continue(self):
+    def parse_Continue(self):
         return LLLnode.from_list('continue', typ=None, pos=getpos(self.stmt))
 
-    def parse_break(self):
+    def parse_Break(self):
         return LLLnode.from_list('break', typ=None, pos=getpos(self.stmt))
 
-    def parse_return(self):
+    def parse_Return(self):
         if self.context.return_type is None:
             if self.stmt.value:
-                raise TypeMismatch("Not expecting to return a value", self.stmt)
+                return
             return LLLnode.from_list(
                 make_return_stmt(self.stmt, self.context, 0, 0),
                 typ=None,
                 pos=getpos(self.stmt),
                 valency=0,
             )
-        if not self.stmt.value:
-            raise TypeMismatch("Expecting to return a value", self.stmt)
 
         sub = Expr(self.stmt.value, self.context).lll_node
 
@@ -644,18 +500,9 @@ class Stmt(object):
             sub = unwrap_location(sub)
 
             if self.context.return_type != sub.typ and not sub.typ.is_literal:
-                raise TypeMismatch(
-                    f"Trying to return base type {sub.typ}, output expecting "
-                    f"{self.context.return_type}",
-                    self.stmt.value,
-                )
+                return
             elif sub.typ.is_literal and (self.context.return_type.typ == sub.typ or 'int' in self.context.return_type.typ and 'int' in sub.typ.typ):  # noqa: E501
-                if not SizeLimits.in_bounds(self.context.return_type.typ, sub.value):
-                    raise InvalidLiteral(
-                        "Number out of range: " + str(sub.value),
-                        self.stmt
-                    )
-                else:
+                if SizeLimits.in_bounds(self.context.return_type.typ, sub.value):
                     return LLLnode.from_list(
                         [
                             'seq',
@@ -673,25 +520,13 @@ class Stmt(object):
                     pos=getpos(self.stmt),
                     valency=0,
                 )
-            else:
-                raise TypeMismatch(
-                    f"Unsupported type conversion: {sub.typ} to {self.context.return_type}",
-                    self.stmt.value,
-                )
+            return
         # Returning a byte array
         elif isinstance(sub.typ, ByteArrayLike):
             if not sub.typ.eq_base(self.context.return_type):
-                raise TypeMismatch(
-                    f"Trying to return base type {sub.typ}, output expecting "
-                    f"{self.context.return_type}",
-                    self.stmt.value,
-                )
+                return
             if sub.typ.maxlen > self.context.return_type.maxlen:
-                raise TypeMismatch(
-                    f"Cannot cast from greater max-length {sub.typ.maxlen} to shorter "
-                    f"max-length {self.context.return_type.maxlen}",
-                    self.stmt.value,
-                )
+                return
 
             # loop memory has to be allocated first.
             loop_memory_position = self.context.new_placeholder(typ=BaseType('uint256'))
@@ -717,17 +552,12 @@ class Stmt(object):
                         loop_memory_position=loop_memory_position,
                     )
                 ], typ=None, pos=getpos(self.stmt), valency=0)
-            else:
-                raise Exception(f"Invalid location: {sub.location}")
+            return
 
         elif isinstance(sub.typ, ListType):
             loop_memory_position = self.context.new_placeholder(typ=BaseType('uint256'))
             if sub.typ != self.context.return_type:
-                raise TypeMismatch(
-                    f"List return type {sub.typ} does not match specified "
-                    f"return type, expecting {self.context.return_type}",
-                    self.stmt
-                )
+                return
             elif sub.location == "memory" and sub.value != "multi":
                 return LLLnode.from_list(
                     make_return_stmt(
@@ -763,41 +593,26 @@ class Stmt(object):
         # Returning a struct
         elif isinstance(sub.typ, StructType):
             retty = self.context.return_type
-            if not isinstance(retty, StructType) or retty.name != sub.typ.name:
-                raise TypeMismatch(
-                    f"Trying to return {sub.typ}, output expecting {self.context.return_type}",
-                    self.stmt.value,
-                )
-            return gen_tuple_return(self.stmt, self.context, sub)
+            if isinstance(retty, StructType) and retty.name == sub.typ.name:
+                return gen_tuple_return(self.stmt, self.context, sub)
 
         # Returning a tuple.
         elif isinstance(sub.typ, TupleType):
             if not isinstance(self.context.return_type, TupleType):
-                raise TypeMismatch(
-                    f"Trying to return tuple type {sub.typ}, output expecting "
-                    f"{self.context.return_type}",
-                    self.stmt.value,
-                )
+                return
 
             if len(self.context.return_type.members) != len(sub.typ.members):
-                raise StructureException("Tuple lengths don't match!", self.stmt)
+                return
 
             # check return type matches, sub type.
             for i, ret_x in enumerate(self.context.return_type.members):
                 s_member = sub.typ.members[i]
                 sub_type = s_member if isinstance(s_member, NodeType) else s_member.typ
                 if type(sub_type) is not type(ret_x):
-                    raise StructureException(
-                        "Tuple return type does not match annotated return. "
-                        f"{type(sub_type)} != {type(ret_x)}",
-                        self.stmt
-                    )
+                    return
             return gen_tuple_return(self.stmt, self.context, sub)
 
-        else:
-            raise TypeMismatch(f"Can't return type {sub.typ}", self.stmt)
-
-    def get_target(self, target):
+    def _get_target(self, target):
         # Check if we are doing assignment of an iteration loop.
         if isinstance(target, vy_ast.Subscript) and self.context.in_for_loop:
             raise_exception = False
@@ -843,12 +658,12 @@ def parse_body(code, context):
     if not isinstance(code, list):
         return parse_stmt(code, context)
 
-    o = ['seq']
+    lll_node = ['seq']
     for stmt in code:
         lll = parse_stmt(stmt, context)
-        o.append(lll)
-    o.append('pass')  # force zerovalent, even last statement
-    return LLLnode.from_list(o, pos=getpos(code[0]) if code else None)
+        lll_node.append(lll)
+    lll_node.append('pass')  # force zerovalent, even last statement
+    return LLLnode.from_list(lll_node, pos=getpos(code[0]) if code else None)
 
 
 def constancy_checks(node, context, stmt):

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -274,11 +274,7 @@ def parse_type(item, location, sigs=None, custom_structs=None, constants=None):
         # Fixed size lists or bytearrays, e.g. num[100]
         is_constant_val = constants.ast_is_constant(item.slice.value)
         if isinstance(item.slice.value, vy_ast.Int) or is_constant_val:
-            n_val = (
-                constants.get_constant(item.slice.value.id, context=None).value
-                if is_constant_val
-                else item.slice.value.n
-            )
+            n_val = item.slice.value.n
             if not isinstance(n_val, int) or n_val <= 0:
                 raise InvalidType(
                     "Arrays / ByteArrays must have a positive integral number of elements",


### PR DESCRIPTION
### What I did
Remove dead code and replace `VyperException` subclasses with `VyperInternalException` subclasses in `vyper/parser/*.py`

### How I did it
Type-check related logic in `parser` has been removed, or replaced with internal exceptions that indicate an unexpected compiler error:

* when the check involves structure validation of a node, such that a later attempt to access the incorrect structure will result in an attribute or key error, I've removed the check altogether
* when I'm not certain the mistake would get caught in the above manner, I've instead replaced it with an internal error or be returning `None`

In the major functions, I'm using a pattern where a check is made on the return value, and if `None`, an internal error is raised.  This reduces the number of unreachable lines of code while still providing a layer of safety in case type checking is insufficient.

All of this is a stop-gap on the way to a full refactor of the `parser/` module - we just need to make sure that if the type check layer misses something, the same exception __isn't__ raised in `parser/` so that we can address the error.

Most of the deleted code was found by looking at this coverage report: https://codecov.io/gh/iamdefinitelyahuman/vyper/tree/685223bf473283ba8e305eb5e6b87bb5e589caf7/vyper

I'm not finished. I still have a short list of exceptions in `parser/` that the test cases hit, where I need to implement logic.  Another smaller but more logic-heavy PR will be coming soon to cover them.

### How to verify it
Observe that test are still passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85329243-2fc16200-b4e3-11ea-8344-f2f89d60d0e4.png)
