### PR TITLE
Size limit optimizations

### DIFF
--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -1,6 +1,8 @@
 import pytest
 from eth_utils import keccak
 
+from vyper.opcodes import EVM_VERSIONS
+
 
 def _make_tx(w3, address, signature, values):
     # helper function to broadcast transactions that fail clamping check
@@ -61,51 +63,55 @@ def foo(s: int128) -> int128:
     assert_tx_failed(lambda: _make_tx(w3, c.address, "foo(int128)", [value]))
 
 
+@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 @pytest.mark.parametrize("value", [0, 1])
-def test_bool_clamper_passing(w3, get_contract, value):
+def test_bool_clamper_passing(w3, get_contract, value, evm_version):
     code = """
 @external
 def foo(s: bool) -> bool:
     return s
     """
 
-    c = get_contract(code)
+    c = get_contract(code, evm_version=evm_version)
     _make_tx(w3, c.address, "foo(bool)", [value])
 
 
+@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 @pytest.mark.parametrize("value", [2, 3, 4, 8, 16, 2 ** 256 - 1])
-def test_bool_clamper_failing(w3, assert_tx_failed, get_contract, value):
+def test_bool_clamper_failing(w3, assert_tx_failed, get_contract, value, evm_version):
     code = """
 @external
 def foo(s: bool) -> bool:
     return s
     """
 
-    c = get_contract(code)
+    c = get_contract(code, evm_version=evm_version)
     assert_tx_failed(lambda: _make_tx(w3, c.address, "foo(bool)", [value]))
 
 
+@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 @pytest.mark.parametrize("value", [0, 1, 2 ** 160 - 1])
-def test_address_clamper_passing(w3, get_contract, value):
+def test_address_clamper_passing(w3, get_contract, value, evm_version):
     code = """
 @external
 def foo(s: address) -> address:
     return s
     """
 
-    c = get_contract(code)
+    c = get_contract(code, evm_version=evm_version)
     _make_tx(w3, c.address, "foo(address)", [value])
 
 
+@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 @pytest.mark.parametrize("value", [2 ** 160, 2 ** 256 - 1])
-def test_address_clamper_failing(w3, assert_tx_failed, get_contract, value):
+def test_address_clamper_failing(w3, assert_tx_failed, get_contract, value, evm_version):
     code = """
 @external
 def foo(s: address) -> address:
     return s
     """
 
-    c = get_contract(code)
+    c = get_contract(code, evm_version=evm_version)
     assert_tx_failed(lambda: _make_tx(w3, c.address, "foo(address)", [value]))
 
 

--- a/tests/parser/syntax/test_self_balance.py
+++ b/tests/parser/syntax/test_self_balance.py
@@ -1,5 +1,6 @@
 import pytest
 
+from vyper import compiler
 from vyper.opcodes import EVM_VERSIONS
 
 
@@ -17,12 +18,13 @@ def get_balance() -> uint256:
 def __default__():
     pass
     """
-    c = get_contract_with_gas_estimation(code, evm_version=evm_version)
-
+    opcodes = compiler.compile_code(code, ["opcodes"], evm_version=evm_version)["opcodes"]
     if evm_version == "istanbul":
-        assert 0x47 in c._classic_contract.bytecode
+        assert "SELFBALANCE" in opcodes
     else:
-        assert 0x47 not in c._classic_contract.bytecode
+        assert "SELFBALANCE" not in opcodes
 
+    c = get_contract_with_gas_estimation(code, evm_version=evm_version)
     w3.eth.sendTransaction({"to": c.address, "value": 1337})
+
     assert c.get_balance() == 1337

--- a/vyper/parser/arg_clamps.py
+++ b/vyper/parser/arg_clamps.py
@@ -1,6 +1,7 @@
 import functools
 import uuid
 
+from vyper.opcodes import version_check
 from vyper.parser.lll_node import LLLnode
 from vyper.types.types import (
     ByteArrayLike,
@@ -60,9 +61,11 @@ def make_arg_clamper(datapos, mempos, typ, is_init=False):
         )
     # Booleans: make sure they're zero or one
     elif is_base_type(typ, "bool"):
-        return LLLnode.from_list(
-            ["uclamplt", data_decl, 2], typ=typ, annotation="checking bool input",
-        )
+        if version_check("constantinople"):
+            lll = ["assert", ["iszero", ["shr", 1, data_decl]]]
+        else:
+            lll = ["uclamplt", data_decl, 2]
+        return LLLnode.from_list(lll, typ=typ, annotation="checking bool input")
     # Addresses: make sure they're in range
     elif is_base_type(typ, "address"):
         return LLLnode.from_list(

--- a/vyper/parser/arg_clamps.py
+++ b/vyper/parser/arg_clamps.py
@@ -61,18 +61,18 @@ def make_arg_clamper(datapos, mempos, typ, is_init=False):
         )
     # Booleans: make sure they're zero or one
     elif is_base_type(typ, "bool"):
-        if version_check("constantinople"):
+        if version_check(begin="constantinople"):
             lll = ["assert", ["iszero", ["shr", 1, data_decl]]]
         else:
             lll = ["uclamplt", data_decl, 2]
         return LLLnode.from_list(lll, typ=typ, annotation="checking bool input")
     # Addresses: make sure they're in range
     elif is_base_type(typ, "address"):
-        return LLLnode.from_list(
-            ["uclamplt", data_decl, ["mload", MemoryPositions.ADDRSIZE]],
-            typ=typ,
-            annotation="checking address input",
-        )
+        if version_check(begin="constantinople"):
+            lll = ["assert", ["iszero", ["shr", 160, data_decl]]]
+        else:
+            lll = ["uclamplt", data_decl, ["mload", MemoryPositions.ADDRSIZE]]
+        return LLLnode.from_list(lll, typ=typ, annotation="checking address input")
     # Bytes: make sure they have the right size
     elif isinstance(typ, ByteArrayLike):
         return LLLnode.from_list(


### PR DESCRIPTION
### What I did
Optimizations around size clamps.

### How I did it
* When compiling for >= constantinople rules, handle sizelimits for `address` and `bool` using `shr` instead of a comparison to the in-memory size limit.
* During LLL optimization, check for unused size limit values. If any are found, remove the initial `mstore` operation to reduce the size of the bytecode.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/94580544-b9bb5c80-0282-11eb-8def-5a8c86d442e4.png)
