### PR TITLE
Ensure sequential memory for internal variables

### DIFF
--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -251,27 +251,26 @@ def pack_logging_data(expected_data, args, context, pos):
             )
             prealloacted[idx] = tmp_variable_node
 
-    requires_dynamic_offset = any([isinstance(data.typ, ByteArrayLike) for data in expected_data])
-    if requires_dynamic_offset:
-        dynamic_offset_counter = context.new_internal_variable(BaseType(32))
-        dynamic_placeholder = context.new_internal_variable(BaseType(32))
-    else:
-        dynamic_offset_counter = None
+    # Create sequential placeholders for dynamic and static args.
+    static_types = []
+    for data in expected_data:
+        static_types.append(data.typ if not isinstance(data.typ, ByteArrayLike) else BaseType(32))
 
-    # Create placeholder for static args. Note: order of new_*() is important.
-    placeholder_map = {}
-    for i, (_arg, data) in enumerate(zip(args, expected_data)):
-        typ = data.typ
-        if not isinstance(typ, ByteArrayLike):
-            placeholder = context.new_internal_variable(typ)
-        else:
-            placeholder = context.new_internal_variable(BaseType(32))
-        placeholder_map[i] = placeholder
+    requires_dynamic_offset = any(isinstance(data.typ, ByteArrayLike) for data in expected_data)
+    if requires_dynamic_offset:
+        (
+            dynamic_offset_counter,
+            dynamic_placeholder,
+            *static_placeholders,
+        ) = context.new_sequential_vars(BaseType(32), BaseType(32), *static_types)
+    else:
+        static_placeholders = context.new_sequential_vars(*static_types)
+        dynamic_offset_counter = None
 
     # Populate static placeholders.
     for i, (arg, data) in enumerate(zip(args, expected_data)):
         typ = data.typ
-        placeholder = placeholder_map[i]
+        placeholder = static_placeholders[i]
         if not isinstance(typ, ByteArrayLike):
             holder, maxlen = pack_args_by_32(
                 holder, maxlen, prealloacted.get(i, arg), typ, context, placeholder, pos=pos,
@@ -290,7 +289,7 @@ def pack_logging_data(expected_data, args, context, pos):
     if requires_dynamic_offset:
         datamem_start = dynamic_placeholder + 32
     else:
-        datamem_start = placeholder_map[0]
+        datamem_start = static_placeholders[0]
 
     # Copy necessary data into allocated dynamic section.
     for i, (arg, data) in enumerate(zip(args, expected_data)):
@@ -302,7 +301,7 @@ def pack_logging_data(expected_data, args, context, pos):
                 arg=prealloacted.get(i, arg),
                 typ=typ,
                 context=context,
-                placeholder=placeholder_map[i],
+                placeholder=static_placeholders[i],
                 datamem_start=datamem_start,
                 dynamic_offset_counter=dynamic_offset_counter,
                 pos=pos,

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -488,8 +488,9 @@ class Stmt:
             # loop memory has to be allocated first.
             loop_memory_position = self.context.new_internal_variable(typ=BaseType("uint256"))
             # len & bytez placeholder have to be declared after each other at all times.
-            len_placeholder = self.context.new_internal_variable(typ=BaseType("uint256"))
-            bytez_placeholder = self.context.new_internal_variable(typ=sub.typ)
+            len_placeholder, bytez_placeholder = self.context.new_sequential_vars(
+                BaseType("uint256"), sub.typ
+            )
 
             if sub.location in ("storage", "memory"):
                 return LLLnode.from_list(

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -169,8 +169,9 @@ class Stmt:
 
         with self.context.internal_memory_scope(id(self.stmt)):
             reason_str = msg.s.strip()
-            sig_placeholder = self.context.new_internal_variable(BaseType(32))
-            arg_placeholder = self.context.new_internal_variable(BaseType(32))
+            sig_placeholder, arg_placeholder = self.context.new_sequential_vars(
+                BaseType(32), BaseType(32)
+            )
             reason_str_type = ByteArrayType(len(reason_str))
             placeholder_bytes = Expr(msg, self.context).lll_node
             method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])


### PR DESCRIPTION
### What I did
Ensure that multiple internal variable placeholders are ordered sequentially.  This fixes an error in events and revert strings that was introduced by #2188 

### How I did it
* Add `Context.new_sequential_vars`, which generates multiple sequential memory offsets.
* Use the new method in `parser/stmt` where sequential memory offsets are required (events, revert reasons, returning bytes arrays).

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95881237-0e7dcd80-0d81-11eb-9d4f-f57b834fa74d.png)
