### PR TITLE
Raise on not-types when type checking

### DIFF
--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -3,6 +3,7 @@ import pytest
 from vyper import compiler
 from vyper.exceptions import (
     ArgumentException,
+    InvalidReference,
     StructureException,
     TypeMismatch,
     UnknownAttribute,
@@ -27,7 +28,7 @@ aba: public(ERC20)
 def test():
     self.aba = ERC20
     """,
-        StructureException,
+        InvalidReference,
     ),
     (
         """


### PR DESCRIPTION
### What I did
When type checking, raise immediately if a non-type value is encountered (e.g. a type primitive or uncalled builtin function)

### How I did it
in `vyper/context/validation/utils.py`, add a kwarg `only_definitions` to `_ExprTypeChecker.get_exact_type_from_node` and `_ExprTypeChecker.get_possible_types_from_node`.  if `True` and any values aren't definitions, raise `InvalidReference`.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/88478120-665d2300-cf4e-11ea-967e-38e5e2f05a7b.png)
