### PR TITLE
Indexed array types

### DIFF
--- a/vyper/signatures/event_signature.py
+++ b/vyper/signatures/event_signature.py
@@ -46,12 +46,6 @@ class EventSignature:
                 if isinstance(typ, vy_ast.Call) and typ.get("func.id") == "indexed":
                     indexed_list.append(True)
                     typ = typ.args[0]
-                    if (
-                        isinstance(typ, vy_ast.Subscript)
-                        and getattr(typ.value, "id", None) == "bytes"
-                        and typ.slice.value.n > 32
-                    ):  # noqa: E501
-                        raise EventDeclarationException("Indexed arguments are limited to 32 bytes")
                 else:
                     indexed_list.append(False)
                 check_valid_varname(

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -154,10 +154,7 @@ def canonicalize_type(t, is_indexed=False):
     if isinstance(t, ByteArrayLike):
         # Check to see if maxlen is small enough for events
         byte_type = "string" if isinstance(t, StringType) else "bytes"
-        if is_indexed:
-            return f"{byte_type}{t.maxlen}"
-        else:
-            return f"{byte_type}"
+        return byte_type
 
     if isinstance(t, ListType):
         if not isinstance(t.subtype, (ListType, BaseType)):


### PR DESCRIPTION
### What I did
Hash non-value types when they are used as indexed topics.  Closes #1699 

This introduces a significant change in that we no longer convert e.g.` bytes[1]` to `bytes1` - bytes and string arrays are always represented as `bytes` and `string` in the event ABI, regardless of length.

We can now also support use of bytes or string arrays >32 bytes, and array types.

### How I did it
In `vyper/parser/events.py`, expanded the logic of `pack_event_topics`.

### How to verify it
Run the tests. I had to modify quite a few based on this change, and I added some new cases to ensure that indexed topics are correct when reading variables from memory, storage, and calldata.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85931958-1b150d80-b8d9-11ea-9fad-d566cd26127e.png)

