### PR TITLE
Fix: function calls within tuples / nested calls

### DIFF
--- a/tests/parser/syntax/test_return_tuple.py
+++ b/tests/parser/syntax/test_return_tuple.py
@@ -17,3 +17,124 @@ def test_tuple_return_fail(bad_code):
 
     with pytest.raises(FunctionDeclarationException):
         compiler.compile_code(bad_code)
+
+
+def test_self_call_in_return_tuple(get_contract):
+    code = """
+@internal
+def _foo() -> uint256:
+    a: uint256[10] = [6,7,8,9,10,11,12,13,14,15]
+    return 3
+
+@external
+def foo() -> (uint256, uint256, uint256, uint256, uint256):
+    return 1, 2, self._foo(), 4, 5
+    """
+
+    c = get_contract(code)
+
+    assert c.foo() == [1, 2, 3, 4, 5]
+
+
+def test_call_in_call(get_contract):
+    code = """
+@internal
+def _foo(a: uint256, b: uint256, c: uint256) -> (uint256, uint256, uint256, uint256, uint256):
+    return 1, a, b, c, 5
+
+@internal
+def _foo2() -> uint256:
+    a: uint256[10] = [6,7,8,9,10,11,12,13,15,16]
+    return 4
+
+@external
+def foo() -> (uint256, uint256, uint256, uint256, uint256):
+    return self._foo(2, 3, self._foo2())
+    """
+
+    c = get_contract(code)
+
+    assert c.foo() == [1, 2, 3, 4, 5]
+
+
+def test_nested_calls_in_tuple_return(get_contract):
+    code = """
+@internal
+def _foo(a: uint256, b: uint256, c: uint256) -> (uint256, uint256):
+    return 415, 3
+
+@internal
+def _foo2(a: uint256) -> uint256:
+    b: uint256[10] = [6,7,8,9,10,11,12,13,14,15]
+    return 99
+
+@internal
+def _foo3(a: uint256, b: uint256) -> uint256:
+    c: uint256[10] = [14,15,16,17,18,19,20,21,22,23]
+    return 42
+
+@internal
+def _foo4() -> uint256:
+    c: uint256[10] = [14,15,16,17,18,19,20,21,22,23]
+    return 4
+
+@external
+def foo() -> (uint256, uint256, uint256, uint256, uint256):
+    return 1, 2, self._foo(6, 7, self._foo2(self._foo3(9, 11)))[1], self._foo4(), 5
+    """
+
+    c = get_contract(code)
+
+    assert c.foo() == [1, 2, 3, 4, 5]
+
+
+def test_external_call_in_return_tuple(get_contract):
+    code = """
+@view
+@external
+def foo() -> (uint256, uint256):
+    return 3, 4
+    """
+
+    code2 = """
+interface Foo:
+    def foo() -> (uint256, uint256): view
+
+@external
+def foo(a: address) -> (uint256, uint256, uint256, uint256, uint256):
+    return 1, 2, Foo(a).foo()[0], 4, 5
+    """
+
+    c = get_contract(code)
+    c2 = get_contract(code2)
+
+    assert c2.foo(c.address) == [1, 2, 3, 4, 5]
+
+
+def test_nested_external_call_in_return_tuple(get_contract):
+    code = """
+@view
+@external
+def foo() -> (uint256, uint256):
+    return 3, 4
+
+@view
+@external
+def bar(a: uint256) -> uint256:
+    return a+1
+    """
+
+    code2 = """
+interface Foo:
+    def foo() -> (uint256, uint256): view
+    def bar(a: uint256) -> uint256: view
+
+@external
+def foo(a: address) -> (uint256, uint256, uint256, uint256, uint256):
+    return 1, 2, Foo(a).foo()[0], 4, Foo(a).bar(Foo(a).foo()[1])
+    """
+
+    c = get_contract(code)
+    c2 = get_contract(code2)
+
+    assert c2.foo(c.address) == [1, 2, 3, 4, 5]

--- a/vyper/parser/self_call.py
+++ b/vyper/parser/self_call.py
@@ -5,7 +5,6 @@ from vyper.exceptions import (
     StateAccessViolation,
     StructureException,
     TypeCheckFailure,
-    TypeMismatch,
 )
 from vyper.parser.lll_node import LLLnode
 from vyper.parser.parser_utils import getpos, pack_arguments
@@ -19,38 +18,6 @@ from vyper.types import (
     get_static_size_of_type,
     has_dynamic_data,
 )
-
-
-def _call_lookup_specs(stmt_expr, context):
-    from vyper.parser.expr import Expr
-
-    method_name = stmt_expr.func.attr
-
-    if len(stmt_expr.keywords):
-        raise TypeMismatch(
-            "Cannot use keyword arguments in calls to functions via 'self'", stmt_expr,
-        )
-    expr_args = [Expr(arg, context).lll_node for arg in stmt_expr.args]
-
-    sig = FunctionSignature.lookup_sig(context.sigs, method_name, expr_args, stmt_expr, context,)
-
-    return method_name, expr_args, sig
-
-
-def make_call(stmt_expr, context):
-    method_name, _, sig = _call_lookup_specs(stmt_expr, context)
-
-    if context.is_constant() and sig.mutability not in ("view", "pure"):
-        raise StateAccessViolation(
-            f"May not call state modifying function "
-            f"'{method_name}' within {context.pp_constancy()}.",
-            getpos(stmt_expr),
-        )
-
-    if not sig.internal:
-        raise StructureException("Cannot call external functions via 'self'", stmt_expr)
-
-    return _call_self_internal(stmt_expr, context, sig)
 
 
 def _call_make_placeholder(stmt_expr, context, sig):
@@ -79,7 +46,7 @@ def _call_make_placeholder(stmt_expr, context, sig):
     return output_placeholder, returner, output_size
 
 
-def _call_self_internal(stmt_expr, context, sig):
+def make_call(stmt_expr, context):
     # ** Internal Call **
     # Steps:
     # (x) push current local variables
@@ -89,12 +56,33 @@ def _call_self_internal(stmt_expr, context, sig):
     # (x) pop return values
     # (x) pop local variables
 
-    method_name, expr_args, sig = _call_lookup_specs(stmt_expr, context)
     pre_init = []
     pop_local_vars = []
     push_local_vars = []
     pop_return_values = []
     push_args = []
+
+    from vyper.parser.expr import Expr
+
+    method_name = stmt_expr.func.attr
+
+    expr_args = []
+    for arg in stmt_expr.args:
+        lll_node = Expr(arg, context).lll_node
+        context.new_placeholder(lll_node.typ)
+        expr_args.append(lll_node)
+
+    sig = FunctionSignature.lookup_sig(context.sigs, method_name, expr_args, stmt_expr, context,)
+
+    if context.is_constant() and sig.mutability not in ("view", "pure"):
+        raise StateAccessViolation(
+            f"May not call state modifying function "
+            f"'{method_name}' within {context.pp_constancy()}.",
+            getpos(stmt_expr),
+        )
+
+    if not sig.internal:
+        raise StructureException("Cannot call external functions via 'self'", stmt_expr)
 
     # Push local variables.
     var_slots = [(v.pos, v.size) for name, v in context.vars.items() if v.location == "memory"]


### PR DESCRIPTION
### What I did
Fix a memory corruption issue when performing a function call inside a tuple or as an argument inside another function call.

### How I did it
The issue was happening because each argument/item was parsed without knowledge of the other items. When pushing memory to the stack prior to performing nested call, previous items were not accounted for and so not correctly preserved.

You can see the bug in action by run the test cases I've added against the current master branch.

To fix this, I've expanded the logic for parsing tuples and function call arguments. All nested calls are performed separately, prior to building the tuple/args. This way memory is correctly preserved.

### How to verify it
Run the tests.  I've added some new cases to verify that the bug no longer exists.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95603573-24c51a00-0a5f-11eb-94f6-e8ef3aa804ae.png)
