### PR TITLE
don't fold exponentiation when power < 0

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Union
 from vyper.exceptions import (
     CompilerPanic,
     InvalidLiteral,
+    InvalidOperation,
     OverflowException,
     SyntaxException,
     TypeMismatch,
@@ -910,6 +911,8 @@ class Pow(VyperNode):
     def _op(self, left, right):
         if isinstance(left, decimal.Decimal):
             raise TypeMismatch("Cannot perform exponentiation on decimal values.", self._parent)
+        if right < 0:
+            raise InvalidOperation("Cannot calculate a negative power", self._parent)
         return int(left ** right)
 
 


### PR DESCRIPTION
### What I did
Don't fold literal exponentiation when the power is negative.

Fixes #1926 - which was mostly already fixed by type checking, but it alerted me to this issue.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86495800-e5b26900-bd8b-11ea-894b-c67b9965c98d.png)
