### PR TITLE
fix: adjust FuncionDef offset to not include decorators

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -604,6 +604,12 @@ class Module(TopLevel):
 class FunctionDef(TopLevel):
     __slots__ = ("args", "returns", "decorator_list", "pos")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.decorator_list and self.decorator_list[-1].end_lineno is not None:
+            # start the source highlight after the decorators to improve annotation readability
+            self.lineno = self.decorator_list[-1].end_lineno + 1
+
 
 class DocStr(VyperNode):
     """


### PR DESCRIPTION
### What I did
Adjust `FunctionDef` offset to not include decorators. This ensures a more readable annotation when an exception is raised.

Before:

```python
vyper.exceptions.FunctionDeclarationException: Missing or unmatched return statements in function 'foo'
line 12:0 
     11
---> 12 @external
--------^
     13 @payable
```

After:

```python
vyper.exceptions.FunctionDeclarationException: Missing or unmatched return statements in function 'foo'
line 14:0 
     13 @payable
---> 14 def foo() -> uint256:
--------^
     15     pass
```


### How I did it
When converting from Python to Vyper AST, modify `FunctionDef.lineno` to be +1 from the `end_lineno` of the final decorator.

### How to verify it
Run tests.


### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86596710-bbd78d00-bfab-11ea-8c9d-d4a9c6091bd9.png)
