### PR TITLE
Reuse memory slots

### DIFF
--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -78,7 +78,7 @@ def gen_tuple_return(stmt, context, sub):
     # (big difference between returning `(bytes,)` and `bytes`.
     abi_typ = ensure_tuple(abi_typ)
     abi_bytes_needed = abi_typ.static_size() + abi_typ.dynamic_size_bound()
-    dst, _ = context.memory_allocator.increase_memory(abi_bytes_needed)
+    dst = context.memory_allocator.increase_memory(abi_bytes_needed)
     return_buffer = LLLnode(
         dst, location="memory", annotation="return_buffer", typ=context.return_type
     )

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -134,7 +134,7 @@ class Context:
             name = self._mangle(name)
         if internal_var or self.is_valid_varname(name, pos):
             var_size = 32 * get_size_of_type(typ)
-            var_pos, _ = self.memory_allocator.increase_memory(var_size)
+            var_pos = self.memory_allocator.increase_memory(var_size)
             self.vars[name] = VariableRecord(
                 name=name, pos=var_pos, typ=typ, mutable=True, blockscopes=self.blockscopes.copy(),
             )

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -103,12 +103,13 @@ class Context:
     def make_blockscope(self, blockscope_id):
         self.blockscopes.add(blockscope_id)
         yield
+
         # Remove all variables that have specific blockscope_id attached.
-        self.vars = {
-            name: var_record
-            for name, var_record in self.vars.items()
-            if blockscope_id not in var_record.blockscopes
-        }
+        released = [(k, v) for k, v in self.vars.items() if blockscope_id in v.blockscopes]
+        for name, var in released:
+            self.memory_allocator.release_memory(var.pos, var.size * 32)
+            del self.vars[name]
+
         # Remove block scopes
         self.blockscopes.remove(blockscope_id)
 

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -99,6 +99,11 @@ class Context:
         yield
         self.in_range_expr = prev_value
 
+    def internal_memory_scope(self, scope_id):
+        # syntactic sugar for `make_blockscope` used to release
+        # memory after creating temporary internal variables
+        return self.make_blockscope(scope_id)
+
     @contextlib.contextmanager
     def make_blockscope(self, blockscope_id):
         self.blockscopes.add(blockscope_id)

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -100,7 +100,7 @@ def parse_external_function(
                 )
             )
         if isinstance(arg.typ, ByteArrayLike):
-            mem_pos, _ = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
+            mem_pos = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
             if sig.name == "__init__":
@@ -109,7 +109,7 @@ def parse_external_function(
                 )
             elif i >= default_args_start_pos:  # default args need to be allocated in memory.
                 type_size = get_size_of_type(arg.typ) * 32
-                default_arg_pos, _ = context.memory_allocator.increase_memory(type_size)
+                default_arg_pos = context.memory_allocator.increase_memory(type_size)
                 context.vars[arg.name] = VariableRecord(
                     name=arg.name, pos=default_arg_pos, typ=arg.typ, mutable=False,
                 )

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -95,7 +95,7 @@ def parse_internal_function(
     # Fill variable positions
     for arg in sig.args:
         if isinstance(arg.typ, ByteArrayLike):
-            mem_pos, _ = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
+            mem_pos = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
             context.vars[arg.name] = VariableRecord(

--- a/vyper/parser/memory_allocator.py
+++ b/vyper/parser/memory_allocator.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from vyper.exceptions import CompilerPanic
 from vyper.utils import MemoryPositions
 
@@ -15,9 +13,9 @@ class MemoryAllocator:
         return self.next_mem
 
     # Grow memory by x bytes
-    def increase_memory(self, size: int) -> Tuple[int, int]:
+    def increase_memory(self, size: int) -> int:
         if size % 32 != 0:
             raise CompilerPanic("Memory misaligment, only multiples of 32 supported.")
         before_value = self.next_mem
         self.next_mem += size
-        return before_value, self.next_mem
+        return before_value

--- a/vyper/parser/memory_allocator.py
+++ b/vyper/parser/memory_allocator.py
@@ -1,5 +1,21 @@
+from typing import List
+
 from vyper.exceptions import CompilerPanic
 from vyper.utils import MemoryPositions
+
+
+class FreeMemory:
+    __slots__ = (
+        "position",
+        "size",
+    )
+
+    def __init__(self, position, size):
+        self.position = position
+        self.size = size
+
+    def __repr__(self):
+        return f"(FreeMemory: pos={self.position}, size={self.size})"
 
 
 class MemoryAllocator:
@@ -7,6 +23,7 @@ class MemoryAllocator:
 
     def __init__(self, start_position: int = MemoryPositions.RESERVED_MEMORY):
         self.next_mem = start_position
+        self.released_mem: List[FreeMemory] = []
 
     # Get the next unused memory location
     def get_next_memory_position(self) -> int:
@@ -16,6 +33,48 @@ class MemoryAllocator:
     def increase_memory(self, size: int) -> int:
         if size % 32 != 0:
             raise CompilerPanic("Memory misaligment, only multiples of 32 supported.")
+
+        # check for released memory prior to expanding
+        for i, free_memory in enumerate(self.released_mem):
+            if free_memory.size == size:
+                del self.released_mem[i]
+                return free_memory.position
+            if free_memory.size > size:
+                position = free_memory.position
+                free_memory.position += size
+                free_memory.size -= size
+                return position
+
+        # if no released slots are avaialble, expand memory
         before_value = self.next_mem
         self.next_mem += size
         return before_value
+
+    def release_memory(self, pos: int, size: int) -> None:
+        if size % 32 != 0:
+            raise CompilerPanic("Memory misaligment, only multiples of 32 supported.")
+
+        # releasing from the end of the allocated memory - reduce the free memory pointer
+        if pos + size == self.next_mem:
+            self.next_mem = pos
+            return
+
+        if not self.released_mem or self.released_mem[-1].position < pos:
+            # no previously released memory, or this is the highest position released
+            self.released_mem.append(FreeMemory(position=pos, size=size))
+        else:
+            # previously released memory exists with a higher offset
+            idx = self.released_mem.index(next(i for i in self.released_mem if i.position > pos))
+            self.released_mem.insert(idx, FreeMemory(position=pos, size=size))
+
+        # iterate over released memory and merge slots where possible
+        i = 1
+        active = self.released_mem[0]
+        while len(self.released_mem) > i:
+            next_slot = self.released_mem[i]
+            if next_slot.position == active.position + active.size:
+                active.size += next_slot.size
+                self.released_mem.remove(next_slot)
+            else:
+                active = next_slot
+                i += 1


### PR DESCRIPTION
### What I did
Allow for releasing and reuse of memory slots.

### How I did it
* Within the memory allocator, add a method `release_memory` that accepts an offset and length.  Released memory is tracked in a a list using `FreeMemory` objects. These objects are essentially 2 item lists, but I think the special class makes the code more readable.
* Calls to `increase_memory` check for available slots in released memory, and if found they are reused instead of expanding memory.
* Upon exiting the `make_blockscope` context manager, all memory variables that are no longer accessible are released.
* Added a new context manager `internal_memory_scope`. It works identically to `make_blockscope`. I added it to differentiate between an actual user-defined scope (for loop, if branches) and an internal scope (event generation, assertions). I applied it to several areas where we generate temporary memory variables.

### How to verify it
Run the tests.  I haven't added any specific cases around this, but it should factor into the majority of the test suite.  I verified the behavior by compiling and running the tests at https://github.com/curvefi/curve-contract and everything works.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95641169-6da1c080-0aa9-11eb-82d6-ec30be401376.png)
