### PR TITLE
Refactor int128 clamps

### DIFF
--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -39,27 +39,29 @@ def foo(s: Bytes[40]) -> Bytes[40]:
     assert_tx_failed(lambda: c.foo(data + b"!"))
 
 
+@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 @pytest.mark.parametrize("value", [0, 1, -1, 2 ** 127 - 1, -(2 ** 127)])
-def test_int128_clamper_passing(w3, get_contract, value):
+def test_int128_clamper_passing(w3, get_contract, value, evm_version):
     code = """
 @external
 def foo(s: int128) -> int128:
     return s
     """
 
-    c = get_contract(code)
+    c = get_contract(code, evm_version=evm_version)
     _make_tx(w3, c.address, "foo(int128)", [value])
 
 
+@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 @pytest.mark.parametrize("value", [2 ** 127, -(2 ** 127) - 1, 2 ** 255 - 1, -(2 ** 255)])
-def test_int128_clamper_failing(w3, assert_tx_failed, get_contract, value):
+def test_int128_clamper_failing(w3, assert_tx_failed, get_contract, value, evm_version):
     code = """
 @external
 def foo(s: int128) -> int128:
     return s
     """
 
-    c = get_contract(code)
+    c = get_contract(code, evm_version=evm_version)
     assert_tx_failed(lambda: _make_tx(w3, c.address, "foo(int128)", [value]))
 
 

--- a/vyper/functions/convert.py
+++ b/vyper/functions/convert.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from vyper import ast as vy_ast
 from vyper.exceptions import InvalidLiteral, StructureException, TypeMismatch
 from vyper.functions.signatures import signature
+from vyper.parser.arg_clamps import int128_clamp
 from vyper.parser.parser_utils import LLLnode, byte_array_to_num, getpos
 from vyper.types import BaseType, ByteArrayType, StringType, get_type
 from vyper.utils import DECIMAL_DIVISOR, MemoryPositions, SizeLimits
@@ -59,14 +60,7 @@ def to_int128(expr, args, kwargs, context):
                 return LLLnode.from_list(in_arg, typ=BaseType("int128"), pos=getpos(expr))
         else:
             return LLLnode.from_list(
-                [
-                    "clamp",
-                    ["mload", MemoryPositions.MINNUM],
-                    in_arg,
-                    ["mload", MemoryPositions.MAXNUM],
-                ],
-                typ=BaseType("int128"),
-                pos=getpos(expr),
+                int128_clamp(in_arg), typ=BaseType("int128"), pos=getpos(expr),
             )
 
     elif input_type == "address":
@@ -99,12 +93,7 @@ def to_int128(expr, args, kwargs, context):
 
     elif input_type == "decimal":
         return LLLnode.from_list(
-            [
-                "clamp",
-                ["mload", MemoryPositions.MINNUM],
-                ["sdiv", in_arg, DECIMAL_DIVISOR],
-                ["mload", MemoryPositions.MAXNUM],
-            ],
+            int128_clamp(["sdiv", in_arg, DECIMAL_DIVISOR]),
             typ=BaseType("int128"),
             pos=getpos(expr),
         )

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -46,6 +46,7 @@ from vyper.exceptions import (
 )
 from vyper.functions.convert import convert
 from vyper.opcodes import version_check
+from vyper.parser.arg_clamps import int128_clamp
 from vyper.parser.expr import Expr
 from vyper.parser.keccak256_helper import keccak256_helper
 from vyper.parser.parser_utils import (
@@ -877,11 +878,7 @@ class Extract32(_SimpleBuiltinFunction):
                 annotation="extracting 32 bytes",
             )
         if ret_type == "int128":
-            return LLLnode.from_list(
-                ["clamp", ["mload", MemoryPositions.MINNUM], o, ["mload", MemoryPositions.MAXNUM]],
-                typ=BaseType("int128"),
-                pos=getpos(expr),
-            )
+            return LLLnode.from_list(int128_clamp(o), typ=BaseType("int128"), pos=getpos(expr),)
         elif ret_type == "address":
             return LLLnode.from_list(
                 ["uclamplt", o, ["mload", MemoryPositions.ADDRSIZE]],

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -11,6 +11,7 @@ from vyper.exceptions import (
 )
 from vyper.opcodes import version_check
 from vyper.parser import external_call, self_call
+from vyper.parser.arg_clamps import int128_clamp
 from vyper.parser.keccak256_helper import keccak256_helper
 from vyper.parser.lll_node import LLLnode
 from vyper.parser.parser_utils import (
@@ -590,14 +591,7 @@ class Expr:
 
         p = ["seq"]
         if new_typ.typ == "int128":
-            p.append(
-                [
-                    "clamp",
-                    ["mload", MemoryPositions.MINNUM],
-                    arith,
-                    ["mload", MemoryPositions.MAXNUM],
-                ]
-            )
+            p.append(int128_clamp(arith))
         elif new_typ.typ == "decimal":
             p.append(
                 [

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -8,6 +8,7 @@ from vyper.exceptions import (
     TypeCheckFailure,
     TypeMismatch,
 )
+from vyper.parser.arg_clamps import int128_clamp
 from vyper.parser.lll_node import LLLnode
 from vyper.types import (
     BaseType,
@@ -234,12 +235,7 @@ def byte_array_to_num(
             ["sload", ["add", 1, ["sha3_32", "_sub"]]], typ=BaseType("int128")
         )
     if out_type == "int128":
-        result = [
-            "clamp",
-            ["mload", MemoryPositions.MINNUM],
-            ["div", "_el1", ["exp", 256, ["sub", 32, "_len"]]],
-            ["mload", MemoryPositions.MAXNUM],
-        ]
+        result = int128_clamp(["div", "_el1", ["exp", 256, ["sub", 32, "_len"]]])
     elif out_type == "uint256":
         result = ["div", "_el1", ["exp", 256, ["sub", offset, "_len"]]]
     return LLLnode.from_list(


### PR DESCRIPTION
### What I did
Refactor the process of clamping `int128` using bitshifting.

### How I did it
The new check can be expressed as:

```python
assert abs(n) >> 127 == 0
```

This check produces smaller bytecode and uses less gas at runtime.

The logic is handled in a new `int128_clamp` function within `vyper.parser.arg_clamps`. All the locations where clamping previously happened are now calling to this function.

### How to verify it
Run the tests.

I still need to verify how well tested this behavior is.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95020784-e6ea7f00-0675-11eb-8e13-4f5e56e53e72.png)
