### PR TITLE
Corrected abi_decode function, used it when compiling function calls and changed how we were handling the tuple/struct return

### DIFF
--- a/tests/functional/codegen/test_struct_return.py
+++ b/tests/functional/codegen/test_struct_return.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
 def test_string_inside_tuple(get_contract, string):
     code = f"""
@@ -28,4 +29,3 @@ def test_values(a: address) -> Person:
 
     c2 = get_contract(code)
     assert c2.test_values(c1.address) == [string, 42]
-

--- a/tests/functional/codegen/test_tuple_return.py
+++ b/tests/functional/codegen/test_tuple_return.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
 def test_string_inside_tuple(get_contract, string):
     code = f"""

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -828,6 +828,7 @@ def test(addr: address) -> (int128, address):
     assert c1.out_literals() == [1, "0x0000000000000000000000000000000000012345"]
     assert c2.test(c1.address) == list(c1.out_literals())
 
+
 def test_struct_return_external_contract_call_2(get_contract_with_gas_estimation):
     contract_1 = """
 struct X:

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -799,7 +799,7 @@ def test(addr: address) -> (int128, address, Bytes[10]):
     assert c2.test(c1.address) == [1, "0x0000000000000000000000000000000000000123", b"random"]
 
 
-def test_struct_return_external_contract_call(get_contract_with_gas_estimation):
+def test_struct_return_external_contract_call_1(get_contract_with_gas_estimation):
     contract_1 = """
 struct X:
     x: int128
@@ -826,6 +826,35 @@ def test(addr: address) -> (int128, address):
     c2 = get_contract_with_gas_estimation(contract_2)
 
     assert c1.out_literals() == [1, "0x0000000000000000000000000000000000012345"]
+    assert c2.test(c1.address) == list(c1.out_literals())
+
+def test_struct_return_external_contract_call_2(get_contract_with_gas_estimation):
+    contract_1 = """
+struct X:
+    x: int128
+    y: String[6]
+@external
+def out_literals() -> X:
+    return X({x: 1, y: "abcdef"})
+    """
+
+    contract_2 = """
+struct X:
+    x: int128
+    y: String[6]
+interface Test:
+    def out_literals() -> X : view
+
+@external
+def test(addr: address) -> (int128, String[6]):
+    ret: X = Test(addr).out_literals()
+    return ret.x, ret.y
+
+    """
+    c1 = get_contract_with_gas_estimation(contract_1)
+    c2 = get_contract_with_gas_estimation(contract_2)
+
+    assert c1.out_literals() == [1, "abcdef"]
     assert c2.test(c1.address) == list(c1.out_literals())
 
 

--- a/vyper/codegen/abi.py
+++ b/vyper/codegen/abi.py
@@ -416,7 +416,8 @@ def abi_decode(lll_node, src, pos=None):
         src_loc = LLLnode("src_loc", typ=o.typ, location=src.location)
         if parent_abi_t.is_tuple():
             if abi_t.is_dynamic():
-                child_loc = LLLnode.from_list(["add", "src", unwrap_location(src_loc)], typ=o.typ, location=src.location)
+                child_loc = ["add", "src", unwrap_location(src_loc)]
+                child_loc = LLLnode.from_list(child_loc, typ=o.typ, location=src.location)
             else:
                 child_loc = src_loc
             # descend into the child tuple

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -1,6 +1,6 @@
 from vyper.parser.lll_node import LLLnode
-from vyper.parser.parser_utils import getpos, zero_pad
-from vyper.types import BaseType, ByteArrayLike, get_size_of_type
+from vyper.parser.parser_utils import getpos
+from vyper.types import BaseType
 from vyper.types.check import check_assign
 from vyper.utils import MemoryPositions
 
@@ -86,7 +86,7 @@ def gen_tuple_return(stmt, context, sub):
     check_assign(return_buffer, sub, pos=getpos(stmt))
 
     # in case of multi we can't create a variable to store location of the return expression
-    # as multi can have data from multiple location like store, calldata etc 
+    # as multi can have data from multiple location like store, calldata etc
     if sub.value == "multi":
         encode_out = abi_encode(return_buffer, sub, pos=getpos(stmt), returns=True)
         load_return_len = ["mload", MemoryPositions.FREE_VAR_SPACE]
@@ -111,6 +111,6 @@ def gen_tuple_return(stmt, context, sub):
             "seq",
             ["mstore", MemoryPositions.FREE_VAR_SPACE, encode_out],
             make_return_stmt(stmt, context, return_buffer, load_return_len),
-        ]
+        ],
     ]
     return LLLnode.from_list(os, typ=None, pos=getpos(stmt), valency=0)

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -1,4 +1,5 @@
 from vyper import ast as vy_ast
+from vyper.codegen.abi import abi_decode
 from vyper.exceptions import (
     StateAccessViolation,
     StructureException,
@@ -15,7 +16,6 @@ from vyper.types import (
     get_static_size_of_type,
     has_dynamic_data,
 )
-from vyper.codegen.abi import abi_decode
 
 
 def external_call(node, context, interface_name, contract_address, pos, value=None, gas=None):

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -705,31 +705,25 @@ def make_setter(left, right, location, pos, in_function_call=False):
         # If tuple assign.
         elif isinstance(left.typ, TupleType) and isinstance(right.typ, TupleType):
             subs = []
-            static_offset_counter = 0
-            zipped_components = zip(left.args, right.typ.members, locations)
             for var_arg in left.args:
                 if var_arg.location == "calldata":
                     return
-            for left_arg, right_arg, loc in zipped_components:
-                if isinstance(right_arg, ByteArrayLike):
-                    RType = ByteArrayType if isinstance(right_arg, ByteArrayType) else StringType
-                    offset = LLLnode.from_list(
-                        ["add", "_R", ["mload", ["add", "_R", static_offset_counter]]],
-                        typ=RType(right_arg.maxlen),
-                        location="memory",
-                        pos=pos,
+
+            right_token = LLLnode.from_list("_R", typ=right.typ, location=right.location)
+            for left_arg, key, loc in zip(left.args, keyz, locations):
+                subs.append(
+                    make_setter(
+                        left_arg, 
+                        add_variable_offset(right_token, key, pos=pos),
+                        loc,
+                        pos=pos
                     )
-                    static_offset_counter += 32
-                else:
-                    offset = LLLnode.from_list(
-                        ["mload", ["add", "_R", static_offset_counter]], typ=right_arg.typ, pos=pos,
-                    )
-                    static_offset_counter += get_size_of_type(right_arg) * 32
-                subs.append(make_setter(left_arg, offset, loc, pos=pos))
+                )
+    
             return LLLnode.from_list(
                 ["with", "_R", right, ["seq"] + subs], typ=None, annotation="Tuple assignment",
             )
-        # If the right side is a variable
+        # If the left side is a variable i.e struct type
         else:
             subs = []
             right_token = LLLnode.from_list("_R", typ=right.typ, location=right.location)

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -15,7 +15,6 @@ from vyper.types import (
     ByteArrayType,
     ListType,
     MappingType,
-    StringType,
     StructType,
     TupleLike,
     TupleType,
@@ -713,13 +712,10 @@ def make_setter(left, right, location, pos, in_function_call=False):
             for left_arg, key, loc in zip(left.args, keyz, locations):
                 subs.append(
                     make_setter(
-                        left_arg, 
-                        add_variable_offset(right_token, key, pos=pos),
-                        loc,
-                        pos=pos
+                        left_arg, add_variable_offset(right_token, key, pos=pos), loc, pos=pos
                     )
                 )
-    
+
             return LLLnode.from_list(
                 ["with", "_R", right, ["seq"] + subs], typ=None, annotation="Tuple assignment",
             )

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -17,6 +17,7 @@ from vyper.types import (
     get_static_size_of_type,
     has_dynamic_data,
 )
+from vyper.codegen.abi import abi_decode
 
 
 def _call_lookup_specs(stmt_expr, context):
@@ -56,13 +57,25 @@ def _call_make_placeholder(stmt_expr, context, sig):
         return 0, 0, 0
 
     output_placeholder = context.new_placeholder(typ=sig.output_type)
-    out_size = get_size_of_type(sig.output_type) * 32
-    returner = output_placeholder
+    output_size = get_size_of_type(sig.output_type) * 32
 
-    if not sig.internal and isinstance(sig.output_type, ByteArrayLike):
-        returner = output_placeholder + 32
-
-    return output_placeholder, returner, out_size
+    if isinstance(sig.output_type, BaseType):
+        returner = output_placeholder
+    elif isinstance(sig.output_type, ByteArrayLike):
+        returner = output_placeholder
+    elif isinstance(sig.output_type, TupleLike):
+        # incase of struct we need to decode the output and then return it
+        returner = ["seq"]
+        decoded_placeholder = context.new_placeholder(typ=sig.output_type)
+        decoded_node = LLLnode(decoded_placeholder, typ=sig.output_type, location="memory")
+        output_node = LLLnode(output_placeholder, typ=sig.output_type, location="memory")
+        returner.append(abi_decode(decoded_node, output_node))
+        returner.extend([decoded_placeholder])
+    elif isinstance(sig.output_type, ListType):
+        returner = output_placeholder
+    else:
+        raise TypeCheckFailure(f"Invalid output type: {sig.output_type}")
+    return output_placeholder, returner, output_size
 
 
 def _call_self_internal(stmt_expr, context, sig):

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -1,8 +1,10 @@
 import itertools
 
+from vyper.codegen.abi import abi_decode
 from vyper.exceptions import (
     StateAccessViolation,
     StructureException,
+    TypeCheckFailure,
     TypeMismatch,
 )
 from vyper.parser.lll_node import LLLnode
@@ -17,7 +19,6 @@ from vyper.types import (
     get_static_size_of_type,
     has_dynamic_data,
 )
-from vyper.codegen.abi import abi_decode
 
 
 def _call_lookup_specs(stmt_expr, context):


### PR DESCRIPTION
### What I did
I fixed the issue: #2155 

### How I did it
* Both internal and external function return abi-encoded data. But we were not decoding the return data. So I corrected the abi_decode function and then used it when parsing function calls
https://github.com/vyperlang/vyper/blob/39cbd404f0cfdd7f93ef40738c9a02421fe1f3da/vyper/codegen/abi.py#L408
* abi-decode function was not being used earlier so to pass the test cases of tuple return we were partially decoding tuples in make_setters util function. But now that we are using the abi-decode function properly, so to avoid decoding already decoded data I had to make changes here too.
https://github.com/vyperlang/vyper/blob/39cbd404f0cfdd7f93ef40738c9a02421fe1f3da/vyper/parser/parser_utils.py#L713
* Changed how tuple return statements were being compiled.
https://github.com/vyperlang/vyper/blob/39cbd404f0cfdd7f93ef40738c9a02421fe1f3da/vyper/codegen/return_.py#L67


### How to verify it
Run the following test case:
```
def test_struct_return_external_contract_call_2(get_contract_with_gas_estimation):
    contract_1 = """
struct X:
    x: int128
    y: String[6]
@external
def out_literals() -> X:
    return X({x: 1, y: "abcdef"})
    """

    contract_2 = """
struct X:
    x: int128
    y: String[6]
interface Test:
    def out_literals() -> X : view

@external
def test(addr: address) -> (int128, String[6]):
    ret: X = Test(addr).out_literals()
    return ret.x, ret.y

    """
    c1 = get_contract_with_gas_estimation(contract_1)
    c2 = get_contract_with_gas_estimation(contract_2)

    assert c1.out_literals() == [1, "abcdef"]
    assert c2.test(c1.address) == list(c1.out_literals())
```

### Description for the changelog

