### PR TITLE
Remove setuptools-markdown (deprecated) in favor of PEP-0566

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,12 +43,15 @@ try:
 except subprocess.CalledProcessError:
     pass
 
+with open("README.md", "r") as f:
+    long_description = f.read()
+
 setup(
     name="vyper",
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version="0.1.0-beta.17",
     description="Vyper: the Pythonic Programming Language for the EVM",
-    long_description_markdown_filename="README.md",
+    long_description=long_description,
     long_description_content_type="text/markdown",
     author="Vyper Team",
     author_email="",
@@ -60,7 +63,7 @@ setup(
     python_requires=">=3.6",
     py_modules=["vyper"],
     install_requires=["asttokens==2.0.3", "pycryptodome>=3.5.1,<4", "semantic-version==2.8.5"],
-    setup_requires=["pytest-runner", "setuptools-markdown"],
+    setup_requires=["pytest-runner"],
     tests_require=extras_require["test"],
     extras_require=extras_require,
     entry_points={


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0566/
https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/

### What I did
Remove `setuptools-markdown` because it was deprecated, and via PEP-566 there is a standard way to do this

### How I did it
Made a few modifications to `setup.py`

### How to verify it
I did:
- `pip install .`
- `python setup.py sdist`
- `python setup.py bdist_wheel`
- `twine check`

None of them had any issues.
But we won't really know until we go to release it :grimacing: 

### Cute Animal Picture
![grimace](https://www.espacebuzz.com/assets/ckeditor/2014/aug/904/originale/740_espacebuzz53ea2e37c3054.jpg)