### PR TITLE
add repr for Mapping

### DIFF
--- a/vyper/context/types/indexable/mapping.py
+++ b/vyper/context/types/indexable/mapping.py
@@ -14,6 +14,9 @@ from vyper.exceptions import StructureException
 class MappingDefinition(IndexableTypeDefinition):
     _id = "HashMap"
 
+    def __repr__(self):
+        return f"{self._id}[{self.key_type}, {self.value_type}]"
+
     def compare_type(self, other):
         return (
             super().compare_type(other)


### PR DESCRIPTION
### What I did
Add a `__repr__` method to `MappingDefinition`.  Without this, the error messages related to mappings are weird.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86495876-1d211580-bd8c-11ea-8a0c-bb2890b56ba9.png)
