### PR TITLE
use uint256 for input in array getter methods

### DIFF
--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -197,7 +197,7 @@ class GlobalContext:
             o = []
             for funname, head, tail, base in cls._mk_getter_helper(typ.subtype, depth + 1):
                 o.append(
-                    (funname, (f"arg{depth}: int128, ") + head, (f"[arg{depth}]") + tail, base,)
+                    (funname, (f"arg{depth}: uint256, ") + head, (f"[arg{depth}]") + tail, base,)
                 )
             return o
         # Mapping type: do not extend the getter name, add an input argument for


### PR DESCRIPTION
### What I did
When generating an array getter, use `uint256` as the input argument.  Closes #1983 

### How I did it
Modification to `parser/global_context.py` - in the future we should refactor this logic to use the new AST mutation ability.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85768879-8a003400-b72a-11ea-83dc-46eee96449b2.png)
