### PR TITLE
fix: improve make freeze

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 OS := $(shell uname -s | tr A-Z a-z)
-VERSION := $(shell vyper --version)
+VERSION := $(shell PYTHONPATH=. python vyper/cli/vyper_compile.py --version)
 
 ifeq (, $(shell which pip3))
 	pip := $(shell which pip3)
@@ -38,10 +38,9 @@ release: clean
 	twine check dist/*
 	#twine upload dist/*
 
-
 freeze: clean
 	echo Generating binary...
-	pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.$(VERSION).$(OS)
+	pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.$(VERSION).$(OS) --add-data vyper:vyper
 
 clean: clean-build clean-docs clean-pyc clean-test
 
@@ -51,6 +50,7 @@ clean-build:
 	@rm -fr dist/
 	@rm -fr *.egg-info
 	@rm -f vyper/vyper_git_version.txt
+	@rm -f *.spec
 
 clean-docs:
 	@echo Cleaning doc build files...

--- a/make.cmd
+++ b/make.cmd
@@ -42,8 +42,9 @@ goto :end
 
 :freeze
 CALL :clean
-for /f "delims=" %%a in ('vyper --version') do @set VERSION=%%a
-pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.%VERSION%.windows
+set PYTHONPATH=.
+for /f "delims=" %%a in ('python vyper/cli/vyper_compile.py --version') do @set VERSION=%%a
+pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.%VERSION%.windows --add-data vyper;vyper
 goto :end
 
 :clean
@@ -56,6 +57,7 @@ goto :end
 if exist build RMDIR /Q /S build
 if exist dist RMDIR /Q /S dist
 for /d %%x in (*.egg-info) do if exist "%%x" RMDIR /Q /S "%%x"
+for /r %%x in (*.spec) do del %%x
 goto :end
 
 


### PR DESCRIPTION
### What I did
* directly execute `vyper/cli/vyper_compile.py` so that the version is accurate without having to install vyper
* when freezing, ensure the entire content of `vyper` is included (interfaces are otherwise missed)
* when cleaning, delete spec files

### How to verify it
Freeze something.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/91043030-77678580-e61b-11ea-8a99-dcade436b890.png)
