### PR TITLE
Refactor the memory allocator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ extras_require = {
         "eth-tester[py-evm]>=0.5.0b1,<0.6",
         "web3>=5.11,<6.0",
         "tox>=3.15,<4.0",
-        "lark-parser>=0.8,<1.0",
-        "hypothesis[lark]>=5.16.2,<6.0",
+        "lark-parser==0.10.0",
+        "hypothesis[lark]>=5.37.1,<6.0",
     ],
     "lint": [
         "black==19.10b0",

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -14,7 +14,7 @@ def make_return_stmt(stmt, context, begin_pos, _size, loop_memory_position=None)
     _, nonreentrant_post = get_nonreentrant_lock(context.sig, context.global_ctx)
     if context.is_internal:
         if loop_memory_position is None:
-            loop_memory_position = context.new_internal_variable(typ=BaseType("uint256"))
+            loop_memory_position = context.new_internal_variable(BaseType("uint256"))
 
         # Make label for stack push loop.
         label_id = "_".join([str(x) for x in (context.method_id, stmt.lineno, stmt.col_offset)])
@@ -78,7 +78,7 @@ def gen_tuple_return(stmt, context, sub):
     # (big difference between returning `(bytes,)` and `bytes`.
     abi_typ = ensure_tuple(abi_typ)
     abi_bytes_needed = abi_typ.static_size() + abi_typ.dynamic_size_bound()
-    dst = context.memory_allocator.increase_memory(abi_bytes_needed)
+    dst = context.memory_allocator.allocate_memory(abi_bytes_needed)
     return_buffer = LLLnode(
         dst, location="memory", annotation="return_buffer", typ=context.return_type
     )

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -79,7 +79,7 @@ def parse_external_function(
         copier = ["pass"]
     elif sig.name == "__init__":
         copier = ["codecopy", MemoryPositions.RESERVED_MEMORY, "~codelen", sig.base_copy_size]
-        context.memory_allocator.increase_memory(sig.max_copy_size)
+        context.memory_allocator.allocate_memory(sig.max_copy_size)
     clampers.append(copier)
 
     if is_contract_payable and sig.mutability != "payable":
@@ -100,7 +100,7 @@ def parse_external_function(
                 )
             )
         if isinstance(arg.typ, ByteArrayLike):
-            mem_pos = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
+            mem_pos = context.memory_allocator.allocate_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
             if sig.name == "__init__":
@@ -109,7 +109,7 @@ def parse_external_function(
                 )
             elif i >= default_args_start_pos:  # default args need to be allocated in memory.
                 type_size = get_size_of_type(arg.typ) * 32
-                default_arg_pos = context.memory_allocator.increase_memory(type_size)
+                default_arg_pos = context.memory_allocator.allocate_memory(type_size)
                 context.vars[arg.name] = VariableRecord(
                     name=arg.name, pos=default_arg_pos, typ=arg.typ, mutable=False,
                 )

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -62,7 +62,7 @@ def parse_internal_function(
     clampers: List[LLLnode] = []
 
     # Allocate variable space.
-    context.memory_allocator.increase_memory(sig.max_copy_size)
+    context.memory_allocator.allocate_memory(sig.max_copy_size)
 
     _post_callback_ptr = f"{sig.name}_{sig.method_id}_post_callback_ptr"
     context.callback_ptr = context.new_internal_variable(typ=BaseType("uint256"))
@@ -95,7 +95,7 @@ def parse_internal_function(
     # Fill variable positions
     for arg in sig.args:
         if isinstance(arg.typ, ByteArrayLike):
-            mem_pos = context.memory_allocator.increase_memory(32 * get_size_of_type(arg.typ))
+            mem_pos = context.memory_allocator.allocate_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
             context.vars[arg.name] = VariableRecord(


### PR DESCRIPTION
### What I did
Refactor the memory allocator.

### How I did it
* Change increase/release to allocate/deallocate
* Add docstrings
* Update references

Longer term I think the memory allocator should be a private object, only referenced directly by `Context`. The current logic for handling function args is fairly reliant upon direct access, and I think this code deserves a larger-scale refactor using, so for now I've left it how it is.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95870380-19326580-0d75-11eb-8068-5e9086dfeaa2.png)
