### PR TITLE
adjust FunctionDef offset using tokens

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -604,12 +604,6 @@ class Module(TopLevel):
 class FunctionDef(TopLevel):
     __slots__ = ("args", "returns", "decorator_list", "pos")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.decorator_list and self.decorator_list[-1].end_lineno is not None:
-            # start the source highlight after the decorators to improve annotation readability
-            self.lineno = self.decorator_list[-1].end_lineno + 1
-
 
 class DocStr(VyperNode):
     """


### PR DESCRIPTION
### What I did
Adjust the start offset for `FunctionDef` nodes using tokens.  This is a more accurate solution to #2102 

### How I did it
In `ast/annotation.py`, modify `FunctionDef.first_token` by searching for the first `def` token after the final decorator.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/86768588-e1719e80-c05e-11ea-8ec8-c19407bfa52d.png)
