### PR TITLE
Pop for loop values from stack prior to returning

### DIFF
--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -214,15 +214,21 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
     # Continue to the next iteration of the for loop
     elif code.value == "continue":
         if not break_dest:
-            raise Exception("Invalid break")
+            raise CompilerPanic("Invalid break")
         dest, continue_dest, break_height = break_dest
         return [continue_dest, "JUMP"]
     # Break from inside a for loop
     elif code.value == "break":
         if not break_dest:
-            raise Exception("Invalid break")
+            raise CompilerPanic("Invalid break")
         dest, continue_dest, break_height = break_dest
         return ["POP"] * (height - break_height) + [dest, "JUMP"]
+    # Break from inside one or more for loops prior to a return statement inside the loop
+    elif code.value == "exit_repeater":
+        if not break_dest:
+            raise CompilerPanic("Invalid break")
+        _, _, break_height = break_dest
+        return ["POP"] * break_height
     # With statements
     elif code.value == "with":
         o = []


### PR DESCRIPTION
### What I did
Fix an issue causing a bad jumpdest when returning from inside a for loop.

During a for loop the stack contains the iterator value and a callback pointer to the start of the loop.  When a loop is completed, or exitted via `break`, each of these values is popped off. A `return` statement inside a for loop was missing these pops, leaving unexpected values on the stack after returning.

This is only problematic when the return in a for loop happens at least 2 internal calls deep, because the callback pointer for each internal function is also placed on the stack.  As such, the attempt to return from the next internal function would instead use the for loop iterator value as it's destination - resulting in a bad jumpdest.

### How I did it
To fix this issue, I've added a new LLL macro `exit_repeater` which adds 2 `POP` instructions for each active for loop prior to the return jump. This macro is added whenever a return statement is encountered within a for loop.

### How to verify it
Run the tests. I've added several cases to verify that the behavior is now working as expected.

### Description for the changelog

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/87698714-877a8280-c79c-11ea-8a33-80929399c5e7.png)

