### PR TITLE
rename ContractFunctionType to ContractFunction

### DIFF
--- a/vyper/context/README.md
+++ b/vyper/context/README.md
@@ -25,7 +25,7 @@ Vyper abstract syntax tree (AST).
   * [`abstract.py`](types/abstract.py): Abstract data type classes
   * [`bases.py`](types/bases.py): Common base classes for all type objects
   * [`event.py`](types/event.py): `Event` type class
-  * [`function.py`](types/function.py): `ContractFunctionType` type class
+  * [`function.py`](types/function.py): `ContractFunction` type class
   * [`utils.py`](types/utils.py): Functions for generating and fetching type objects
 * [`validation/`](validation): Subpackage for type checking and syntax verification logic
   * [`base.py`](validation/base.py): Base validation class

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -55,7 +55,7 @@ class StateMutability(StringEnum):
         #       specifying a state mutability modifier at all. Do the same here.
 
 
-class ContractFunctionType(BaseTypeDefinition):
+class ContractFunction(BaseTypeDefinition):
     """
     Contract function type.
 
@@ -117,9 +117,9 @@ class ContractFunctionType(BaseTypeDefinition):
         return f"contract function '{self.name}'"
 
     @classmethod
-    def from_abi(cls, abi: Dict) -> "ContractFunctionType":
+    def from_abi(cls, abi: Dict) -> "ContractFunction":
         """
-        Generate a `ContractFunctionType` object from an ABI interface.
+        Generate a `ContractFunction` object from an ABI interface.
 
         Arguments
         ---------
@@ -163,9 +163,9 @@ class ContractFunctionType(BaseTypeDefinition):
         node: vy_ast.FunctionDef,
         is_interface: Optional[bool] = False,
         include_defaults: Optional[bool] = True,
-    ) -> "ContractFunctionType":
+    ) -> "ContractFunction":
         """
-        Generate a `ContractFunctionType` object from a `FunctionDef` node.
+        Generate a `ContractFunction` object from a `FunctionDef` node.
 
         Arguments
         ---------
@@ -180,7 +180,7 @@ class ContractFunctionType(BaseTypeDefinition):
 
         Returns
         -------
-        ContractFunctionType
+        ContractFunction
         """
         kwargs: Dict[str, Any] = {}
         if is_interface:
@@ -315,9 +315,9 @@ class ContractFunctionType(BaseTypeDefinition):
         return cls(node.name, arguments, arg_count, return_type, **kwargs)
 
     @classmethod
-    def from_AnnAssign(cls, node: vy_ast.AnnAssign) -> "ContractFunctionType":
+    def from_AnnAssign(cls, node: vy_ast.AnnAssign) -> "ContractFunction":
         """
-        Generate a `ContractFunctionType` object from an `AnnAssign` node.
+        Generate a `ContractFunction` object from an `AnnAssign` node.
 
         Used to create function definitions for public variables.
 
@@ -328,7 +328,7 @@ class ContractFunctionType(BaseTypeDefinition):
 
         Returns
         -------
-        ContractFunctionType
+        ContractFunction
         """
         if not isinstance(node.annotation, vy_ast.Call):
             raise CompilerPanic("Annotation must be a call to public()")

--- a/vyper/context/types/indexable/sequence.py
+++ b/vyper/context/types/indexable/sequence.py
@@ -86,7 +86,7 @@ class TupleDefinition(_SequenceDefinition):
     Tuple type definition.
 
     This class has no corresponding primitive. It is used to represent
-    multiple return values from `types.function.ContractFunctionType`.
+    multiple return values from `types.function.ContractFunction`.
     """
 
     def __init__(self, value_type: Tuple[BaseTypeDefinition, ...]) -> None:

--- a/vyper/context/types/meta/interface.py
+++ b/vyper/context/types/meta/interface.py
@@ -5,7 +5,7 @@ from vyper import ast as vy_ast
 from vyper.ast.validation import validate_call_args
 from vyper.context.namespace import get_namespace
 from vyper.context.types.bases import DataLocation, MemberTypeDefinition
-from vyper.context.types.function import ContractFunctionType
+from vyper.context.types.function import ContractFunction
 from vyper.context.types.value.address import AddressDefinition
 from vyper.context.validation.utils import validate_expected_type
 from vyper.exceptions import (
@@ -98,7 +98,7 @@ def build_primitive_from_abi(name: str, abi: dict) -> InterfacePrimitive:
     """
     members: OrderedDict = OrderedDict()
     for item in [i for i in abi if i.get("type") == "function"]:
-        func = ContractFunctionType.from_abi(item)
+        func = ContractFunction.from_abi(item)
         if func.name in members:
             # TODO overloaded functions
             raise NamespaceCollision(
@@ -143,10 +143,10 @@ def _get_module_functions(base_node: vy_ast.Module) -> OrderedDict:
     functions = OrderedDict()
     for node in base_node.get_children(vy_ast.FunctionDef):
         if "public" in [i.id for i in node.decorator_list]:
-            func = ContractFunctionType.from_FunctionDef(node, include_defaults=True)
+            func = ContractFunction.from_FunctionDef(node, include_defaults=True)
             functions[node.name] = func
     for node in base_node.get_children(vy_ast.AnnAssign, {"annotation.func.id": "public"}):
-        functions[node.target.id] = ContractFunctionType.from_AnnAssign(node)
+        functions[node.target.id] = ContractFunction.from_AnnAssign(node)
     return functions
 
 
@@ -156,6 +156,6 @@ def _get_class_functions(base_node: vy_ast.InterfaceDef) -> OrderedDict:
         if not isinstance(node, vy_ast.FunctionDef):
             raise StructureException("Interfaces can only contain function definitions", node)
 
-        functions[node.name] = ContractFunctionType.from_FunctionDef(node, is_interface=True)
+        functions[node.name] = ContractFunction.from_FunctionDef(node, is_interface=True)
 
     return functions

--- a/vyper/context/validation/local.py
+++ b/vyper/context/validation/local.py
@@ -11,7 +11,7 @@ from vyper.context.namespace import get_namespace
 from vyper.context.types.abstract import IntegerAbstractType
 from vyper.context.types.bases import DataLocation
 from vyper.context.types.function import (
-    ContractFunctionType,
+    ContractFunction,
     FunctionVisibility,
     StateMutability,
 )
@@ -380,7 +380,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         if isinstance(fn_type, Event):
             raise StructureException("To call an event you must use the `log` statement", node)
 
-        if isinstance(fn_type, ContractFunctionType):
+        if isinstance(fn_type, ContractFunction):
             if (
                 fn_type.mutability > StateMutability.VIEW
                 and self.func.mutability <= StateMutability.VIEW
@@ -396,7 +396,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                 )
 
         return_value = fn_type.fetch_call_return(node.value)
-        if return_value and not isinstance(fn_type, ContractFunctionType):
+        if return_value and not isinstance(fn_type, ContractFunction):
             raise StructureException(
                 f"Function '{node.value.func}' cannot be called without assigning the result", node
             )

--- a/vyper/context/validation/module.py
+++ b/vyper/context/validation/module.py
@@ -7,7 +7,7 @@ from vyper import ast as vy_ast
 from vyper.ast.validation import validate_call_args
 from vyper.context.namespace import get_namespace
 from vyper.context.types.bases import DataLocation
-from vyper.context.types.function import ContractFunctionType
+from vyper.context.types.function import ContractFunction
 from vyper.context.types.meta.event import Event
 from vyper.context.types.utils import check_literal, get_type_from_annotation
 from vyper.context.validation.base import VyperNodeVisitorBase
@@ -177,7 +177,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
             raise exc.with_annotation(node) from None
 
     def visit_FunctionDef(self, node):
-        func = ContractFunctionType.from_FunctionDef(node)
+        func = ContractFunction.from_FunctionDef(node)
         try:
             self.namespace["self"].add_member(func.name, func)
         except VyperException as exc:


### PR DESCRIPTION
### What I did
rename `ContractFunctionType` to `ContractFunction`

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/85998396-d47bfc00-ba1b-11ea-8980-4ca7e2d085ca.png)
