### PR TITLE
Fix TypeError in do_GET

### DIFF
--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -58,7 +58,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_cors_all()
             self.end_headers()
-            self.wfile.write('Vyper Compiler. Version: ' + (vyper.__version__).encode() + '\n')
+            self.wfile.write(f'Vyper Compiler. Version: {vyper.__version__}\n'.encode())
         else:
             self.send_404()
 


### PR DESCRIPTION
Fix 'TypeError: can only concatenate str (not "bytes") to str'  in do_GET. Encoding should be after concatenation.