### PR TITLE
Overflow checks during constant folding

### DIFF
--- a/tests/ast/nodes/test_evaluate_binop_decimal.py
+++ b/tests/ast/nodes/test_evaluate_binop_decimal.py
@@ -5,7 +5,11 @@ from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 from vyper import ast as vy_ast
-from vyper.exceptions import TypeMismatch, ZeroDivisionException
+from vyper.exceptions import (
+    OverflowException,
+    TypeMismatch,
+    ZeroDivisionException,
+)
 
 st_decimals = st.decimals(
     min_value=-(2 ** 32), max_value=2 ** 32, allow_nan=False, allow_infinity=False, places=10,
@@ -76,8 +80,8 @@ def foo({input_value}) -> decimal:
         vy_ast.folding.replace_literal_ops(vyper_ast)
         expected = vyper_ast.body[0].value.value
         is_valid = -(2 ** 127) <= expected < 2 ** 127
-    except ZeroDivisionException:
-        # for division/modulus by 0, expect the contract call to revert
+    except (OverflowException, ZeroDivisionException):
+        # for overflow or division/modulus by 0, expect the contract call to revert
         is_valid = False
 
     if is_valid:

--- a/tests/parser/functions/test_convert_to_decimal.py
+++ b/tests/parser/functions/test_convert_to_decimal.py
@@ -45,7 +45,7 @@ def test_convert_from_uint256_overflow(get_contract_with_gas_estimation, assert_
     code = """
 @public
 def foo() -> decimal:
-    return convert(2**256 - 1, decimal)
+    return convert(2**127, decimal)
     """
 
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), InvalidLiteral)

--- a/tests/parser/functions/test_convert_to_int128.py
+++ b/tests/parser/functions/test_convert_to_int128.py
@@ -158,7 +158,7 @@ def test() -> int128:
     code = """
 @public
 def test() -> int128:
-    return convert(2**256 - 1, int128)
+    return convert(2**127, int128)
     """
 
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), InvalidLiteral)

--- a/tests/parser/types/numbers/test_uint256.py
+++ b/tests/parser/types/numbers/test_uint256.py
@@ -183,20 +183,3 @@ def max_ne() -> (bool):
     assert c.max_gte() is False
     assert c.max_gt() is False
     assert c.max_ne() is True
-
-
-def test_uint256_constant_folding(get_contract_with_gas_estimation):
-    code = """
-@public
-def maximum() -> uint256:
-    return 2**256 - 1
-
-
-@public
-def minimum() -> uint256:
-    return 2**256 - 2**256
-    """
-
-    c = get_contract_with_gas_estimation(code)
-    assert c.maximum() == 2 ** 256 - 1
-    assert c.minimum() == 0


### PR DESCRIPTION
### What I did
Fix a constant folding issue where nested math operations were able to overflow as long as the final result was in bounds.

For example, prior to this PR the following statement was valid because the binary operation was completely folded prior to the overflow check:

```
a: uint256 = 2 ** 256 - 1
```

However, the following would revert during runtime because `2 ** 256` overflows:

```
a: uint256 = 256
b: uint256 = 2 ** a - 1
```

Although writing `2 ** 256 - 1` may be convenient, I feel strongly that folding should always have a consistent behavior with the outcome at runtime.

Closes #2046 

### Hw I did it
In `vyper/ast/nodes.py`, immediately check the bounds on results after folding all `BinOp` and `UnaryOp` nodes.

### How to verify it
Run the tests.  I added some new cases to test the behavior.

Note that I also encountered and fixed some existing tests that were expecting and relying on this behavior, so this definitely amounts to a breaking change.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85919520-c643a980-b87c-11ea-9b32-048c2d4f936c.png)
