### PR TITLE
Improve exception on incorrect interface

### DIFF
--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -187,8 +187,18 @@ class ContractFunction(BaseTypeDefinition):
                 # Interfaces are always public
                 kwargs["function_visibility"] = FunctionVisibility.EXTERNAL
                 kwargs["state_mutability"] = StateMutability(node.body[0].value.id)
+            elif len(node.body) == 1 and node.body[0].get("value.id") in ("constant", "modifying"):
+                if node.body[0].value.id == "constant":
+                    expected = "view or pure"
+                else:
+                    expected = "payable or nonpayable"
+                raise StructureException(
+                    f"State mutability should be set to {expected}", node.body[0]
+                )
             else:
-                raise StructureException("Body must only contain state mutability label", node)
+                raise StructureException(
+                    "Body must only contain state mutability label", node.body[0]
+                )
 
         else:
 


### PR DESCRIPTION
### What I did
Improve the error message when using a `0.1.x` style interface.

### How I did it
* If an interface contains `constant` or `modifying`, inform the user to change it to `view`/`pure` or `payable`/`nonpayable`.
* If an interface is completely wrong, ensure the annotation points at the body

### How to verify it
Make sure tests are passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/90625446-40136600-e222-11ea-99b0-edf1ba2e525e.png)
