### PR TITLE
Better exception on invalid subscript

### DIFF
--- a/tests/functional/context/types/test_type_from_annotation.py
+++ b/tests/functional/context/types/test_type_from_annotation.py
@@ -9,6 +9,7 @@ from vyper.exceptions import (
     ArrayIndexException,
     InvalidType,
     StructureException,
+    UndeclaredDefinition,
 )
 
 BASE_TYPES = ["int128", "uint256", "bool", "address", "bytes32"]
@@ -73,7 +74,7 @@ def test_base_types_as_multidimensional_arrays(build_node, namespace, type_str):
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
 def test_invalid_index(build_node, idx, type_str):
     node = build_node(f"{type_str}[{idx}]")
-    with pytest.raises((ArrayIndexException, InvalidType)):
+    with pytest.raises((ArrayIndexException, InvalidType, UndeclaredDefinition)):
         get_type_from_annotation(node, DataLocation.STORAGE)
 
 

--- a/vyper/context/validation/utils.py
+++ b/vyper/context/validation/utils.py
@@ -426,6 +426,15 @@ def get_index_value(node: vy_ast.Index) -> int:
     """
 
     if not isinstance(node.get("value"), vy_ast.Int):
+        if hasattr(node, "value"):
+            # even though the subscript is an invalid type, first check if it's a valid _something_
+            # this gives a more accurate error in case of e.g. a typo in a constant variable name
+            try:
+                get_possible_types_from_node(node.value)
+            except StructureException:
+                # StructureException is a very broad error, better to raise InvalidType in this case
+                pass
+
         raise InvalidType("Subscript must be a literal integer", node)
 
     if node.value.value <= 0:


### PR DESCRIPTION
### What I did
Improve the exception raised on an invalid subscript.

### How I did it
Prior to the general "Subscript must be a literal integer", first check that the subscript is a valid _something_.  If it isn't, the exception raised can be more useful in determining what went wrong.  For example, a typo in a constant variable name.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/94991216-40757f80-058a-11eb-97c1-a04045e4d9c9.png)
