### PR TITLE
Refactor Namespace object

### DIFF
--- a/tests/functional/context/types/test_type_from_abi.py
+++ b/tests/functional/context/types/test_type_from_abi.py
@@ -9,21 +9,19 @@ BASE_TYPES = ["int128", "uint256", "bool", "address", "bytes32"]
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
-def test_base_types(namespace, type_str):
+def test_base_types(type_str):
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_abi({"type": type_str})
+    type_definition = get_type_from_abi({"type": type_str})
 
     assert isinstance(type_definition, primitive._type)
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
-def test_base_types_as_arrays(namespace, type_str):
+def test_base_types_as_arrays(type_str):
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_abi({"type": f"{type_str}[3]"})
+    type_definition = get_type_from_abi({"type": f"{type_str}[3]"})
 
     assert isinstance(type_definition, ArrayDefinition)
     assert type_definition.length == 3
@@ -31,11 +29,10 @@ def test_base_types_as_arrays(namespace, type_str):
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
-def test_base_types_as_multidimensional_arrays(namespace, type_str):
+def test_base_types_as_multidimensional_arrays(type_str):
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_abi({"type": f"{type_str}[3][5]"})
+    type_definition = get_type_from_abi({"type": f"{type_str}[3][5]"})
 
     assert isinstance(type_definition, ArrayDefinition)
     assert type_definition.length == 5
@@ -45,7 +42,6 @@ def test_base_types_as_multidimensional_arrays(namespace, type_str):
 
 
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
-def test_invalid_index(namespace, idx):
-    with namespace.enter_builtin_scope():
-        with pytest.raises(UnknownType):
-            get_type_from_abi({"type": f"int128[{idx}]"})
+def test_invalid_index(idx):
+    with pytest.raises(UnknownType):
+        get_type_from_abi({"type": f"int128[{idx}]"})

--- a/tests/functional/context/types/test_type_from_annotation.py
+++ b/tests/functional/context/types/test_type_from_annotation.py
@@ -16,34 +16,31 @@ ARRAY_VALUE_TYPES = ["string", "bytes"]
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
-def test_base_types(build_node, namespace, type_str):
+def test_base_types(build_node, type_str):
     node = build_node(type_str)
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
+    type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
 
     assert isinstance(type_definition, primitive._type)
 
 
 @pytest.mark.parametrize("type_str", ARRAY_VALUE_TYPES)
-def test_array_value_types(build_node, namespace, type_str):
+def test_array_value_types(build_node, type_str):
     node = build_node(f"{type_str}[1]")
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
+    type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
 
     assert isinstance(type_definition, primitive._type)
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
-def test_base_types_as_arrays(build_node, namespace, type_str):
+def test_base_types_as_arrays(build_node, type_str):
     node = build_node(f"{type_str}[3]")
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
+    type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
 
     assert isinstance(type_definition, ArrayDefinition)
     assert type_definition.length == 3
@@ -51,12 +48,11 @@ def test_base_types_as_arrays(build_node, namespace, type_str):
 
 
 @pytest.mark.parametrize("type_str", ARRAY_VALUE_TYPES)
-def test_array_value_types_as_arrays(build_node, namespace, type_str):
+def test_array_value_types_as_arrays(build_node, type_str):
     node = build_node(f"{type_str}[1][1]")
 
-    with namespace.enter_builtin_scope():
-        with pytest.raises(StructureException):
-            get_type_from_annotation(node, DataLocation.STORAGE)
+    with pytest.raises(StructureException):
+        get_type_from_annotation(node, DataLocation.STORAGE)
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
@@ -64,8 +60,7 @@ def test_base_types_as_multidimensional_arrays(build_node, namespace, type_str):
     node = build_node(f"{type_str}[3][5]")
     primitive = get_primitive_types()[type_str]
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
+    type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
 
     assert isinstance(type_definition, ArrayDefinition)
     assert type_definition.length == 5
@@ -76,21 +71,19 @@ def test_base_types_as_multidimensional_arrays(build_node, namespace, type_str):
 
 @pytest.mark.parametrize("type_str", ["int128", "string"])
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
-def test_invalid_index(build_node, namespace, idx, type_str):
+def test_invalid_index(build_node, idx, type_str):
     node = build_node(f"{type_str}[{idx}]")
-    with namespace.enter_builtin_scope():
-        with pytest.raises((ArrayIndexException, InvalidType)):
-            get_type_from_annotation(node, DataLocation.STORAGE)
+    with pytest.raises((ArrayIndexException, InvalidType)):
+        get_type_from_annotation(node, DataLocation.STORAGE)
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
 @pytest.mark.parametrize("type_str2", BASE_TYPES)
-def test_mapping(build_node, namespace, type_str, type_str2):
+def test_mapping(build_node, type_str, type_str2):
     node = build_node(f"map({type_str}, {type_str2})")
     primitives = get_primitive_types()
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
+    type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
 
     assert isinstance(type_definition, MappingDefinition)
     assert isinstance(type_definition.key_type, primitives[type_str]._type)
@@ -99,12 +92,11 @@ def test_mapping(build_node, namespace, type_str, type_str2):
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
 @pytest.mark.parametrize("type_str2", BASE_TYPES)
-def test_multidimensional_mapping(build_node, namespace, type_str, type_str2):
+def test_multidimensional_mapping(build_node, type_str, type_str2):
     node = build_node(f"map({type_str}, map({type_str}, {type_str2}))")
     primitives = get_primitive_types()
 
-    with namespace.enter_builtin_scope():
-        type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
+    type_definition = get_type_from_annotation(node, DataLocation.STORAGE)
 
     assert isinstance(type_definition, MappingDefinition)
     assert isinstance(type_definition.key_type, primitives[type_str]._type)

--- a/tests/functional/context/validation/test_cyclic_function_calls.py
+++ b/tests/functional/context/validation/test_cyclic_function_calls.py
@@ -16,7 +16,7 @@ def bar():
     self.foo()
     """
     vyper_module = parse_to_ast(code)
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(CallViolation):
             ModuleNodeVisitor(vyper_module, {}, namespace)
 
@@ -40,6 +40,6 @@ def potato():
     self.foo()
     """
     vyper_module = parse_to_ast(code)
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(CallViolation):
             ModuleNodeVisitor(vyper_module, {}, namespace)

--- a/tests/functional/context/validation/test_potential_types.py
+++ b/tests/functional/context/validation/test_potential_types.py
@@ -24,14 +24,14 @@ STRING_LITERALS = [("'hi'", "'there'"), ("'foo'", "'bar'"), ("'longer'", "'short
 def test_attribute(build_node, namespace):
     node = build_node("self.foo")
     type_def = Int128Definition()
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         namespace["self"].add_member("foo", type_def)
         assert get_possible_types_from_node(node) == [type_def]
 
 
 def test_attribute_missing_self(build_node, namespace):
     node = build_node("foo")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         namespace["self"].add_member("foo", Int128Definition())
         with pytest.raises(InvalidReference):
             get_possible_types_from_node(node)
@@ -39,7 +39,7 @@ def test_attribute_missing_self(build_node, namespace):
 
 def test_attribute_not_in_self(build_node, namespace):
     node = build_node("self.foo")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         namespace["foo"] = Int128Definition()
         with pytest.raises(InvalidReference):
             get_possible_types_from_node(node)
@@ -47,7 +47,7 @@ def test_attribute_not_in_self(build_node, namespace):
 
 def test_attribute_unknown(build_node, namespace):
     node = build_node("foo.bar")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         namespace["foo"] = AddressDefinition()
         with pytest.raises(UnknownAttribute):
             get_possible_types_from_node(node)
@@ -55,7 +55,7 @@ def test_attribute_unknown(build_node, namespace):
 
 def test_attribute_not_member_type(build_node, namespace):
     node = build_node("foo.bar")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         namespace["foo"] = Int128Definition()
         with pytest.raises(StructureException):
             get_possible_types_from_node(node)
@@ -65,7 +65,7 @@ def test_attribute_not_member_type(build_node, namespace):
 @pytest.mark.parametrize("left,right", INTEGER_LITERALS + DECIMAL_LITERALS)
 def test_binop(build_node, namespace, op, left, right):
     node = build_node(f"{left}{op}{right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         get_possible_types_from_node(node)
 
 
@@ -73,14 +73,14 @@ def test_binop(build_node, namespace, op, left, right):
 @pytest.mark.parametrize("left,right", [(42, "2.3"), (-1, 2 ** 128)])
 def test_binop_type_mismatch(build_node, namespace, op, left, right):
     node = build_node(f"{left}{op}{right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(TypeMismatch):
             get_possible_types_from_node(node)
 
 
 def test_binop_invalid_decimal_pow(build_node, namespace):
     node = build_node("2.1 ** 2.1")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(InvalidOperation):
             get_possible_types_from_node(node)
 
@@ -89,7 +89,7 @@ def test_binop_invalid_decimal_pow(build_node, namespace):
 @pytest.mark.parametrize("op", "+-*/%")
 def test_binop_invalid_op(build_node, namespace, op, left, right):
     node = build_node(f"{left} {op} {right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(InvalidOperation):
             get_possible_types_from_node(node)
 
@@ -98,7 +98,7 @@ def test_binop_invalid_op(build_node, namespace, op, left, right):
 @pytest.mark.parametrize("op", ["and", "or"])
 def test_boolop(build_node, namespace, op, left, right):
     node = build_node(f"{left} {op} {right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         types_list = get_possible_types_from_node(node)
 
     assert len(types_list) == 1
@@ -109,7 +109,7 @@ def test_boolop(build_node, namespace, op, left, right):
 @pytest.mark.parametrize("op", ["and", "or"])
 def test_boolop_invalid_op(build_node, namespace, op, left, right):
     node = build_node(f"{left} {op} {right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(InvalidOperation):
             get_possible_types_from_node(node)
 
@@ -118,7 +118,7 @@ def test_boolop_invalid_op(build_node, namespace, op, left, right):
 @pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
 def test_compare_lt_gt(build_node, namespace, op, left, right):
     node = build_node(f"{left} {op} {right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         types_list = get_possible_types_from_node(node)
 
     assert len(types_list) == 1
@@ -131,7 +131,7 @@ def test_compare_lt_gt(build_node, namespace, op, left, right):
 @pytest.mark.parametrize("op", ["==", "!="])
 def test_compare_eq_ne(build_node, namespace, op, left, right):
     node = build_node(f"{left} {op} {right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         types_list = get_possible_types_from_node(node)
 
     assert len(types_list) == 1
@@ -142,7 +142,7 @@ def test_compare_eq_ne(build_node, namespace, op, left, right):
 @pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
 def test_compare_invalid_op(build_node, namespace, op, left, right):
     node = build_node(f"{left} {op} {right}")
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         with pytest.raises(InvalidOperation):
             get_possible_types_from_node(node)
 
@@ -165,7 +165,7 @@ def test_name_unknown(build_node, namespace):
 def test_list(build_node, namespace, left, right):
     node = build_node(f"[{left}, {right}]")
 
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         types_list = get_possible_types_from_node(node)
 
     assert types_list

--- a/vyper/context/README.md
+++ b/vyper/context/README.md
@@ -49,8 +49,7 @@ consists of three steps:
 ### 1. Preparing the builtin namespace
 
 The [`Namespace`](namespace.py) object represents the namespace for a contract.
-Prior to beginning type checking, builtins are added via the `Namespace.enter_builtin_scope`
-method. This includes:
+Builtins are added upon initialization of the object. This includes:
 
 * Adding primitive type classes from the [`types/`](types) subpackage
 * Adding environment variables and builtin constants from [`environment.py`](environment.py)
@@ -187,10 +186,6 @@ with namespace.enter_scope():
 
 namespace['foo']  # this raises an UndeclaredDefinition
 ```
-
-Prior to beginning type checking, the first scope **must** be initiated using
-`Namespace.enter_builtin_scope`. This ensures that all builtin objects have
-been added, and resets the content of `self` and `log`.
 
 ### Validation
 

--- a/vyper/context/validation/__init__.py
+++ b/vyper/context/validation/__init__.py
@@ -6,6 +6,6 @@ from vyper.context.validation.module import add_module_namespace
 def validate_semantics(vyper_ast, interface_codes):
     namespace = get_namespace()
 
-    with namespace.enter_builtin_scope():
+    with namespace.enter_scope():
         add_module_namespace(vyper_ast, interface_codes)
         validate_functions(vyper_ast)


### PR DESCRIPTION
### What I did
Simplify the `Namespace` object.

### How I did it
Remove `Namespace.enter_builtin_scope`, and instead add the builtins when initializing `Namespace`.  This makes for simpler code and solves an issue I'm having when implementing #1980.  I'm not sure why I didn't do it this way to begin with :grimacing: 

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85738163-dd658880-b710-11ea-9961-3e218874a942.png)
