### PR TITLE
ignore E203, W503 in flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ exclude =
 	.tox
 	docs
 	build
+ignore = E203, W503
 per-file-ignores = 
 	*/__init__.py: F401
 


### PR DESCRIPTION
### What I did
Ignore `203 whitespace before ':'` and `W503 line break before binary operator` in `flake8`.

These settings are not PEP8 compliant and conflict with `black`.  You can read about this in detail in the `black` [code style guide](https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-breaks--binary-operators).

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85437257-5f33a580-b59b-11ea-90d1-75dddadc6712.png)
