### PR TITLE
Missing type checks

### DIFF
--- a/tests/parser/exceptions/test_call_violation.py
+++ b/tests/parser/exceptions/test_call_violation.py
@@ -19,18 +19,6 @@ def b():
     p: int128 = self.a(10)
     """,
     """
-f:int128
-
-@public
-def a (x:int128):
-    self.f = 100
-
-@constant
-@public
-def b():
-    self.a(10)
-    """,
-    """
 @private
 def foo():
     self.goo()

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -86,6 +86,18 @@ def foo():
     for i in range(x):
         pass
     """,
+    """
+f:int128
+
+@public
+def a (x:int128):
+    self.f = 100
+
+@constant
+@public
+def b():
+    self.a(10)
+    """,
 ]
 
 

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -5,7 +5,6 @@ import pytest
 from vyper.exceptions import (
     ArgumentException,
     ConstancyViolation,
-    InvalidLiteral,
     InvalidType,
     NamespaceCollision,
     StructureException,
@@ -335,7 +334,7 @@ def foo(x: int128):
 def foo():
     for i in range(-3):
         pass
-    """, InvalidType),
+    """, StructureException),
     """
 @public
 def foo():
@@ -347,7 +346,7 @@ def foo():
 def foo():
     for i in range(5,3):
         pass
-    """, InvalidLiteral),
+    """, StructureException),
     ("""
 @public
 def foo():

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -109,11 +109,15 @@ TEST_WEI: constant(uint256) = 1
 
 @private
 def test():
-   raw_call(0x0000000000000000000000000000000000000005, b'hello', max_outsize=TEST_C, gas=2000)
+   foo: bytes[1] = raw_call(
+       0x0000000000000000000000000000000000000005, b'hello', max_outsize=TEST_C, gas=2000
+    )
 
 @private
 def test1():
-    raw_call(0x0000000000000000000000000000000000000005, b'hello', max_outsize=256, gas=TEST_WEI)
+    foo: bytes[256] = raw_call(
+        0x0000000000000000000000000000000000000005, b'hello', max_outsize=256, gas=TEST_WEI
+    )
     """,
     """
 LIMIT: constant(int128) = 1

--- a/vyper/context/validation/local.py
+++ b/vyper/context/validation/local.py
@@ -149,10 +149,10 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
     def visit_Assert(self, node):
         if node.msg:
-            if not (
-                (isinstance(node.msg, vy_ast.Name) and node.msg.id == "UNREACHABLE")
-                or isinstance(node.msg, vy_ast.Str)
-            ):
+            if isinstance(node.msg, vy_ast.Str):
+                if not node.msg.value.strip():
+                    raise StructureException("Reason string cannot be empty", node.msg)
+            elif not (isinstance(node.msg, vy_ast.Name) and node.msg.id == "UNREACHABLE"):
                 raise InvalidType("Reason must UNREACHABLE or a string literal", node.msg)
 
         try:

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -249,11 +249,6 @@ class Stmt:
         if self._is_list_iter():
             return self._parse_for_list()
 
-        if not isinstance(self.stmt.iter, vy_ast.Call):
-            if isinstance(self.stmt.iter, vy_ast.Subscript):
-                raise StructureException("Cannot iterate over a nested list", self.stmt.iter)
-            return
-
         if self.stmt.get('iter.func.id') != "range":
             return
         if not 0 < len(self.stmt.iter.args) < 3:
@@ -286,11 +281,7 @@ class Stmt:
 
             r = rounds if isinstance(rounds, int) else rounds.value
             if r < 1:
-                raise StructureException(
-                    f"For loop has invalid number of iterations ({r}),"
-                    " the value must be greater than zero",
-                    self.stmt.iter
-                )
+                return
 
             varname = self.stmt.target.id
             pos = self.context.new_variable(varname, BaseType('int128'), pos=getpos(self.stmt))
@@ -331,7 +322,7 @@ class Stmt:
         with self.context.range_scope():
             iter_list_node = Expr(self.stmt.iter, self.context).lll_node
         if not isinstance(iter_list_node.typ.subtype, BaseType):  # Sanity check on list subtype.
-            raise StructureException('For loops allowed only on basetype lists.', self.stmt.iter)
+            return
         iter_var_type = (
             self.context.vars.get(self.stmt.iter.id).typ
             if isinstance(self.stmt.iter, vy_ast.Name)

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -194,10 +194,6 @@ class Stmt:
         if isinstance(msg, vy_ast.Name) and msg.id == 'UNREACHABLE':
             return LLLnode.from_list(['assert_unreachable', test_expr], typ=None, pos=getpos(msg))
 
-        if len(msg.s.strip()) == 0:
-            raise StructureException(
-                'Empty reason string not allowed.', self.stmt
-            )
         reason_str = msg.s.strip()
         sig_placeholder = self.context.new_placeholder(BaseType(32))
         arg_placeholder = self.context.new_placeholder(BaseType(32))

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -5,7 +5,7 @@ from vyper.exceptions import (
     StructureException,
     TypeCheckFailure,
 )
-from vyper.functions import DISPATCH_TABLE, STMT_DISPATCH_TABLE
+from vyper.functions import STMT_DISPATCH_TABLE
 from vyper.parser import external_call, self_call
 from vyper.parser.context import Context
 from vyper.parser.events import pack_logging_data, pack_logging_topics
@@ -140,15 +140,7 @@ class Stmt:
 
         if isinstance(self.stmt.func, vy_ast.Name):
             funcname = self.stmt.func.id
-            if funcname in STMT_DISPATCH_TABLE:
-                return STMT_DISPATCH_TABLE[funcname].build_LLL(self.stmt, self.context)
-            elif funcname in DISPATCH_TABLE:
-                raise StructureException(
-                    f"Function {funcname} can not be called without being used.",
-                    self.stmt,
-                )
-            else:
-                return
+            return STMT_DISPATCH_TABLE[funcname].build_LLL(self.stmt, self.context)
         elif is_self_function:
             return self_call.make_call(self.stmt, self.context)
         elif is_log_call:


### PR DESCRIPTION
### What I did
Add misc checks that were missing from the type check logic:

* `assert` with an empty reason string
* calls to builtin functions where the output is not assignment
* constancy checks for contract functions
* for loop correctness

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85424447-fc391300-b588-11ea-9f46-ba2cd8cc43d7.png)
