### PR TITLE
Serialize AST

### DIFF
--- a/tests/parser/ast_utils/test_ast_dict.py
+++ b/tests/parser/ast_utils/test_ast_dict.py
@@ -1,3 +1,5 @@
+import json
+
 from vyper import compiler
 from vyper.ast.utils import ast_to_dict, dict_to_ast, parse_to_ast
 
@@ -78,15 +80,20 @@ def test_dict_to_ast():
 def test() -> int128:
     a: uint256 = 100
     b: int128 = -22
-    c: decimal = 3.31337
+    c: decimal = -3.3133700
     d: Bytes[11] = b"oh hai mark"
-    e: address = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
-    f: bool = False
+    e: Bytes[1] = 0b01010101
+    f: Bytes[88] = b"\x01\x70"
+    g: String[100] = "  baka baka   "
+    h: address = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+    i: bool = False
     return 123
     """
 
     original_ast = parse_to_ast(code)
     out_dict = ast_to_dict(original_ast)
-    new_ast = dict_to_ast(out_dict)
+    out_json = json.dumps(out_dict)
+    new_dict = json.loads(out_json)
+    new_ast = dict_to_ast(new_dict)
 
     assert new_ast == original_ast

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -696,6 +696,16 @@ class Decimal(Num):
 
     __slots__ = ()
 
+    def __init__(self, parent: Optional["VyperNode"] = None, **kwargs: dict):
+        super().__init__(parent, **kwargs)
+        if not isinstance(self.value, decimal.Decimal):
+            self.value = decimal.Decimal(self.value)
+
+    def to_dict(self):
+        ast_dict = super().to_dict()
+        ast_dict["value"] = self.node_source_code
+        return ast_dict
+
     def validate(self):
         if self.value.as_tuple().exponent < -MAX_DECIMAL_PLACES:
             raise InvalidLiteral("Vyper supports a maximum of ten decimal points", self)
@@ -737,6 +747,16 @@ class Str(Constant):
 class Bytes(Constant):
     __slots__ = ()
     _translated_fields = {"s": "value"}
+
+    def __init__(self, parent: Optional["VyperNode"] = None, **kwargs: dict):
+        super().__init__(parent, **kwargs)
+        if isinstance(self.value, str):
+            self.value = self.value.encode("utf8")
+
+    def to_dict(self):
+        ast_dict = super().to_dict()
+        ast_dict["value"] = self.value.decode("utf8")
+        return ast_dict
 
     @property
     def s(self):


### PR DESCRIPTION
### What I did
Ensure AST nodes as dicts are serializable.  Fixes #2121 

### How I did it
* Add unique `to_dict` and `__init__` logic on the `Decimal` and `Bytes` nodes.
* Expand the test case around this behavior to also include creating and loading a JSON string based on the AST-dict.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/88787071-fa6ffa00-d19b-11ea-937d-1855a55dff4e.png)
