### PR TITLE
0.2.1 Release Notes

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -3,7 +3,7 @@
 Release Notes
 #############
 
-v0.2.0
+v0.2.1
 ******
 
 Date released: 03-07-2020
@@ -62,6 +62,8 @@ Some of the bug and stability fixes:
 - Private function calls no longer generate a call signature (`#2058 <https://github.com/vyperlang/vyper/pull/2058>`_)
 
 Significant codebase refactor, thanks to (`@iamdefinitelyahuman <https://github.com/iamdefinitelyahuman>`_)!
+
+**NOTE**: ``v0.2.0`` was not used due to a conflict in PyPI with a previous release. Both tags ``v0.2.0`` and ``v0.2.1`` are identical.
 
 v0.1.0-beta.17
 **************

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open("README.md", "r") as f:
 setup(
     name="vyper",
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version="0.2.0",
+    version="0.2.1",
     description="Vyper: the Pythonic Programming Language for the EVM",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
0.2.0 had a conflict on PyPI, so releasing 0.2.1 instead