### PR TITLE
Raise immediately on certain exceptions during module-scope type check

### DIFF
--- a/vyper/context/types/utils.py
+++ b/vyper/context/types/utils.py
@@ -151,11 +151,12 @@ def get_type_from_annotation(
     try:
         # get id of leftmost `Name` node from the annotation
         type_name = next(i.id for i in node.get_descendants(vy_ast.Name, include_self=True))
-        type_obj = namespace[type_name]
     except StopIteration:
         raise StructureException("Invalid syntax for type declaration", node)
+    try:
+        type_obj = namespace[type_name]
     except UndeclaredDefinition:
-        raise UnknownType("Not a valid type - value is undeclared", node) from None
+        raise UnknownType(f"No builtin or user-defined type named '{type_name}'", node) from None
 
     if getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript):
         # if type can be an array and node is a subscript, create an `ArrayDefinition`
@@ -166,7 +167,7 @@ def get_type_from_annotation(
     try:
         return type_obj.from_annotation(node, location, is_immutable, is_public)
     except AttributeError:
-        raise UnknownType(f"'{type_name}' is not a valid type", node) from None
+        raise InvalidType(f"'{type_name}' is not a valid type", node) from None
 
 
 def check_literal(node: vy_ast.VyperNode) -> bool:

--- a/vyper/context/validation/module.py
+++ b/vyper/context/validation/module.py
@@ -16,6 +16,8 @@ from vyper.exceptions import (
     CallViolation,
     CompilerPanic,
     ExceptionList,
+    InvalidLiteral,
+    InvalidType,
     NamespaceCollision,
     StateAccessViolation,
     StructureException,
@@ -66,6 +68,10 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
                 try:
                     self.visit(node)
                     module_nodes.remove(node)
+                except (InvalidLiteral, InvalidType, VariableDeclarationException):
+                    # these exceptions cannot be caused by another statement not yet being
+                    # parsed, so we raise them immediately
+                    raise
                 except VyperException as e:
                     err_list.append(e)
 


### PR DESCRIPTION
### What I did
Raise immediately on certain exceptions while type-checking the module scope. This prevents long error messages where other nodes fail the type checking because they rely on a previous node.

### How I did it
Raise immediately on `InvalidLiteral`, `InvalidType`, and `VariableDeclarationException`.  Each of these exceptions will not happen as a result of another node not yet being parsed.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86574471-f418a480-bf86-11ea-9034-32d5cc011fb6.png)
