### PR TITLE
Do not add signature to memory for private function calls

### DIFF
--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -27,7 +27,11 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
     method_name = node.func.attr
     sig = context.sigs[interface_name][method_name]
     inargs, inargsize, _ = pack_arguments(
-        sig, [Expr(arg, context).lll_node for arg in node.args], context, node.func,
+        sig,
+        [Expr(arg, context).lll_node for arg in node.args],
+        context,
+        node.func,
+        is_external_call=True,
     )
     output_placeholder, output_size, returner = get_external_call_output(sig, context)
     sub = [

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -117,7 +117,7 @@ def _call_self_private(stmt_expr, context, sig):
     # Push Arguments
     if expr_args:
         inargs, inargsize, arg_pos = pack_arguments(
-            sig, expr_args, context, stmt_expr, return_placeholder=False,
+            sig, expr_args, context, stmt_expr, is_external_call=False
         )
         push_args += [inargs]  # copy arguments first, to not mess up the push/pop sequencing.
 


### PR DESCRIPTION
### What I did
Do not write a signature to memory when preparing args for a private function call.  Fixes #1695 

### How I did it
In `vyper/parser/parser_utils.py::pack_arguments`, replaced the `return_placeholder`  kwarg with `is_external_call`. When `False`, the signature is stored in memory.

I had to adjust some memory offsets to make this work, but I think the resulting code is a bit cleaner.

### How to verify it
Run the tests.  I didn't add any cases, but I did confirm that we have sufficient coverage around this functionality.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85926310-bbeed300-b8af-11ea-80f4-ce18029f3963.png)
