### PR TITLE
Merge `Context.get_placeholder` and `Context.get_internal_variable`

### DIFF
--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -14,7 +14,7 @@ def make_return_stmt(stmt, context, begin_pos, _size, loop_memory_position=None)
     _, nonreentrant_post = get_nonreentrant_lock(context.sig, context.global_ctx)
     if context.is_internal:
         if loop_memory_position is None:
-            loop_memory_position = context.new_placeholder(typ=BaseType("uint256"))
+            loop_memory_position = context.new_internal_variable(typ=BaseType("uint256"))
 
         # Make label for stack push loop.
         label_id = "_".join([str(x) for x in (context.method_id, stmt.lineno, stmt.col_offset)])

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -46,7 +46,7 @@ def pack_logging_topics(event_id, args, expected_topics, context, pos):
 
             else:
                 # storage or calldata
-                placeholder = context.new_placeholder(value.typ)
+                placeholder = context.new_internal_variable(value.typ)
                 placeholder_node = LLLnode.from_list(placeholder, typ=value.typ, location="memory")
                 copier = make_byte_array_copier(
                     placeholder_node,
@@ -67,7 +67,7 @@ def pack_logging_topics(event_id, args, expected_topics, context, pos):
 
             else:
                 # storage or calldata
-                placeholder = context.new_placeholder(value.typ)
+                placeholder = context.new_internal_variable(value.typ)
                 placeholder_node = LLLnode.from_list(placeholder, typ=value.typ, location="memory")
                 setter = make_setter(placeholder_node, value, "memory", value.pos)
                 lll_node = ["seq", setter, ["sha3", placeholder, size]]
@@ -234,9 +234,7 @@ def pack_logging_data(expected_data, args, context, pos):
                 if len(arg.s) > typ.maxlen:
                     raise TypeMismatch(f"Data input bytes are to big: {len(arg.s)} {typ}", pos)
 
-            tmp_variable = context.new_internal_variable(
-                f"_log_pack_var_{arg.lineno}_{arg.col_offset}", source_lll.typ,
-            )
+            tmp_variable = context.new_internal_variable(source_lll.typ)
             tmp_variable_node = LLLnode.from_list(
                 tmp_variable,
                 typ=source_lll.typ,
@@ -255,8 +253,8 @@ def pack_logging_data(expected_data, args, context, pos):
 
     requires_dynamic_offset = any([isinstance(data.typ, ByteArrayLike) for data in expected_data])
     if requires_dynamic_offset:
-        dynamic_offset_counter = context.new_placeholder(BaseType(32))
-        dynamic_placeholder = context.new_placeholder(BaseType(32))
+        dynamic_offset_counter = context.new_internal_variable(BaseType(32))
+        dynamic_placeholder = context.new_internal_variable(BaseType(32))
     else:
         dynamic_offset_counter = None
 
@@ -265,9 +263,9 @@ def pack_logging_data(expected_data, args, context, pos):
     for i, (_arg, data) in enumerate(zip(args, expected_data)):
         typ = data.typ
         if not isinstance(typ, ByteArrayLike):
-            placeholder = context.new_placeholder(typ)
+            placeholder = context.new_internal_variable(typ)
         else:
-            placeholder = context.new_placeholder(BaseType(32))
+            placeholder = context.new_internal_variable(BaseType(32))
         placeholder_map[i] = placeholder
 
     # Populate static placeholders.

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -255,7 +255,7 @@ class Expr:
         return self._make_bytelike(typ, bytez, bytez_length)
 
     def _make_bytelike(self, btype, bytez, bytez_length):
-        placeholder = self.context.new_placeholder(btype)
+        placeholder = self.context.new_internal_variable(btype)
         seq = []
         seq.append(["mstore", placeholder, bytez_length])
         for i in range(0, len(bytez), 32):
@@ -613,14 +613,16 @@ class Expr:
         left = Expr(self.expr.left, self.context).lll_node
         right = Expr(self.expr.right, self.context).lll_node
 
-        result_placeholder = self.context.new_placeholder(BaseType("bool"))
+        result_placeholder = self.context.new_internal_variable(BaseType("bool"))
         setter = []
 
         # Load nth item from list in memory.
         if right.value == "multi":
             # Copy literal to memory to be compared.
             tmp_list = LLLnode.from_list(
-                obj=self.context.new_placeholder(ListType(right.typ.subtype, right.typ.count)),
+                obj=self.context.new_internal_variable(
+                    ListType(right.typ.subtype, right.typ.count)
+                ),
                 typ=ListType(right.typ.subtype, right.typ.count),
                 location="memory",
             )
@@ -963,7 +965,7 @@ class Expr:
                 # assign it's result to memory - otherwise there is potential for memory corruption
                 lll_node = Expr(node, self.context).lll_node
                 target = LLLnode.from_list(
-                    self.context.new_placeholder(lll_node.typ),
+                    self.context.new_internal_variable(lll_node.typ),
                     typ=lll_node.typ,
                     location="memory",
                     pos=getpos(self.expr),

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -131,7 +131,7 @@ def external_call(node, context, interface_name, contract_address, pos, value=No
 def get_external_call_output(sig, context):
     if not sig.output_type:
         return 0, 0, []
-    output_placeholder = context.new_placeholder(typ=sig.output_type)
+    output_placeholder = context.new_internal_variable(typ=sig.output_type)
     output_size = get_size_of_type(sig.output_type) * 32
     if isinstance(sig.output_type, BaseType):
         returner = [0, output_placeholder]
@@ -140,7 +140,7 @@ def get_external_call_output(sig, context):
     elif isinstance(sig.output_type, TupleLike):
         # incase of struct we need to decode the output and then return it
         returner = ["seq"]
-        decoded_placeholder = context.new_placeholder(typ=sig.output_type)
+        decoded_placeholder = context.new_internal_variable(typ=sig.output_type)
         decoded_node = LLLnode(decoded_placeholder, typ=sig.output_type, location="memory")
         output_node = LLLnode(output_placeholder, typ=sig.output_type, location="memory")
         returner.append(abi_decode(decoded_node, output_node))

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -65,7 +65,7 @@ def parse_internal_function(
     context.memory_allocator.increase_memory(sig.max_copy_size)
 
     _post_callback_ptr = f"{sig.name}_{sig.method_id}_post_callback_ptr"
-    context.callback_ptr = context.new_placeholder(typ=BaseType("uint256"))
+    context.callback_ptr = context.new_internal_variable(typ=BaseType("uint256"))
     clampers.append(
         LLLnode.from_list(
             ["mstore", context.callback_ptr, "pass"], annotation="pop callback pointer",
@@ -105,7 +105,7 @@ def parse_internal_function(
     # internal function copiers. No clamping for internal functions.
     dyn_variable_names = [a.name for a in sig.base_args if isinstance(a.typ, ByteArrayLike)]
     if dyn_variable_names:
-        i_placeholder = context.new_placeholder(typ=BaseType("uint256"))
+        i_placeholder = context.new_internal_variable(typ=BaseType("uint256"))
         unpackers: List[Any] = []
         for idx, var_name in enumerate(dyn_variable_names):
             var = context.vars[var_name]
@@ -182,7 +182,7 @@ def parse_internal_function(
 
                 # Unpack byte array if necessary.
                 if dynamics:
-                    i_placeholder = context.new_placeholder(typ=BaseType("uint256"))
+                    i_placeholder = context.new_internal_variable(typ=BaseType("uint256"))
                     for idx, var_pos in enumerate(dynamics):
                         ident = f"unpack_default_sig_dyn_{default_sig.method_id}_arg{idx}"
                         default_copiers.append(

--- a/vyper/parser/keccak256_helper.py
+++ b/vyper/parser/keccak256_helper.py
@@ -35,7 +35,7 @@ def keccak256_helper(expr, args, kwargs, context):
     else:
         # This should never happen, but just left here for future compiler-writers.
         raise Exception(f"Unsupported location: {sub.location}")  # pragma: no test
-    placeholder = context.new_placeholder(sub.typ)
+    placeholder = context.new_internal_variable(sub.typ)
     placeholder_node = LLLnode.from_list(placeholder, typ=sub.typ, location="memory")
     copier = make_byte_array_copier(
         placeholder_node, LLLnode.from_list("_sub", typ=sub.typ, location=sub.location),

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -445,7 +445,7 @@ def pack_arguments(signature, args, context, stmt_expr, is_external_call):
         maxlen += 32
 
     placeholder_typ = ByteArrayType(maxlen=maxlen)
-    placeholder = context.new_placeholder(placeholder_typ)
+    placeholder = context.new_internal_variable(placeholder_typ)
     if is_external_call:
         setters.append(["mstore", placeholder, signature.method_id])
         placeholder += 32

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -169,8 +169,8 @@ class Stmt:
 
         with self.context.internal_memory_scope(id(self.stmt)):
             reason_str = msg.s.strip()
-            sig_placeholder = self.context.new_placeholder(BaseType(32))
-            arg_placeholder = self.context.new_placeholder(BaseType(32))
+            sig_placeholder = self.context.new_internal_variable(BaseType(32))
+            arg_placeholder = self.context.new_internal_variable(BaseType(32))
             reason_str_type = ByteArrayType(len(reason_str))
             placeholder_bytes = Expr(msg, self.context).lll_node
             method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])
@@ -289,8 +289,7 @@ class Stmt:
         subtype = iter_list_node.typ.subtype.typ
         varname = self.stmt.target.id
         value_pos = self.context.new_variable(varname, BaseType(subtype),)
-        i_pos_raw_name = "_index_for_" + varname
-        i_pos = self.context.new_internal_variable(i_pos_raw_name, BaseType(subtype),)
+        i_pos = self.context.new_internal_variable(BaseType(subtype))
         self.context.forvars[varname] = True
 
         # Is a list that is already allocated to memory.
@@ -324,7 +323,7 @@ class Stmt:
             # Allocate list to memory.
             count = iter_list_node.typ.count
             tmp_list = LLLnode.from_list(
-                obj=self.context.new_placeholder(ListType(iter_list_node.typ.subtype, count)),
+                obj=self.context.new_internal_variable(ListType(iter_list_node.typ.subtype, count)),
                 typ=ListType(iter_list_node.typ.subtype, count),
                 location="memory",
             )
@@ -487,10 +486,10 @@ class Stmt:
                 return
 
             # loop memory has to be allocated first.
-            loop_memory_position = self.context.new_placeholder(typ=BaseType("uint256"))
+            loop_memory_position = self.context.new_internal_variable(typ=BaseType("uint256"))
             # len & bytez placeholder have to be declared after each other at all times.
-            len_placeholder = self.context.new_placeholder(typ=BaseType("uint256"))
-            bytez_placeholder = self.context.new_placeholder(typ=sub.typ)
+            len_placeholder = self.context.new_internal_variable(typ=BaseType("uint256"))
+            bytez_placeholder = self.context.new_internal_variable(typ=sub.typ)
 
             if sub.location in ("storage", "memory"):
                 return LLLnode.from_list(
@@ -518,7 +517,7 @@ class Stmt:
             return
 
         elif isinstance(sub.typ, ListType):
-            loop_memory_position = self.context.new_placeholder(typ=BaseType("uint256"))
+            loop_memory_position = self.context.new_internal_variable(typ=BaseType("uint256"))
             if sub.typ != self.context.return_type:
                 return
             elif sub.location == "memory" and sub.value != "multi":
@@ -536,7 +535,7 @@ class Stmt:
                 )
             else:
                 new_sub = LLLnode.from_list(
-                    self.context.new_placeholder(self.context.return_type),
+                    self.context.new_internal_variable(self.context.return_type),
                     typ=self.context.return_type,
                     location="memory",
                 )


### PR DESCRIPTION
### What I did
Merge `Context.get_placeholder` and `Context.get_internal_variable`

### How I did it
Both of these methods served an identical purpose and `get_internal_variable` was only used twice in the codebase.  I've merged the logic into a single function and added docstrings to make it more clear what is happening.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95798360-763d0580-0cfa-11eb-840a-864dfd36cade.png)
