### PR TITLE
Optimize nonpayable checks

### DIFF
--- a/tests/parser/features/decorators/test_payable.py
+++ b/tests/parser/features/decorators/test_payable.py
@@ -52,3 +52,151 @@ def test_payable_compile_fail(source, get_contract, assert_compile_failed):
     assert_compile_failed(
         lambda: get_contract(source), CallViolation,
     )
+
+
+nonpayable_code = [
+    """
+# single function, nonpayable
+@external
+def foo() -> bool:
+    return True
+    """,
+    """
+# multiple functions, one is payable
+@external
+def foo() -> bool:
+    return True
+
+@payable
+@external
+def bar() -> bool:
+    return True
+    """,
+    """
+# multiple functions, nonpayable
+@external
+def foo() -> bool:
+    return True
+
+@external
+def bar() -> bool:
+    return True
+    """,
+    """
+# multiple functions, nonpayable (view)
+@external
+def foo() -> bool:
+    return True
+
+@view
+@external
+def bar() -> bool:
+    return True
+    """,
+    """
+# payable init function
+@external
+@payable
+def __init__():
+    a: int128 = 1
+
+@external
+def foo() -> bool:
+    return True
+    """,
+    """
+# payable default function
+@external
+@payable
+def __default__():
+    a: int128 = 1
+
+@external
+def foo() -> bool:
+    return True
+    """,
+]
+
+
+@pytest.mark.parametrize("code", nonpayable_code)
+def test_nonpayable_runtime_assertion(assert_tx_failed, get_contract, code):
+    c = get_contract(code)
+
+    c.foo(transact={"value": 0})
+    assert_tx_failed(lambda: c.foo(transact={"value": 10 ** 18}))
+
+
+payable_code = [
+    """
+# single function, payable
+@payable
+@external
+def foo() -> bool:
+    return True
+    """,
+    """
+# multiple functions, one is payable
+@payable
+@external
+def foo() -> bool:
+    return True
+
+@external
+def bar() -> bool:
+    return True
+    """,
+    """
+# multiple functions, payable
+@payable
+@external
+def foo() -> bool:
+    return True
+
+@payable
+@external
+def bar() -> bool:
+    return True
+    """,
+    """
+# multiple functions, one nonpayable (view)
+@payable
+@external
+def foo() -> bool:
+    return True
+
+@view
+@external
+def bar() -> bool:
+    return True
+    """,
+    """
+# init function
+@external
+def __init__():
+    a: int128 = 1
+
+@payable
+@external
+def foo() -> bool:
+    return True
+    """,
+    """
+# default function
+@external
+def __default__():
+    a: int128 = 1
+
+@external
+@payable
+def foo() -> bool:
+    return True
+    """,
+]
+
+
+@pytest.mark.parametrize("code", payable_code)
+def test_payable_runtime_assertion(get_contract, code):
+    c = get_contract(code)
+
+    c.foo(transact={"value": 10 ** 18})
+    c.foo(transact={"value": 0})

--- a/tests/parser/features/test_gas.py
+++ b/tests/parser/features/test_gas.py
@@ -1,7 +1,3 @@
-from vyper.parser import parser_utils
-from vyper.parser.parser import parse_to_lll
-
-
 def test_gas_call(get_contract_with_gas_estimation):
     gas_call = """
 @external
@@ -13,19 +9,3 @@ def foo() -> uint256:
 
     assert c.foo(call={"gas": 50000}) < 50000
     assert c.foo(call={"gas": 50000}) > 25000
-
-    print("Passed gas test")
-
-
-def test_gas_estimate_repr():
-    code = """
-x: int128
-
-@external
-def __init__():
-    self.x = 1
-    """
-    parser_utils.LLLnode.repr_show_gas = True
-    out = parse_to_lll(code)
-    assert "35261" in str(out)[:28]
-    parser_utils.LLLnode.repr_show_gas = False

--- a/tests/parser/functions/test_send.py
+++ b/tests/parser/functions/test_send.py
@@ -14,17 +14,6 @@ def fop():
     assert_tx_failed(lambda: c.fop(transact={}))
 
 
-def test_payable_tx_fail(assert_tx_failed, get_contract, w3):
-    code = """
-@external
-def pay_me() -> bool:
-    return True
-    """
-    c = get_contract(code)
-
-    assert_tx_failed(lambda: c.pay_me(transact={"value": w3.toWei(0.1, "ether")}))
-
-
 def test_default_gas(get_contract, w3):
     """
     Tests to verify that send to default function will send limited gas (2300),

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -55,13 +55,14 @@ def validate_external_function(
 
 
 def parse_external_function(
-    code: ast.FunctionDef, sig: FunctionSignature, context: Context
+    code: ast.FunctionDef, sig: FunctionSignature, context: Context, is_contract_payable: bool
 ) -> LLLnode:
     """
     Parse a external function (FuncDef), and produce full function body.
 
     :param sig: the FuntionSignature
     :param code: ast of function
+    :param is_contract_payable: bool - does this contract contain payable functions?
     :return: full sig compare & function body
     """
 
@@ -81,8 +82,9 @@ def parse_external_function(
         context.memory_allocator.increase_memory(sig.max_copy_size)
     clampers.append(copier)
 
-    # Add asserts for payable and internal
-    if sig.mutability != "payable":
+    if is_contract_payable and sig.mutability != "payable":
+        # if the contract contains payable functions, but this is not one of them
+        # add an assertion that the value of the call is zero
         clampers.append(["assert", ["iszero", "callvalue"]])
 
     # Fill variable positions

--- a/vyper/parser/function_definitions/parse_function.py
+++ b/vyper/parser/function_definitions/parse_function.py
@@ -20,7 +20,7 @@ def is_default_func(code):
     return code.name == "__default__"
 
 
-def parse_function(code, sigs, origcode, global_ctx, _vars=None):
+def parse_function(code, sigs, origcode, global_ctx, is_contract_payable, _vars=None):
     """
     Parses a function and produces LLL code for the function, includes:
         - Signature method if statement
@@ -54,7 +54,9 @@ def parse_function(code, sigs, origcode, global_ctx, _vars=None):
     if sig.internal:
         o = parse_internal_function(code=code, sig=sig, context=context,)
     else:
-        o = parse_external_function(code=code, sig=sig, context=context,)
+        o = parse_external_function(
+            code=code, sig=sig, context=context, is_contract_payable=is_contract_payable
+        )
 
     o.context = context
     o.total_gas = o.gas + calc_mem_gas(o.context.memory_allocator.get_next_memory_position())


### PR DESCRIPTION
### What I did
When a contract contains no payable functions, only perform a single `ASSERT CALLVALUE ISZERO` at the beginning of the bytecode instead of at the start of each function.

Closes https://github.com/vyperlang/vyper/issues/1776

### How I did it
* In `parser.parser::parse_tree_to_lll`, prior to parsing the individual functions, check the signature of every function to see if any are payable.
* Pass the result of this check to `parser.function_definitions.parse_external_function::parse_external_function`, so the per-function check may be omitted.
* If required, insert the check at the start of the LLL once it has been generated.

### How to verify it
Run the tests.  I added some new test cases to verify that this behavior works as expected.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/94557378-27598f80-0267-11eb-979a-018756bfa18a.png)
