### PR TITLE
Namespace collisions

### DIFF
--- a/vyper/context/types/bases.py
+++ b/vyper/context/types/bases.py
@@ -439,9 +439,9 @@ class MemberTypeDefinition(ValueTypeDefinition):
 
     def add_member(self, name: str, type_: BaseTypeDefinition) -> None:
         if name in self.members:
-            raise NamespaceCollision(f"Member {name} already exists in {self}")
+            raise NamespaceCollision(f"Member '{name}' already exists in {self}")
         if name in getattr(self, "_type_members", []):
-            raise NamespaceCollision(f"Member {name} already exists in {self}")
+            raise NamespaceCollision(f"Member '{name}' already exists in {self}")
         self.members[name] = type_
 
     def get_member(self, key: str, node: vy_ast.VyperNode) -> BaseTypeDefinition:

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -159,10 +159,7 @@ class ContractFunction(BaseTypeDefinition):
 
     @classmethod
     def from_FunctionDef(
-        cls,
-        node: vy_ast.FunctionDef,
-        is_interface: Optional[bool] = False,
-        include_defaults: Optional[bool] = True,
+        cls, node: vy_ast.FunctionDef, is_interface: Optional[bool] = False,
     ) -> "ContractFunction":
         """
         Generate a `ContractFunction` object from a `FunctionDef` node.
@@ -173,9 +170,6 @@ class ContractFunction(BaseTypeDefinition):
             Vyper ast node to generate the function definition from.
         is_interface: bool, optional
             Boolean indicating if the function definition is part of an interface.
-        include_defaults: bool, optional
-            If False, default arguments are ignored when parsing generating the
-            object. Used for interfaces.
 
         Returns
         -------
@@ -265,10 +259,7 @@ class ContractFunction(BaseTypeDefinition):
             )
 
         arguments = OrderedDict()
-        if include_defaults:
-            defaults = [None] * (len(node.args.args) - len(node.args.defaults)) + node.args.defaults
-        else:
-            defaults = [None] * len(node.args.args)
+        defaults = [None] * (len(node.args.args) - len(node.args.defaults)) + node.args.defaults
 
         namespace = get_namespace()
         for arg, value in zip(node.args.args, defaults):

--- a/vyper/context/types/meta/interface.py
+++ b/vyper/context/types/meta/interface.py
@@ -140,14 +140,25 @@ def build_primitive_from_node(
 
 
 def _get_module_functions(base_node: vy_ast.Module) -> OrderedDict:
-    functions = OrderedDict()
+    functions: OrderedDict = OrderedDict()
     for node in base_node.get_children(vy_ast.FunctionDef):
-        if node.name in functions:
-            raise NamespaceCollision(
-                f"Interface contains multiple functions named '{node.name}'", base_node
-            )
         if "external" in [i.id for i in node.decorator_list]:
             func = ContractFunction.from_FunctionDef(node, include_defaults=True)
+            if node.name in functions:
+                # compare the input arguments of the new function and the previous one
+                # if one function extends the inputs, this is a valid function name overload
+                existing_args = list(functions[node.name].arguments)
+                new_args = list(func.arguments)
+                for a, b in zip(existing_args, new_args):
+                    if not isinstance(a, type(b)):
+                        raise NamespaceCollision(
+                            f"Interface contains multiple functions named '{node.name}' "
+                            "with incompatible input types",
+                            base_node,
+                        )
+                if len(new_args) <= len(existing_args):
+                    # only keep the `ContractFunction` with the longest set of input args
+                    continue
             functions[node.name] = func
     for node in base_node.get_children(vy_ast.AnnAssign, {"annotation.func.id": "public"}):
         name = node.target.id

--- a/vyper/context/types/meta/interface.py
+++ b/vyper/context/types/meta/interface.py
@@ -143,7 +143,7 @@ def _get_module_functions(base_node: vy_ast.Module) -> OrderedDict:
     functions: OrderedDict = OrderedDict()
     for node in base_node.get_children(vy_ast.FunctionDef):
         if "external" in [i.id for i in node.decorator_list]:
-            func = ContractFunction.from_FunctionDef(node, include_defaults=True)
+            func = ContractFunction.from_FunctionDef(node)
             if node.name in functions:
                 # compare the input arguments of the new function and the previous one
                 # if one function extends the inputs, this is a valid function name overload

--- a/vyper/context/validation/module.py
+++ b/vyper/context/validation/module.py
@@ -16,6 +16,7 @@ from vyper.exceptions import (
     CallViolation,
     CompilerPanic,
     ExceptionList,
+    NamespaceCollision,
     StateAccessViolation,
     UndeclaredDefinition,
     VariableDeclarationException,
@@ -166,6 +167,8 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
             )
         try:
             self.namespace["self"].add_member(name, type_definition)
+        except NamespaceCollision:
+            raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
         except VyperException as exc:
             raise exc.with_annotation(node) from None
 


### PR DESCRIPTION
### What I did
* Add checks for duplicates names when declaring interfaces - fixes #1959 
* Improve the error message for namespace collisions when assigning storage variables. Currently it is "`Member [x] already exists in address`" - not sure how i missed this!

### How I did it
Minor edits.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86262139-8e1bce00-bbd0-11ea-8deb-d02933625d14.png)
