### PR TITLE
fix: remove print statement (oops)

### DIFF
--- a/vyper/functions/convert.py
+++ b/vyper/functions/convert.py
@@ -14,7 +14,6 @@ from vyper.utils import DECIMAL_DIVISOR, MemoryPositions, SizeLimits
 def to_bool(expr, args, kwargs, context):
     in_arg = args[0]
     input_type, _ = get_type(in_arg)
-    print(input_type)
 
     if input_type == "Bytes":
         if in_arg.typ.maxlen > 32:


### PR DESCRIPTION
### What I did
Remove a `print` statement that shouldn't be.

### How I did it
Shamefully.

### How to verify it
Grep for other print statements.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86511308-e1786100-be08-11ea-9c9f-e979cecca37b.png)
