### PR TITLE
Added check that version string is non-zero, as NpmSpec passes it

### DIFF
--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -44,6 +44,11 @@ def validate_version_pragma(version_str: str, start: ParserPosition) -> None:
     strict_file_version = _convert_version_str(raw_file_version)
     strict_compiler_version = Version(_convert_version_str(__version__))
 
+    if len(strict_file_version) == 0:
+        raise VersionException(
+            "Version specification cannot be empty", start,
+        )
+
     try:
         npm_spec = NpmSpec(strict_file_version)
     except ValueError:


### PR DESCRIPTION
### What I did
There was a bug where if no version string was specified, and it was _not_ a pre-release version, then NpmSpec would match it as being valid. See https://github.com/vyperlang/vyper/runs/835228433

### How I did it
Added an additional check

### How to verify it
Tests pass with this, and with  #2082

### Cute Animal Picture
![d'oh](https://i.pinimg.com/236x/6a/3b/be/6a3bbe6ecc3984ea89102cfe2f279a58--baby-polar-bears-teddy-bears.jpg)