### PR TITLE
Update Struct public getter to return whole Struct

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -664,7 +664,7 @@ def test_bad_code_struct_exc(assert_compile_failed, get_contract_with_gas_estima
     assert_compile_failed(lambda: get_contract_with_gas_estimation(bad_code), ArgumentException)
 
 
-def test_external__value_arg_without_return(w3, get_contract_with_gas_estimation):
+def test_external_value_arg_without_return(w3, get_contract_with_gas_estimation):
     contract_1 = """
 @payable
 @public

--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -48,9 +48,9 @@ def __init__():
     assert c.x() == 7
     assert c.y(1) == 9
     assert c.z() == b"cow"
-    assert c.w__a(1) == 11
-    assert c.w__b(1, 2) == 13
-    assert c.w__c(1) == b"horse"
-    assert c.w__e(2, 1, 2) == 17
-    assert c.w__f(3) == 750
-    assert c.w__g(3) == 751
+    assert c.w(1)[0] == 11  # W.a
+    assert c.w(1)[1][2] == 13  # W.b[2]
+    assert c.w(1)[2] == b"horse"  # W.c
+    assert c.w(2)[3][1][2] == 17  # W.e[1][2]
+    assert c.w(3)[4] == 750  # W.f
+    assert c.w(3)[5] == 751  # W.g

--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_state_accessor(get_contract_with_gas_estimation_for_constants):
     state_accessor = """
 y: HashMap[int128, int128]
@@ -17,6 +20,9 @@ def foo() -> int128:
     assert c.foo() == 5
 
 
+# TODO: Either wait for this, or refactor test suite to use Brownie
+#       (which doesn't suffer from this issue)
+@pytest.mark.xfail(reason="https://github.com/ethereum/web3.py/issues/1634#issuecomment-650797252")
 def test_getter_code(get_contract_with_gas_estimation_for_constants):
     getter_code = """
 struct W:

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -190,15 +190,9 @@ class GlobalContext:
                     )
                 )
             return o
-        # Struct type: for each member variable, make a separate getter, extend
-        # its function name with the name of the variable, do not add input
-        # arguments, add a member access to the return statement
+        # Struct type: return type is just the abi-encoded struct
         elif isinstance(typ, StructType):
-            o = []
-            for k, v in typ.members.items():
-                for funname, head, tail, base in cls._mk_getter_helper(v, depth):
-                    o.append(("__" + k + funname, head, "." + k + tail, base))
-            return o
+            return [("", "", "", typ.name)]
         else:
             raise Exception("Unexpected type")
 


### PR DESCRIPTION
Closes: #1702

### What I did
We had some funky handling prior for struct members because of a bug in web3py. This PR makes the correct change to support returning structs from public getters directly, making it compatible with how Solidity handles it.

### How I did it
Just returning the struct name as a type directly instead of iterating over it's members

### How to verify it
I updated the tests to use the tuple sequence returned from the public getter. Also note the xfail on the one test case that couldn't be handled by web3py's current configuration. We can remove this once web3py releases a fix, or we change to using Brownie

### Description for the changelog
Public getters for structs now return the whole struct

### Cute Animal Picture
![exhausted](http://www.duskyswondersite.com/wp-content/uploads/2016/04/animals-dog-tired-2.jpg)