### PR TITLE
default type arg in `method_id`

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -114,14 +114,26 @@ contracts.
 
     Returns the square root of the provided decimal number, using the Babylonian square root algorithm.
 
-.. py:function:: method_id(method, type_) -> Union[bytes32, bytes[4]]
+.. py:function:: method_id(method, output_type: type = bytes[4]) -> Union[bytes32, bytes[4]]
 
     Takes a function declaration and returns its method_id (used in data field to call it).
 
-    * ``method``: Method declaration as ``str_literal``
-    * ``type_``: Type of output (``bytes32`` or ``bytes[4]``)
+    * ``method``: Method declaration as given as a literal string
+    * ``output_type``: The type of output (``bytes[4]`` or ``bytes32``). Defaults to ``bytes[4]``.
 
-    Returns a value of the type specified by ``type_``.
+    Returns a value of the type specified by ``output_type``.
+
+    .. code-block:: python
+
+        @public
+        @constant
+        def foo() -> bytes[4]:
+            return method_id('transfer(address,uint256)', output_type=bytes[4])
+
+    .. code-block:: python
+
+        >>> ExampleContract.foo("hello")
+        b"\xa9\x05\x9c\xbb"
 
 .. py:function:: ecrecover(hash: bytes32, v: uint256, r: uint256, s: uint256) -> address
 

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -280,7 +280,7 @@ def safeTransferFrom(
     if _to.is_contract: # check if `_to` is a contract address
         returnValue: bytes32 = ERC721Receiver(_to).onERC721Received(msg.sender, _from, _tokenId, _data)
         # Throws if transfer destination is a contract which does not implement 'onERC721Received'
-        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", bytes32)
+        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
 
 
 @public

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -248,7 +248,7 @@ def onERC721Received(
         _tokenId: uint256,
         _data: bytes[1024]
     ) -> bytes32:
-    return method_id("onERC721Received(address,address,uint256,bytes)", bytes32)
+    return method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
     """
     )
     tx_hash = c.safeTransferFrom(

--- a/tests/parser/functions/test_method_id.py
+++ b/tests/parser/functions/test_method_id.py
@@ -6,35 +6,44 @@ def double(x: int128) -> int128:
 
 @public
 def returnten() -> int128:
-    ans: bytes[32] = raw_call(self, concat(method_id("double(int128)", bytes[4]), convert(5, bytes32)), gas=50000, max_outsize=32)  # noqa: E501
+    ans: bytes[32] = raw_call(self, concat(method_id("double(int128)"), convert(5, bytes32)), gas=50000, max_outsize=32)  # noqa: E501
     return convert(convert(ans, bytes32), int128)
     """
     c = get_contract_with_gas_estimation(method_id_test)
     assert c.returnten() == 10
-    print("Passed method ID test")
 
 
-# Disabled because existing codebase does not allow bytes32 to be represented as
-# a bytestring - enable again once typechecking is refactored out of parser/stmt.py
+def test_method_id_bytes32(get_contract):
+    code = """
+@public
+def sig() -> bytes32:
+    return method_id('transfer(address,uint256)', output_type=bytes32)
+    """
+    c = get_contract(code)
+    sig = c.sig()
 
-# def test_method_id_bytes32(get_contract):
-#     code = """
-# @public
-# def sig() -> bytes32:
-#     return method_id('transfer(address,uint256)', bytes32)
-#     """
-#     c = get_contract(code)
-#     sig = c.sig()
-
-#     assert len(sig) == 32
-#     assert sig[-4:] == b"\xa9\x05\x9c\xbb"
+    assert len(sig) == 32
+    assert sig[-4:] == b"\xa9\x05\x9c\xbb"
 
 
 def test_method_id_bytes4(get_contract):
     code = """
 @public
 def sig() -> bytes[4]:
-    return method_id('transfer(address,uint256)', bytes[4])
+    return method_id('transfer(address,uint256)', output_type=bytes[4])
+    """
+    c = get_contract(code)
+    sig = c.sig()
+
+    # assert len(sig) == 4
+    assert sig == b"\xa9\x05\x9c\xbb"
+
+
+def test_method_id_bytes4_default(get_contract):
+    code = """
+@public
+def sig() -> bytes[4]:
+    return method_id('transfer(address,uint256)')
     """
     c = get_contract(code)
     sig = c.sig()
@@ -47,7 +56,7 @@ def test_method_id_invalid_space(get_contract, assert_compile_failed):
     code = """
 @public
 def sig() -> bytes32:
-    return method_id('transfer(address, uint256)', bytes32)
+    return method_id('transfer(address, uint256)', output_type=bytes32)
     """
     assert_compile_failed(lambda: get_contract(code))
 
@@ -56,6 +65,6 @@ def test_method_id_invalid_type(get_contract, assert_compile_failed):
     code = """
 @public
 def sig() -> int128:
-    return method_id('transfer(address,uint256)', int128)
+    return method_id('transfer(address,uint256)', output_type=int128)
     """
     assert_compile_failed(lambda: get_contract(code))

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -130,7 +130,7 @@ def __init__(_owner_setter: address):
 @public
 def set(i: int128, owner: address):
     # delegate setting owners to other contract.s
-    cdata: bytes[68] = concat(method_id("set_owner(int128,address)", bytes[4]), convert(i, bytes32), convert(owner, bytes32))  # noqa: E501
+    cdata: bytes[68] = concat(method_id("set_owner(int128,address)"), convert(i, bytes32), convert(owner, bytes32))  # noqa: E501
     raw_call(
         self.owner_setter_contract,
         cdata,
@@ -172,7 +172,7 @@ def foo(_bar: bytes32):
 @public
 def foo_call(_addr: address):
     cdata: bytes[40] = concat(
-        method_id("foo(bytes32)", bytes[4]),
+        method_id("foo(bytes32)"),
         0x0000000000000000000000000000000000000000000000000000000000000001
     )
     raw_call(_addr, cdata, max_outsize=0{})
@@ -206,7 +206,7 @@ def foo() -> int128:
 def foo(_addr: address) -> int128:
     _response: bytes[32] = raw_call(
         _addr,
-        method_id("foo()", bytes[4]),
+        method_id("foo()"),
         max_outsize=32,
         is_static_call=True,
     )
@@ -236,7 +236,7 @@ def foo() -> int128:
 def foo(_addr: address) -> int128:
     _response: bytes[32] = raw_call(
         _addr,
-        method_id("foo()", bytes[4]),
+        method_id("foo()"),
         max_outsize=32,
         is_static_call=True,
     )
@@ -255,7 +255,7 @@ uncompilable_code = [
 @public
 @constant
 def foo(_addr: address):
-    raw_call(_addr, method_id("foo()", bytes[4]))
+    raw_call(_addr, method_id("foo()"))
     """,
         ConstancyViolation,
     ),
@@ -263,7 +263,7 @@ def foo(_addr: address):
         """
 @public
 def foo(_addr: address):
-    raw_call(_addr, method_id("foo()", bytes[4]), is_delegate_call=True, is_static_call=True)
+    raw_call(_addr, method_id("foo()"), is_delegate_call=True, is_static_call=True)
     """,
         ArgumentException,
     ),


### PR DESCRIPTION
### What I did
Make the `type` argument in `method_id` optional.

Closes #1980

### How I did it
* the keyword is set as `output_type`
* if not given, the default is `bytes[4]`

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85751120-58cc3780-b71b-11ea-8bc2-5cbae20f986a.png)
