### PR TITLE
Add test for loop var exceeding type bounds

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -10,6 +10,7 @@ from vyper.exceptions import (
     NamespaceCollision,
     StateAccessViolation,
     StructureException,
+    TypeMismatch,
 )
 
 BASIC_FOR_LOOP_CODE = [
@@ -494,6 +495,17 @@ def foo():
     for i in x[1]:
         pass
     """,
+    (
+        """
+@public
+def test_for() -> int128:
+    a: int128 = 0
+    for i in range(MAX_INT128, MAX_INT128+2):
+        a = i
+    return a
+    """,
+        TypeMismatch,
+    ),
 ]
 
 


### PR DESCRIPTION
### What I did
The test case described in #1712 did not exist, so I added it. The condition is appropiately caught in #2029, so this just updates the test cases.

### Cute Animal Picture
![cute zebra](https://discoveringsecrets.files.wordpress.com/2013/12/dsc01922.jpg)