### PR TITLE
Ease restrictions on self-call

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -54,9 +54,16 @@ Function calls can happen internally or externally and have different levels of 
 Public Functions
 ----------------
 
-Public functions (decorated with ``@public``) are a part of the contract interface and may be called via transactions or from other contracts. They cannot be called internally.
 
-Public functions in Vyper are equivalent to external functions in Solidity.
+Public functions (decorated with ``@public``) are a part of the contract interface and may be called via transactions or from other contracts. Public functions in Vyper are equivalent to external functions in Solidity.
+
+.. code-block:: python
+
+    @public
+    def add_seven(a: int128) -> int128:
+        return a + 7
+
+A vyper contract cannot call directly between two public functions. If you must do this, you can use an :ref:`interface <contract_structure-interfaces>`.
 
 .. _structure-functions-private:
 
@@ -291,6 +298,8 @@ file should also be produced and should look like this:
       "title" : "A simulator for Bug Bunny, the most famous Rabbit"
     }
 
+.. _contract_structure-interfaces:
+
 Contract Interfaces
 ===================
 
@@ -362,7 +371,7 @@ Imported interfaces are written using standard Vyper syntax, with the body of ea
     def calculate() -> uint256:
         pass
 
-You can also import a fully implemented contract and Vyper will automatically convert it to an interface.
+You can also import a fully implemented contract and Vyper will automatically convert it to an interface. It is even possible for a contract to import itself to gain access to it's own interface.
 
 Imports via ``import``
 **********************

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -277,9 +277,10 @@ def _expr(x: address) -> int128:
     c2 = get_contract(contract_2)
 
     c2._stmt(c1.address)
-    c2._expr(c1.address)
-    assert_tx_failed(lambda: c2._stmt(c2.address))
-    assert_tx_failed(lambda: c2._expr(c2.address))
+    c2._stmt(c2.address)
+
+    assert c2._expr(c1.address) == 1
+    assert c2._expr(c2.address) == 1
 
 
 def test_invalid_nonexistent_contract_call(w3, assert_tx_failed, get_contract):

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -316,7 +316,7 @@ def foo() -> uint256:
     assert global_compiled == local_compiled
 
 
-def test_self_interface_cannot_compile(assert_compile_failed):
+def test_self_interface_is_allowed(get_contract):
     code = """
 interface Bar:
     def foo() -> uint256: view
@@ -329,10 +329,11 @@ def foo() -> uint256 :
 def bar() -> uint256:
     return Bar(self).foo()
 """
-    assert_compile_failed(lambda: compile_code(code), StructureException)
+    c = get_contract(code)
+    assert c.bar() == 42
 
 
-def test_self_interface_via_storage_raises(get_contract, assert_tx_failed):
+def test_self_interface_via_storage(get_contract):
     code = """
 interface Bar:
     def foo() -> uint256: view
@@ -352,10 +353,10 @@ def bar() -> uint256:
     return self.bar_contract.foo()
     """
     c = get_contract(code)
-    assert_tx_failed(lambda: c.bar())
+    assert c.bar() == 42
 
 
-def test_self_interface_via_calldata_raises(get_contract, assert_tx_failed):
+def test_self_interface_via_calldata(get_contract):
     code = """
 interface Bar:
     def foo() -> uint256: view
@@ -369,7 +370,7 @@ def bar(a: address) -> uint256:
     return Bar(a).foo()
     """
     c = get_contract(code)
-    assert_tx_failed(lambda: c.bar(c.address))
+    assert c.bar(c.address) == 42
 
 
 type_str_params = [

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -22,8 +22,7 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
         value = 0
     if gas is None:
         gas = "gas"
-    if contract_address.value == "address":
-        raise StructureException("External calls to self are not permitted.", node)
+
     method_name = node.func.attr
     sig = context.sigs[interface_name][method_name]
     inargs, inargsize, _ = pack_arguments(
@@ -33,7 +32,6 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
     sub = [
         "seq",
         ["assert", ["extcodesize", contract_address]],
-        ["assert", ["ne", "address", contract_address]],
     ]
     if context.is_constant() and not sig.const:
         # TODO this can probably go


### PR DESCRIPTION
### What I did
Ease restrictions on a contract calling into itself:

* remove the runtime assertion
* remove the compile-time check on an interface cast to `self`

Closes #1696

### How I did it
* Deleted a couple of checks in `vyper/parser/external_call.py`
* Minor documentation update - we never really explicitly said this _didn't_ work, so there wasn't much to modify here.  I could write more, but..  I'll do a proper documentation update soon:tm:, promise

### How to verify it
Run the tests. I flipped a few tests around that were verifying this behavior wasn't working, now they check that it works.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85926967-f78b9c00-b8b3-11ea-9b8b-5ed2620c3418.png)
