### PR TITLE
Fix issue #1841

### DIFF
--- a/tests/functional/codegen/test_tuple_return.py
+++ b/tests/functional/codegen/test_tuple_return.py
@@ -1,0 +1,44 @@
+import pytest
+
+@pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
+def test_string_inside_tuple(get_contract, string):
+    code = f"""
+@external
+def test_return() -> (String[6], uint256):
+    return "{string}", 42
+    """
+    c1 = get_contract(code)
+
+    code = """
+interface jsonabi:
+    def test_return() -> (String[6], uint256): view
+
+@external
+def test_values(a: address) -> (String[6], uint256):
+    return jsonabi(a).test_return()
+    """
+
+    c2 = get_contract(code)
+    assert c2.test_values(c1.address) == [string, 42]
+
+
+@pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
+def test_bytes_inside_tuple(get_contract, string):
+    code = f"""
+@external
+def test_return() -> (Bytes[6], uint256):
+    return b"{string}", 42
+    """
+    c1 = get_contract(code)
+
+    code = """
+interface jsonabi:
+    def test_return() -> (Bytes[6], uint256): view
+
+@external
+def test_values(a: address) -> (Bytes[6], uint256):
+    return jsonabi(a).test_return()
+    """
+
+    c2 = get_contract(code)
+    assert c2.test_values(c1.address) == [bytes(string, "utf-8"), 42]

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -66,7 +66,7 @@ def make_return_stmt(stmt, context, begin_pos, _size, loop_memory_position=None)
 # Generate code for returning a tuple or struct.
 def gen_tuple_return(stmt, context, sub):
     # Is from a call expression.
-    if sub.args and len(sub.args[0].args) > 0 and sub.args[0].args[0].value == "call":
+    if sub.args and len(sub.args[0].args) > 0 and (sub.args[0].args[0].value == "call" or sub.args[0].args[0].value == "staticcall"):
         # self-call to external.
         mem_pos = sub
         mem_size = get_size_of_type(sub.typ) * 32


### PR DESCRIPTION
### What I did
Fixed issue: ABI issue with bytes and string arrays inside tuples #1841

### How I did it
I modified below line:
https://github.com/vyperlang/vyper/blob/3eb9e7a9bbb69f578c22db2f8a9c89669b95566c/vyper/codegen/return_.py#L69

In this line, we are checking if the return expression is an external function call, and is it is an external functional we are not encoding the data as the return from the external call is already encoded. Here we forgot to add the condition 
``` sub.args[0].args[0].value == "staticcall"```

### How to verify it
Run below test case:
```
def test_bytes_inside_tuple(get_contract):
    code = """
@external
def test_return() -> (String[6], uint256):
    return "potato", 42
    """
    c1 = get_contract(code)

    code = """
interface jsonabi:
    def test_return() -> (String[6], uint256): view

@external
def test_values(a: address) -> (String[6], uint256):
    return jsonabi(a).test_return()
    """

    c2 = get_contract(code)
    assert c2.test_values(c1.address) == ["potato", 42]
```

