### PR TITLE
Remove module-level order restrictions

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -8,12 +8,6 @@ fail_list = [
 x[5] = 4
     """,
     """
-@public
-def foo(): pass
-
-x: int128
-    """,
-    """
 send(0x1234567890123456789012345678901234567890, 5)
     """,
     """
@@ -42,12 +36,6 @@ def foo() -> int128:
 def foo() -> int128:
     x: address = 0x1234567890123456789012345678901234567890
     return x.codesize()
-    """,
-    """
-interface F:
-    def foo(): view
-struct S:
-    x: int128
     """,
     """
 @public


### PR DESCRIPTION
### What I did
Remove restrictions on ordering of elements within the module-level namespace of a contract.

The only restriction this _does not_ remove is that functions may only call upward - that logic is fairly intertwined with `global_context` and will take some work to eliminate.

### How I did it
* Removed some checks in `global_context`
* Removed failing tests
* Checked the documentation - this behavior was never documented so nothing needs to be changed there

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85922530-21819600-b895-11ea-8736-e40ee51e176e.png)
