### PR TITLE
Check length of return data from external calls

### DIFF
--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -227,8 +227,9 @@ def test_external_call_to_builtin_interface(w3, get_contract):
 balanceOf: public(HashMap[address, uint256])
 
 @external
-def transfer(to: address, _value: uint256):
+def transfer(to: address, _value: uint256) -> bool:
     self.balanceOf[to] += _value
+    return True
     """
 
     code = """

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -97,19 +97,25 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
             static_offset = output_placeholder
             static_output_size = 0
             for typ in types_list:
+                # ensure length of bytes does not exceed max allowable length for type
                 if isinstance(typ, ByteArrayLike):
                     static_output_size += 32
-                    # ensure length of bytes does not exceed max allowable length for type
-                    dynamic_checks.append(
-                        [
-                            "assert",
+                    # do not perform this check on calls to a JSON interface - we don't know
+                    # for certain how long the expected data is
+                    if not sig.is_from_json:
+                        dynamic_checks.append(
                             [
-                                "lt",
-                                ["mload", ["add", ["mload", static_offset], output_placeholder]],
-                                typ.maxlen + 1,
-                            ],
-                        ]
-                    )
+                                "assert",
+                                [
+                                    "lt",
+                                    [
+                                        "mload",
+                                        ["add", ["mload", static_offset], output_placeholder],
+                                    ],
+                                    typ.maxlen + 1,
+                                ],
+                            ]
+                        )
                 static_offset += get_static_size_of_type(typ) * 32
                 static_output_size += get_static_size_of_type(typ) * 32
 

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -13,6 +13,7 @@ from vyper.types import (
     TupleLike,
     get_size_of_type,
     get_static_size_of_type,
+    has_dynamic_data,
 )
 
 
@@ -36,7 +37,8 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
     output_placeholder, output_size, returner = get_external_call_output(sig, context)
     sub = ["seq"]
     if not output_size:
-        # if we are not expecting return data, check that a contract exists at the target address
+        # if we do not expect return data, check that a contract exists at the target address
+        # we can omit this when we _do_ expect return data because we later check `returndatasize`
         sub.append(["assert", ["extcodesize", contract_address]])
     if context.is_constant() and sig.mutability not in ("view", "pure"):
         # TODO this can probably go
@@ -78,9 +80,42 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
             ]
         )
     if output_size:
-        # when return data is expected, revert if the length is insufficient
-        static_output_size = get_static_size_of_type(sig.output_type) * 32
-        sub.append(["assert", ["gt", "returndatasize", static_output_size - 1]])
+        # when return data is expected, revert when the length of `returndatasize` is insufficient
+        output_type = sig.output_type
+        if not has_dynamic_data(output_type):
+            static_output_size = get_static_size_of_type(output_type) * 32
+            sub.append(["assert", ["gt", "returndatasize", static_output_size - 1]])
+        else:
+            if isinstance(output_type, ByteArrayLike):
+                types_list = (output_type,)
+            elif isinstance(output_type, TupleLike):
+                types_list = output_type.members
+            else:
+                raise
+
+            dynamic_checks = []
+            static_offset = output_placeholder
+            static_output_size = 0
+            for typ in types_list:
+                if isinstance(typ, ByteArrayLike):
+                    static_output_size += 32
+                    # ensure length of bytes does not exceed max allowable length for type
+                    dynamic_checks.append(
+                        [
+                            "assert",
+                            [
+                                "lt",
+                                ["mload", ["add", ["mload", static_offset], output_placeholder]],
+                                typ.maxlen + 1,
+                            ],
+                        ]
+                    )
+                static_offset += get_static_size_of_type(typ) * 32
+                static_output_size += get_static_size_of_type(typ) * 32
+
+            sub.append(["assert", ["gt", "returndatasize", static_output_size - 1]])
+            sub.extend(dynamic_checks)
+
     sub.extend(returner)
 
     return LLLnode.from_list(sub, typ=sig.output_type, location="memory", pos=getpos(node))

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -68,6 +68,7 @@ class FunctionSignature:
         sig,
         method_id,
         func_ast_code,
+        is_from_json,
     ):
         self.name = name
         self.args = args
@@ -79,6 +80,7 @@ class FunctionSignature:
         self.gas = None
         self.nonreentrant_key = nonreentrant_key
         self.func_ast_code = func_ast_code
+        self.is_from_json = is_from_json
         self.calculate_arg_totals()
 
     def __str__(self):
@@ -154,6 +156,7 @@ class FunctionSignature:
         interface_def=False,
         constants=None,
         constant_override=False,
+        is_from_json=False,
     ):
         if not custom_structs:
             custom_structs = {}
@@ -285,7 +288,16 @@ class FunctionSignature:
         # Take the first 4 bytes of the hash of the sig to get the method ID
         method_id = fourbytes_to_int(keccak256(bytes(sig, "utf-8"))[:4])
         return cls(
-            name, args, output_type, mutability, internal, nonreentrant_key, sig, method_id, code
+            name,
+            args,
+            output_type,
+            mutability,
+            internal,
+            nonreentrant_key,
+            sig,
+            method_id,
+            code,
+            is_from_json,
         )
 
     @iterable_cast(dict)

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -97,6 +97,7 @@ def mk_full_signature_from_json(abi):
             ),
             custom_structs=dict(),
             constants=Constants(),
+            is_from_json=True,
         )
         sigs.append(sig)
     return sigs


### PR DESCRIPTION
### What I did
* Check the length of return data when making an external call.  Closes #1978 
* Validate that returned `bytes` and `string` data does now have a length longer than the max allowed for the given type. Closes #1840 

### How I did it
* Add a check that `RETURNDATASIZE` > expected length -1 after making a call.
* In cases where we are expecting return data, do not include the check involving `EXTCODESIZE`.  An address that is not a contract will not return any data, so this check isn't required.
* For dynamic types (bytes and string), assert that the length of the returned data does not exceed the max allowable length for the contract type

It is still possible for a call to return _more_ data than expected by the interface.  This is consistent with how Solidity handles the check.

### How to verify it
Run the tests. I added a few test cases, and removed one that is no longer valid.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86245473-949f4b00-bbba-11ea-8814-d4ebc3f0e41a.png)
