### PR TITLE
Fix default params

### DIFF
--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -111,6 +111,45 @@ def fooBar(a: bytes[100], b: uint256[2], c: bytes[6] = b"hello", d: int128[3] = 
     assert c.fooBar(b"booo", [55, 66]) == [b"booo", 66, c_default, d_default]
 
 
+def test_default_param_internal_function(get_contract):
+    code = """
+@internal
+@view
+def _foo(a: int128[3] = [1, 2, 3]) -> int128[3]:
+    b: int128[3] = a
+    return b
+
+
+@external
+@view
+def foo() -> int128[3]:
+    return self._foo([4, 5, 6])
+
+@external
+@view
+def foo2() -> int128[3]:
+    return self._foo()
+    """
+    c = get_contract(code)
+
+    assert c.foo() == [4, 5, 6]
+    assert c.foo2() == [1, 2, 3]
+
+
+def test_default_param_external_function(get_contract):
+    code = """
+@external
+@view
+def foo(a: int128[3] = [1, 2, 3]) -> int128[3]:
+    b: int128[3] = a
+    return b
+    """
+    c = get_contract(code)
+
+    assert c.foo([4, 5, 6]) == [4, 5, 6]
+    assert c.foo() == [1, 2, 3]
+
+
 def test_default_param_clamp(get_contract, monkeypatch, assert_tx_failed):
     code = """
 @external

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -106,7 +106,8 @@ def parse_external_function(
                     arg.name, MemoryPositions.RESERVED_MEMORY + arg.pos, arg.typ, False,
                 )
             elif i >= default_args_start_pos:  # default args need to be allocated in memory.
-                default_arg_pos, _ = context.memory_allocator.increase_memory(32)
+                type_size = get_size_of_type(arg.typ) * 32
+                default_arg_pos, _ = context.memory_allocator.increase_memory(type_size)
                 context.vars[arg.name] = VariableRecord(
                     name=arg.name, pos=default_arg_pos, typ=arg.typ, mutable=False,
                 )


### PR DESCRIPTION
### What I did
Properly handle default arguments with a size > 1 word.  Fixes #1987

### How I did it
In `vyper/parser/function_definitions/parse_external_function.py::parse_external_function`, use `get_size_of_type` to determine the size in memory for each default argument.

### How to verify it
Run the tests. I added some cases based on the example in the issue.  I also verified the behavior for internal functions.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86258446-e56b6f80-bbcb-11ea-955f-3f4f2091eb81.png)
