### PR TITLE
fix: add trailing whitespace for EOF exception

### DIFF
--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -90,14 +90,15 @@ class VyperException(Exception):
         for node in self.nodes:
             try:
                 source_annotation = annotate_source_code(
-                    self.source_code,
+                    # add trailing space because EOF exceptions point one char beyond the length
+                    f"{self.source_code} ",
                     node.lineno,
                     node.col_offset,
                     context_lines=VYPER_ERROR_CONTEXT_LINES,
                     line_numbers=VYPER_ERROR_LINE_NUMBERS,
                 )
             except Exception:
-                # necessary for certian types of syntax exceptions
+                # necessary for certain types of syntax exceptions
                 return msg
 
             if isinstance(node, vy_ast.VyperNode):


### PR DESCRIPTION
### What I did
Fix a bug preventing annotation of end-of-file syntax errors

### How I did it
Append `" "` to source prior to annotation. The EOF error always points to one character beyond the length of the source, as this is the offset the error was encountered at.

### How to verify it
Try to compile an incomplete source.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/88463181-a0301a00-ceb9-11ea-8935-ba46bb16a974.png)
