### PR TITLE
Improve exception for invalid use of dynamically sized struct

### DIFF
--- a/tests/parser/exceptions/test_argument_exception.py
+++ b/tests/parser/exceptions/test_argument_exception.py
@@ -89,6 +89,31 @@ def foo():
     for i in range(1, 2, 3, 4):
         pass
     """,
+    """
+struct Foo:
+    a: Bytes[32]
+
+@external
+def foo(a: Foo):
+    pass
+    """,
+    """
+struct Foo:
+    a: String[32]
+
+@external
+def foo(a: Foo):
+    pass
+    """,
+    """
+struct Foo:
+    b: uint256
+    a: String[32]
+
+@external
+def foo(a: Foo):
+    pass
+    """,
 ]
 
 

--- a/vyper/context/types/bases.py
+++ b/vyper/context/types/bases.py
@@ -187,6 +187,8 @@ class BaseTypeDefinition:
         If `True`, the value of this object cannot be modified after assignment.
     """
 
+    is_dynamic_size = False
+
     def __init__(
         self,
         location: DataLocation = DataLocation.UNSET,

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -7,6 +7,7 @@ from vyper.ast.validation import validate_call_args
 from vyper.context.namespace import get_namespace
 from vyper.context.types.bases import BaseTypeDefinition, DataLocation
 from vyper.context.types.indexable.sequence import TupleDefinition
+from vyper.context.types.meta.struct import StructDefinition
 from vyper.context.types.utils import (
     StringEnum,
     check_constant,
@@ -290,6 +291,13 @@ class ContractFunction(BaseTypeDefinition):
             type_definition = get_type_from_annotation(
                 arg.annotation, location=DataLocation.CALLDATA, is_immutable=True
             )
+            if isinstance(type_definition, StructDefinition) and type_definition.is_dynamic_size:
+                # this is a temporary restriction and should be removed once support for dynamically
+                # sized structs is implemented - https://github.com/vyperlang/vyper/issues/2190
+                raise ArgumentException(
+                    "Struct with dynamically sized data cannot be used as a function input", arg
+                )
+
             if value is not None:
                 if not check_constant(value):
                     raise StateAccessViolation(

--- a/vyper/context/types/indexable/sequence.py
+++ b/vyper/context/types/indexable/sequence.py
@@ -66,6 +66,10 @@ class ArrayDefinition(_SequenceDefinition):
     def __repr__(self):
         return f"{self.value_type}[{self.length}]"
 
+    @property
+    def is_dynamic_size(self):
+        return self.value_type.is_dynamic_size
+
     def get_index_type(self, node):
         if isinstance(node, vy_ast.Int):
             if node.value < 0:
@@ -106,6 +110,10 @@ class TupleDefinition(_SequenceDefinition):
 
     def __repr__(self):
         return self._id
+
+    @property
+    def is_dynamic_size(self):
+        return any(i for i in self.self.value_type if i.is_dynamic_size)
 
     def get_index_type(self, node):
         if not isinstance(node, vy_ast.Int):

--- a/vyper/context/types/meta/struct.py
+++ b/vyper/context/types/meta/struct.py
@@ -28,6 +28,10 @@ class StructDefinition(MemberTypeDefinition):
         for key, type_ in members.items():
             self.add_member(key, type_)
 
+    @property
+    def is_dynamic_size(self):
+        return any(i for i in self.members.values() if i.is_dynamic_size)
+
     def compare_type(self, other):
         return super().compare_type(other) and self._id == other._id
 

--- a/vyper/context/types/value/array_value.py
+++ b/vyper/context/types/value/array_value.py
@@ -34,6 +34,8 @@ class _ArrayValueDefinition(ValueTypeDefinition):
         is applied to a literal definition.
     """
 
+    is_dynamic_size = True
+
     def __repr__(self):
         return f"{self._id}[{self.length}]"
 


### PR DESCRIPTION
### What I did
Raise `ArgumentException` when using a dynamically-sized struct as a function input.

### How I did it
* Added `is_dynamic_size` attribute to all type objects within `vyper.context`
* When generating the function signature, raise if an input is a struct with dynamic size.

### How to verify it
Run the tests. I added some new cases.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95654871-a70b1800-0b0b-11eb-94f1-43f0a6f54954.png)
