### PR TITLE
Fix issue: #2142

### DIFF
--- a/tests/functional/codegen/test_struct_return.py
+++ b/tests/functional/codegen/test_struct_return.py
@@ -1,0 +1,31 @@
+import pytest
+
+@pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
+def test_string_inside_tuple(get_contract, string):
+    code = f"""
+struct Person:
+    name: String[6]
+    age: uint256
+
+@external
+def test_return() -> Person:
+    return Person({{ name:"{string}", age:42 }})
+    """
+    c1 = get_contract(code)
+
+    code = """
+struct Person:
+    name: String[6]
+    age: uint256
+
+interface jsonabi:
+    def test_return() -> Person: view
+
+@external
+def test_values(a: address) -> Person:
+    return jsonabi(a).test_return()
+    """
+
+    c2 = get_contract(code)
+    assert c2.test_values(c1.address) == [string, 42]
+

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -89,7 +89,7 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
             if isinstance(output_type, ByteArrayLike):
                 types_list = (output_type,)
             elif isinstance(output_type, TupleLike):
-                types_list = output_type.members
+                types_list = output_type.tuple_members()
             else:
                 raise
 


### PR DESCRIPTION
### What I did
Fixed the issue #2142 

### How I did it
https://github.com/vyperlang/vyper/blob/ce88755c57e32fbce39658e28cc9bb31b9e69080/vyper/parser/external_call.py#L92
Changed ```types_list = output_type.members ```  to ``` types_list = output_type.tuple_members()```. In the case of **struct**, ``` output_type.members``` returns a dict object, but types_list should be a list of types
### How to verify it
Runt the following test case
```
import pytest

@pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
def test_string_inside_tuple(get_contract, string):
    code = f"""
struct Person:
    name: String[6]
    age: uint256

@external
def test_return() -> Person:
    return Person({{ name:"{string}", age:42 }})
    """
    c1 = get_contract(code)

    code = """
struct Person:
    name: String[6]
    age: uint256

interface jsonabi:
    def test_return() -> Person: view

@external
def test_values(a: address) -> Person:
    return jsonabi(a).test_return()
    """

    c2 = get_contract(code)
    assert c2.test_values(c1.address) == [string, 42]
```

