### PR TITLE
use folded ast for natspec generation

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -23,12 +23,12 @@ def build_ast_dict(compiler_data: CompilerData) -> dict:
 
 
 def build_devdoc(compiler_data: CompilerData) -> dict:
-    userdoc, devdoc = parse_natspec(compiler_data.vyper_module, compiler_data.global_ctx)
+    userdoc, devdoc = parse_natspec(compiler_data.vyper_module_folded, compiler_data.global_ctx)
     return devdoc
 
 
 def build_userdoc(compiler_data: CompilerData) -> dict:
-    userdoc, devdoc = parse_natspec(compiler_data.vyper_module, compiler_data.global_ctx)
+    userdoc, devdoc = parse_natspec(compiler_data.vyper_module_folded, compiler_data.global_ctx)
     return userdoc
 
 


### PR DESCRIPTION
### What I did
Use folded AST when generating Natspec.

This fixes a bug when a function input uses a constant, e.g:

```python
FOO: constant(2)

@external
def foo(a: uint256[FOO]): pass
```

Parsing the natspec fails because the function signature cannot be determined from the unfolded AST.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86514529-ec8cba80-be23-11ea-9c53-80e501889ffa.png)
