### PR TITLE
fix-#2183: Incorrect output while passing multi-dimensional array as argument

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -273,7 +273,7 @@ def test_values(arr: int128[2][1], i: int128) -> (int128[2][1], int128):
     assert c.test_values([[1, 2]], 3) == [[[1, 2]], 3]
 
 
-def test_2d_array_input_1(get_contract):
+def test_2d_array_input_2(get_contract):
     code = """
 @internal
 def test_input(arr: int128[2][3], s: String[10]) -> (int128[2][3], String[10]):
@@ -286,4 +286,3 @@ def test_values(arr: int128[2][3], s: String[10]) -> (int128[2][3], String[10]):
 
     c = get_contract(code)
     assert c.test_values([[1, 2], [3, 4], [5, 6]], "abcdef") == [[[1, 2], [3, 4], [5, 6]], "abcdef"]
-

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -256,3 +256,34 @@ def parse_list_fail():
     pass
     """
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatch)
+
+
+def test_2d_array_input_1(get_contract):
+    code = """
+@internal
+def test_input(arr: int128[2][1], i: int128) -> (int128[2][1], int128):
+    return arr, i
+
+@external
+def test_values(arr: int128[2][1], i: int128) -> (int128[2][1], int128):
+    return self.test_input(arr, i)
+    """
+
+    c = get_contract(code)
+    assert c.test_values([[1, 2]], 3) == [[[1, 2]], 3]
+
+
+def test_2d_array_input_1(get_contract):
+    code = """
+@internal
+def test_input(arr: int128[2][3], s: String[10]) -> (int128[2][3], String[10]):
+    return arr, s
+
+@external
+def test_values(arr: int128[2][3], s: String[10]) -> (int128[2][3], String[10]):
+    return self.test_input(arr, s)
+    """
+
+    c = get_contract(code)
+    assert c.test_values([[1, 2], [3, 4], [5, 6]], "abcdef") == [[[1, 2], [3, 4], [5, 6]], "abcdef"]
+

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -498,11 +498,7 @@ def pack_arguments(signature, args, context, stmt_expr, is_external_call):
                 [placeholder + staticarray_offset + i * 32], typ=typ, location="memory",
             )
             setters.append(make_setter(target, arg, "memory", pos=pos))
-            if isinstance(typ, ListType):
-                count = typ.count
-            else:
-                count = len(typ.tuple_items())
-            staticarray_offset += 32 * (count - 1)
+            staticarray_offset += 32 * (get_size_of_type(typ) - 1)
 
         else:
             return


### PR DESCRIPTION

### What I did
Fixed: #2183 

### How I did it
In this line it is assumed that size of each subtype of a array/struct is 32, which is wrong:
https://github.com/vyperlang/vyper/blob/51158673c394f5b3decb4fbd5f88eca98c1b2b33/vyper/parser/parser_utils.py#L505
So I replaced the above line with this.
```
staticarray_offset += 32 * (get_size_of_type(typ) - 1)
```
And since the variable count is not needed anymore we can avoid its calculation here:
https://github.com/vyperlang/vyper/blob/51158673c394f5b3decb4fbd5f88eca98c1b2b33/vyper/parser/parser_utils.py#L501
