### PR TITLE
Remove Excessive Scoping Rules on Local Variables

### DIFF
--- a/tests/parser/syntax/test_blockscope.py
+++ b/tests/parser/syntax/test_blockscope.py
@@ -57,11 +57,10 @@ def test_fail_undeclared(bad_code):
 
 fail_list_collision = [
     """
-a: int128
-
 @external
 def foo():
     a: int128 = 5
+    a: int128 = 7
     """
 ]
 
@@ -90,6 +89,13 @@ def foo(choice: bool):
     else:
         a: uint256 = 42
     a: bool = True
+    """,
+    """
+a: int128
+
+@external
+def foo():
+    a: int128 = 5
     """,
 ]
 

--- a/vyper/context/validation/local.py
+++ b/vyper/context/validation/local.py
@@ -37,7 +37,6 @@ from vyper.exceptions import (
     InvalidLiteral,
     InvalidType,
     IteratorException,
-    NamespaceCollision,
     NonPayableViolation,
     StateAccessViolation,
     StructureException,
@@ -175,15 +174,12 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             raise VariableDeclarationException(
                 "Memory variables must be declared with an initial value", node
             )
-        name = node.target.id
-        if name in self.namespace["self"].members:
-            raise NamespaceCollision("Variable name shadows an existing storage-scoped value", node)
 
         type_definition = get_type_from_annotation(node.annotation, DataLocation.MEMORY)
         validate_expected_type(node.value, type_definition)
 
         try:
-            self.namespace[name] = type_definition
+            self.namespace[node.target.id] = type_definition
         except VyperException as exc:
             raise exc.with_annotation(node) from None
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -119,7 +119,7 @@ class Context:
                 name, custom_structs=self.structs, pos=pos,
             )
             # Local context duplicate context check.
-            if any((name in self.vars, name in self.globals)):
+            if name in self.vars:
                 raise TypeCheckFailure(f"Duplicate variable name: {name}")
         return True
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -1,7 +1,7 @@
 import contextlib
 import enum
 
-from vyper.exceptions import CompilerPanic, TypeCheckFailure
+from vyper.exceptions import CompilerPanic
 from vyper.signatures.function_signature import VariableRecord
 from vyper.types import get_size_of_type
 from vyper.utils import check_valid_varname
@@ -118,9 +118,6 @@ class Context:
             check_valid_varname(
                 name, custom_structs=self.structs, pos=pos,
             )
-            # Local context duplicate context check.
-            if name in self.vars:
-                raise TypeCheckFailure(f"Duplicate variable name: {name}")
         return True
 
     def _mangle(self, name):

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -4,7 +4,6 @@ from vyper import ast as vy_ast
 from vyper.exceptions import (
     InvalidType,
     StructureException,
-    VariableDeclarationException,
 )
 from vyper.parser.parser_utils import getpos, set_offsets
 from vyper.signatures.function_signature import ContractRecord, VariableRecord

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -274,10 +274,6 @@ def {varname}{funname}({head.rstrip(', ')}) -> {base}:
     def is_valid_varname(self, name, item):
         """ Valid variable name, checked against global context. """
         check_valid_varname(name, self._structs, item)
-        if name in self._globals:
-            raise VariableDeclarationException(
-                f'Invalid name "{name}", previously defined as global.', item
-            )
         return True
 
     @staticmethod

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -1,10 +1,7 @@
 from typing import Optional
 
 from vyper import ast as vy_ast
-from vyper.exceptions import (
-    InvalidType,
-    StructureException,
-)
+from vyper.exceptions import InvalidType, StructureException
 from vyper.parser.parser_utils import getpos, set_offsets
 from vyper.signatures.function_signature import ContractRecord, VariableRecord
 from vyper.types import (


### PR DESCRIPTION
fixes: #2127

### Description for the changelog
No longer throws when a local variable has the same name as a global, due to the namespacing by `self.`

### Cute Animal Picture
![hooray](https://images.huffingtonpost.com/2015-06-30-1435644840-2334395-046224677malelions-thumb.jpg)