### PR TITLE
Changes to how version and commit hash are stored / retrieved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ release: clean
 	twine check dist/*
 	#twine upload dist/*
 
-freeze: clean
+freeze: clean init
 	echo Generating binary...
 	pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.$(VERSION).$(OS) --add-data vyper:vyper
 

--- a/make.cmd
+++ b/make.cmd
@@ -42,6 +42,7 @@ goto :end
 
 :freeze
 CALL :clean
+CALL :init
 set PYTHONPATH=.
 for /f "delims=" %%a in ('python vyper/cli/vyper_compile.py --version') do @set VERSION=%%a
 pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.%VERSION%.windows --add-data vyper;vyper

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import subprocess
 
 from setuptools import find_packages, setup
 
+__version__ = "0.2.4"
+
 extras_require = {
     "test": [
         "pytest>=5.4,<6.0",
@@ -39,7 +41,7 @@ try:
     commithash = subprocess.check_output("git rev-parse HEAD".split())
     commithash_str = commithash.decode("utf-8").strip()
     with open(hashfile, "w") as fh:
-        fh.write(commithash_str)
+        fh.write(f"{__version__}\n{commithash_str}")
 except subprocess.CalledProcessError:
     pass
 
@@ -48,7 +50,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="vyper",
-    version="0.2.4",
+    version=__version__,
     description="Vyper: the Pythonic Programming Language for the EVM",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -1,4 +1,5 @@
 import sys as _sys
+from pathlib import Path as _Path
 
 import pkg_resources as _pkg_resources
 
@@ -9,13 +10,14 @@ if (_sys.version_info.major, _sys.version_info.minor) < (3, 6):
     raise Exception("Requires python3.6+")  # pragma: no cover
 
 
-try:
-    __version__ = _pkg_resources.get_distribution("vyper").version
-except _pkg_resources.DistributionNotFound:
-    __version__ = "0.0.0development"
-
-try:
-    __commit__ = _pkg_resources.resource_string("vyper", "vyper_git_version.txt").decode("utf-8")
-    __commit__ = __commit__[:7]
-except FileNotFoundError:
+_version_file = _Path(__file__).parent.joinpath("vyper_git_version.txt")
+if _version_file.exists():
+    with _version_file.open() as fp:
+        __version__, __commit__ = fp.read().split("\n")
+        __commit__ = __commit__[:7]
+else:
     __commit__ = "unknown"
+    try:
+        __version__ = _pkg_resources.get_distribution("vyper").version
+    except _pkg_resources.DistributionNotFound:
+        __version__ = "0.0.0development"


### PR DESCRIPTION
### What I did
Adjust how the version and commit hash are stored.  This simplifies the process of creating standalone binaries - with the current approach, because the binary is not installed by pip, the version shows as `0.0.0-development`.

### How I did it
* Along with recording the commit hash in `vyper_git_version.txt`, the version is also saved.
* The lookup process for the version is reversed. The first checks is the text file, and if this fails it falls back to `pkg_resources`.
* The version in `setup.py` is recorded as `__version__` at the top, so it's accessible when writing the text file
* `init` is added as a requirement for `freeze` in the makefile, to ensure the version txt exists and is up-to-date prior to building the binary.

### How to verify it
Build some binaries.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/94501689-167b3080-020b-11eb-9e82-2e5d0fa5c21c.png)
