### PR TITLE
Fix: use of calldata array with `in` comparator

### DIFF
--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -44,6 +44,24 @@ def in_test(x: int128) -> bool:
     assert c.in_test(32000) is False
 
 
+def test_in_calldata_list(get_contract_with_gas_estimation):
+    code = """
+@public
+def in_test(x: int128, y: int128[10]) -> bool:
+    if x in y:
+        return True
+    return False
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.in_test(1, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) is True
+    assert c.in_test(9, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) is True
+    assert c.in_test(11, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) is False
+    assert c.in_test(-1, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) is False
+    assert c.in_test(32000, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) is False
+
+
 def test_cmp_in_list(get_contract_with_gas_estimation):
     code = """
 @public

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -493,8 +493,9 @@ class Expr:
                 ["add", ["sha3_32", right], ["mload", MemoryPositions.FREE_LOOP_INDEX]],
             ]
         else:
+            load_operation = "mload" if right.location == "memory" else "calldataload"
             load_i_from_list = [
-                "mload",
+                load_operation,
                 ["add", right, ["mul", 32, ["mload", MemoryPositions.FREE_LOOP_INDEX]]],
             ]
 


### PR DESCRIPTION
### What I did
Support calldata arrays with the `in` comparator - fixes #1904 

### How I did it
Expand logic in `parser/expr.py` to also handle calldata.

### How to verify it
Run tests. I added a test case.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86032499-84fff500-ba48-11ea-80aa-ad2a65a2326f.png)
