### PR TITLE
Update testing-contracts-brownie.rst

### DIFF
--- a/docs/testing-contracts-brownie.rst
+++ b/docs/testing-contracts-brownie.rst
@@ -97,10 +97,10 @@ To test events, we examine the :py:class:`TransactionReceipt <brownie.network.tr
 
         # Check log contents
         assert len(tx1.events) == 1
-        assert tx1.events[0]['_value'] == 10
+        assert tx1.events[0]['value'] == 10
 
         assert len(tx2.events) == 1
-        assert tx2.events[0]['_setter'] == accounts[1]
+        assert tx2.events[0]['setter'] == accounts[1]
 
         assert not tx3.events   # tx3 does not generate a log
 


### PR DESCRIPTION
After following the doc and executing brownie test, I faced an error: E       brownie.exceptions.EventLookupError: Unknown key '_value' - the 'DataChange' event includes these keys: setter, value

The error is quite explanatory, the event DataChange has been defined with keys `value` and `setter` and were being accessed in the test cases by `_value` and `_setter`.
Thus the proposed change

### What I did
Fixed brownie.exceptions.EventLookupError:

### How I did it
Renamed the event DataChange keys from `_value` & `_setter` in the tests to `value` & `setter`
### How to verify it
Executing `brownie test` all tests are passing
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.verywellmind.com/thmb/tQggy7DZhrO6gqoq6YM9vJUUiZ0=/768x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/iStock-619961796-edit-59cabaf6845b3400111119b7.jpg)
