### PR TITLE
Fix: constant folding on lhs of assignments

### DIFF
--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -90,6 +90,8 @@ constants_modified = [
     "def bar(a: int128 = FOO): pass",
     "log bar(FOO)",
     "FOO + 1",
+    "a: int128[FOO / 2]",
+    "a[FOO - 1] = 44",
 ]
 
 
@@ -112,6 +114,7 @@ constants_unmodified = [
     "bar = self.FOO",
     "log FOO(bar)",
     "[1, 2, FOO()]",
+    "FOO[42] = 2",
 ]
 
 

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -228,9 +228,10 @@ def replace_constant(
         if isinstance(parent, vy_ast.Dict) and node in parent.keys:
             continue
 
-        if not isinstance(parent, vy_ast.Index):
+        if not node.get_ancestor(vy_ast.Index):
             # do not replace left-hand side of assignments
             assign = node.get_ancestor((vy_ast.Assign, vy_ast.AnnAssign, vy_ast.AugAssign))
+
             if assign and node in assign.target.get_descendants(include_self=True):
                 continue
 


### PR DESCRIPTION
### What I did
Fix a folding issue where constants used in binaries operations inside a subscript were not being correctly folded.

For example, the following currently fails to compile because `FOO+1` is not folded:

```
FOO: constant(int128) = 3
bar: int128[100]

def foo():
    self.bar[FOO+1] = 1
```

### How I did it
The existing logic does not fold constants on the left-hand side of an assignment, unless the constant's parent is a `Subscript`. To fix this, I'm now checking that the constant has an _ancestor_ who is a `Subscript`.

### How to verify it
Run tests. I expanded the test cases around this functionality to check this specific occurrence.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/91672052-81661880-eb34-11ea-9b5b-6f7aa2009dcf.png)
