### PR TITLE
Make bytes and string uppercase

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -48,7 +48,7 @@ contracts.
     * ``value``: Value for the ether unit
     * ``unit``: Ether unit name (e.g. ``"wei"``, ``"ether"``, ``"gwei"``, etc.) indicating the denomination of ``value``.
 
-.. py:function:: slice(b: Union[bytes, bytes32, string], start: uint256, length: uint256) -> Union[bytes, string]
+.. py:function:: slice(b: Union[Bytes, bytes32, String], start: uint256, length: uint256) -> Union[Bytes, String]
 
     Copy a list of bytes and return a specified slice.
 
@@ -56,7 +56,7 @@ contracts.
     * ``start``: start position of the slice
     * ``length``: length of the slice
 
-    If the value being sliced is a ``bytes`` or ``bytes32``, the return type is ``bytes``.  If it is a ``string``, the return type is ``string``.
+    If the value being sliced is a ``Bytes`` or ``bytes32``, the return type is ``Bytes``.  If it is a ``String``, the return type is ``String``.
 
     .. code-block:: python
 
@@ -70,15 +70,15 @@ contracts.
         >>> ExampleContract.foo("why hello! how are you?")
         "hello"
 
-.. py:function:: len(b: Union[bytes, string]) -> uint256
+.. py:function:: len(b: Union[Bytes, String]) -> uint256
 
-    Return the length of a given ``bytes`` or ``string``.
+    Return the length of a given ``Bytes`` or ``String``.
 
     .. code-block:: python
 
         @external
         @view
-        def foo(s: string[32]) -> uint256:
+        def foo(s: String[32]) -> uint256:
             return len(s)
 
     .. code-block:: python
@@ -86,21 +86,21 @@ contracts.
         >>> ExampleContract.foo("hello")
         5
 
-.. py:function:: concat(a, b, *args) -> bytes
+.. py:function:: concat(a, b, *args) -> Bytes
 
-    Takes 2 or more bytes arrays of type ``bytes32`` or ``bytes`` and combines them into a single ``bytes`` list.
+    Takes 2 or more bytes arrays of type ``bytes32`` or ``Bytes`` and combines them into a single ``Bytes`` list.
 
 .. py:function:: keccak256(value) -> bytes32
 
     Returns a ``keccak256`` hash of the given value.
 
-    * ``value``: Value to hash. Can be ``str_literal``, ``bytes``, or ``bytes32``.
+    * ``value``: Value to hash. Can be a literal string, ``Bytes``, or ``bytes32``.
 
 .. py:function:: sha256(value) -> bytes32
 
     Returns a ``sha256`` (SHA2 256bit output) hash of the given value.
 
-    * ``value``: Value to hash. Can be ``str_literal``, ``bytes``, or ``bytes32``.
+    * ``value``: Value to hash. Can be a literal string, ``Bytes``, or ``bytes32``.
 
 .. py:function:: uint256_addmod(a: uint256, b: uint256, c: uint256) -> uint256
 
@@ -132,12 +132,12 @@ contracts.
         >>> ExampleContract.foo(100, 100)
         59041770658110225754900818312084884949620587934026984283048776718299468660736
 
-.. py:function:: method_id(method, output_type: type = bytes[4]) -> Union[bytes32, bytes[4]]
+.. py:function:: method_id(method, output_type: type = Bytes[4]) -> Union[bytes32, Bytes[4]]
 
     Takes a function declaration and returns its method_id (used in data field to call it).
 
     * ``method``: Method declaration as given as a literal string
-    * ``output_type``: The type of output (``bytes[4]`` or ``bytes32``). Defaults to ``bytes[4]``.
+    * ``output_type``: The type of output (``Bytes[4]`` or ``bytes32``). Defaults to ``Bytes[4]``.
 
     Returns a value of the type specified by ``output_type``.
 
@@ -145,8 +145,8 @@ contracts.
 
         @external
         @view
-        def foo() -> bytes[4]:
-            return method_id('transfer(address,uint256)', output_type=bytes[4])
+        def foo() -> Bytes[4]:
+            return method_id('transfer(address,uint256)', output_type=Bytes[4])
 
     .. code-block:: python
 
@@ -174,11 +174,11 @@ contracts.
     * ``point``: Point to be multiplied
     * ``scalar``: Scalar value
 
-.. py:function:: extract32(b: bytes, start: int128, output_type=bytes32) -> Union[bytes32, int128, address]
+.. py:function:: extract32(b: Bytes, start: int128, output_type=bytes32) -> Union[bytes32, int128, address]
 
-    Extract a value from a ``bytes`` list.
+    Extract a value from a ``Bytes`` list.
 
-    * ``b``: ``bytes`` list to extract from
+    * ``b``: ``Bytes`` list to extract from
     * ``start``: Start point to extract from
     * ``output_type``: Type of output (``bytes32``, ``int128``, or ``address``). Defaults to ``bytes32``.
 
@@ -188,7 +188,7 @@ contracts.
 
         @external
         @view
-        def foo(bytes[32]) -> address:
+        def foo(Bytes[32]) -> address:
             return extract32(b, 12, output_type=address)
 
     .. code-block:: python
@@ -213,7 +213,7 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
 
         The amount to send is always specified in ``wei``.
 
-.. py:function:: raw_call(to: address, data: bytes, max_outsize: int = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False, is_static_call: bool = False) -> bytes[max_outsize]
+.. py:function:: raw_call(to: address, data: Bytes, max_outsize: int = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False, is_static_call: bool = False) -> Bytes[max_outsize]
 
     Calls to the specified Ethereum address.
 
@@ -225,7 +225,7 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
     * ``is_delegate_call``: If ``True``, the call will be sent as ``DELEGATECALL`` (Optional, default ``False``)
     * ``is_static_call``: If ``True``, the call will be sent as ``STATICCALL`` (Optional, default ``False``)
 
-    Returns the data returned by the call as a ``bytes`` list, with ``max_outsize`` as the max length.
+    Returns the data returned by the call as a ``Bytes`` list, with ``max_outsize`` as the max length.
 
     Returns ``None`` if ``max_outsize`` is omitted or set to ``0``.
 
@@ -279,7 +279,7 @@ Vyper contains a set of built in functions which execute opcodes such as ``SEND`
 
         To give it a more Python-like syntax, the assert function can be called without parenthesis, the syntax would be ``assert your_bool_condition``. Even though both options will compile, it's recommended to use the Pythonic version without parenthesis.
 
-.. py:function:: raw_log(topics: bytes32[4], data: bytes) -> None
+.. py:function:: raw_log(topics: bytes32[4], data: Bytes) -> None
 
     Provides low level access to the ``LOG`` opcodes, emitting a log without having to specify an ABI type.
 

--- a/docs/compiler-exceptions.rst
+++ b/docs/compiler-exceptions.rst
@@ -74,7 +74,7 @@ of the error within the code:
 
         @external
         def foo():
-            a: string[10] = "hello" * 2
+            a: String[10] = "hello" * 2
 
     This example raises ``InvalidOperation`` because multiplication is not possible on string types.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -303,30 +303,30 @@ Where ``x`` is a byte array and ``_start`` as well as ``_len`` are integer value
 Fixed-size Byte Arrays
 ======================
 
-**Keyword:** ``bytes``
+**Keyword:** ``Bytes``
 
 A byte array with a fixed size.
-The syntax being ``bytes[maxLen]``, where ``maxLen`` is an integer which denotes the maximum number of bytes.
+The syntax being ``Bytes[maxLen]``, where ``maxLen`` is an integer which denotes the maximum number of bytes.
 On the ABI level the Fixed-size bytes array is annotated as ``bytes``.
 
 **Example:**
 ::
 
-    example_bytes: bytes[100] = b"\x01\x02\x03"
+    example_bytes: Bytes[100] = b"\x01\x02\x03"
 
 .. index:: !string
 
 Fixed-size Strings
 ==================
 
-**Keyword:** ``string``
+**Keyword:** ``String``
 Fixed-size strings can hold strings with equal or fewer characters than the maximum length of the string.
 On the ABI level the Fixed-size bytes array is annotated as ``string``.
 
 **Example:**
 ::
 
-    example_str: string[100] = "Test String"
+    example_str: String[100] = "Test String"
 
 Operators
 ---------
@@ -341,7 +341,7 @@ Keyword                               Description
 ====================================  ============================================================
 
 Where ``x`` is a byte array or string while ``_start`` and ``_len`` are integers.
-The ``len``, ``keccak256``, ``concat``, ``slice`` operators can be used with ``string`` and ``bytes`` types.
+The ``len``, ``keccak256``, ``concat``, ``slice`` operators can be used with ``String`` and ``Bytes`` types.
 
 .. index:: !reference
 
@@ -470,7 +470,7 @@ Here you can find a list of all types and default values:
      - ``'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'``
 
 .. note::
-    In ``bytes`` the array starts with the bytes all set to ``'\x00'``
+    In ``Bytes`` the array starts with the bytes all set to ``'\x00'``
 
 .. note::
     In reference types all the type's members are set to their initial values.
@@ -511,7 +511,7 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
      - ``(0x00 * 32)...(0xFF * 32)``
      - Has the effective conversion logic of: ``return (a != 0x00)``
    * - ``bool``
-     - ``bytes``
+     - ``Bytes``
      - ``(0x00 * 1)...(0xFF * 32)``
      - Has the effective conversion logic of: ``return (a != 0x00)``
    * -
@@ -539,7 +539,7 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
      - ``(0x00 * 32)...(0xFF * 32)``
      -
    * - ``decimal``
-     - ``bytes``
+     - ``Bytes``
      - ``(0x00 * 1)...(0xFF * 32)``
      -
    * -
@@ -567,7 +567,7 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
      - ``(0x00 * 32)...(0xFF * 32)``
      -
    * - ``int128``
-     - ``bytes``
+     - ``Bytes``
      - ``(0x00 * 1)...(0xFF * 32)``
      -
    * -
@@ -595,7 +595,7 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
      - ``(0x00 * 32)...(0xFF * 32)``
      -
    * - ``uint256``
-     - ``bytes``
+     - ``Bytes``
      - ``(0x00 * 1)...(0xFF * 32)``
      -
    * -
@@ -623,9 +623,9 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
      - —
      - Do not allow converting to/from the same type
    * - ``bytes32``
-     - ``bytes``
+     - ``Bytes``
      - ``(0x00 * 1)...(0xFF * 32)``
-     - Left-pad input ``bytes`` to size of ``32``
+     - Left-pad input ``Bytes`` to size of ``32``
 
 
 .. index:: !conversion

--- a/examples/name_registry/name_registry.vy
+++ b/examples/name_registry/name_registry.vy
@@ -1,13 +1,13 @@
 
-registry: HashMap[bytes[100], address]
+registry: HashMap[Bytes[100], address]
 
 @external
-def register(name: bytes[100], owner: address):
+def register(name: Bytes[100], owner: address):
     assert self.registry[name] == ZERO_ADDRESS  # check name has not been set yet.
     self.registry[name] = owner
 
 
 @view
 @external
-def lookup(name: bytes[100]) -> address:
+def lookup(name: Bytes[100]) -> address:
     return self.registry[name]

--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -16,8 +16,8 @@ event Approval:
     spender: indexed(address)
     value: uint256
 
-name: public(string[64])
-symbol: public(string[32])
+name: public(String[64])
+symbol: public(String[32])
 decimals: public(uint256)
 
 # NOTE: By declaring `balanceOf` as public, vyper automatically generates a 'balanceOf()' getter
@@ -31,7 +31,7 @@ minter: address
 
 
 @external
-def __init__(_name: string[64], _symbol: string[32], _decimals: uint256, _supply: uint256):
+def __init__(_name: String[64], _symbol: String[32], _decimals: uint256, _supply: uint256):
     init_supply: uint256 = _supply * 10 ** _decimals
     self.name = _name
     self.symbol = _symbol

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -12,7 +12,7 @@ interface ERC721Receiver:
             _operator: address,
             _from: address,
             _tokenId: uint256,
-            _data: bytes[1024]
+            _data: Bytes[1024]
         ) -> bytes32: view
 
 
@@ -256,7 +256,7 @@ def safeTransferFrom(
         _from: address,
         _to: address,
         _tokenId: uint256,
-        _data: bytes[1024]=b""
+        _data: Bytes[1024]=b""
     ):
     """
     @dev Transfers the ownership of an NFT from one address to another address.

--- a/examples/wallet/wallet.vy
+++ b/examples/wallet/wallet.vy
@@ -25,7 +25,7 @@ def testEcrecover(h: bytes32, v:uint256, r:uint256, s:uint256) -> address:
 # `@payable` allows functions to receive ether
 @external
 @payable
-def approve(_seq: int128, to: address, _value: uint256, data: bytes[4096], sigdata: uint256[3][5]) -> bytes[4096]:
+def approve(_seq: int128, to: address, _value: uint256, data: Bytes[4096], sigdata: uint256[3][5]) -> Bytes[4096]:
     # Throws if the value sent to the contract is less than the sum of the value to be sent
     assert msg.value >= _value
     # Every time the number of approvals starts at 0 (multiple signatures can be added through the sigdata argument)

--- a/tests/ast/nodes/test_binary.py
+++ b/tests/ast/nodes/test_binary.py
@@ -5,12 +5,12 @@ from vyper.exceptions import SyntaxException
 
 
 def test_binary_becomes_bytes():
-    expected = vy_ast.parse_to_ast("foo: bytes[1] = b'\x01'")
-    mutated = vy_ast.parse_to_ast("foo: bytes[1] = 0b00000001")
+    expected = vy_ast.parse_to_ast("foo: Bytes[1] = b'\x01'")
+    mutated = vy_ast.parse_to_ast("foo: Bytes[1] = 0b00000001")
 
     assert vy_ast.compare_nodes(expected, mutated)
 
 
 def test_binary_length():
     with pytest.raises(SyntaxException):
-        vy_ast.parse_to_ast("foo: bytes[1] = 0b01")
+        vy_ast.parse_to_ast("foo: Bytes[1] = 0b01")

--- a/tests/ast/test_natspec.py
+++ b/tests/ast/test_natspec.py
@@ -17,7 +17,7 @@ test_code = """
 
 @external
 @payable
-def doesEat(food: string[30], qty: uint256) -> bool:
+def doesEat(food: String[30], qty: uint256) -> bool:
     '''
     @notice Determine if Bugs will accept `qty` of `food` to eat
     @dev Compares the entire string and does not rely on a hash

--- a/tests/compiler/test_pre_parser.py
+++ b/tests/compiler/test_pre_parser.py
@@ -20,7 +20,7 @@ def test_valid_semicolons(get_contract):
 def test() -> int128:
     a: int128 = 1
     b: int128 = 2
-    s: string[300] = "this should not be a problem; because it is in a string"
+    s: String[300] = "this should not be a problem; because it is in a string"
     s = \"\"\"this should not be a problem; because it's in a string\"\"\"
     s = 'this should not be a problem;;; because it\\\'s in a string'
     s = '''this should not ; \'cause it\'s in a string'''

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -246,7 +246,7 @@ def onERC721Received(
         _operator: address,
         _from: address,
         _tokenId: uint256,
-        _data: bytes[1024]
+        _data: Bytes[1024]
     ) -> bytes32:
     return method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
     """

--- a/tests/functional/context/types/test_pure_types.py
+++ b/tests/functional/context/types/test_pure_types.py
@@ -28,10 +28,10 @@ PRIMITIVES = {
     AddressPrimitive: "address",
     BoolPrimitive: "bool",
     Bytes32Primitive: "bytes32",
-    BytesArrayPrimitive: "bytes[1]",
+    BytesArrayPrimitive: "Bytes[1]",
     DecimalPrimitive: "decimal",
     Int128Primitive: "int128",
-    StringPrimitive: "string[1]",
+    StringPrimitive: "String[1]",
     Uint256Primitive: "uint256",
 }
 

--- a/tests/functional/context/types/test_type_from_annotation.py
+++ b/tests/functional/context/types/test_type_from_annotation.py
@@ -12,7 +12,7 @@ from vyper.exceptions import (
 )
 
 BASE_TYPES = ["int128", "uint256", "bool", "address", "bytes32"]
-ARRAY_VALUE_TYPES = ["string", "bytes"]
+ARRAY_VALUE_TYPES = ["String", "Bytes"]
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)
@@ -69,7 +69,7 @@ def test_base_types_as_multidimensional_arrays(build_node, namespace, type_str):
     assert isinstance(type_definition.value_type.value_type, primitive._type)
 
 
-@pytest.mark.parametrize("type_str", ["int128", "string"])
+@pytest.mark.parametrize("type_str", ["int128", "String"])
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
 def test_invalid_index(build_node, idx, type_str):
     node = build_node(f"{type_str}[{idx}]")

--- a/tests/functions/folding/test_keccak_sha.py
+++ b/tests/functions/folding/test_keccak_sha.py
@@ -16,7 +16,7 @@ def test_string(get_contract, value, fn_name):
 
     source = f"""
 @external
-def foo(a: string[100]) -> bytes32:
+def foo(a: String[100]) -> bytes32:
     return {fn_name}(a)
     """
     contract = get_contract(source)
@@ -35,7 +35,7 @@ def foo(a: string[100]) -> bytes32:
 def test_bytes(get_contract, value, fn_name):
     source = f"""
 @external
-def foo(a: bytes[100]) -> bytes32:
+def foo(a: Bytes[100]) -> bytes32:
     return {fn_name}(a)
     """
     contract = get_contract(source)
@@ -54,7 +54,7 @@ def foo(a: bytes[100]) -> bytes32:
 def test_hex(get_contract, value, fn_name):
     source = f"""
 @external
-def foo(a: bytes[100]) -> bytes32:
+def foo(a: Bytes[100]) -> bytes32:
     return {fn_name}(a)
     """
     contract = get_contract(source)

--- a/tests/functions/folding/test_len.py
+++ b/tests/functions/folding/test_len.py
@@ -8,7 +8,7 @@ from vyper import functions as vy_fn
 def test_len_string(get_contract, length):
     source = """
 @external
-def foo(a: string[1024]) -> uint256:
+def foo(a: String[1024]) -> uint256:
     return len(a)
     """
     contract = get_contract(source)
@@ -26,7 +26,7 @@ def foo(a: string[1024]) -> uint256:
 def test_len_bytes(get_contract, length):
     source = """
 @external
-def foo(a: bytes[1024]) -> uint256:
+def foo(a: Bytes[1024]) -> uint256:
     return len(a)
     """
     contract = get_contract(source)
@@ -44,7 +44,7 @@ def foo(a: bytes[1024]) -> uint256:
 def test_len_hex(get_contract, length):
     source = """
 @external
-def foo(a: bytes[1024]) -> uint256:
+def foo(a: Bytes[1024]) -> uint256:
     return len(a)
     """
     contract = get_contract(source)

--- a/tests/parser/ast_utils/test_ast_dict.py
+++ b/tests/parser/ast_utils/test_ast_dict.py
@@ -79,7 +79,7 @@ def test() -> int128:
     a: uint256 = 100
     b: int128 = -22
     c: decimal = 3.31337
-    d: bytes[11] = b"oh hai mark"
+    d: Bytes[11] = b"oh hai mark"
     e: address = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
     f: bool = False
     return 123

--- a/tests/parser/exceptions/test_argument_exception.py
+++ b/tests/parser/exceptions/test_argument_exception.py
@@ -30,19 +30,19 @@ def foo():
     """
 @external
 def foo():
-    x: bytes[4] = raw_call(0x1234567890123456789012345678901234567890, outsize=4)
+    x: Bytes[4] = raw_call(0x1234567890123456789012345678901234567890, outsize=4)
     """,
     """
 @external
 def foo():
-    x: bytes[4] = raw_call(
+    x: Bytes[4] = raw_call(
         0x1234567890123456789012345678901234567890, b"cow", gas=111111, outsize=4, moose=9
     )
     """,
     """
 @external
 def foo():
-    x: bytes[4] = create_forwarder_to(0x1234567890123456789012345678901234567890, outsize=4)
+    x: Bytes[4] = create_forwarder_to(0x1234567890123456789012345678901234567890, outsize=4)
     """,
     """
 x: public()
@@ -55,12 +55,12 @@ def foo():
     """
 @external
 def foo():
-    x: bytes[10] = concat(b"")
+    x: Bytes[10] = concat(b"")
     """,
     """
 @external
 def foo():
-    x: bytes[4] = create_forwarder_to(0x1234567890123456789012345678901234567890, b"cow")
+    x: Bytes[4] = create_forwarder_to(0x1234567890123456789012345678901234567890, b"cow")
     """,
 ]
 

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -38,7 +38,7 @@ def foo() -> int128:
 @external
 @view
 def foo() -> int128:
-    x: bytes[4] = raw_call(
+    x: Bytes[4] = raw_call(
         0x1234567890123456789012345678901234567890, b"cow", max_outsize=4, gas=595757, value=9
     )
     return 5""",

--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -37,17 +37,17 @@ def foo():
     """
 @external
 def foo():
-    x: bytes[4] = raw_call(0x123456789012345678901234567890123456789, "cow", max_outsize=4)
+    x: Bytes[4] = raw_call(0x123456789012345678901234567890123456789, "cow", max_outsize=4)
     """,
     """
 @external
 def foo():
-    x: string[100] = "these bytes are nо gооd because the o's are from the Russian alphabet"
+    x: String[100] = "these bytes are nо gооd because the o's are from the Russian alphabet"
     """,
     """
 @external
 def foo():
-    x: string[100] = "这个傻老外不懂中文"
+    x: String[100] = "这个傻老外不懂中文"
     """,
     """
 @external
@@ -67,7 +67,7 @@ def foo():
     """
 @external
 def foo():
-    a: bytes[100] = "ѓtest"
+    a: Bytes[100] = "ѓtest"
     """,
     """
 @external

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -62,10 +62,10 @@ def double_nonreentrant():
 x: 5
     """,
     """
-x: bytes <= wei
+x: Bytes <= wei
     """,
     """
-x: string <= 33
+x: String <= 33
     """,
 ]
 

--- a/tests/parser/exceptions/test_syntax_exception.py
+++ b/tests/parser/exceptions/test_syntax_exception.py
@@ -6,7 +6,7 @@ from vyper.exceptions import SyntaxException
 
 fail_list = [
     """
-x: bytes[1:3]
+x: Bytes[1:3]
     """,
     """
 b: int128[int128: address]

--- a/tests/parser/exceptions/test_type_mismatch_exception.py
+++ b/tests/parser/exceptions/test_type_mismatch_exception.py
@@ -8,7 +8,7 @@ fail_list = [
     """
 @external
 def foo():
-    b: bytes[1] = 0x05
+    b: Bytes[1] = 0x05
     x: uint256 = as_wei_value(b, "babbage")
     """,
 ]

--- a/tests/parser/exceptions/test_variable_declaration_exception.py
+++ b/tests/parser/exceptions/test_variable_declaration_exception.py
@@ -8,7 +8,7 @@ fail_list = [
 CALLDATACOPY: int128
     """,
     """
-int128: bytes[3]
+int128: Bytes[3]
     """,
     """
 @external

--- a/tests/parser/features/decorators/test_nonreentrant.py
+++ b/tests/parser/features/decorators/test_nonreentrant.py
@@ -1,9 +1,9 @@
 def test_nonrentrant_decorator(get_contract, assert_tx_failed):
     calling_contract_code = """
 interface SpecialContract:
-    def unprotected_function(val: string[100], do_callback: bool): nonpayable
-    def protected_function(val: string[100], do_callback: bool): nonpayable
-    def special_value() -> string[100]: nonpayable
+    def unprotected_function(val: String[100], do_callback: bool): nonpayable
+    def protected_function(val: String[100], do_callback: bool): nonpayable
+    def special_value() -> String[100]: nonpayable
 
 @external
 def updated():
@@ -19,7 +19,7 @@ interface Callback:
     def updated(): nonpayable
     def updated_protected(): nonpayable
 
-special_value: public(string[100])
+special_value: public(String[100])
 callback: public(Callback)
 
 @external
@@ -28,7 +28,7 @@ def set_callback(c: address):
 
 @external
 @nonreentrant('protect_special_value')
-def protected_function(val: string[100], do_callback: bool) -> uint256:
+def protected_function(val: String[100], do_callback: bool) -> uint256:
     self.special_value = val
 
     if do_callback:
@@ -38,7 +38,7 @@ def protected_function(val: string[100], do_callback: bool) -> uint256:
         return 2
 
 @external
-def unprotected_function(val: string[100], do_callback: bool):
+def unprotected_function(val: String[100], do_callback: bool):
     self.special_value = val
 
     if do_callback:

--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -118,19 +118,19 @@ def return_it() -> uint256:
 
 def test_private_bytes(get_contract_with_gas_estimation):
     private_test_code = """
-greeting: public(bytes[100])
+greeting: public(Bytes[100])
 
 @external
 def __init__():
     self.greeting = b"Hello "
 
 @internal
-def construct(greet: bytes[100]) -> bytes[200]:
+def construct(greet: Bytes[100]) -> Bytes[200]:
     return concat(self.greeting, greet)
 
 @external
-def hithere(name: bytes[100]) -> bytes[200]:
-    d: bytes[200] = self.construct(name)
+def hithere(name: Bytes[100]) -> Bytes[200]:
+    d: Bytes[200] = self.construct(name)
     return d
     """
 
@@ -141,14 +141,14 @@ def hithere(name: bytes[100]) -> bytes[200]:
 
 def test_private_statement(get_contract_with_gas_estimation):
     private_test_code = """
-greeting: public(bytes[20])
+greeting: public(Bytes[20])
 
 @external
 def __init__():
     self.greeting = b"Hello "
 
 @internal
-def set_greeting(_greeting: bytes[20]):
+def set_greeting(_greeting: Bytes[20]):
     a: uint256 = 332
     b: uint256 = 333
     c: uint256 = 334
@@ -158,11 +158,11 @@ def set_greeting(_greeting: bytes[20]):
 
 @internal
 @view
-def construct(greet: bytes[20]) -> bytes[40]:
+def construct(greet: Bytes[20]) -> Bytes[40]:
     return concat(self.greeting, greet)
 
 @external
-def iprefer(_greeting: bytes[20]):
+def iprefer(_greeting: Bytes[20]):
     a: uint256 = 112
     b: uint256 = 211
     self.set_greeting(_greeting)
@@ -170,8 +170,8 @@ def iprefer(_greeting: bytes[20]):
     assert b == 211
 
 @external
-def hithere(name: bytes[20]) -> bytes[40]:
-    d: bytes[40] = self.construct(name)
+def hithere(name: Bytes[20]) -> Bytes[40]:
+    d: Bytes[40] = self.construct(name)
     return d
     """
 
@@ -214,48 +214,48 @@ def added(a: uint256, b: uint256) -> uint256:
 
 def test_private_return_bytes(get_contract_with_gas_estimation):
     code = """
-a_message: bytes[50]
+a_message: Bytes[50]
 
 @internal
-def _test() -> (bytes[100]):
-    b: bytes[50] = b"hello                   1           2"
+def _test() -> (Bytes[100]):
+    b: Bytes[50] = b"hello                   1           2"
     return b
 
 @internal
-def _test_b(a: bytes[100]) -> (bytes[100]):
-    b: bytes[50] = b"hello there"
+def _test_b(a: Bytes[100]) -> (Bytes[100]):
+    b: Bytes[50] = b"hello there"
     if len(a) > 1:
         return a
     else:
         return b
 
 @internal
-def get_msg() -> (bytes[100]):
+def get_msg() -> (Bytes[100]):
     return self.a_message
 
 @external
-def test() -> (bytes[100]):
-    d: bytes[100] = b""
+def test() -> (Bytes[100]):
+    d: Bytes[100] = b""
     d = self._test()
     return d
 
 @external
-def test2() -> (bytes[100]):
-    d: bytes[100] = b'xyzxyzxyzxyz'
+def test2() -> (Bytes[100]):
+    d: Bytes[100] = b'xyzxyzxyzxyz'
     return self._test()
 
 @external
-def test3(a: bytes[50]) -> (bytes[100]):
-    d: bytes[100] = b'xyzxyzxyzxyz'
+def test3(a: Bytes[50]) -> (Bytes[100]):
+    d: Bytes[100] = b'xyzxyzxyzxyz'
     return self._test_b(a)
 
 @external
-def set(a: bytes[50]):
+def set(a: Bytes[50]):
     self.a_message = a
 
 @external
-def test4() -> (bytes[100]):
-    d: bytes[100] = b'xyzxyzxyzxyz'
+def test4() -> (Bytes[100]):
+    d: Bytes[100] = b'xyzxyzxyzxyz'
     return self.get_msg()
     """
 
@@ -271,19 +271,19 @@ def test4() -> (bytes[100]):
 def test_private_bytes_as_args(get_contract_with_gas_estimation):
     code = """
 @internal
-def _test(a: bytes[40]) -> (bytes[100]):
-    b: bytes[40] = b"hello "
+def _test(a: Bytes[40]) -> (Bytes[100]):
+    b: Bytes[40] = b"hello "
     return concat(b, a)
 
 @external
-def test(a: bytes[10]) -> bytes[100]:
-    b: bytes[40] = concat(a, b", jack attack")
-    out: bytes[100] = self._test(b)
+def test(a: Bytes[10]) -> Bytes[100]:
+    b: Bytes[40] = concat(a, b", jack attack")
+    out: Bytes[100] = self._test(b)
     return out
 
 @external
-def test2() -> bytes[100]:
-    c: bytes[10] = b"alice"
+def test2() -> Bytes[100]:
+    c: Bytes[10] = b"alice"
     return self._test(c)
     """
 
@@ -323,41 +323,41 @@ def test2(a: bytes32) -> (bytes32, uint256, int128):
 def test_private_return_tuple_bytes(get_contract_with_gas_estimation):
     code = """
 @internal
-def _test(a: int128, b: bytes[50]) -> (int128, bytes[100]):
+def _test(a: int128, b: Bytes[50]) -> (int128, Bytes[100]):
     return a + 2, concat(b"badabing:", b)
 
 @internal
-def _test_combined(a: bytes[50], x: int128, c:bytes[50]) -> (int128, bytes[100], bytes[100]):
+def _test_combined(a: Bytes[50], x: int128, c:Bytes[50]) -> (int128, Bytes[100], Bytes[100]):
     assert x == 8
     return x + 2, a, concat(c, b'_two')
 
 @external
-def test(a: int128, b: bytes[40]) -> (int128, bytes[100], bytes[50]):
+def test(a: int128, b: Bytes[40]) -> (int128, Bytes[100], Bytes[50]):
     c: int128 = 1
-    x: bytes[50] = concat(b, b"_one")
-    d: bytes[100] = b""
+    x: Bytes[50] = concat(b, b"_one")
+    d: Bytes[100] = b""
     c, d = self._test(a + c, x)
     return c, d, x
 
 @external
-def test2(b: bytes[40]) -> (int128, bytes[100]):
+def test2(b: Bytes[40]) -> (int128, Bytes[100]):
     a: int128 = 4
-    x: bytes[50] = concat(b, b"_one")
-    d: bytes[100] = b""
+    x: Bytes[50] = concat(b, b"_one")
+    d: Bytes[100] = b""
     return self._test(a, x)
 
 @external
-def test3(a: bytes[32]) -> (int128, bytes[100], bytes[100]):
-    q: bytes[100] = b"random data1"
-    w: bytes[100] = b"random data2"
+def test3(a: Bytes[32]) -> (int128, Bytes[100], Bytes[100]):
+    q: Bytes[100] = b"random data1"
+    w: Bytes[100] = b"random data2"
     x: int128 = 8
-    b: bytes[32] = a
+    b: Bytes[32] = a
     x, q, w = self._test_combined(a, x, b)
     return x, q, w
 
 @external
-def test4(a: bytes[40]) -> (int128, bytes[100], bytes[100]):
-    b: bytes[50] = concat(a, b"_one")
+def test4(a: Bytes[40]) -> (int128, Bytes[100], Bytes[100]):
+    b: Bytes[50] = concat(a, b"_one")
     return self._test_combined(a, 8, b)
     """
 
@@ -538,10 +538,10 @@ def call_arr() -> int128:
 def test_private_zero_bytearray(get_contract):
     private_test_code = """
 @internal
-def inner(xs: bytes[256]):
+def inner(xs: Bytes[256]):
     pass
 @external
-def outer(xs: bytes[256] = b"") -> bool:
+def outer(xs: Bytes[256] = b"") -> bool:
     self.inner(xs)
     return True
     """

--- a/tests/parser/features/external_contracts/test_erc20_abi.py
+++ b/tests/parser/features/external_contracts/test_erc20_abi.py
@@ -21,8 +21,8 @@ def erc20(get_contract):
 def erc20_caller(erc20, get_contract):
     erc20_caller_code = """
 interface ERC20Contract:
-    def name() -> string[64]: view
-    def symbol() -> string[32]: view
+    def name() -> String[64]: view
+    def symbol() -> String[32]: view
     def decimals() -> uint256: view
     def balanceOf(_owner: address) -> uint256: view
     def totalSupply() -> uint256: view
@@ -38,11 +38,11 @@ def __init__(token_addr: address):
     self.token_address = ERC20Contract(token_addr)
 
 @external
-def name() -> string[64]:
+def name() -> String[64]:
     return self.token_address.name()
 
 @external
-def symbol() -> string[32]:
+def symbol() -> String[32]:
     return self.token_address.symbol()
 
 @external

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -45,7 +45,7 @@ def foo() -> int128:
     return self.lucky
 
 @external
-def array() -> bytes[3]:
+def array() -> Bytes[3]:
     return b'dog'
     """
 
@@ -55,7 +55,7 @@ def array() -> bytes[3]:
     contract_2 = """
 interface Foo:
     def foo() -> int128: nonpayable
-    def array() -> bytes[3]: view
+    def array() -> Bytes[3]: view
 
 @external
 def bar(arg1: address) -> int128:
@@ -71,7 +71,7 @@ def bar(arg1: address) -> int128:
 def test_external_contract_calls_with_bytes(get_contract, length):
     contract_1 = f"""
 @external
-def array() -> bytes[{length}]:
+def array() -> Bytes[{length}]:
     return b'dog'
     """
 
@@ -79,10 +79,10 @@ def array() -> bytes[{length}]:
 
     contract_2 = """
 interface Foo:
-    def array() -> bytes[3]: view
+    def array() -> Bytes[3]: view
 
 @external
-def get_array(arg1: address) -> bytes[3]:
+def get_array(arg1: address) -> Bytes[3]:
     return Foo(arg1).array()
 """
 
@@ -93,7 +93,7 @@ def get_array(arg1: address) -> bytes[3]:
 def test_bytes_too_long(get_contract, assert_tx_failed):
     contract_1 = """
 @external
-def array() -> bytes[4]:
+def array() -> Bytes[4]:
     return b'doge'
     """
 
@@ -101,10 +101,10 @@ def array() -> bytes[4]:
 
     contract_2 = """
 interface Foo:
-    def array() -> bytes[3]: view
+    def array() -> Bytes[3]: view
 
 @external
-def get_array(arg1: address) -> bytes[3]:
+def get_array(arg1: address) -> Bytes[3]:
     return Foo(arg1).array()
 """
 
@@ -117,7 +117,7 @@ def get_array(arg1: address) -> bytes[3]:
 def test_tuple_with_bytes(get_contract, assert_tx_failed, a, b, actual):
     contract_1 = f"""
 @external
-def array() -> (bytes[{actual}], int128, bytes[{actual}]):
+def array() -> (Bytes[{actual}], int128, Bytes[{actual}]):
     return b'dog', 255, b'cat'
     """
 
@@ -125,13 +125,13 @@ def array() -> (bytes[{actual}], int128, bytes[{actual}]):
 
     contract_2 = f"""
 interface Foo:
-    def array() -> (bytes[{a}], int128, bytes[{b}]): view
+    def array() -> (Bytes[{a}], int128, Bytes[{b}]): view
 
 @external
-def get_array(arg1: address) -> (bytes[{a}], int128, bytes[{b}]):
-    a: bytes[{a}] = b""
+def get_array(arg1: address) -> (Bytes[{a}], int128, Bytes[{b}]):
+    a: Bytes[{a}] = b""
     b: int128 = 0
-    c: bytes[{b}] = b""
+    c: Bytes[{b}] = b""
     a, b, c = Foo(arg1).array()
     return a, b, c
 """
@@ -146,7 +146,7 @@ def get_array(arg1: address) -> (bytes[{a}], int128, bytes[{b}]):
 def test_tuple_with_bytes_too_long(get_contract, assert_tx_failed, a, c, b, d):
     contract_1 = f"""
 @external
-def array() -> (bytes[{c}], int128, bytes[{d}]):
+def array() -> (Bytes[{c}], int128, Bytes[{d}]):
     return b'nineteen characters', 255, b'seven!!'
     """
 
@@ -154,13 +154,13 @@ def array() -> (bytes[{c}], int128, bytes[{d}]):
 
     contract_2 = f"""
 interface Foo:
-    def array() -> (bytes[{a}], int128, bytes[{b}]): view
+    def array() -> (Bytes[{a}], int128, Bytes[{b}]): view
 
 @external
-def get_array(arg1: address) -> (bytes[{a}], int128, bytes[{b}]):
-    a: bytes[{a}] = b""
+def get_array(arg1: address) -> (Bytes[{a}], int128, Bytes[{b}]):
+    a: Bytes[{a}] = b""
     b: int128 = 0
-    c: bytes[{b}] = b""
+    c: Bytes[{b}] = b""
     a, b, c = Foo(arg1).array()
     return a, b, c
 """
@@ -173,7 +173,7 @@ def get_array(arg1: address) -> (bytes[{a}], int128, bytes[{b}]):
 def test_tuple_with_bytes_too_long_two(get_contract, assert_tx_failed):
     contract_1 = """
 @external
-def array() -> (bytes[30], int128, bytes[30]):
+def array() -> (Bytes[30], int128, Bytes[30]):
     return b'nineteen characters', 255, b'seven!!'
     """
 
@@ -181,13 +181,13 @@ def array() -> (bytes[30], int128, bytes[30]):
 
     contract_2 = """
 interface Foo:
-    def array() -> (bytes[30], int128, bytes[3]): view
+    def array() -> (Bytes[30], int128, Bytes[3]): view
 
 @external
-def get_array(arg1: address) -> (bytes[30], int128, bytes[3]):
-    a: bytes[30] = b""
+def get_array(arg1: address) -> (Bytes[30], int128, Bytes[3]):
+    a: Bytes[30] = b""
     b: int128 = 0
-    c: bytes[3] = b""
+    c: Bytes[3] = b""
     a, b, c = Foo(arg1).array()
     return a, b, c
 """
@@ -775,19 +775,19 @@ def test_bad_code_struct_exc(assert_compile_failed, get_contract_with_gas_estima
 def test_tuple_return_external_contract_call(get_contract):
     contract_1 = """
 @external
-def out_literals() -> (int128, address, bytes[10]):
+def out_literals() -> (int128, address, Bytes[10]):
     return 1, 0x0000000000000000000000000000000000000123, b"random"
     """
 
     contract_2 = """
 interface Test:
-    def out_literals() -> (int128, address, bytes[10]) : view
+    def out_literals() -> (int128, address, Bytes[10]) : view
 
 @external
-def test(addr: address) -> (int128, address, bytes[10]):
+def test(addr: address) -> (int128, address, Bytes[10]):
     a: int128 = 0
     b: address = ZERO_ADDRESS
-    c: bytes[10] = b""
+    c: Bytes[10] = b""
     (a, b, c) = Test(addr).out_literals()
     return a, b,c
 

--- a/tests/parser/features/test_bytes_map_keys.py
+++ b/tests/parser/features/test_bytes_map_keys.py
@@ -5,14 +5,14 @@ from vyper.exceptions import TypeMismatch
 
 def test_basic_bytes_keys(w3, get_contract):
     code = """
-mapped_bytes: HashMap[bytes[5], int128]
+mapped_bytes: HashMap[Bytes[5], int128]
 
 @external
-def set(k: bytes[5], v: int128):
+def set(k: Bytes[5], v: int128):
     self.mapped_bytes[k] = v
 
 @external
-def get(k: bytes[5]) -> int128:
+def get(k: Bytes[5]) -> int128:
     return self.mapped_bytes[k]
     """
 
@@ -25,14 +25,14 @@ def get(k: bytes[5]) -> int128:
 
 def test_basic_bytes_literal_key(get_contract):
     code = """
-mapped_bytes: HashMap[bytes[5], int128]
+mapped_bytes: HashMap[Bytes[5], int128]
 
 @external
 def set(v: int128):
     self.mapped_bytes[b"test"] = v
 
 @external
-def get(k: bytes[5]) -> int128:
+def get(k: Bytes[5]) -> int128:
     return self.mapped_bytes[k]
     """
 
@@ -45,14 +45,14 @@ def get(k: bytes[5]) -> int128:
 
 def test_basic_long_bytes_as_keys(get_contract):
     code = """
-mapped_bytes: HashMap[bytes[34], int128]
+mapped_bytes: HashMap[Bytes[34], int128]
 
 @external
-def set(k: bytes[34], v: int128):
+def set(k: Bytes[34], v: int128):
     self.mapped_bytes[k] = v
 
 @external
-def get(k: bytes[34]) -> int128:
+def get(k: Bytes[34]) -> int128:
     return self.mapped_bytes[k]
     """
 
@@ -65,10 +65,10 @@ def get(k: bytes[34]) -> int128:
 
 def test_mismatched_byte_length(get_contract):
     code = """
-mapped_bytes: HashMap[bytes[34], int128]
+mapped_bytes: HashMap[Bytes[34], int128]
 
 @external
-def set(k: bytes[35], v: int128):
+def set(k: Bytes[35], v: int128):
     self.mapped_bytes[k] = v
     """
 
@@ -78,7 +78,7 @@ def set(k: bytes[35], v: int128):
 
 def test_extended_bytes_key_from_storage(get_contract):
     code = """
-a: HashMap[bytes[100000], int128]
+a: HashMap[Bytes[100000], int128]
 
 @external
 def __init__():
@@ -86,7 +86,7 @@ def __init__():
 
 @external
 def get_it1() -> int128:
-    key: bytes[100000] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    key: Bytes[100000] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     return self.a[key]
 
 @external
@@ -94,7 +94,7 @@ def get_it2() -> int128:
     return self.a[b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
 
 @external
-def get_it3(key: bytes[100000]) -> int128:
+def get_it3(key: Bytes[100000]) -> int128:
     return self.a[key]
     """
 

--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -12,7 +12,7 @@ def _make_tx(w3, address, signature, values):
 def test_bytes_clamper(assert_tx_failed, get_contract_with_gas_estimation):
     clamper_test_code = """
 @external
-def foo(s: bytes[3]) -> bytes[3]:
+def foo(s: Bytes[3]) -> Bytes[3]:
     return s
     """
 
@@ -25,7 +25,7 @@ def foo(s: bytes[3]) -> bytes[3]:
 def test_bytes_clamper_multiple_slots(assert_tx_failed, get_contract_with_gas_estimation):
     clamper_test_code = """
 @external
-def foo(s: bytes[40]) -> bytes[40]:
+def foo(s: Bytes[40]) -> Bytes[40]:
     return s
     """
 

--- a/tests/parser/features/test_constructor.py
+++ b/tests/parser/features/test_constructor.py
@@ -41,7 +41,7 @@ def test_constructor_advanced_code2(get_contract_with_gas_estimation):
 comb: uint256
 
 @external
-def __init__(x: uint256[2], y: bytes[3], z: uint256):
+def __init__(x: uint256[2], y: Bytes[3], z: uint256):
     self.comb = x[0] * 1000 + x[1] * 100 + len(y) * 10 + z
 
 @external

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -52,7 +52,7 @@ def return_hash_of_rzpadded_cow() -> bytes32:
 def test_selfcall_code_3(get_contract_with_gas_estimation, keccak):
     selfcall_code_3 = """
 @internal
-def _hashy2(x: bytes[100]) -> bytes32:
+def _hashy2(x: Bytes[100]) -> bytes32:
     return keccak256(x)
 
 @external
@@ -60,7 +60,7 @@ def return_hash_of_cow_x_30() -> bytes32:
     return self._hashy2(b"cowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcow")  # noqa: E501
 
 @internal
-def _len(x: bytes[100]) -> uint256:
+def _len(x: Bytes[100]) -> uint256:
     return len(x)
 
 @external
@@ -82,15 +82,15 @@ def _summy(x: int128, y: int128) -> int128:
     return x + y
 
 @internal
-def _catty(x: bytes[5], y: bytes[5]) -> bytes[10]:
+def _catty(x: Bytes[5], y: Bytes[5]) -> Bytes[10]:
     return concat(x, y)
 
 @internal
-def _slicey1(x: bytes[10], y: uint256) -> bytes[10]:
+def _slicey1(x: Bytes[10], y: uint256) -> Bytes[10]:
     return slice(x, 0, y)
 
 @internal
-def _slicey2(y: uint256, x: bytes[10]) -> bytes[10]:
+def _slicey2(y: uint256, x: Bytes[10]) -> Bytes[10]:
     return slice(x, 0, y)
 
 @external
@@ -98,15 +98,15 @@ def returnten() -> int128:
     return self._summy(3, 7)
 
 @external
-def return_mongoose() -> bytes[10]:
+def return_mongoose() -> Bytes[10]:
     return self._catty(b"mon", b"goose")
 
 @external
-def return_goose() -> bytes[10]:
+def return_goose() -> Bytes[10]:
     return self._slicey1(b"goosedog", 5)
 
 @external
-def return_goose2() -> bytes[10]:
+def return_goose2() -> Bytes[10]:
     return self._slicey2(5, b"goosedog")
     """
 
@@ -141,22 +141,22 @@ def returnten() -> int128:
 
 def test_selfcall_code_6(get_contract_with_gas_estimation):
     selfcall_code_6 = """
-excls: bytes[32]
+excls: Bytes[32]
 
 @internal
-def _set_excls(arg: bytes[32]):
+def _set_excls(arg: Bytes[32]):
     self.excls = arg
 
 @internal
-def _underscore() -> bytes[1]:
+def _underscore() -> Bytes[1]:
     return b"_"
 
 @internal
-def _hardtest(x: bytes[100], y: uint256, z: uint256, a: bytes[100], b: uint256, c: uint256) -> bytes[201]:  # noqa: E501
+def _hardtest(x: Bytes[100], y: uint256, z: uint256, a: Bytes[100], b: uint256, c: uint256) -> Bytes[201]:  # noqa: E501
     return concat(slice(x, y, z), self._underscore(), slice(a, b, c))
 
 @external
-def return_mongoose_revolution_32_excls() -> bytes[201]:
+def return_mongoose_revolution_32_excls() -> Bytes[201]:
     self._set_excls(b"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     return self._hardtest(b"megamongoose123", 4, 8, concat(b"russian revolution", self.excls), 8, 42)
     """
@@ -334,11 +334,11 @@ def bar() -> (int128, decimal):
 def test_internal_function_multiple_lists_as_args(get_contract_with_gas_estimation):
     code = """
 @internal
-def _foo(y: int128[2], x: bytes[5]) -> int128:
+def _foo(y: int128[2], x: Bytes[5]) -> int128:
     return y[0]
 
 @internal
-def _foo2(x: bytes[5], y: int128[2]) -> int128:
+def _foo2(x: Bytes[5], y: int128[2]) -> int128:
     return y[0]
 
 @external
@@ -358,23 +358,23 @@ def bar2() -> int128:
 def test_multi_mixed_arg_list_bytes_call(get_contract_with_gas_estimation):
     code = """
 @internal
-def _fooz(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> bytes[11]:
+def _fooz(x: int128[2], y: decimal, z: Bytes[11], a: decimal) -> Bytes[11]:
     return z
 
 @internal
-def _fooa(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> decimal:
+def _fooa(x: int128[2], y: decimal, z: Bytes[11], a: decimal) -> decimal:
     return a
 
 @internal
-def _foox(x: int128[2], y: decimal, z: bytes[11], a: decimal) -> int128:
+def _foox(x: int128[2], y: decimal, z: Bytes[11], a: decimal) -> int128:
     return x[1]
 
 
 @external
-def bar() -> (bytes[11], decimal, int128):
+def bar() -> (Bytes[11], decimal, int128):
     x: int128[2] = [33, 44]
     y: decimal = 55.44
-    z: bytes[11] = b"hello world"
+    z: Bytes[11] = b"hello world"
     a: decimal = 66.77
 
     return self._fooz(x, y, z, a), self._fooa(x, y, z, a), self._foox(x, y, z, a)

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -44,10 +44,10 @@ def foo():
 def test_event_logging_with_topics(w3, tester, keccak, get_logs, get_contract_with_gas_estimation):
     loggy_code = """
 
-a: bytes[3]
+a: Bytes[3]
 
 event MyLog:
-    arg1: indexed(bytes[3])
+    arg1: indexed(Bytes[3])
 
 @external
 def foo():
@@ -193,8 +193,8 @@ def test_event_logging_cannot_have_more_than_three_topics(
 ):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[3])
-    arg2: indexed(bytes[4])
+    arg1: indexed(Bytes[3])
+    arg2: indexed(Bytes[4])
     arg3: indexed(address)
     arg4: indexed(int128)
     """
@@ -284,12 +284,12 @@ def test_logging_with_input_bytes_1(
 ):
     loggy_code = """
 event MyLog:
-    arg1: bytes[4]
-    arg2: indexed(bytes[29])
-    arg3: bytes[31]
+    arg1: Bytes[4]
+    arg2: indexed(Bytes[29])
+    arg3: Bytes[31]
 
 @external
-def foo(arg1: bytes[29], arg2: bytes[31]):
+def foo(arg1: Bytes[29], arg2: Bytes[31]):
     log MyLog(b'bar', arg1, arg2)
 """
 
@@ -324,10 +324,10 @@ def test_event_logging_with_bytes_input_2(
 ):
     loggy_code = """
 event MyLog:
-    arg1: bytes[20]
+    arg1: Bytes[20]
 
 @external
-def foo(_arg1: bytes[20]):
+def foo(_arg1: Bytes[20]):
     log MyLog(_arg1)
     """
 
@@ -353,10 +353,10 @@ def foo(_arg1: bytes[20]):
 def test_event_logging_with_bytes_input_3(w3, tester, keccak, get_logs, get_contract):
     loggy_code = """
 event MyLog:
-    arg1: bytes[5]
+    arg1: Bytes[5]
 
 @external
-def foo(_arg1: bytes[5]):
+def foo(_arg1: Bytes[5]):
     log MyLog(_arg1)
     """
 
@@ -385,8 +385,8 @@ def test_event_logging_with_data_with_different_types(
     loggy_code = """
 event MyLog:
     arg1: int128
-    arg2: bytes[4]
-    arg3: bytes[3]
+    arg2: Bytes[4]
+    arg3: Bytes[3]
     arg4: address
     arg5: address
     arg6: uint256
@@ -436,7 +436,7 @@ def test_event_logging_with_topics_and_data_1(
     loggy_code = """
 event MyLog:
     arg1: indexed(int128)
-    arg2: bytes[3]
+    arg2: Bytes[3]
 
 @external
 def foo():
@@ -473,10 +473,10 @@ def test_event_logging_with_multiple_logs_topics_and_data(
     loggy_code = """
 event MyLog:
     arg1: indexed(int128)
-    arg2: bytes[3]
+    arg2: Bytes[3]
 event YourLog:
     arg1: indexed(address)
-    arg2: bytes[5]
+    arg2: Bytes[5]
 
 @external
 def foo():
@@ -543,7 +543,7 @@ def foo_():
 def test_fails_when_topic_is_the_wrong_size(assert_tx_failed, get_contract_with_gas_estimation):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[3])
+    arg1: indexed(Bytes[3])
 
 
 @external
@@ -559,10 +559,10 @@ def test_fails_when_input_topic_is_the_wrong_size(
 ):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[3])
+    arg1: indexed(Bytes[3])
 
 @external
-def foo(arg1: bytes[4]):
+def foo(arg1: Bytes[4]):
     log MyLog(arg1)
 """
 
@@ -572,7 +572,7 @@ def foo(arg1: bytes[4]):
 def test_fails_when_data_is_the_wrong_size(assert_tx_failed, get_contract_with_gas_estimation):
     loggy_code = """
 event MyLog:
-    arg1: bytes[3]
+    arg1: Bytes[3]
 
 @external
 def foo():
@@ -587,10 +587,10 @@ def test_fails_when_input_data_is_the_wrong_size(
 ):
     loggy_code = """
 event MyLog:
-    arg1: bytes[3]
+    arg1: Bytes[3]
 
 @external
-def foo(arg1: bytes[4]):
+def foo(arg1: Bytes[4]):
     log MyLog(arg1)
 """
 
@@ -600,7 +600,7 @@ def foo(arg1: bytes[4]):
 def test_topic_over_32_bytes(get_contract_with_gas_estimation):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[100])
+    arg1: indexed(Bytes[100])
 
 @external
 def foo():
@@ -669,7 +669,7 @@ def foo():
 def test_logging_fails_with_data_type_mismatch(assert_tx_failed, get_contract_with_gas_estimation):
     loggy_code = """
 event MyLog:
-    arg1: bytes[3]
+    arg1: Bytes[3]
 
 @external
 def foo():
@@ -710,7 +710,7 @@ def foo():
 
 def test_loggy_code(w3, tester, get_contract_with_gas_estimation):
     loggy_code = """
-s: bytes[100]
+s: Bytes[100]
 
 @external
 def foo():
@@ -726,7 +726,7 @@ def hoo():
     raw_log([], self.s)
 
 @external
-def ioo(inp: bytes[100]):
+def ioo(inp: Bytes[100]):
     raw_log([], inp)
     """
 
@@ -885,9 +885,9 @@ def test_storage_byte_packing(get_logs, bytes_helper, get_contract_with_gas_esti
 
     code = """
 event MyLog:
-    arg1: bytes[29]
+    arg1: Bytes[29]
 
-x:bytes[5]
+x:Bytes[5]
 
 @external
 def foo(a: int128):
@@ -943,10 +943,10 @@ def set_list():
 def test_logging_fails_when_input_is_too_big(assert_tx_failed, get_contract_with_gas_estimation):
     code = """
 event Bar:
-    _value: indexed(bytes[32])
+    _value: indexed(Bytes[32])
 
 @external
-def foo(inp: bytes[33]):
+def foo(inp: Bytes[33]):
     log Bar(inp)
 """
     assert_tx_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatch)
@@ -999,7 +999,7 @@ def test_mixed_var_list_packing(get_logs, get_contract_with_gas_estimation):
 event Bar:
     arg1: int128
     arg2: int128[4]
-    arg3 :bytes[4]
+    arg3 :Bytes[4]
     arg4: int128[3]
     arg5: int128[2]
 
@@ -1039,12 +1039,12 @@ def set_list():
 def test_hashed_indexed_topics_calldata(tester, keccak, get_contract):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[36])
+    arg1: indexed(Bytes[36])
     arg2: indexed(int128[2])
-    arg3: indexed(string[7])
+    arg3: indexed(String[7])
 
 @external
-def foo(a: bytes[36], b: int128[2], c: string[7]):
+def foo(a: Bytes[36], b: int128[2], c: String[7]):
     log MyLog(a, b, c)
     """
 
@@ -1081,15 +1081,15 @@ def foo(a: bytes[36], b: int128[2], c: string[7]):
 def test_hashed_indexed_topics_memory(tester, keccak, get_contract):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[10])
+    arg1: indexed(Bytes[10])
     arg2: indexed(int128[3])
-    arg3: indexed(string[44])
+    arg3: indexed(String[44])
 
 @external
 def foo():
-    a: bytes[10] = b"potato"
+    a: Bytes[10] = b"potato"
     b: int128[3] = [-777, 42, 8008135]
-    c: string[44] = "why hello, neighbor! how are you today?"
+    c: String[44] = "why hello, neighbor! how are you today?"
     log MyLog(a, b, c)
     """
 
@@ -1126,17 +1126,17 @@ def foo():
 def test_hashed_indexed_topics_storage(tester, keccak, get_contract):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[32])
+    arg1: indexed(Bytes[32])
     arg2: indexed(int128[2])
-    arg3: indexed(string[6])
+    arg3: indexed(String[6])
 
-a: bytes[32]
+a: Bytes[32]
 b: int128[2]
-c: string[6]
+c: String[6]
 
 
 @external
-def setter(_a: bytes[32], _b: int128[2], _c: string[6]):
+def setter(_a: Bytes[32], _b: int128[2], _c: String[6]):
     self.a = _a
     self.b = _b
     self.c = _c
@@ -1180,9 +1180,9 @@ def foo():
 def test_hashed_indexed_topics_storxxage(tester, keccak, get_contract):
     loggy_code = """
 event MyLog:
-    arg1: indexed(bytes[64])
+    arg1: indexed(Bytes[64])
     arg2: indexed(int128[3])
-    arg3: indexed(string[21])
+    arg3: indexed(String[21])
 
 @external
 def foo():

--- a/tests/parser/features/test_logging_bytes_extended.py
+++ b/tests/parser/features/test_logging_bytes_extended.py
@@ -2,7 +2,7 @@ def test_bytes_logging_extended(get_contract_with_gas_estimation, get_logs):
     code = """
 event MyLog:
     arg1: int128
-    arg2: bytes[64]
+    arg2: Bytes[64]
     arg3: int128
 
 @external
@@ -21,15 +21,15 @@ def foo():
 def test_bytes_logging_extended_variables(get_contract_with_gas_estimation, get_logs):
     code = """
 event MyLog:
-    arg1: bytes[64]
-    arg2: bytes[64]
-    arg3: bytes[64]
+    arg1: Bytes[64]
+    arg2: Bytes[64]
+    arg3: Bytes[64]
 
 @external
 def foo():
-    a: bytes[64] = b'hellohellohellohellohellohellohellohellohello'
-    b: bytes[64] = b'hellohellohellohellohellohellohellohello'
-    c: bytes[64] = b'hellohellohellohellohellohellohello'
+    a: Bytes[64] = b'hellohellohellohellohellohellohellohellohello'
+    b: Bytes[64] = b'hellohellohellohellohellohellohellohello'
+    c: Bytes[64] = b'hellohellohellohellohellohellohello'
     log MyLog(a, b, c)
     """
 
@@ -45,11 +45,11 @@ def test_bytes_logging_extended_passthrough(get_contract_with_gas_estimation, ge
     code = """
 event MyLog:
     arg1: int128
-    arg2: bytes[64]
+    arg2: Bytes[64]
     arg3: int128
 
 @external
-def foo(a: int128, b: bytes[64], c: int128):
+def foo(a: int128, b: Bytes[64], c: int128):
     log MyLog(a, b, c)
     """
 
@@ -66,11 +66,11 @@ def test_bytes_logging_extended_storage(get_contract_with_gas_estimation, get_lo
     code = """
 event MyLog:
     arg1: int128
-    arg2: bytes[64]
+    arg2: Bytes[64]
     arg3: int128
 
 a: int128
-b: bytes[64]
+b: Bytes[64]
 c: int128
 
 @external
@@ -78,7 +78,7 @@ def foo():
     log MyLog(self.a, self.b, self.c)
 
 @external
-def set(x: int128, y: bytes[64], z: int128):
+def set(x: int128, y: Bytes[64], z: int128):
     self.a = x
     self.b = y
     self.c = z
@@ -105,9 +105,9 @@ def test_bytes_logging_extended_mixed_with_lists(get_contract_with_gas_estimatio
     code = """
 event MyLog:
     arg1: int128[2][2]
-    arg2: bytes[64]
+    arg2: Bytes[64]
     arg3: int128
-    arg4: bytes[64]
+    arg4: Bytes[64]
 
 @external
 def foo():

--- a/tests/parser/features/test_logging_from_call.py
+++ b/tests/parser/features/test_logging_from_call.py
@@ -2,12 +2,12 @@ def test_log_dynamic_static_combo(get_logs, get_contract_with_gas_estimation, w3
     code = """
 event TestLog:
     testData1: bytes32
-    testData2: bytes[60]
-    testData3: bytes[8]
+    testData2: Bytes[60]
+    testData3: Bytes[8]
 
 @internal
 @view
-def to_bytes(_value: uint256) -> bytes[8]:
+def to_bytes(_value: uint256) -> Bytes[8]:
     return slice(concat(b"", convert(_value, bytes32)), 24, 8)
 
 @internal
@@ -17,11 +17,11 @@ def to_bytes32(_value: uint256) -> bytes32:
 
 @external
 def test_func(_value: uint256):
-    data2: bytes[60] = concat(self.to_bytes32(_value),self.to_bytes(_value),b"testing")
+    data2: Bytes[60] = concat(self.to_bytes32(_value),self.to_bytes(_value),b"testing")
     log TestLog(self.to_bytes32(_value), data2, self.to_bytes(_value))
 
     loggedValue: bytes32 = self.to_bytes32(_value)
-    loggedValue2: bytes[8] = self.to_bytes(_value)
+    loggedValue2: Bytes[8] = self.to_bytes(_value)
     log TestLog(loggedValue, data2, loggedValue2)
     """
 
@@ -46,12 +46,12 @@ def test_log_dynamic_static_combo2(get_logs, get_contract, w3):
     code = """
 event TestLog:
     testData1: bytes32
-    testData2: bytes[133]
-    testData3: string[8]
+    testData2: Bytes[133]
+    testData3: String[8]
 
 @internal
 @view
-def to_bytes(_value: uint256) -> bytes[8]:
+def to_bytes(_value: uint256) -> Bytes[8]:
     return slice(concat(b"", convert(_value, bytes32)), 24, 8)
 
 @internal
@@ -60,9 +60,9 @@ def to_bytes32(_value: uint256) -> bytes32:
     return convert(_value, bytes32)
 
 @external
-def test_func(_value: uint256,input: bytes[133]):
+def test_func(_value: uint256,input: Bytes[133]):
 
-    data2: bytes[200] = b"hello world"
+    data2: Bytes[200] = b"hello world"
 
     # log TestLog(self.to_bytes32(_value),input,self.to_bytes(_value))
     log TestLog(self.to_bytes32(_value),input,"bababa")
@@ -87,7 +87,7 @@ def test_log_single_function_call(get_logs, get_contract, w3):
     code = """
 event TestLog:
     testData1: bytes32
-    testData2: bytes[133]
+    testData2: Bytes[133]
 
 @internal
 @view
@@ -95,9 +95,9 @@ def to_bytes32(_value: uint256) -> bytes32:
     return convert(_value, bytes32)
 
 @external
-def test_func(_value: uint256,input: bytes[133]):
+def test_func(_value: uint256,input: Bytes[133]):
 
-    data2: bytes[200] = b"hello world"
+    data2: Bytes[200] = b"hello world"
 
     # log will be malformed
     # log TestLog(self.to_bytes32(_value),input,self.to_bytes(_value))
@@ -119,12 +119,12 @@ def test_original_problem_function(get_logs, get_contract, w3):
     code = """
 event TestLog:
     testData1: bytes32
-    testData2: bytes[2064]
-    testData3: bytes[8]
+    testData2: Bytes[2064]
+    testData3: Bytes[8]
 
 @internal
 @view
-def to_bytes(_value: uint256) -> bytes[8]:
+def to_bytes(_value: uint256) -> Bytes[8]:
     return slice(concat(b"", convert(_value, bytes32)), 24, 8)
 
 @internal
@@ -133,14 +133,14 @@ def to_bytes32(_value: uint256) -> bytes32:
     return convert(_value, bytes32)
 
 @external
-def test_func(_value: uint256,input: bytes[2048]):
+def test_func(_value: uint256,input: Bytes[2048]):
 
-    data2: bytes[2064] = concat(self.to_bytes(_value),self.to_bytes(_value),input)
+    data2: Bytes[2064] = concat(self.to_bytes(_value),self.to_bytes(_value),input)
 
     # log will be malformed
     log TestLog(self.to_bytes32(_value), data2, self.to_bytes(_value))
 
-    loggedValue: bytes[8] = self.to_bytes(_value)
+    loggedValue: Bytes[8] = self.to_bytes(_value)
 
     # log will be normal
     log TestLog(self.to_bytes32(_value),data2,loggedValue)

--- a/tests/parser/functions/test_abi.py
+++ b/tests/parser/functions/test_abi.py
@@ -49,7 +49,7 @@ def test_method_identifiers():
 x: public(int128)
 
 @external
-def foo(y: uint256) -> bytes[100]:
+def foo(y: uint256) -> Bytes[100]:
     return b"hello"
     """
 

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -4,11 +4,11 @@ from vyper.exceptions import TypeMismatch
 def test_concat(get_contract_with_gas_estimation):
     test_concat = """
 @external
-def foo2(input1: bytes[50], input2: bytes[50]) -> bytes[1000]:
+def foo2(input1: Bytes[50], input2: Bytes[50]) -> Bytes[1000]:
     return concat(input1, input2)
 
 @external
-def foo3(input1: bytes[50], input2: bytes[50], input3: bytes[50]) -> bytes[1000]:
+def foo3(input1: Bytes[50], input2: Bytes[50], input3: Bytes[50]) -> Bytes[1000]:
     return concat(input1, input2, input3)
     """
 
@@ -30,8 +30,8 @@ def foo3(input1: bytes[50], input2: bytes[50], input3: bytes[50]) -> bytes[1000]
 def test_concat2(get_contract_with_gas_estimation):
     test_concat2 = """
 @external
-def foo(inp: bytes[50]) -> bytes[1000]:
-    x: bytes[50] = inp
+def foo(inp: Bytes[50]) -> Bytes[1000]:
+    x: Bytes[50] = inp
     return concat(x, inp, x, inp, x, inp, x, inp, x, inp)
     """
 
@@ -42,11 +42,11 @@ def foo(inp: bytes[50]) -> bytes[1000]:
 
 def test_crazy_concat_code(get_contract_with_gas_estimation):
     crazy_concat_code = """
-y: bytes[10]
+y: Bytes[10]
 
 @external
-def krazykonkat(z: bytes[10]) -> bytes[25]:
-    x: bytes[3] = b"cow"
+def krazykonkat(z: Bytes[10]) -> Bytes[25]:
+    x: Bytes[3] = b"cow"
     self.y = b"horse"
     return concat(x, b" ", self.y, b" ", z)
     """
@@ -61,11 +61,11 @@ def krazykonkat(z: bytes[10]) -> bytes[25]:
 def test_concat_bytes32(get_contract_with_gas_estimation):
     test_concat_bytes32 = """
 @external
-def sandwich(inp: bytes[100], inp2: bytes32) -> bytes[164]:
+def sandwich(inp: Bytes[100], inp2: bytes32) -> Bytes[164]:
     return concat(inp2, inp, inp2)
 
 @external
-def fivetimes(inp: bytes32) -> bytes[160]:
+def fivetimes(inp: bytes32) -> Bytes[160]:
     return concat(inp, inp, inp, inp, inp)
     """
 
@@ -87,17 +87,17 @@ def test_konkat_code(get_contract_with_gas_estimation):
 ecks: bytes32
 
 @external
-def foo(x: bytes32, y: bytes32) -> bytes[64]:
+def foo(x: bytes32, y: bytes32) -> Bytes[64]:
     self.ecks = x
     return concat(self.ecks, y)
 
 @external
-def goo(x: bytes32, y: bytes32) -> bytes[64]:
+def goo(x: bytes32, y: bytes32) -> Bytes[64]:
     self.ecks = x
     return concat(self.ecks, y)
 
 @external
-def hoo(x: bytes32, y: bytes32) -> bytes[64]:
+def hoo(x: bytes32, y: bytes32) -> Bytes[64]:
     return concat(x, y)
     """
 
@@ -112,8 +112,8 @@ def hoo(x: bytes32, y: bytes32) -> bytes[64]:
 def test_small_output(get_contract_with_gas_estimation):
     code = """
 @external
-def small_output(a: string[5], b: string[4]) -> string[9]:
-    c: string[9] = concat(a, b)
+def small_output(a: String[5], b: String[4]) -> String[9]:
+    c: String[9] = concat(a, b)
     return c
     """
     c = get_contract_with_gas_estimation(code)
@@ -124,8 +124,8 @@ def small_output(a: string[5], b: string[4]) -> string[9]:
 def test_large_output(get_contract_with_gas_estimation, assert_compile_failed):
     code = """
 @external
-def large_output(a: string[33], b: string[33]) -> string[64]:
-    c: string[64] = concat(a, b)
+def large_output(a: String[33], b: String[33]) -> String[64]:
+    c: String[64] = concat(a, b)
     return c
     """
 

--- a/tests/parser/functions/test_convert_to_bool.py
+++ b/tests/parser/functions/test_convert_to_bool.py
@@ -146,11 +146,11 @@ def hoo() -> bool:
 def test_convert_from_bytes(get_contract_with_gas_estimation, assert_compile_failed):
     code = """
 @external
-def foo(bar: bytes[5]) -> bool:
+def foo(bar: Bytes[5]) -> bool:
     return convert(bar, bool)
 
 @external
-def goo(nar: bytes[32]) -> bool:
+def goo(nar: Bytes[32]) -> bool:
     return convert(nar, bool)
     """
 
@@ -167,7 +167,7 @@ def goo(nar: bytes[32]) -> bool:
 
     code = """
 @external
-def foo(bar: bytes[33]) -> bool:
+def foo(bar: Bytes[33]) -> bool:
     return convert(bar, bool)
     """
 
@@ -176,7 +176,7 @@ def foo(bar: bytes[33]) -> bool:
     code = """
 @external
 def foo() -> bool:
-    bar: bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
+    bar: Bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
     return convert(bar, bool)
     """
 

--- a/tests/parser/functions/test_convert_to_bytes32.py
+++ b/tests/parser/functions/test_convert_to_bytes32.py
@@ -6,7 +6,7 @@ def test_convert_to_bytes32(w3, get_contract_with_gas_estimation, bytes_helper):
 a: int128
 b: uint256
 c: address
-d: bytes[32]
+d: Bytes[32]
 
 @external
 def int128_to_bytes32(inp: int128) -> (bytes32, bytes32, bytes32):
@@ -32,14 +32,14 @@ def address_to_bytes32(inp: address) -> (bytes32, bytes32):
     return  memory, storage
 
 @external
-def bytes_to_bytes32(inp: bytes[32]) -> (bytes32, bytes32):
+def bytes_to_bytes32(inp: Bytes[32]) -> (bytes32, bytes32):
     self.d = inp
     memory: bytes32 = convert(inp, bytes32)
     storage: bytes32 = convert(self.d, bytes32)
     return  memory, storage
 
 @external
-def bytes_to_bytes32_from_smaller(inp: bytes[10]) -> bytes32:
+def bytes_to_bytes32_from_smaller(inp: Bytes[10]) -> bytes32:
     memory: bytes32 = convert(inp, bytes32)
     return memory
     """

--- a/tests/parser/functions/test_convert_to_decimal.py
+++ b/tests/parser/functions/test_convert_to_decimal.py
@@ -90,11 +90,11 @@ def foo() -> decimal:
 def test_convert_from_bytes(get_contract_with_gas_estimation):
     code = """
 @external
-def foo(bar: bytes[5]) -> decimal:
+def foo(bar: Bytes[5]) -> decimal:
     return convert(bar, decimal)
 
 @external
-def goo(bar: bytes[32]) -> decimal:
+def goo(bar: Bytes[32]) -> decimal:
     return convert(bar, decimal)
     """
 
@@ -115,7 +115,7 @@ def goo(bar: bytes[32]) -> decimal:
 def test_convert_from_too_many_bytes(get_contract_with_gas_estimation, assert_compile_failed):
     code = """
 @external
-def foo(bar: bytes[33]) -> decimal:
+def foo(bar: Bytes[33]) -> decimal:
     return convert(bar, decimal)
     """
 
@@ -126,7 +126,7 @@ def foo(bar: bytes[33]) -> decimal:
     code = """
 @external
 def foobar() -> decimal:
-    barfoo: bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
+    barfoo: Bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
     return convert(barfoo, decimal)
     """
 

--- a/tests/parser/functions/test_convert_to_int128.py
+++ b/tests/parser/functions/test_convert_to_int128.py
@@ -6,7 +6,7 @@ def test_convert_to_int128(get_contract_with_gas_estimation):
     code = """
 a: uint256
 b: bytes32
-c: bytes[1]
+c: Bytes[1]
 
 @external
 def uint256_to_num(inp: uint256) -> (int128, int128):
@@ -30,7 +30,7 @@ def bytes_to_num() -> (int128, int128):
     return literal, storage
 
 @external
-def zero_bytes(inp: bytes[1]) -> int128:
+def zero_bytes(inp: Bytes[1]) -> int128:
     return convert(inp, int128)
     """
 
@@ -49,7 +49,7 @@ def test_convert_from_bytes(
     # Test valid bytes input for conversion
     test_success = """
 @external
-def foo(bar: bytes[5]) -> int128:
+def foo(bar: Bytes[5]) -> int128:
     return convert(bar, int128)
     """
 
@@ -59,7 +59,7 @@ def foo(bar: bytes[5]) -> int128:
 
     test_success = """
 @external
-def foo(bar: bytes[32]) -> int128:
+def foo(bar: Bytes[32]) -> int128:
     return convert(bar, int128)
     """
 
@@ -75,7 +75,7 @@ def foo(bar: bytes[32]) -> int128:
     assert_tx_failed(lambda: c.foo(b"\x01" * 33))
 
     bytes_to_num_code = """
-astor: bytes[10]
+astor: Bytes[10]
 
 @external
 def bar_storage() -> int128:
@@ -89,7 +89,7 @@ def bar_storage() -> int128:
     # Test overflow bytes input for conversion
     test_fail = """
 @external
-def foo(bar: bytes[33]) -> int128:
+def foo(bar: Bytes[33]) -> int128:
     return convert(bar, int128)
     """
 
@@ -98,7 +98,7 @@ def foo(bar: bytes[33]) -> int128:
     test_fail = """
 @external
 def foobar() -> int128:
-    barfoo: bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
+    barfoo: Bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
     return convert(barfoo, int128)
     """
 

--- a/tests/parser/functions/test_convert_to_uint256.py
+++ b/tests/parser/functions/test_convert_to_uint256.py
@@ -33,7 +33,7 @@ def test_convert_from_bytes(assert_compile_failed, get_contract_with_gas_estimat
     # Test valid bytes input for conversion
     test_success = """
 @external
-def foo(bar: bytes[5]) -> uint256:
+def foo(bar: Bytes[5]) -> uint256:
     return convert(bar, uint256)
     """
 
@@ -43,7 +43,7 @@ def foo(bar: bytes[5]) -> uint256:
 
     test_success = """
 @external
-def foo(bar: bytes[32]) -> uint256:
+def foo(bar: Bytes[32]) -> uint256:
     return convert(bar, uint256)
     """
 
@@ -54,7 +54,7 @@ def foo(bar: bytes[32]) -> uint256:
     # Test overflow bytes input for conversion
     test_fail = """
 @external
-def foo(bar: bytes[33]) -> uint256:
+def foo(bar: Bytes[33]) -> uint256:
     return convert(bar, uint256)
     """
 
@@ -63,7 +63,7 @@ def foo(bar: bytes[33]) -> uint256:
     test_fail = """
 @external
 def foobar() -> uint256:
-    barfoo: bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
+    barfoo: Bytes[63] = b"Hello darkness, my old friend I've come to talk with you again."
     return convert(barfoo, uint256)
     """
 

--- a/tests/parser/functions/test_create_with_code_of.py
+++ b/tests/parser/functions/test_create_with_code_of.py
@@ -18,7 +18,7 @@ def test_create_forwarder_to_call(get_contract, w3):
 
 interface SubContract:
 
-    def hello() -> bytes[100]: view
+    def hello() -> Bytes[100]: view
 
 
 other: public(address)
@@ -31,12 +31,12 @@ def test() -> address:
 
 
 @external
-def hello() -> bytes[100]:
+def hello() -> Bytes[100]:
     return b"hello world!"
 
 
 @external
-def test2() -> bytes[100]:
+def test2() -> Bytes[100]:
     return SubContract(self.other).hello()
 
     """
@@ -53,7 +53,7 @@ def test_create_with_code_exception(w3, get_contract, assert_tx_failed):
 
 interface SubContract:
 
-    def hello(a: uint256) -> bytes[100]: view
+    def hello(a: uint256) -> Bytes[100]: view
 
 
 other: public(address)
@@ -66,13 +66,13 @@ def test() -> address:
 
 
 @external
-def hello(a: uint256) -> bytes[100]:
+def hello(a: uint256) -> Bytes[100]:
     assert a > 0, "invaliddddd"
     return b"hello world!"
 
 
 @external
-def test2(a: uint256) -> bytes[100]:
+def test2(a: uint256) -> Bytes[100]:
     return SubContract(self.other).hello(a)
     """
 

--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -14,7 +14,7 @@ def test_default_param_abi(get_contract):
     code = """
 @external
 @payable
-def safeTransferFrom(_data: bytes[100] = b"test", _b: int128 = 1):
+def safeTransferFrom(_data: Bytes[100] = b"test", _b: int128 = 1):
     pass
     """
     abi = get_contract(code)._classic_contract.abi
@@ -32,7 +32,7 @@ def safeTransferFrom(_data: bytes[100] = b"test", _b: int128 = 1):
 def test_basic_default_param_passthrough(get_contract):
     code = """
 @external
-def fooBar(_data: bytes[100] = b"test", _b: int128 = 1) -> int128:
+def fooBar(_data: Bytes[100] = b"test", _b: int128 = 1) -> int128:
     return 12321
     """
 
@@ -78,7 +78,7 @@ def fooBar(a:int128, b: uint256 = 999, c: address = 0x00000000000000000000000000
 def test_default_param_bytes(get_contract):
     code = """
 @external
-def fooBar(a: bytes[100], b: int128, c: bytes[100] = b"testing", d: uint256 = 999) -> (bytes[100], int128, bytes[100], uint256):  # noqa: E501
+def fooBar(a: Bytes[100], b: int128, c: Bytes[100] = b"testing", d: uint256 = 999) -> (Bytes[100], int128, Bytes[100], uint256):  # noqa: E501
     return a, b, c, d
     """
     c = get_contract(code)
@@ -96,7 +96,7 @@ def fooBar(a: bytes[100], b: int128, c: bytes[100] = b"testing", d: uint256 = 99
 def test_default_param_array(get_contract):
     code = """
 @external
-def fooBar(a: bytes[100], b: uint256[2], c: bytes[6] = b"hello", d: int128[3] = [6, 7, 8]) -> (bytes[100], uint256, bytes[6], int128):  # noqa: E501
+def fooBar(a: Bytes[100], b: uint256[2], c: Bytes[6] = b"hello", d: int128[3] = [6, 7, 8]) -> (Bytes[100], uint256, Bytes[6], int128):  # noqa: E501
     return a, b[1], c, d[2]
     """
     c = get_contract(code)
@@ -174,19 +174,19 @@ def bar(a: int128, b: int128 = -1) -> (int128, int128):  # noqa: E501
 def test_default_param_private(get_contract):
     code = """
 @internal
-def fooBar(a: bytes[100], b: uint256, c: bytes[20] = b"crazy") -> (bytes[100], uint256, bytes[20]):
+def fooBar(a: Bytes[100], b: uint256, c: Bytes[20] = b"crazy") -> (Bytes[100], uint256, Bytes[20]):
     return a, b, c
 
 @external
-def callMe() -> (bytes[100], uint256, bytes[20]):
+def callMe() -> (Bytes[100], uint256, Bytes[20]):
     return self.fooBar(b'I just met you', 123456)
 
 @external
-def callMeMaybe() -> (bytes[100], uint256, bytes[20]):
+def callMeMaybe() -> (Bytes[100], uint256, Bytes[20]):
     # return self.fooBar(b'here is my number', 555123456, b'baby')
-    a: bytes[100] = b""
+    a: Bytes[100] = b""
     b: uint256 = 0
-    c: bytes[20] = b""
+    c: Bytes[20] = b""
     a, b, c = self.fooBar(b'here is my number', 555123456, b'baby')
     return a, b, c
     """
@@ -259,7 +259,7 @@ def foo(a: int128 = -31, b: int128[2] = [64, -46]): pass
     """,
     """
 @external
-def foo(a: bytes[6] = b"potato"): pass
+def foo(a: Bytes[6] = b"potato"): pass
     """,
     """
 @external

--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -265,15 +265,15 @@ def test_clear_literals(contract, assert_compile_failed, get_contract_with_gas_e
 
 def test_empty_bytes(get_contract_with_gas_estimation):
     code = """
-foobar: bytes[5]
+foobar: Bytes[5]
 
 @external
-def foo() -> (bytes[5], bytes[5]):
+def foo() -> (Bytes[5], Bytes[5]):
     self.foobar = b'Hello'
-    bar: bytes[5] = b'World'
+    bar: Bytes[5] = b'World'
 
-    self.foobar = empty(bytes[5])
-    bar = empty(bytes[5])
+    self.foobar = empty(Bytes[5])
+    bar = empty(Bytes[5])
 
     return (self.foobar, bar)
     """
@@ -342,7 +342,7 @@ def test_param_empty(get_contract_with_gas_estimation):
     code = """
 interface Mirror:
     # reuse the contract for this test by compiling two copies of it
-    def test_empty(xs: int128[111], ys: bytes[1024], zs: bytes[31]) -> bool: view
+    def test_empty(xs: int128[111], ys: Bytes[1024], zs: Bytes[31]) -> bool: view
 
 # a helper function which will write all over memory with random stuff
 @internal
@@ -351,13 +351,13 @@ def write_junk_to_memory():
     for i in range(1024):
         xs[i] = -(i + 1)
 @internal
-def priv(xs: int128[111], ys: bytes[1024], zs: bytes[31]) -> bool:
+def priv(xs: int128[111], ys: Bytes[1024], zs: Bytes[31]) -> bool:
     return xs[1] == 0 and ys == b'' and zs == b''
 
 @external
-def test_empty(xs: int128[111], ys: bytes[1024], zs: bytes[31]) -> bool:
-    empty_bytes1024: bytes[1024] = empty(bytes[1024])
-    empty_bytes31: bytes[31] = empty(bytes[31])
+def test_empty(xs: int128[111], ys: Bytes[1024], zs: Bytes[31]) -> bool:
+    empty_bytes1024: Bytes[1024] = empty(Bytes[1024])
+    empty_bytes31: Bytes[31] = empty(Bytes[31])
     self.write_junk_to_memory()
     # no list equality yet so test some sample values
     return xs[0] == 0 and xs[110] == 0 and ys == empty_bytes1024 and zs == empty_bytes31
@@ -365,12 +365,12 @@ def test_empty(xs: int128[111], ys: bytes[1024], zs: bytes[31]) -> bool:
 @external
 def pub2() -> bool:
     self.write_junk_to_memory()
-    return self.priv(empty(int128[111]), empty(bytes[1024]), empty(bytes[31]))
+    return self.priv(empty(int128[111]), empty(Bytes[1024]), empty(Bytes[31]))
 
 @external
 def pub3(x: address) -> bool:
     self.write_junk_to_memory()
-    return Mirror(x).test_empty(empty(int128[111]), empty(bytes[1024]), empty(bytes[31]))
+    return Mirror(x).test_empty(empty(int128[111]), empty(Bytes[1024]), empty(Bytes[31]))
     """
     c = get_contract_with_gas_estimation(code)
     mirror = get_contract_with_gas_estimation(code)
@@ -413,9 +413,9 @@ def c() -> uint256[5][5]:
     return empty(uint256[5][5])
 
 @external
-def d() -> bytes[55]:
+def d() -> Bytes[55]:
     self.write_junk_to_memory()
-    return empty(bytes[55])
+    return empty(Bytes[55])
 
 @external
 def e() -> X:
@@ -527,7 +527,7 @@ def foo():
         """
 @external
 def bar():
-    ys: bytes[33] = empty(bytes[32])
+    ys: Bytes[33] = empty(Bytes[32])
     """,
         """
 @external

--- a/tests/parser/functions/test_extract32.py
+++ b/tests/parser/functions/test_extract32.py
@@ -1,17 +1,17 @@
 def test_extract32_extraction(assert_tx_failed, get_contract_with_gas_estimation):
     extract32_code = """
-y: bytes[100]
+y: Bytes[100]
 @external
-def extrakt32(inp: bytes[100], index: int128) -> bytes32:
+def extrakt32(inp: Bytes[100], index: int128) -> bytes32:
     return extract32(inp, index)
 
 @external
-def extrakt32_mem(inp: bytes[100], index: int128) -> bytes32:
-    x: bytes[100] = inp
+def extrakt32_mem(inp: Bytes[100], index: int128) -> bytes32:
+    x: Bytes[100] = inp
     return extract32(x, index)
 
 @external
-def extrakt32_storage(index: int128, inp: bytes[100]) -> bytes32:
+def extrakt32_storage(index: int128, inp: Bytes[100]) -> bytes32:
     self.y = inp
     return extract32(self.y, index)
     """
@@ -49,23 +49,23 @@ def extrakt32_storage(index: int128, inp: bytes[100]) -> bytes32:
 def test_extract32_code(assert_tx_failed, get_contract_with_gas_estimation):
     extract32_code = """
 @external
-def foo(inp: bytes[32]) -> int128:
+def foo(inp: Bytes[32]) -> int128:
     return extract32(inp, 0, output_type=int128)
 
 @external
-def bar(inp: bytes[32]) -> uint256:
+def bar(inp: Bytes[32]) -> uint256:
     return extract32(inp, 0, output_type=uint256)
 
 @external
-def baz(inp: bytes[32]) -> bytes32:
+def baz(inp: Bytes[32]) -> bytes32:
     return extract32(inp, 0, output_type=bytes32)
 
 @external
-def fop(inp: bytes[32]) -> bytes32:
+def fop(inp: Bytes[32]) -> bytes32:
     return extract32(inp, 0)
 
 @external
-def foq(inp: bytes[32]) -> address:
+def foq(inp: Bytes[32]) -> address:
     return extract32(inp, 0, output_type=address)
     """
 

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -381,8 +381,8 @@ type_str_params = [
     ("address", "0x1234567890123456789012345678901234567890"),
     ("bytes32", b"bytes32bytes32bytes32bytes32poop"),
     ("decimal", Decimal("3.1337")),
-    ("bytes[4]", b"newp"),
-    ("string[6]", "potato"),
+    ("Bytes[4]", b"newp"),
+    ("String[6]", "potato"),
 ]
 
 interface_test_code = """

--- a/tests/parser/functions/test_keccak256.py
+++ b/tests/parser/functions/test_keccak256.py
@@ -1,7 +1,7 @@
 def test_hash_code(get_contract_with_gas_estimation, keccak):
     hash_code = """
 @external
-def foo(inp: bytes[100]) -> bytes32:
+def foo(inp: Bytes[100]) -> bytes32:
     return keccak256(inp)
 
 @external
@@ -24,7 +24,7 @@ def bar() -> bytes32:
 def test_hash_code2(get_contract_with_gas_estimation):
     hash_code2 = """
 @external
-def foo(inp: bytes[100]) -> bool:
+def foo(inp: Bytes[100]) -> bool:
     return keccak256(inp) == keccak256("badminton")
     """
     c = get_contract_with_gas_estimation(hash_code2)
@@ -34,23 +34,23 @@ def foo(inp: bytes[100]) -> bool:
 
 def test_hash_code3(get_contract_with_gas_estimation):
     hash_code3 = """
-test: bytes[100]
+test: Bytes[100]
 
 @external
-def set_test(inp: bytes[100]):
+def set_test(inp: Bytes[100]):
     self.test = inp
 
 @external
-def tryy(inp: bytes[100]) -> bool:
+def tryy(inp: Bytes[100]) -> bool:
     return keccak256(inp) == keccak256(self.test)
 
 @external
-def tryy_str(inp: string[100]) -> bool:
+def tryy_str(inp: String[100]) -> bool:
     return keccak256(inp) == keccak256(self.test)
 
 @external
-def trymem(inp: bytes[100]) -> bool:
-    x: bytes[100] = self.test
+def trymem(inp: Bytes[100]) -> bool:
+    x: Bytes[100] = self.test
     return keccak256(inp) == keccak256(x)
 
 @external

--- a/tests/parser/functions/test_length.py
+++ b/tests/parser/functions/test_length.py
@@ -1,10 +1,10 @@
 def test_test_length(get_contract_with_gas_estimation):
     test_length = """
-y: bytes[10]
+y: Bytes[10]
 
 @external
-def foo(inp: bytes[10]) -> uint256:
-    x: bytes[5] = slice(inp,1, 5)
+def foo(inp: Bytes[10]) -> uint256:
+    x: Bytes[5] = slice(inp,1, 5)
     self.y = slice(inp, 2, 4)
     return len(inp) * 100 + len(x) * 10 + len(self.y)
     """

--- a/tests/parser/functions/test_method_id.py
+++ b/tests/parser/functions/test_method_id.py
@@ -6,7 +6,7 @@ def double(x: int128) -> int128:
 
 @external
 def returnten() -> int128:
-    ans: bytes[32] = raw_call(self, concat(method_id("double(int128)"), convert(5, bytes32)), gas=50000, max_outsize=32)  # noqa: E501
+    ans: Bytes[32] = raw_call(self, concat(method_id("double(int128)"), convert(5, bytes32)), gas=50000, max_outsize=32)  # noqa: E501
     return convert(convert(ans, bytes32), int128)
     """
     c = get_contract_with_gas_estimation(method_id_test)
@@ -29,8 +29,8 @@ def sig() -> bytes32:
 def test_method_id_bytes4(get_contract):
     code = """
 @external
-def sig() -> bytes[4]:
-    return method_id('transfer(address,uint256)', output_type=bytes[4])
+def sig() -> Bytes[4]:
+    return method_id('transfer(address,uint256)', output_type=Bytes[4])
     """
     c = get_contract(code)
     sig = c.sig()
@@ -42,7 +42,7 @@ def sig() -> bytes[4]:
 def test_method_id_bytes4_default(get_contract):
     code = """
 @external
-def sig() -> bytes[4]:
+def sig() -> Bytes[4]:
     return method_id('transfer(address,uint256)')
     """
     c = get_contract(code)

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -8,7 +8,7 @@ from vyper.functions import get_create_forwarder_to_bytecode
 def test_max_outsize_exceeds_returndatasize(get_contract):
     source_code = """
 @external
-def foo() -> bytes[7]:
+def foo() -> Bytes[7]:
     return raw_call(0x0000000000000000000000000000000000000004, b"moose", max_outsize=7)
     """
     c = get_contract(source_code)
@@ -18,7 +18,7 @@ def foo() -> bytes[7]:
 def test_returndatasize_exceeds_max_outsize(get_contract):
     source_code = """
 @external
-def foo() -> bytes[3]:
+def foo() -> Bytes[3]:
     return raw_call(0x0000000000000000000000000000000000000004, b"moose", max_outsize=3)
     """
     c = get_contract(source_code)
@@ -28,7 +28,7 @@ def foo() -> bytes[3]:
 def test_returndatasize_matches_max_outsize(get_contract):
     source_code = """
 @external
-def foo() -> bytes[5]:
+def foo() -> Bytes[5]:
     return raw_call(0x0000000000000000000000000000000000000004, b"moose", max_outsize=5)
     """
     c = get_contract(source_code)
@@ -48,7 +48,7 @@ def returnten() -> int128:
 @external
 def create_and_call_returnten(inp: address) -> int128:
     x: address = create_forwarder_to(inp)
-    o: int128 = extract32(raw_call(x, convert("\xd0\x1f\xb1\xb8", bytes[4]), max_outsize=32, gas=50000), 0, output_type=int128)  # noqa: E501
+    o: int128 = extract32(raw_call(x, convert("\xd0\x1f\xb1\xb8", Bytes[4]), max_outsize=32, gas=50000), 0, output_type=int128)  # noqa: E501
     return o
 
 @external
@@ -90,7 +90,7 @@ def returnten() -> int128:
 @external
 def create_and_call_returnten(inp: address) -> int128:
     x: address = create_forwarder_to(inp)
-    o: int128 = extract32(raw_call(x, convert("\xd0\x1f\xb1\xb8", bytes[4]), max_outsize=32, gas=50000), 0, output_type=int128)  # noqa: E501
+    o: int128 = extract32(raw_call(x, convert("\xd0\x1f\xb1\xb8", Bytes[4]), max_outsize=32, gas=50000), 0, output_type=int128)  # noqa: E501
     return o
 
 @external
@@ -130,7 +130,7 @@ def __init__(_owner_setter: address):
 @external
 def set(i: int128, owner: address):
     # delegate setting owners to other contract.s
-    cdata: bytes[68] = concat(method_id("set_owner(int128,address)"), convert(i, bytes32), convert(owner, bytes32))  # noqa: E501
+    cdata: Bytes[68] = concat(method_id("set_owner(int128,address)"), convert(i, bytes32), convert(owner, bytes32))  # noqa: E501
     raw_call(
         self.owner_setter_contract,
         cdata,
@@ -171,7 +171,7 @@ def foo(_bar: bytes32):
     outer_code = """
 @external
 def foo_call(_addr: address):
-    cdata: bytes[40] = concat(
+    cdata: Bytes[40] = concat(
         method_id("foo(bytes32)"),
         0x0000000000000000000000000000000000000000000000000000000000000001
     )
@@ -204,7 +204,7 @@ def foo() -> int128:
 @external
 @view
 def foo(_addr: address) -> int128:
-    _response: bytes[32] = raw_call(
+    _response: Bytes[32] = raw_call(
         _addr,
         method_id("foo()"),
         max_outsize=32,
@@ -234,7 +234,7 @@ def foo() -> int128:
 @external
 @view
 def foo(_addr: address) -> int128:
-    _response: bytes[32] = raw_call(
+    _response: Bytes[32] = raw_call(
         _addr,
         method_id("foo()"),
         max_outsize=32,

--- a/tests/parser/functions/test_return.py
+++ b/tests/parser/functions/test_return.py
@@ -1,7 +1,7 @@
 def test_correct_abi_right_padding(tester, w3, get_contract_with_gas_estimation):
     selfcall_code_6 = """
 @external
-def hardtest(arg1: bytes[64], arg2: bytes[64]) -> bytes[128]:
+def hardtest(arg1: Bytes[64], arg2: Bytes[64]) -> Bytes[128]:
     return concat(arg1, arg2)
     """
 

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -6,8 +6,8 @@ def test_return_type(get_contract_with_gas_estimation):
 
     code = """
 struct Chunk:
-    a: bytes[8]
-    b: bytes[8]
+    a: Bytes[8]
+    b: Bytes[8]
     c: int128
 chunk: Chunk
 
@@ -22,31 +22,31 @@ def out() -> (int128, address):
     return 3333, 0x0000000000000000000000000000000000000001
 
 @external
-def out_literals() -> (int128, address, bytes[6]):
+def out_literals() -> (int128, address, Bytes[6]):
     return 1, 0x0000000000000000000000000000000000000000, b"random"
 
 @external
-def out_bytes_first() -> (bytes[4], int128):
+def out_bytes_first() -> (Bytes[4], int128):
     return b"test", 1234
 
 @external
-def out_bytes_a(x: int128, y: bytes[4]) -> (int128, bytes[4]):
+def out_bytes_a(x: int128, y: Bytes[4]) -> (int128, Bytes[4]):
     return x, y
 
 @external
-def out_bytes_b(x: int128, y: bytes[4]) -> (bytes[4], int128, bytes[4]):
+def out_bytes_b(x: int128, y: Bytes[4]) -> (Bytes[4], int128, Bytes[4]):
     return y, x, y
 
 @external
-def four() -> (int128, bytes[8], bytes[8], int128):
+def four() -> (int128, Bytes[8], Bytes[8], int128):
     return 1234, b"bytes", b"test", 4321
 
 @external
-def out_chunk() -> (bytes[8], int128, bytes[8]):
+def out_chunk() -> (Bytes[8], int128, Bytes[8]):
     return self.chunk.a, self.chunk.c, self.chunk.b
 
 @external
-def out_very_long_bytes() -> (int128, bytes[1024], int128, address):
+def out_very_long_bytes() -> (int128, Bytes[1024], int128, address):
     return 5555, b"testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest", 6666, 0x0000000000000000000000000000000000001234  # noqa
     """
 
@@ -70,7 +70,7 @@ def out_very_long_bytes() -> (int128, bytes[1024], int128, address):
 def test_return_type_signatures(get_contract_with_gas_estimation):
     code = """
 @external
-def out_literals() -> (int128, address, bytes[6]):
+def out_literals() -> (int128, address, Bytes[6]):
     return 1, 0x0000000000000000000000000000000000000000, b"random"
     """
 
@@ -85,18 +85,18 @@ def out_literals() -> (int128, address, bytes[6]):
 def test_return_tuple_assign(get_contract_with_gas_estimation):
     code = """
 @internal
-def _out_literals() -> (int128, address, bytes[10]):
+def _out_literals() -> (int128, address, Bytes[10]):
     return 1, 0x0000000000000000000000000000000000000000, b"random"
 
 @external
-def out_literals() -> (int128, address, bytes[10]):
+def out_literals() -> (int128, address, Bytes[10]):
     return self._out_literals()
 
 @external
-def test() -> (int128, address, bytes[10]):
+def test() -> (int128, address, Bytes[10]):
     a: int128 = 0
     b: address = ZERO_ADDRESS
-    c: bytes[10] = b""
+    c: Bytes[10] = b""
     (a, b, c) = self._out_literals()
     return a, b, c
     """
@@ -110,19 +110,19 @@ def test_return_tuple_assign_storage(get_contract_with_gas_estimation):
     code = """
 a: int128
 b: address
-c: bytes[20]
-d: bytes[20]
+c: Bytes[20]
+d: Bytes[20]
 
 @internal
-def _out_literals() -> (int128, bytes[20], address, bytes[20]):
+def _out_literals() -> (int128, Bytes[20], address, Bytes[20]):
     return 1, b"testtesttest", 0x0000000000000000000000000000000000000023, b"random"
 
 @external
-def out_literals() -> (int128, bytes[20], address, bytes[20]):
+def out_literals() -> (int128, Bytes[20], address, Bytes[20]):
     return self._out_literals()
 
 @external
-def test1() -> (int128, bytes[20], address, bytes[20]):
+def test1() -> (int128, Bytes[20], address, Bytes[20]):
     self.a, self.c, self.b, self.d = self._out_literals()
     return self.a, self.c, self.b, self.d
 

--- a/tests/parser/functions/test_sha256.py
+++ b/tests/parser/functions/test_sha256.py
@@ -42,7 +42,7 @@ def bar(a: bytes32) -> bytes32:
 def test_sha256_bytearraylike(get_contract_with_gas_estimation):
     code = """
 @external
-def bar(a: string[100]) -> bytes32:
+def bar(a: String[100]) -> bytes32:
     return sha256(a)
     """
 
@@ -56,10 +56,10 @@ def bar(a: string[100]) -> bytes32:
 
 def test_sha256_bytearraylike_storage(get_contract_with_gas_estimation):
     code = """
-a: public(bytes[100])
+a: public(Bytes[100])
 
 @external
-def set(b: bytes[100]):
+def set(b: Bytes[100]):
     self.a = b
 
 @external

--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -2,16 +2,16 @@ def test_test_slice(get_contract_with_gas_estimation):
     test_slice = """
 
 @external
-def foo(inp1: bytes[10]) -> bytes[3]:
+def foo(inp1: Bytes[10]) -> Bytes[3]:
     x: int128 = 5
-    s: bytes[3] = slice(inp1, 3, 3)
+    s: Bytes[3] = slice(inp1, 3, 3)
     y: int128 = 7
     return s
 
 @external
-def bar(inp1: bytes[10]) -> int128:
+def bar(inp1: Bytes[10]) -> int128:
     x: int128 = 5
-    s: bytes[3] = slice(inp1, 3, 3)
+    s: Bytes[3] = slice(inp1, 3, 3)
     y: int128 = 7
     return x * y
     """
@@ -29,8 +29,8 @@ def test_test_slice2(get_contract_with_gas_estimation):
     # TODO once parser is refactored so that `i` is `uint256`, remove call to `convert`
     test_slice2 = """
 @external
-def slice_tower_test(inp1: bytes[50]) -> bytes[50]:
-    inp: bytes[50] = inp1
+def slice_tower_test(inp1: Bytes[50]) -> Bytes[50]:
+    inp: Bytes[50] = inp1
     for i in range(1, 11):
         inp = slice(inp, 1, convert(30 - i * 2, uint256))
     return inp
@@ -45,17 +45,17 @@ def slice_tower_test(inp1: bytes[50]) -> bytes[50]:
 def test_test_slice3(get_contract_with_gas_estimation):
     test_slice3 = """
 x: int128
-s: bytes[50]
+s: Bytes[50]
 y: int128
 @external
-def foo(inp1: bytes[50]) -> bytes[50]:
+def foo(inp1: Bytes[50]) -> Bytes[50]:
     self.x = 5
     self.s = slice(inp1, 3, 3)
     self.y = 7
     return self.s
 
 @external
-def bar(inp1: bytes[50]) -> int128:
+def bar(inp1: Bytes[50]) -> int128:
     self.x = 5
     self.s = slice(inp1,3, 3)
     self.y = 7
@@ -74,7 +74,7 @@ def bar(inp1: bytes[50]) -> int128:
 def test_test_slice4(get_contract_with_gas_estimation, assert_tx_failed):
     test_slice4 = """
 @external
-def foo(inp: bytes[10], start: uint256, _len: uint256) -> bytes[10]:
+def foo(inp: Bytes[10], start: uint256, _len: uint256) -> Bytes[10]:
     return slice(inp, start, _len)
     """
 
@@ -97,9 +97,9 @@ def foo(inp: bytes[10], start: uint256, _len: uint256) -> bytes[10]:
 def test_slice_at_end(get_contract):
     code = """
 @external
-def ret10_slice() -> bytes[10]:
-    b: bytes[32] = concat(convert(65, bytes32), b'')
-    c: bytes[10] = slice(b, 31, 1)
+def ret10_slice() -> Bytes[10]:
+    b: Bytes[32] = concat(convert(65, bytes32), b'')
+    c: Bytes[10] = slice(b, 31, 1)
     return c
     """
 

--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -28,13 +28,13 @@ def test_getter_code(get_contract_with_gas_estimation_for_constants):
 struct W:
     a: uint256
     b: int128[7]
-    c: bytes[100]
+    c: Bytes[100]
     e: int128[3][3]
     f: uint256
     g: uint256
 x: public(uint256)
 y: public(int128[5])
-z: public(bytes[100])
+z: public(Bytes[100])
 w: public(HashMap[int128, W])
 
 @external

--- a/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
+++ b/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
@@ -20,7 +20,7 @@ struct S:
     b: int128
 
 interface ERC20Contract:
-    def name() -> string[64]: view
+    def name() -> String[64]: view
 
 @external
 def foo() -> int128:

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -32,7 +32,7 @@ def foo() -> decimal:
         """
 @external
 def foo():
-    x: bytes[10] = slice(b"cow", -1, block.timestamp)
+    x: Bytes[10] = slice(b"cow", -1, block.timestamp)
     """,
         InvalidType,
     ),
@@ -69,7 +69,7 @@ def add_record():
     """,
     """
 @external
-def foo(inp: bytes[10]) -> bytes[3]:
+def foo(inp: Bytes[10]) -> Bytes[3]:
     return slice(inp, block.timestamp, 6)
     """,
     (
@@ -132,7 +132,7 @@ def add_record():
 def foo():
     x: uint256 = block.difficulty + 185
     if tx.origin == self:
-        y: bytes[35] = concat(block.prevhash, b"dog")
+        y: Bytes[35] = concat(block.prevhash, b"dog")
     """,
 ]
 

--- a/tests/parser/syntax/test_byte_string.py
+++ b/tests/parser/syntax/test_byte_string.py
@@ -5,17 +5,17 @@ from vyper import compiler
 valid_list = [
     """
 @external
-def foo() -> string[10]:
+def foo() -> String[10]:
     return "badminton"
     """,
     """
 @external
 def foo():
-    x: string[11] = "¡très bien!"
+    x: String[11] = "¡très bien!"
     """,
     """
 @external
-def test() -> string[100]:
+def test() -> String[100]:
     return "hello world!"
     """,
 ]

--- a/tests/parser/syntax/test_bytes.py
+++ b/tests/parser/syntax/test_bytes.py
@@ -13,53 +13,53 @@ fail_list = [
         """
 @external
 def baa():
-    x: bytes[50] = b""
-    y: bytes[50] = b""
-    z: bytes[50] = x + y
+    x: Bytes[50] = b""
+    y: Bytes[50] = b""
+    z: Bytes[50] = x + y
     """,
         InvalidOperation,
     ),
     """
 @external
 def baa():
-    x: bytes[50] = b""
+    x: Bytes[50] = b""
     y: int128 = 0
     y = x
     """,
     """
 @external
 def baa():
-    x: bytes[50] = b""
+    x: Bytes[50] = b""
     y: int128 = 0
     x = y
     """,
     """
 @external
 def baa():
-    x: bytes[50] = b""
-    y: bytes[60] = b""
+    x: Bytes[50] = b""
+    y: Bytes[60] = b""
     x = y
     """,
     """
 @external
-def foo(x: bytes[100]) -> bytes[75]:
+def foo(x: Bytes[100]) -> Bytes[75]:
     return x
     """,
     """
 @external
-def foo(x: bytes[100]) -> int128:
+def foo(x: Bytes[100]) -> int128:
     return x
     """,
     """
 @external
-def foo(x: int128) -> bytes[75]:
+def foo(x: int128) -> Bytes[75]:
     return x
     """,
     (
         """
 @external
-def foo() -> bytes[10]:
-    x: bytes[10] = '0x1234567890123456789012345678901234567890'
+def foo() -> Bytes[10]:
+    x: Bytes[10] = '0x1234567890123456789012345678901234567890'
     x = 0x1234567890123456789012345678901234567890
     return x
     """,
@@ -68,7 +68,7 @@ def foo() -> bytes[10]:
     (
         """
 @external
-def foo() -> bytes[10]:
+def foo() -> Bytes[10]:
     return "badmintonzz"
     """,
         InvalidType,
@@ -76,8 +76,8 @@ def foo() -> bytes[10]:
     (
         """
 @external
-def test() -> bytes[1]:
-    a: bytes[1] = 0b0000001  # needs multiple of 8 bits.
+def test() -> Bytes[1]:
+    a: Bytes[1] = 0b0000001  # needs multiple of 8 bits.
     return a
     """,
         SyntaxException,
@@ -98,18 +98,18 @@ def test_bytes_fail(bad_code):
 valid_list = [
     """
 @external
-def foo(x: bytes[100]) -> bytes[100]:
+def foo(x: Bytes[100]) -> Bytes[100]:
     return x
     """,
     """
 @external
-def foo(x: bytes[100]) -> bytes[150]:
+def foo(x: Bytes[100]) -> Bytes[150]:
     return x
     """,
     """
 @external
 def baa():
-    x: bytes[50] = b""
+    x: Bytes[50] = b""
     """,
 ]
 

--- a/tests/parser/syntax/test_chainid.py
+++ b/tests/parser/syntax/test_chainid.py
@@ -59,7 +59,7 @@ def add_record():
     (
         """
 @external
-def foo(inp: bytes[10]) -> bytes[3]:
+def foo(inp: Bytes[10]) -> Bytes[3]:
     return slice(inp, chain.id, -3)
     """,
         InvalidType,

--- a/tests/parser/syntax/test_concat.py
+++ b/tests/parser/syntax/test_concat.py
@@ -7,7 +7,7 @@ fail_list = [
     (
         """
 @external
-def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
+def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
     return concat(i1, i2, i1, i1)
     """,
         TypeMismatch,
@@ -15,7 +15,7 @@ def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
     (
         """
 @external
-def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
+def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
     return concat(i1, 5)
     """,
         InvalidType,
@@ -23,18 +23,18 @@ def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
     (
         """
 @external
-def sandwich(inp: bytes[100], inp2: bytes32) -> bytes[163]:
+def sandwich(inp: Bytes[100], inp2: bytes32) -> Bytes[163]:
     return concat(inp2, inp, inp2)
     """,
         TypeMismatch,
     ),
     (
         """
-y: bytes[10]
+y: Bytes[10]
 
 @external
-def krazykonkat(z: bytes[10]) -> bytes[24]:
-    x: bytes[10] = b"cow"
+def krazykonkat(z: Bytes[10]) -> Bytes[24]:
+    x: Bytes[10] = b"cow"
     self.y = b"horse"
     return concat(x, b" ", self.y, b" ", z)
     """,
@@ -43,7 +43,7 @@ def krazykonkat(z: bytes[10]) -> bytes[24]:
     (
         """
 @external
-def cat_list(y: int128) -> bytes[40]:
+def cat_list(y: int128) -> Bytes[40]:
     x: int128[1] = [y]
     return concat("test", y)
     """,
@@ -62,30 +62,30 @@ def test_block_fail(bad_code, exc):
 valid_list = [
     """
 @external
-def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
+def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
     return concat(i1, i2)
     """,
     """
 @external
-def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
+def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
     return concat(i1, i1, i1, i1)
     """,
     """
 @external
-def cat(i1: bytes[10], i2: bytes[30]) -> bytes[40]:
+def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
     return concat(i1, i1)
     """,
     """
 @external
-def sandwich(inp: bytes[100], inp2: bytes32) -> bytes[165]:
+def sandwich(inp: Bytes[100], inp2: bytes32) -> Bytes[165]:
     return concat(inp2, inp, inp2)
     """,
     """
-y: bytes[10]
+y: Bytes[10]
 
 @external
-def krazykonkat(z: bytes[10]) -> bytes[25]:
-    x: bytes[3] = b"cow"
+def krazykonkat(z: Bytes[10]) -> Bytes[25]:
+    x: Bytes[3] = b"cow"
     self.y = b"horse"
     return concat(x, b" ", self.y, b" ", z)
     """,

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -58,14 +58,14 @@ VAL: constant(uint256) = 11
     # bytearray too long.
     (
         """
-VAL: constant(bytes[4]) = b"testtest"
+VAL: constant(Bytes[4]) = b"testtest"
     """,
         InvalidType,
     ),
     # global with same name
     (
         """
-VAL: constant(bytes[4]) = b"t"
+VAL: constant(Bytes[4]) = b"t"
 VAL: uint256
     """,
         VariableDeclarationException,
@@ -73,7 +73,7 @@ VAL: uint256
     # signature variable with same name
     (
         """
-VAL: constant(bytes[4]) = b"t"
+VAL: constant(Bytes[4]) = b"t"
 
 @external
 def test(VAL: uint256):
@@ -142,13 +142,13 @@ TEST_WEI: constant(uint256) = 1
 
 @internal
 def test():
-   foo: bytes[1] = raw_call(
+   foo: Bytes[1] = raw_call(
        0x0000000000000000000000000000000000000005, b'hello', max_outsize=TEST_C, gas=2000
     )
 
 @internal
 def test1():
-    foo: bytes[256] = raw_call(
+    foo: Bytes[256] = raw_call(
         0x0000000000000000000000000000000000000005, b'hello', max_outsize=256, gas=TEST_WEI
     )
     """,
@@ -173,7 +173,7 @@ MAX_DEPOSIT: constant(decimal) = 32.0  # ETH
 
 @payable
 @external
-def deposit(deposit_input: bytes[2048]):
+def deposit(deposit_input: Bytes[2048]):
     assert msg.value >= as_wei_value(MIN_DEPOSIT, "ether")
     assert msg.value <= as_wei_value(MAX_DEPOSIT, "ether")
     """,

--- a/tests/parser/syntax/test_extract32.py
+++ b/tests/parser/syntax/test_extract32.py
@@ -31,14 +31,14 @@ def foo() -> uint256:
     )
     """,
     """
-x: bytes[100]
+x: Bytes[100]
 @external
 def foo() -> uint256:
     self.x = b"cowcowcowcowcowccowcowcowcowcowccowcowcowcowcowccowcowcowcowcowc"
     return extract32(self.x, 0, output_type=uint256)
     """,
     """
-x: bytes[100]
+x: Bytes[100]
 @external
 def foo() -> uint256:
     self.x = b"cowcowcowcowcowccowcowcowcowcowccowcowcowcowcowccowcowcowcowcowc"

--- a/tests/parser/syntax/test_len.py
+++ b/tests/parser/syntax/test_len.py
@@ -7,7 +7,7 @@ from vyper.exceptions import TypeMismatch
 fail_list = [
     """
 @external
-def foo(inp: bytes[4]) -> int128:
+def foo(inp: Bytes[4]) -> int128:
     return len(inp)
     """,
     """
@@ -32,12 +32,12 @@ def test_block_fail(bad_code):
 valid_list = [
     """
 @external
-def foo(inp: bytes[10]) -> uint256:
+def foo(inp: Bytes[10]) -> uint256:
     return len(inp)
     """,
     """
 @external
-def foo(inp: string[10]) -> uint256:
+def foo(inp: String[10]) -> uint256:
     return len(inp)
     """,
 ]

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -8,7 +8,7 @@ fail_list = [
         """
 @external
 def foo():
-    x: bytes[9] = raw_call(
+    x: Bytes[9] = raw_call(
         0x1234567890123456789012345678901234567890, b"cow", max_outsize=4, max_outsize=9
     )
     """,
@@ -32,7 +32,7 @@ def foo():
 @external
 def foo():
     # fails because raw_call without max_outsize does not return a value
-    x: bytes[9] = raw_call(0x1234567890123456789012345678901234567890, b"cow")
+    x: Bytes[9] = raw_call(0x1234567890123456789012345678901234567890, b"cow")
     """,
         InvalidType,
     ),
@@ -54,7 +54,7 @@ valid_list = [
     """
 @external
 def foo():
-    x: bytes[9] = raw_call(
+    x: Bytes[9] = raw_call(
         0x1234567890123456789012345678901234567890,
         b"cow",
         max_outsize=4,
@@ -64,7 +64,7 @@ def foo():
     """
 @external
 def foo():
-    x: bytes[9] = raw_call(
+    x: Bytes[9] = raw_call(
         0x1234567890123456789012345678901234567890,
         b"cow",
         max_outsize=4,
@@ -75,7 +75,7 @@ def foo():
     """
 @external
 def foo():
-    x: bytes[9] = raw_call(
+    x: Bytes[9] = raw_call(
         0x1234567890123456789012345678901234567890,
         b"cow",
         max_outsize=4,

--- a/tests/parser/syntax/test_return_tuple.py
+++ b/tests/parser/syntax/test_return_tuple.py
@@ -6,7 +6,7 @@ from vyper.exceptions import FunctionDeclarationException
 fail_list = [
     """
 @external
-def unmatched_tupl_length() -> (bytes[8], int128, bytes[8]):
+def unmatched_tupl_length() -> (Bytes[8], int128, Bytes[8]):
     return "test", 123
     """
 ]

--- a/tests/parser/syntax/test_slice.py
+++ b/tests/parser/syntax/test_slice.py
@@ -7,7 +7,7 @@ fail_list = [
     (
         """
 @external
-def foo(inp: bytes[10]) -> bytes[2]:
+def foo(inp: Bytes[10]) -> Bytes[2]:
     return slice(inp, 2, 3)
     """,
         TypeMismatch,
@@ -15,7 +15,7 @@ def foo(inp: bytes[10]) -> bytes[2]:
     (
         """
 @external
-def foo(inp: int128) -> bytes[3]:
+def foo(inp: int128) -> Bytes[3]:
     return slice(inp, 2, 3)
     """,
         TypeMismatch,
@@ -23,7 +23,7 @@ def foo(inp: int128) -> bytes[3]:
     (
         """
 @external
-def foo(inp: bytes[10]) -> bytes[3]:
+def foo(inp: Bytes[10]) -> Bytes[3]:
     return slice(inp, 4.0, 3)
     """,
         InvalidType,
@@ -41,17 +41,17 @@ def test_slice_fail(bad_code, exc):
 valid_list = [
     """
 @external
-def foo(inp: bytes[10]) -> bytes[3]:
+def foo(inp: Bytes[10]) -> Bytes[3]:
     return slice(inp, 2, 3)
     """,
     """
 @external
-def foo(inp: bytes[10]) -> bytes[4]:
+def foo(inp: Bytes[10]) -> Bytes[4]:
     return slice(inp, 2, 3)
     """,
     """
 @external
-def foo() -> bytes[10]:
+def foo() -> Bytes[10]:
     return slice(b"badmintonzzz", 1, 10)
     """,
 ]

--- a/tests/parser/syntax/test_string.py
+++ b/tests/parser/syntax/test_string.py
@@ -5,26 +5,26 @@ from vyper import compiler
 valid_list = [
     """
 @external
-def foo() -> string[10]:
+def foo() -> String[10]:
     return "badminton"
     """,
     """
 @external
 def foo():
-    x: string[11] = "¡très bien!"
+    x: String[11] = "¡très bien!"
     """,
     """
 @external
 def foo() -> bool:
-    x: string[15] = "¡très bien!"
-    y: string[15] = "test"
+    x: String[15] = "¡très bien!"
+    y: String[15] = "test"
     return x != y
     """,
     """
 @external
 def foo() -> bool:
-    x: string[15] = "¡très bien!"
-    y: string[12] = "test"
+    x: String[15] = "¡très bien!"
+    y: String[12] = "test"
     return x != y
     """,
 ]

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -23,11 +23,11 @@ def test():
     ),
     """
 @internal
-def out_literals() -> (int128, int128, bytes[10]):
+def out_literals() -> (int128, int128, Bytes[10]):
     return 1, 2, b"3333"
 
 @external
-def test() -> (int128, address, bytes[10]):
+def test() -> (int128, address, Bytes[10]):
     a: int128 = 0
     b: int128 = 0
     a, b, b = self.out_literals()  # incorrect bytes type
@@ -35,11 +35,11 @@ def test() -> (int128, address, bytes[10]):
     """,
     """
 @internal
-def out_literals() -> (int128, int128, bytes[10]):
+def out_literals() -> (int128, int128, Bytes[10]):
     return 1, 2, b"3333"
 
 @external
-def test() -> (int128, address, bytes[10]):
+def test() -> (int128, address, Bytes[10]):
     a: int128 = 0
     b: address = ZERO_ADDRESS
     a, b = self.out_literals()  # tuple count mismatch
@@ -51,23 +51,23 @@ def out_literals() -> (int128, int128, int128):
     return 1, 2, 3
 
 @external
-def test() -> (int128, int128, bytes[10]):
+def test() -> (int128, int128, Bytes[10]):
     a: int128 = 0
     b: int128 = 0
-    c: bytes[10] = b""
+    c: Bytes[10] = b""
     a, b, c = self.out_literals()
     return a, b, c
     """,
     """
 @internal
-def out_literals() -> (int128, int128, bytes[100]):
+def out_literals() -> (int128, int128, Bytes[100]):
     return 1, 2, b"test"
 
 @external
 def test():
     a: int128 = 0
     b: int128 = 0
-    c: bytes[1] = b""
+    c: Bytes[1] = b""
     a, b, c = self.out_literals()
     """,
     (

--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -151,11 +151,11 @@ def is_owner() -> bool:
 def test_constant_bytes(get_contract):
     test_str = b"Alabama, Arkansas. I do love my ma and pa"
     code = f"""
-X: constant(bytes[100]) = b"{test_str.decode()}"
+X: constant(Bytes[100]) = b"{test_str.decode()}"
 
 @external
-def test() -> bytes[100]:
-    y: bytes[100] = X
+def test() -> Bytes[100]:
+    y: Bytes[100] = X
 
     return y
     """

--- a/tests/parser/types/numbers/test_sqrt.py
+++ b/tests/parser/types/numbers/test_sqrt.py
@@ -83,12 +83,12 @@ def test2() -> decimal:
 def test_sqrt_inline_memory_correct(get_contract_with_gas_estimation):
     code = """
 @external
-def test(a: decimal) -> (decimal, decimal, decimal, decimal, decimal, string[100]):
+def test(a: decimal) -> (decimal, decimal, decimal, decimal, decimal, String[100]):
     x: decimal = 1.0
     y: decimal = 2.0
     z: decimal = 3.0
     e: decimal = sqrt(a)
-    f: string[100] = 'hello world'
+    f: String[100] = 'hello world'
     return a, x, y, z, e, f
     """
 

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -4,7 +4,7 @@ from vyper.exceptions import TypeMismatch
 def test_test_bytes(get_contract_with_gas_estimation, assert_tx_failed):
     test_bytes = """
 @external
-def foo(x: bytes[100]) -> bytes[100]:
+def foo(x: Bytes[100]) -> Bytes[100]:
     return x
     """
 
@@ -27,8 +27,8 @@ def foo(x: bytes[100]) -> bytes[100]:
 def test_test_bytes2(get_contract_with_gas_estimation):
     test_bytes2 = """
 @external
-def foo(x: bytes[100]) -> bytes[100]:
-    y: bytes[100] = x
+def foo(x: Bytes[100]) -> Bytes[100]:
+    y: Bytes[100] = x
     return y
     """
 
@@ -45,7 +45,7 @@ def foo(x: bytes[100]) -> bytes[100]:
 def test_test_bytes3(get_contract_with_gas_estimation):
     test_bytes3 = """
 x: int128
-maa: bytes[60]
+maa: Bytes[60]
 y: int128
 
 @external
@@ -54,21 +54,21 @@ def __init__():
     self.y = 37
 
 @external
-def set_maa(inp: bytes[60]):
+def set_maa(inp: Bytes[60]):
     self.maa = inp
 
 @external
-def set_maa2(inp: bytes[60]):
-    ay: bytes[60] = inp
+def set_maa2(inp: Bytes[60]):
+    ay: Bytes[60] = inp
     self.maa = ay
 
 @external
-def get_maa() -> bytes[60]:
+def get_maa() -> Bytes[60]:
     return self.maa
 
 @external
-def get_maa2() -> bytes[60]:
-    ay: bytes[60] = self.maa
+def get_maa2() -> Bytes[60]:
+    ay: Bytes[60] = self.maa
     return ay
 
 @external
@@ -95,16 +95,16 @@ def get_xy() -> int128:
 
 def test_test_bytes4(get_contract_with_gas_estimation):
     test_bytes4 = """
-a: bytes[60]
+a: Bytes[60]
 @external
-def foo(inp: bytes[60]) -> bytes[60]:
+def foo(inp: Bytes[60]) -> Bytes[60]:
     self.a = inp
     self.a = b""
     return self.a
 
 @external
-def bar(inp: bytes[60]) -> bytes[60]:
-    b: bytes[60] = inp
+def bar(inp: Bytes[60]) -> Bytes[60]:
+    b: Bytes[60] = inp
     b = b""
     return b
     """
@@ -119,38 +119,38 @@ def bar(inp: bytes[60]) -> bytes[60]:
 def test_test_bytes5(get_contract_with_gas_estimation):
     test_bytes5 = """
 struct G:
-    a: bytes[50]
-    b: bytes[50]
+    a: Bytes[50]
+    b: Bytes[50]
 struct H:
-    a: bytes[40]
-    b: bytes[45]
+    a: Bytes[40]
+    b: Bytes[45]
 
 g: G
 
 @external
-def foo(inp1: bytes[40], inp2: bytes[45]):
+def foo(inp1: Bytes[40], inp2: Bytes[45]):
     self.g = G({a: inp1, b: inp2})
 
 @external
-def check1() -> bytes[50]:
+def check1() -> Bytes[50]:
     return self.g.a
 
 @external
-def check2() -> bytes[50]:
+def check2() -> Bytes[50]:
     return self.g.b
 
 @external
-def bar(inp1: bytes[40], inp2: bytes[45]) -> bytes[50]:
+def bar(inp1: Bytes[40], inp2: Bytes[45]) -> Bytes[50]:
     h: H = H({a: inp1, b: inp2})
     return h.a
 
 @external
-def bat(inp1: bytes[40], inp2: bytes[45]) -> bytes[50]:
+def bat(inp1: Bytes[40], inp2: Bytes[45]) -> Bytes[50]:
     h: H = H({a: inp1, b: inp2})
     return h.b
 
 @external
-def quz(inp1: bytes[40], inp2: bytes[45]):
+def quz(inp1: Bytes[40], inp2: Bytes[45]):
     h:  H = H({a: inp1, b: inp2})
     self.g.a = h.a
     self.g.b = h.b
@@ -171,22 +171,22 @@ def quz(inp1: bytes[40], inp2: bytes[45]):
 
 def test_binary_literal(get_contract_with_gas_estimation):
     bytes_to_num_code = """
-r: bytes[1]
+r: Bytes[1]
 
 @external
-def get(a: bytes[1]) -> bytes[2]:
+def get(a: Bytes[1]) -> Bytes[2]:
     return concat(a, 0b00000001)
 
 @external
-def getsome() -> bytes[1]:
+def getsome() -> Bytes[1]:
     return 0b00001110
 
 @external
-def testsome(a: bytes[1]) -> bool:
+def testsome(a: Bytes[1]) -> bool:
     return a == 0b01100001
 
 @external
-def testsome_storage(y: bytes[1]) -> bool:
+def testsome_storage(y: Bytes[1]) -> bool:
     self.r = 0b01100001
     return self.r == y
     """
@@ -205,13 +205,13 @@ def testsome_storage(y: bytes[1]) -> bool:
 def test_bytes_comparison(get_contract_with_gas_estimation):
     code = """
 @external
-def get_mismatch(a: bytes[1]) -> bool:
-    b: bytes[2] = b'ab'
+def get_mismatch(a: Bytes[1]) -> bool:
+    b: Bytes[2] = b'ab'
     return a == b
 
 @external
-def get_large(a: bytes[100]) -> bool:
-    b: bytes[100] = b'ab'
+def get_large(a: Bytes[100]) -> bool:
+    b: Bytes[100] = b'ab'
     return a == b
     """
 
@@ -242,7 +242,7 @@ counter: uint256
 
 @internal
 @view
-def to_little_endian_64(_value: uint256) -> bytes[8]:
+def to_little_endian_64(_value: uint256) -> Bytes[8]:
     y: uint256 = 0
     x: uint256 = _value
     for _ in range(8):
@@ -257,7 +257,7 @@ def set_count(i: uint256):
 
 @external
 @view
-def get_count() -> bytes[24]:
+def get_count() -> Bytes[24]:
     return self.to_little_endian_64(self.counter)
     """
 
@@ -276,7 +276,7 @@ def test_bytes_to_bytes32_assigment(get_contract, assert_compile_failed):
     code = """
 @external
 def assign():
-    xs: bytes[32] = b'abcdef'
+    xs: Bytes[32] = b'abcdef'
     y: bytes32 = xs
     """
     assert_compile_failed(lambda: get_contract(code), TypeMismatch)

--- a/tests/parser/types/test_bytes_literal.py
+++ b/tests/parser/types/test_bytes_literal.py
@@ -1,27 +1,27 @@
 def test_bytes_literal_code(get_contract_with_gas_estimation):
     bytes_literal_code = """
 @external
-def foo() -> bytes[5]:
+def foo() -> Bytes[5]:
     return b"horse"
 
 @external
-def bar() -> bytes[10]:
+def bar() -> Bytes[10]:
     return concat(b"b", b"a", b"d", b"m", b"i", b"", b"nton")
 
 @external
-def baz() -> bytes[40]:
+def baz() -> Bytes[40]:
     return concat(b"0123456789012345678901234567890", b"12")
 
 @external
-def baz2() -> bytes[40]:
+def baz2() -> Bytes[40]:
     return concat(b"01234567890123456789012345678901", b"12")
 
 @external
-def baz3() -> bytes[40]:
+def baz3() -> Bytes[40]:
     return concat(b"0123456789012345678901234567890", b"1")
 
 @external
-def baz4() -> bytes[100]:
+def baz4() -> Bytes[100]:
     return concat(b"01234567890123456789012345678901234567890123456789",
                   b"01234567890123456789012345678901234567890123456789")
     """
@@ -40,29 +40,29 @@ def baz4() -> bytes[100]:
 def test_bytes_literal_splicing_fuzz(get_contract_with_gas_estimation):
     for i in range(95, 96, 97):
         kode = f"""
-moo: bytes[100]
+moo: Bytes[100]
 
 @external
-def foo(s: uint256, L: uint256) -> bytes[100]:
+def foo(s: uint256, L: uint256) -> Bytes[100]:
         x: int128 = 27
-        r: bytes[100] = slice(b"{("c" * i)}", s, L)
+        r: Bytes[100] = slice(b"{("c" * i)}", s, L)
         y: int128 = 37
         if x * y == 999:
             return r
         return b"3434346667777"
 
 @external
-def bar(s: uint256, L: uint256) -> bytes[100]:
+def bar(s: uint256, L: uint256) -> Bytes[100]:
         self.moo = b"{("c" * i)}"
         x: int128 = 27
-        r: bytes[100] = slice(self.moo, s, L)
+        r: Bytes[100] = slice(self.moo, s, L)
         y: int128  = 37
         if x * y == 999:
             return r
         return b"3434346667777"
 
 @external
-def baz(s: uint256, L: uint256) -> bytes[100]:
+def baz(s: uint256, L: uint256) -> Bytes[100]:
         x: int128 = 27
         self.moo = slice(b"{("c" * i)}", s, L)
         y: int128 = 37

--- a/tests/parser/types/test_bytes_zero_padding.py
+++ b/tests/parser/types/test_bytes_zero_padding.py
@@ -7,7 +7,7 @@ def little_endian_contract(get_contract_module):
     code = """
 @internal
 @view
-def to_little_endian_64(_value: uint256) -> bytes[8]:
+def to_little_endian_64(_value: uint256) -> Bytes[8]:
     y: uint256 = 0
     x: uint256 = _value
     for _ in range(8):
@@ -18,7 +18,7 @@ def to_little_endian_64(_value: uint256) -> bytes[8]:
 
 @external
 @view
-def get_count(counter: uint256) -> bytes[24]:
+def get_count(counter: uint256) -> Bytes[24]:
     return self.to_little_endian_64(counter)
     """
     c = get_contract_module(code)

--- a/tests/parser/types/test_string.py
+++ b/tests/parser/types/test_string.py
@@ -1,12 +1,12 @@
 def test_string_return(get_contract_with_gas_estimation):
     code = """
 @external
-def testb() -> string[100]:
-    a: string[100] = "test return"
+def testb() -> String[100]:
+    a: String[100] = "test return"
     return a
 
 @external
-def testa(inp: string[100]) -> string[100]:
+def testa(inp: String[100]) -> String[100]:
     return inp
     """
 
@@ -19,14 +19,14 @@ def testa(inp: string[100]) -> string[100]:
 def test_string_concat(get_contract_with_gas_estimation):
     code = """
 @external
-def testb(inp: string[10]) -> string[128]:
-    a: string[100] = "return message:"
-    b: string[128] = concat(a, " ", inp)
+def testb(inp: String[10]) -> String[128]:
+    a: String[100] = "return message:"
+    b: String[128] = concat(a, " ", inp)
     return b
 
 @external
-def testa(inp: string[10]) -> string[160]:
-    a: string[100] = "<-- return message"
+def testa(inp: String[10]) -> String[160]:
+    a: String[100] = "<-- return message"
     return concat("Funny ", inp, " ", inp, a)
     """
 
@@ -38,14 +38,14 @@ def testa(inp: string[10]) -> string[160]:
 
 def test_basic_long_string_as_keys(get_contract, w3):
     code = """
-mapped_string: HashMap[string[34], int128]
+mapped_string: HashMap[String[34], int128]
 
 @external
-def set(k: string[34], v: int128):
+def set(k: String[34], v: int128):
     self.mapped_string[k] = v
 
 @external
-def get(k: string[34]) -> int128:
+def get(k: String[34]) -> int128:
     return self.mapped_string[k]
     """
 
@@ -59,7 +59,7 @@ def get(k: string[34]) -> int128:
 def test_string_slice(get_contract_with_gas_estimation, assert_tx_failed):
     test_slice4 = """
 @external
-def foo(inp: string[10], start: uint256, _len: uint256) -> string[10]:
+def foo(inp: String[10], start: uint256, _len: uint256) -> String[10]:
     return slice(inp, start, _len)
     """
 
@@ -79,19 +79,19 @@ def foo(inp: string[10], start: uint256, _len: uint256) -> string[10]:
 
 def test_private_string(get_contract_with_gas_estimation):
     private_test_code = """
-greeting: public(string[100])
+greeting: public(String[100])
 
 @external
 def __init__():
     self.greeting = "Hello "
 
 @internal
-def construct(greet: string[100]) -> string[200]:
+def construct(greet: String[100]) -> String[200]:
     return concat(self.greeting, greet)
 
 @external
-def hithere(name: string[100]) -> string[200]:
-    d: string[200] = self.construct(name)
+def hithere(name: String[100]) -> String[200]:
+    d: String[200] = self.construct(name)
     return d
     """
 
@@ -104,7 +104,7 @@ def test_logging_extended_string(get_contract_with_gas_estimation, get_logs):
     code = """
 event MyLog:
     arg1: int128
-    arg2: string[64]
+    arg2: String[64]
     arg3: int128
 
 @external
@@ -123,19 +123,19 @@ def foo():
 def test_tuple_return_external_contract_call_string(get_contract_with_gas_estimation):
     contract_1 = """
 @external
-def out_literals() -> (int128, address, string[10]):
+def out_literals() -> (int128, address, String[10]):
     return 1, 0x0000000000000000000000000000000000000123, "random"
     """
 
     contract_2 = """
 interface Test:
-    def out_literals() -> (int128, address, string[10]) : view
+    def out_literals() -> (int128, address, String[10]) : view
 
 @external
-def test(addr: address) -> (int128, address, string[10]):
+def test(addr: address) -> (int128, address, String[10]):
     a: int128 = 0
     b: address = ZERO_ADDRESS
-    c: string[10] = ""
+    c: String[10] = ""
     (a, b, c) = Test(addr).out_literals()
     return a, b,c
     """
@@ -150,10 +150,10 @@ def test_default_arg_string(get_contract_with_gas_estimation):
 
     code = """
 @external
-def test(a: uint256, b: string[50] = "foo") -> bytes[100]:
+def test(a: uint256, b: String[50] = "foo") -> Bytes[100]:
     return concat(
         convert(a, bytes32),
-        convert(b, bytes[50])
+        convert(b, Bytes[50])
     )
     """
 
@@ -165,31 +165,31 @@ def test(a: uint256, b: string[50] = "foo") -> bytes[100]:
 
 def test_string_equality(get_contract_with_gas_estimation):
     code = """
-_compA: string[100]
-_compB: string[100]
+_compA: String[100]
+_compB: String[100]
 
 @external
 def equal_true() -> bool:
-    compA: string[100] = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy dog"
+    compA: String[100] = "The quick brown fox jumps over the lazy dog"
+    compB: String[100] = "The quick brown fox jumps over the lazy dog"
     return compA == compB
 
 @external
 def equal_false() -> bool:
-    compA: string[100] = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy hog"
+    compA: String[100] = "The quick brown fox jumps over the lazy dog"
+    compB: String[100] = "The quick brown fox jumps over the lazy hog"
     return compA == compB
 
 @external
 def not_equal_true() -> bool:
-    compA: string[100] = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy hog"
+    compA: String[100] = "The quick brown fox jumps over the lazy dog"
+    compB: String[100] = "The quick brown fox jumps over the lazy hog"
     return compA != compB
 
 @external
 def not_equal_false() -> bool:
-    compA: string[100] = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy dog"
+    compA: String[100] = "The quick brown fox jumps over the lazy dog"
+    compB: String[100] = "The quick brown fox jumps over the lazy dog"
     return compA != compB
 
 @external
@@ -237,45 +237,45 @@ def storage_not_equal_false() -> bool:
     return self._compA != self._compB
 
 @external
-def string_compare_equal(str1: string[100], str2: string[100]) -> bool:
+def string_compare_equal(str1: String[100], str2: String[100]) -> bool:
     return str1 == str2
 
 @external
-def string_compare_not_equal(str1: string[100], str2: string[100]) -> bool:
+def string_compare_not_equal(str1: String[100], str2: String[100]) -> bool:
     return str1 != str2
 
 @external
-def compare_passed_storage_equal(str: string[100]) -> bool:
+def compare_passed_storage_equal(str: String[100]) -> bool:
     self._compA = "The quick brown fox jumps over the lazy dog"
     return self._compA == str
 
 @external
-def compare_passed_storage_not_equal(str: string[100]) -> bool:
+def compare_passed_storage_not_equal(str: String[100]) -> bool:
     self._compA = "The quick brown fox jumps over the lazy dog"
     return self._compA != str
 
 @external
 def compare_var_storage_equal_true() -> bool:
     self._compA = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy dog"
+    compB: String[100] = "The quick brown fox jumps over the lazy dog"
     return self._compA == compB
 
 @external
 def compare_var_storage_equal_false() -> bool:
     self._compA = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy hog"
+    compB: String[100] = "The quick brown fox jumps over the lazy hog"
     return self._compA == compB
 
 @external
 def compare_var_storage_not_equal_true() -> bool:
     self._compA = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy hog"
+    compB: String[100] = "The quick brown fox jumps over the lazy hog"
     return self._compA != compB
 
 @external
 def compare_var_storage_not_equal_false() -> bool:
     self._compA = "The quick brown fox jumps over the lazy dog"
-    compB: string[100] = "The quick brown fox jumps over the lazy dog"
+    compB: String[100] = "The quick brown fox jumps over the lazy dog"
     return self._compA != compB
     """
 

--- a/tests/parser/types/test_string_literal.py
+++ b/tests/parser/types/test_string_literal.py
@@ -1,12 +1,12 @@
 def test_string_literal_return(get_contract_with_gas_estimation):
     code = """
 @external
-def test() -> string[100]:
+def test() -> String[100]:
     return "hello world!"
 
 
 @external
-def testb() -> bytes[100]:
+def testb() -> Bytes[100]:
     return b"hello world!"
     """
 
@@ -19,12 +19,12 @@ def testb() -> bytes[100]:
 def test_string_convert(get_contract_with_gas_estimation):
     code = """
 @external
-def testb() -> string[100]:
-    return convert(b"hello world!", string[100])
+def testb() -> String[100]:
+    return convert(b"hello world!", String[100])
 
 @external
-def testbb() -> string[100]:
-    return convert(convert("hello world!", bytes[100]), string[100])
+def testbb() -> String[100]:
+    return convert(convert("hello world!", Bytes[100]), String[100])
     """
 
     c = get_contract_with_gas_estimation(code)
@@ -36,8 +36,8 @@ def testbb() -> string[100]:
 def test_str_assign(get_contract_with_gas_estimation):
     code = """
 @external
-def test() -> string[100]:
-    a: string[100] = "baba black sheep"
+def test() -> String[100]:
+    a: String[100] = "baba black sheep"
     return a
     """
 

--- a/vyper/context/types/utils.py
+++ b/vyper/context/types/utils.py
@@ -91,7 +91,8 @@ def get_type_from_abi(
     type_string = abi_type["type"]
     if type_string == "fixed168x10":
         type_string = "decimal"
-    # TODO string and bytes
+    if type_string in ("string", "bytes"):
+        type_string = type_string.capitalize()
 
     namespace = get_namespace()
 

--- a/vyper/context/types/value/array_value.py
+++ b/vyper/context/types/value/array_value.py
@@ -139,20 +139,20 @@ class _ArrayValuePrimitive(BasePrimitive):
 
 
 class BytesArrayDefinition(BytesAbstractType, ArrayValueAbstractType, _ArrayValueDefinition):
-    _id = "bytes"
+    _id = "Bytes"
 
 
 class StringDefinition(ArrayValueAbstractType, _ArrayValueDefinition):
-    _id = "string"
+    _id = "String"
 
 
 class BytesArrayPrimitive(_ArrayValuePrimitive):
-    _id = "bytes"
+    _id = "Bytes"
     _type = BytesArrayDefinition
     _valid_literal = (vy_ast.Bytes, vy_ast.Hex)
 
 
 class StringPrimitive(_ArrayValuePrimitive):
-    _id = "string"
+    _id = "String"
     _type = StringDefinition
     _valid_literal = (vy_ast.Str,)

--- a/vyper/functions/convert.py
+++ b/vyper/functions/convert.py
@@ -10,12 +10,13 @@ from vyper.types import BaseType, ByteArrayType, StringType, get_type
 from vyper.utils import DECIMAL_DIVISOR, MemoryPositions, SizeLimits
 
 
-@signature(("decimal", "int128", "uint256", "address", "bytes32", "bytes"), "*")
+@signature(("decimal", "int128", "uint256", "address", "bytes32", "Bytes"), "*")
 def to_bool(expr, args, kwargs, context):
     in_arg = args[0]
     input_type, _ = get_type(in_arg)
+    print(input_type)
 
-    if input_type == "bytes":
+    if input_type == "Bytes":
         if in_arg.typ.maxlen > 32:
             raise TypeMismatch(
                 f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to bool", expr,
@@ -33,7 +34,7 @@ def to_bool(expr, args, kwargs, context):
 
 
 @signature(
-    ("num_literal", "bool", "decimal", "uint256", "address", "bytes32", "bytes", "string"), "*"
+    ("num_literal", "bool", "decimal", "uint256", "address", "bytes32", "Bytes", "String"), "*"
 )
 def to_int128(expr, args, kwargs, context):
     in_arg = args[0]
@@ -76,7 +77,7 @@ def to_int128(expr, args, kwargs, context):
             pos=getpos(expr),
         )
 
-    elif input_type in ("string", "bytes"):
+    elif input_type in ("String", "Bytes"):
         if in_arg.typ.maxlen > 32:
             raise TypeMismatch(
                 f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to int128", expr,
@@ -116,7 +117,7 @@ def to_int128(expr, args, kwargs, context):
         raise InvalidLiteral(f"Invalid input for int128: {in_arg}", expr)
 
 
-@signature(("num_literal", "int128", "bytes32", "bytes", "address", "bool", "decimal"), "*")
+@signature(("num_literal", "int128", "bytes32", "Bytes", "address", "bool", "decimal"), "*")
 def to_uint256(expr, args, kwargs, context):
     in_arg = args[0]
     input_type, _ = get_type(in_arg)
@@ -151,7 +152,7 @@ def to_uint256(expr, args, kwargs, context):
             value=in_arg.value, args=in_arg.args, typ=BaseType("uint256"), pos=getpos(expr)
         )
 
-    elif isinstance(in_arg, LLLnode) and input_type == "bytes":
+    elif isinstance(in_arg, LLLnode) and input_type == "Bytes":
         if in_arg.typ.maxlen > 32:
             raise InvalidLiteral(
                 f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to uint256", expr,
@@ -162,12 +163,12 @@ def to_uint256(expr, args, kwargs, context):
         raise InvalidLiteral(f"Invalid input for uint256: {in_arg}", expr)
 
 
-@signature(("bool", "int128", "uint256", "bytes32", "bytes", "address"), "*")
+@signature(("bool", "int128", "uint256", "bytes32", "Bytes", "address"), "*")
 def to_decimal(expr, args, kwargs, context):
     in_arg = args[0]
     input_type, _ = get_type(in_arg)
 
-    if input_type == "bytes":
+    if input_type == "Bytes":
         if in_arg.typ.maxlen > 32:
             raise TypeMismatch(
                 f"Cannot convert bytes array of max length {in_arg.typ.maxlen} to decimal", expr,
@@ -241,12 +242,12 @@ def to_decimal(expr, args, kwargs, context):
             raise InvalidLiteral(f"Invalid input for decimal: {in_arg}", expr)
 
 
-@signature(("int128", "uint256", "address", "bytes", "bool", "decimal"), "*")
+@signature(("int128", "uint256", "address", "Bytes", "bool", "decimal"), "*")
 def to_bytes32(expr, args, kwargs, context):
     in_arg = args[0]
     input_type, _len = get_type(in_arg)
 
-    if input_type == "bytes":
+    if input_type == "Bytes":
         if _len > 32:
             raise TypeMismatch(
                 f"Unable to convert bytes[{_len}] to bytes32, max length is too " "large."
@@ -273,9 +274,9 @@ def to_address(expr, args, kwargs, context):
 
 
 def _to_bytelike(expr, args, kwargs, context, bytetype):
-    if bytetype == "string":
+    if bytetype == "String":
         ReturnType = StringType
-    elif bytetype == "bytes":
+    elif bytetype == "Bytes":
         ReturnType = ByteArrayType
     else:
         raise TypeMismatch(f"Invalid {bytetype} supplied")
@@ -295,14 +296,14 @@ def _to_bytelike(expr, args, kwargs, context, bytetype):
     )
 
 
-@signature(("bytes"), "*")
+@signature(("Bytes"), "*")
 def to_string(expr, args, kwargs, context):
-    return _to_bytelike(expr, args, kwargs, context, bytetype="string")
+    return _to_bytelike(expr, args, kwargs, context, bytetype="String")
 
 
-@signature(("string"), "*")
+@signature(("String"), "*")
 def to_bytes(expr, args, kwargs, context):
-    return _to_bytelike(expr, args, kwargs, context, bytetype="bytes")
+    return _to_bytelike(expr, args, kwargs, context, bytetype="Bytes")
 
 
 def convert(expr, context):
@@ -336,6 +337,6 @@ CONVERSION_TABLE = {
     "decimal": to_decimal,
     "bytes32": to_bytes32,
     "address": to_address,
-    "string": to_string,
-    "bytes": to_bytes,
+    "String": to_string,
+    "Bytes": to_bytes,
 }

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -207,7 +207,7 @@ class Convert:
 class Slice:
 
     _id = "slice"
-    _inputs = [("b", ("bytes", "bytes32", "string")), ("start", "uint256"), ("length", "uint256")]
+    _inputs = [("b", ("Bytes", "bytes32", "String")), ("start", "uint256"), ("length", "uint256")]
     _return_type = None
 
     def fetch_call_return(self, node):
@@ -387,9 +387,9 @@ class Concat:
                 raise TypeMismatch("Concat expects string, bytes or bytes32 objects", expr_arg)
 
             current_type = (
-                "bytes"
+                "Bytes"
                 if isinstance(arg.typ, ByteArrayType) or is_base_type(arg.typ, "bytes32")
-                else "string"
+                else "String"
             )
             if prev_type and current_type != prev_type:
                 raise TypeMismatch(
@@ -401,7 +401,7 @@ class Concat:
                 )
             prev_type = current_type
 
-        if current_type == "string":
+        if current_type == "String":
             ReturnType = OldStringType
         else:
             ReturnType = ByteArrayType
@@ -1131,7 +1131,7 @@ class BlockHash(_SimpleBuiltinFunction):
 class RawLog:
 
     _id = "raw_log"
-    _inputs = [("topics", "*"), ("data", ("bytes32", "bytes"))]
+    _inputs = [("topics", "*"), ("data", ("bytes32", "Bytes"))]
 
     def fetch_call_return(self, node):
         validate_call_args(node, 2)

--- a/vyper/functions/signatures.py
+++ b/vyper/functions/signatures.py
@@ -45,15 +45,15 @@ def process_arg(index, arg, expected_arg_typelist, function_name, context):
         elif expected_arg == "name_literal":
             if isinstance(arg, vy_ast.Name):
                 return arg.id
-            elif isinstance(arg, vy_ast.Subscript) and arg.value.id == "bytes":
-                return f"bytes[{arg.slice.value.n}]"
+            elif isinstance(arg, vy_ast.Subscript) and arg.value.id == "Bytes":
+                return f"Bytes[{arg.slice.value.n}]"
         elif expected_arg == "*":
             return arg
-        elif expected_arg == "bytes":
+        elif expected_arg == "Bytes":
             sub = Expr(arg, context).lll_node
             if isinstance(sub.typ, ByteArrayType):
                 return sub
-        elif expected_arg == "string":
+        elif expected_arg == "String":
             sub = Expr(arg, context).lll_node
             if isinstance(sub.typ, StringType):
                 return sub

--- a/vyper/interfaces/ERC721.py
+++ b/vyper/interfaces/ERC721.py
@@ -52,7 +52,7 @@ def safeTransferFrom(_from: address, _to: address, _tokenId: uint256):
     pass
 
 @external
-def safeTransferFrom(_from: address, _to: address, _tokenId: uint256, _data: bytes[1024]):
+def safeTransferFrom(_from: address, _to: address, _tokenId: uint256, _data: Bytes[1024]):
     pass
 
 @external

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -43,7 +43,8 @@ def abi_type_to_ast(atype, expected_size):
     elif atype in ("bytes", "string"):
         # expected_size is the maximum length for inputs, minimum length for outputs
         return vy_ast.Subscript(
-            value=vy_ast.Name(id=atype), slice=vy_ast.Index(value=vy_ast.Int(value=expected_size))
+            value=vy_ast.Name(id=atype.capitalize()),
+            slice=vy_ast.Index(value=vy_ast.Int(value=expected_size)),
         )
     else:
         raise StructureException(f"Type {atype} not supported by vyper.")

--- a/vyper/types/types.py
+++ b/vyper/types/types.py
@@ -64,13 +64,13 @@ class ByteArrayLike(NodeType):
 
 class StringType(ByteArrayLike):
     def __repr__(self):
-        return f"string[{self.maxlen}]"
+        return f"String[{self.maxlen}]"
 
 
 # Data structure for a byte array
 class ByteArrayType(ByteArrayLike):
     def __repr__(self):
-        return f"bytes[{self.maxlen}]"
+        return f"Bytes[{self.maxlen}]"
 
 
 # Data structure for a list with some fixed length
@@ -229,9 +229,9 @@ def parse_type(item, location, sigs=None, custom_structs=None, constants=None):
                     item.slice.value,
                 )
             # ByteArray
-            if getattr(item.value, "id", None) == "bytes":
+            if getattr(item.value, "id", None) == "Bytes":
                 return ByteArrayType(n_val)
-            elif getattr(item.value, "id", None) == "string":
+            elif getattr(item.value, "id", None) == "String":
                 return StringType(n_val)
             # List
             else:
@@ -331,7 +331,7 @@ def get_type(input):
     if not hasattr(input, "typ"):
         typ, len = "num_literal", 32
     elif hasattr(input.typ, "maxlen"):
-        typ, len = "bytes", input.typ.maxlen
+        typ, len = "Bytes", input.typ.maxlen
     else:
         typ, len = input.typ.typ, 32
     return typ, len


### PR DESCRIPTION
### What I did
Rename `bytes` and `string` to `Bytes` and `String`

Related to #1440 

### How I did it
A lot of grepping.

### How to verify it
Run tests.

### Description for the changelog
`bytes` and `string` have been changed to `Bytes` and `String`

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86362844-f62ceb80-bc86-11ea-8313-2ec393d92d95.png)
