### PR TITLE
Add contract name to exceptions

### DIFF
--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -17,8 +17,10 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         source_code: str,
         modification_offsets: Optional[ModificationOffsets] = None,
         source_id: int = 0,
+        contract_name: Optional[str] = None,
     ):
         self._source_id = source_id
+        self._contract_name = contract_name
         self._source_code: str = source_code
         self.counter: int = 0
         self._modification_offsets = {}
@@ -69,6 +71,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         return node
 
     def visit_Module(self, node):
+        node.name = self._contract_name
         return self._visit_docstring(node)
 
     def visit_FunctionDef(self, node):
@@ -210,6 +213,7 @@ def annotate_python_ast(
     source_code: str,
     modification_offsets: Optional[ModificationOffsets] = None,
     source_id: int = 0,
+    contract_name: Optional[str] = None,
 ) -> python_ast.AST:
     """
     Annotate and optimize a Python AST in preparation conversion to a Vyper AST.
@@ -229,6 +233,6 @@ def annotate_python_ast(
     """
 
     asttokens.ASTTokens(source_code, tree=parsed_ast)
-    AnnotatingVisitor(source_code, modification_offsets, source_id).visit(parsed_ast)
+    AnnotatingVisitor(source_code, modification_offsets, source_id, contract_name).visit(parsed_ast)
 
     return parsed_ast

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -1,5 +1,5 @@
 import ast as python_ast
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.annotation import annotate_python_ast
@@ -7,7 +7,9 @@ from vyper.ast.pre_parser import pre_parse
 from vyper.exceptions import CompilerPanic, ParserException, SyntaxException
 
 
-def parse_to_ast(source_code: str, source_id: int = 0) -> vy_ast.Module:
+def parse_to_ast(
+    source_code: str, source_id: int = 0, contract_name: Optional[str] = None
+) -> vy_ast.Module:
     """
     Parses a Vyper source string and generates basic Vyper AST nodes.
 
@@ -31,7 +33,7 @@ def parse_to_ast(source_code: str, source_id: int = 0) -> vy_ast.Module:
     except SyntaxError as e:
         # TODO: Ensure 1-to-1 match of source_code:reformatted_code SyntaxErrors
         raise SyntaxException(str(e), source_code, e.lineno, e.offset) from e
-    annotate_python_ast(py_ast, source_code, class_types, source_id)
+    annotate_python_ast(py_ast, source_code, class_types, source_id, contract_name)
 
     # Convert to Vyper AST.
     return vy_ast.get_node(py_ast)  # type: ignore

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -71,7 +71,7 @@ class CompilerData:
     @property
     def vyper_module(self) -> vy_ast.Module:
         if not hasattr(self, "_vyper_module"):
-            self._vyper_module = generate_ast(self.source_code, self.source_id)
+            self._vyper_module = generate_ast(self.source_code, self.source_id, self.contract_name)
 
         return self._vyper_module
 
@@ -133,7 +133,7 @@ class CompilerData:
         return self._bytecode_runtime
 
 
-def generate_ast(source_code: str, source_id: int) -> vy_ast.Module:
+def generate_ast(source_code: str, source_id: int, contract_name: str) -> vy_ast.Module:
     """
     Generate a Vyper AST from source code.
 
@@ -143,13 +143,15 @@ def generate_ast(source_code: str, source_id: int) -> vy_ast.Module:
         Vyper source code.
     source_id : int
         ID number used to identify this contract in the source map.
+    contract_name : str
+        Name of the contract.
 
     Returns
     -------
     vy_ast.Module
         Top-level Vyper AST node
     """
-    return vy_ast.parse_to_ast(source_code, source_id)
+    return vy_ast.parse_to_ast(source_code, source_id, contract_name)
 
 
 def generate_folded_ast(vyper_module: vy_ast.Module) -> vy_ast.Module:

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -101,9 +101,13 @@ class VyperException(Exception):
                 return msg
 
             if isinstance(node, vy_ast.VyperNode):
+                module_node = node.get_ancestor(vy_ast.Module)
+                if module_node.get("name") not in (None, "<unknown>"):
+                    msg += f'contract "{module_node.name}", '
+
                 fn_node = node.get_ancestor(vy_ast.FunctionDef)
                 if fn_node:
-                    msg += f"function '{fn_node.name}', "
+                    msg += f'function "{fn_node.name}", '
 
             col_offset_str = "" if node.col_offset is None else str(node.col_offset)
             msg += f"line {node.lineno}:{col_offset_str} \n{source_annotation}\n"

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -102,7 +102,7 @@ class GlobalContext:
                     if interface_name not in interface_codes:
                         raise StructureException(f"Unknown interface {interface_name}", item)
                     global_ctx._interfaces[assigned_name] = extract_sigs(
-                        interface_codes[interface_name]
+                        interface_codes[interface_name], interface_name
                     )
             elif isinstance(item, vy_ast.Import):
                 interface_name = item.alias
@@ -111,7 +111,7 @@ class GlobalContext:
                 if interface_name not in interface_codes:
                     raise StructureException(f"Unknown interface {interface_name}", item)
                 global_ctx._interfaces[interface_name] = extract_sigs(
-                    interface_codes[interface_name]
+                    interface_codes[interface_name], interface_name
                 )
             else:
                 raise StructureException("Invalid top-level statement", item)

--- a/vyper/signatures/interface.py
+++ b/vyper/signatures/interface.py
@@ -21,7 +21,8 @@ def get_builtin_interfaces():
             {
                 "type": "vyper",
                 "code": importlib.import_module(f"vyper.interfaces.{name}",).interface_code,
-            }
+            },
+            name,
         )
         for name in interface_names
     }
@@ -101,11 +102,11 @@ def mk_full_signature_from_json(abi):
     return sigs
 
 
-def extract_sigs(sig_code):
+def extract_sigs(sig_code, interface_name=None):
     if sig_code["type"] == "vyper":
         interface_ast = [
             i
-            for i in vy_ast.parse_to_ast(sig_code["code"])
+            for i in vy_ast.parse_to_ast(sig_code["code"], contract_name=interface_name)
             if isinstance(i, vy_ast.FunctionDef)
             or isinstance(i, vy_ast.EventDef)
             or (isinstance(i, vy_ast.AnnAssign) and i.target.id != "implements")


### PR DESCRIPTION
### What I did
* Display the name of the active contract when raising an exception.  This is useful when an exception occurs while parsing an interface.
* Ensure the correct annotation shows when parsing interfaces.

### How I did it
* Add a `name` field to the `Module` AST node. This gets added via a new kwarg for `parse_to_ast`
* Include the `contract_name` kwarg when generating ASTs in `compiler` and `signatures`

### How to verify it
Cause an exception.  It should give output like this:

```python
UnknownType: Not a valid type - value is undeclared
contract "cERC20", function "transfer", line 21:18 
     20 @external
---> 21 def transfer(_to: oopsie, _value: uint256) -> bool:
--------------------------^
     22     pass
```

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86600230-d2ccae00-bfb0-11ea-9307-12a7cd90e001.png)
