### PR TITLE
Memory scoping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,3 +146,26 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
+
+  memory:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install Tox
+      run: pip install tox
+
+    - name: Run Tox
+      run: TOXENV=memory tox -r
+
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from .base_conftest import (
 )
 
 # Import the base_conftest fixtures
-pytest_plugins = ["tests.base_conftest"]
+pytest_plugins = ["tests.base_conftest", "tests.fixtures.memorymock"]
 
 ############
 # PATCHING #

--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup(memory_mocker):
+    pass

--- a/tests/fixtures/memorymock.py
+++ b/tests/fixtures/memorymock.py
@@ -1,0 +1,49 @@
+import pytest
+
+from vyper.parser.context import Context
+from vyper.types import BaseType
+
+
+class ContextMock(Context):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mock_vars = False
+        self._size = 0
+
+    def internal_memory_scope(self):
+        if not self._mock_vars:
+            for i in range(20):
+                self._new_variable(f"#mock{i}", BaseType(self._size), self._size, bool(i % 2))
+            self._mock_vars = True
+        return super().internal_memory_scope()
+
+    @classmethod
+    def set_mock_var_size(cls, size):
+        cls._size = size * 32
+
+
+def pytest_addoption(parser):
+    parser.addoption("--memorymock", action="store_true", help="Run tests with mock allocated vars")
+
+
+def pytest_generate_tests(metafunc):
+    if "memory_mocker" in metafunc.fixturenames:
+        params = range(1, 11, 2) if metafunc.config.getoption("memorymock") else [False]
+        metafunc.parametrize("memory_mocker", params, indirect=True)
+
+
+def pytest_collection_modifyitems(items, config):
+    if config.getoption("memorymock"):
+        for item in list(items):
+            if "memory_mocker" not in item.fixturenames:
+                items.remove(item)
+
+        # hacky magic to ensure the correct number of tests is shown in collection report
+        config.pluginmanager.get_plugin("terminalreporter")._numcollected = len(items)
+
+
+@pytest.fixture
+def memory_mocker(monkeypatch, request):
+    if request.param:
+        monkeypatch.setattr("vyper.parser.context.Context", ContextMock)
+        ContextMock.set_mock_var_size(request.param)

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -9,7 +9,7 @@ from vyper.exceptions import (
 )
 
 
-def test_external_contract_calls(get_contract, get_contract_with_gas_estimation):
+def test_external_contract_calls(get_contract, get_contract_with_gas_estimation, memory_mocker):
     contract_1 = """
 @external
 def foo(arg1: int128) -> int128:
@@ -32,7 +32,9 @@ def bar(arg1: address, arg2: int128) -> int128:
     print("Successfully executed an external contract call")
 
 
-def test_complicated_external_contract_calls(get_contract, get_contract_with_gas_estimation):
+def test_complicated_external_contract_calls(
+    get_contract, get_contract_with_gas_estimation, memory_mocker
+):
     contract_1 = """
 lucky: public(int128)
 
@@ -68,7 +70,7 @@ def bar(arg1: address) -> int128:
 
 
 @pytest.mark.parametrize("length", [3, 32, 33, 64])
-def test_external_contract_calls_with_bytes(get_contract, length):
+def test_external_contract_calls_with_bytes(get_contract, length, memory_mocker):
     contract_1 = f"""
 @external
 def array() -> Bytes[{length}]:
@@ -90,7 +92,7 @@ def get_array(arg1: address) -> Bytes[3]:
     assert c2.get_array(c.address) == b"dog"
 
 
-def test_bytes_too_long(get_contract, assert_tx_failed):
+def test_bytes_too_long(get_contract, assert_tx_failed, memory_mocker):
     contract_1 = """
 @external
 def array() -> Bytes[4]:
@@ -114,7 +116,7 @@ def get_array(arg1: address) -> Bytes[3]:
 
 @pytest.mark.parametrize("a,b", [(3, 3), (4, 3), (3, 4), (32, 32), (33, 33), (64, 64)])
 @pytest.mark.parametrize("actual", [3, 32, 64])
-def test_tuple_with_bytes(get_contract, assert_tx_failed, a, b, actual):
+def test_tuple_with_bytes(get_contract, assert_tx_failed, a, b, actual, memory_mocker):
     contract_1 = f"""
 @external
 def array() -> (Bytes[{actual}], int128, Bytes[{actual}]):
@@ -143,7 +145,7 @@ def get_array(arg1: address) -> (Bytes[{a}], int128, Bytes[{b}]):
 
 @pytest.mark.parametrize("a,b", [(18, 7), (18, 18), (19, 6), (64, 6), (7, 19)])
 @pytest.mark.parametrize("c,d", [(19, 7), (64, 64)])
-def test_tuple_with_bytes_too_long(get_contract, assert_tx_failed, a, c, b, d):
+def test_tuple_with_bytes_too_long(get_contract, assert_tx_failed, a, c, b, d, memory_mocker):
     contract_1 = f"""
 @external
 def array() -> (Bytes[{c}], int128, Bytes[{d}]):
@@ -170,7 +172,7 @@ def get_array(arg1: address) -> (Bytes[{a}], int128, Bytes[{b}]):
     assert_tx_failed(lambda: c2.get_array(c.address))
 
 
-def test_tuple_with_bytes_too_long_two(get_contract, assert_tx_failed):
+def test_tuple_with_bytes_too_long_two(get_contract, assert_tx_failed, memory_mocker):
     contract_1 = """
 @external
 def array() -> (Bytes[30], int128, Bytes[30]):
@@ -197,7 +199,7 @@ def get_array(arg1: address) -> (Bytes[30], int128, Bytes[3]):
     assert_tx_failed(lambda: c2.get_array(c.address))
 
 
-def test_external_contract_call_state_change(get_contract):
+def test_external_contract_call_state_change(get_contract, memory_mocker):
     contract_1 = """
 lucky: public(int128)
 
@@ -247,7 +249,7 @@ def set_lucky_stmt(arg1: address, arg2: int128) -> int128:
     print("Successfully blocked an external contract call from a constant function")
 
 
-def test_external_contract_can_be_changed_based_on_address(get_contract):
+def test_external_contract_can_be_changed_based_on_address(get_contract, memory_mocker):
     contract_1 = """
 lucky: public(int128)
 
@@ -317,7 +319,7 @@ def bar(arg1: address) -> int128:
     print("Successfully executed an external contract call with public globals")
 
 
-def test_external_contract_calls_with_multiple_contracts(get_contract):
+def test_external_contract_calls_with_multiple_contracts(get_contract, memory_mocker):
     contract_1 = """
 lucky: public(int128)
 
@@ -517,7 +519,9 @@ def get_lucky(contract_address: address) -> int128:
     assert c2.get_lucky(c1.address) == 1
 
 
-def test_complex_external_contract_call_declaration(get_contract_with_gas_estimation):
+def test_complex_external_contract_call_declaration(
+    get_contract_with_gas_estimation, memory_mocker
+):
     contract_1 = """
 @external
 def get_lucky() -> int128:
@@ -772,7 +776,7 @@ def test_bad_code_struct_exc(assert_compile_failed, get_contract_with_gas_estima
     assert_compile_failed(lambda: get_contract_with_gas_estimation(bad_code), ArgumentException)
 
 
-def test_tuple_return_external_contract_call(get_contract):
+def test_tuple_return_external_contract_call(get_contract, memory_mocker):
     contract_1 = """
 @external
 def out_literals() -> (int128, address, Bytes[10]):

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -21,7 +21,7 @@ def foo():
     assert tx_receipt["gasUsed"] < gas_sent
 
 
-def test_assert_reason(w3, get_contract_with_gas_estimation, assert_tx_failed):
+def test_assert_reason(w3, get_contract_with_gas_estimation, assert_tx_failed, memory_mocker):
     code = """
 @external
 def test(a: int128) -> int128:
@@ -127,7 +127,7 @@ def test_valid_assertions(get_contract, code):
     get_contract(code)
 
 
-def test_assert_staticcall(get_contract, assert_tx_failed):
+def test_assert_staticcall(get_contract, assert_tx_failed, memory_mocker):
     foreign_code = """
 state: uint256
 @external
@@ -149,7 +149,7 @@ def test():
     assert_tx_failed(lambda: c2.test())
 
 
-def test_assert_in_for_loop(get_contract, assert_tx_failed):
+def test_assert_in_for_loop(get_contract, assert_tx_failed, memory_mocker):
     code = """
 @external
 def test(x: uint256[3]) -> bool:
@@ -166,7 +166,7 @@ def test(x: uint256[3]) -> bool:
     assert_tx_failed(lambda: c.test([1, 3, 5]))
 
 
-def test_assert_with_reason_in_for_loop(get_contract, assert_tx_failed):
+def test_assert_with_reason_in_for_loop(get_contract, assert_tx_failed, memory_mocker):
     code = """
 @external
 def test(x: uint256[3]) -> bool:
@@ -183,7 +183,7 @@ def test(x: uint256[3]) -> bool:
     assert_tx_failed(lambda: c.test([1, 3, 5]))
 
 
-def test_assest_reason_revert_length(w3, get_contract):
+def test_assest_reason_revert_length(w3, get_contract, memory_mocker):
     code = """
 @external
 def test() -> int128:

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -5,6 +5,8 @@ import pytest
 from vyper.compiler import compile_code
 from vyper.exceptions import ArgumentException, CallViolation
 
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
 
 def test_selfcall_code(get_contract_with_gas_estimation):
     selfcall_code = """

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import eth_abi
+import pytest
 
 from vyper.exceptions import (
     ArgumentException,
@@ -11,6 +12,8 @@ from vyper.exceptions import (
     UndeclaredDefinition,
 )
 from vyper.utils import keccak256
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
 
 
 def test_empty_event_logging(w3, tester, keccak, get_contract_with_gas_estimation):

--- a/tests/parser/features/test_logging_from_call.py
+++ b/tests/parser/features/test_logging_from_call.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
+
 def test_log_dynamic_static_combo(get_logs, get_contract_with_gas_estimation, w3):
     code = """
 event TestLog:

--- a/tests/parser/features/test_packing.py
+++ b/tests/parser/features/test_packing.py
@@ -1,4 +1,4 @@
-def test_packing_test(get_contract_with_gas_estimation):
+def test_packing_test(get_contract_with_gas_estimation, memory_mocker):
     packing_test = """
 struct Bar:
     a: int128

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -4,6 +4,8 @@ from vyper import compiler
 from vyper.exceptions import ArgumentException, StateAccessViolation
 from vyper.functions import get_create_forwarder_to_bytecode
 
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
 
 def test_max_outsize_exceeds_returndatasize(get_contract):
     source_code = """

--- a/tests/parser/functions/test_return_struct.py
+++ b/tests/parser/functions/test_return_struct.py
@@ -1,4 +1,8 @@
+import pytest
+
 from vyper.compiler import compile_code
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
 
 
 def test_struct_return_abi(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -1,4 +1,8 @@
+import pytest
+
 from vyper.exceptions import TypeMismatch
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
 
 
 def test_return_type(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_sha256.py
+++ b/tests/parser/functions/test_sha256.py
@@ -1,5 +1,9 @@
 import hashlib
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
 
 def test_sha256_string_literal(get_contract_with_gas_estimation):
     code = """

--- a/tests/parser/syntax/test_return_tuple.py
+++ b/tests/parser/syntax/test_return_tuple.py
@@ -3,6 +3,8 @@ import pytest
 from vyper import compiler
 from vyper.exceptions import FunctionDeclarationException
 
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
 fail_list = [
     """
 @external

--- a/tests/parser/types/test_string.py
+++ b/tests/parser/types/test_string.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
+
 def test_string_return(get_contract_with_gas_estimation):
     code = """
 @external

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,14 @@ extras =
     test
 whitelist_externals = make
 
+[testenv:memory]
+basepython = python3.8
+commands =
+    pytest --memorymock {posargs:tests/}
+extras =
+    test
+whitelist_externals = make
+
 [testenv:lint]
 basepython = python
 extras = lint

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -78,7 +78,7 @@ def gen_tuple_return(stmt, context, sub):
     # (big difference between returning `(bytes,)` and `bytes`.
     abi_typ = ensure_tuple(abi_typ)
     abi_bytes_needed = abi_typ.static_size() + abi_typ.dynamic_size_bound()
-    dst = context.memory_allocator.allocate_memory(abi_bytes_needed)
+    dst = context.memory_allocator.expand_memory(abi_bytes_needed)
     return_buffer = LLLnode(
         dst, location="memory", annotation="return_buffer", typ=context.return_type
     )

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -1,7 +1,6 @@
 import contextlib
 import enum
 import itertools
-from typing import Tuple
 
 from vyper.ast import VyperNode
 from vyper.exceptions import CompilerPanic
@@ -50,16 +49,12 @@ class Context:
         self.in_range_expr = False
         # Is the function payable?
         self.is_payable = is_payable
-        # Number of internal variables generated (used to generate random names)
-        self.internal_variable_count = itertools.count()
         # Original code (for error pretty-printing purposes)
         self.origcode = origcode
         # In Loop status. Whether body is currently evaluating within a for-loop or not.
         self.in_for_loop = set()
         # Count returns in function
         self.function_return_count = 0
-        # Current block scope
-        self.blockscopes = set()
         # In assignment. Whether expression is currently evaluating an assignment expression.
         self.in_assignment = False
         # List of custom structs that have been defined.
@@ -73,10 +68,16 @@ class Context:
         self.global_ctx = global_ctx
         # full function signature
         self.sig = sig
+        # Active scopes
+        self._scopes = set()
 
         # Memory alloctor, keeps track of currently allocated memory.
         # Not intended to be accessed directly
         self.memory_allocator = memory_allocator
+
+        # Private iterators for generating IDs
+        self._internal_var_iter = itertools.count()
+        self._scope_id_iter = itertools.count()
 
     def is_constant(self):
         return self.constancy is Constancy.Constant or self.in_assertion or self.in_range_expr
@@ -104,28 +105,62 @@ class Context:
         yield
         self.in_range_expr = prev_value
 
-    def internal_memory_scope(self, scope_id):
-        # syntactic sugar for `make_blockscope` used to release
-        # memory after creating temporary internal variables
-        return self.make_blockscope(scope_id)
-
     @contextlib.contextmanager
-    def make_blockscope(self, blockscope_id):
-        self.blockscopes.add(blockscope_id)
+    def internal_memory_scope(self):
+        """
+        Internal memory scope context manager.
+
+        Internal variables that are declared within this context are de-allocated
+        upon exitting the context.
+        """
+        scope_id = next(self._scope_id_iter)
+        self._scopes.add(scope_id)
         yield
 
-        # Remove all variables that have specific blockscope_id attached.
-        released = [(k, v) for k, v in self.vars.items() if blockscope_id in v.blockscopes]
+        # Remove all variables that have specific scope_id attached
+        released = [
+            (k, v) for k, v in self.vars.items() if v.is_internal and scope_id in v.blockscopes
+        ]
         for name, var in released:
             self.memory_allocator.deallocate_memory(var.pos, var.size * 32)
             del self.vars[name]
 
         # Remove block scopes
-        self.blockscopes.remove(blockscope_id)
+        self._scopes.remove(scope_id)
 
-    def _new_variable(self, name: str, typ: NodeType, var_pos: int) -> int:
+    @contextlib.contextmanager
+    def block_scope(self):
+        """
+        Block scope context manager.
+
+        All variables (public and internal) that are declared within this context
+        are de-allocated upon exiting the context.
+        """
+        scope_id = next(self._scope_id_iter)
+        self._scopes.add(scope_id)
+        yield
+
+        # Remove all variables that have specific scope_id attached
+        released = [(k, v) for k, v in self.vars.items() if scope_id in v.blockscopes]
+        for name, var in released:
+            self.memory_allocator.deallocate_memory(var.pos, var.size * 32)
+            del self.vars[name]
+
+        # Remove block scopes
+        self._scopes.remove(scope_id)
+
+    def _new_variable(self, name: str, typ: NodeType, var_size: int, is_internal: bool) -> int:
+        if is_internal:
+            var_pos = self.memory_allocator.expand_memory(var_size)
+        else:
+            var_pos = self.memory_allocator.allocate_memory(var_size)
         self.vars[name] = VariableRecord(
-            name=name, pos=var_pos, typ=typ, mutable=True, blockscopes=self.blockscopes.copy(),
+            name=name,
+            pos=var_pos,
+            typ=typ,
+            mutable=True,
+            blockscopes=self._scopes.copy(),
+            is_internal=is_internal,
         )
         return var_pos
 
@@ -149,13 +184,10 @@ class Context:
             Memory offset for the variable
         """
         self.global_ctx.is_valid_varname(name, pos)
-        check_valid_varname(
-            name, custom_structs=self.structs, pos=pos,
-        )
+        check_valid_varname(name, custom_structs=self.structs, pos=pos)
 
         var_size = 32 * get_size_of_type(typ)
-        var_pos = self.memory_allocator.allocate_memory(var_size)
-        return self._new_variable(name, typ, var_pos)
+        return self._new_variable(name, typ, var_size, False)
 
     def new_internal_variable(self, typ: NodeType) -> int:
         """
@@ -172,36 +204,10 @@ class Context:
             Memory offset for the variable
         """
         # internal variable names begin with a number sign so there is no chance for collision
-        name = f"#internal_{next(self.internal_variable_count)}"
+        name = f"#internal_{next(self._internal_var_iter)}"
 
         var_size = 32 * get_size_of_type(typ)
-        var_pos = self.memory_allocator.allocate_memory(var_size)
-        return self._new_variable(name, typ, var_pos)
-
-    def new_sequential_vars(self, *types: NodeType) -> Tuple[int, ...]:
-        """
-        Allocate memory for multiple internal variables, ensuring they are positioned sequentially.
-
-        Arguments
-        ---------
-        types : NodeType
-            Variable types, used to determine the size of memory allocation
-
-        Returns
-        -------
-        Tuple[int,...]
-            Tuple of memory offsets for the variables
-        """
-        total_size = sum(get_size_of_type(i) for i in types) * 32
-        placeholders: Tuple[int, ...] = ()
-        var_pos = self.memory_allocator.allocate_memory(total_size)
-        for typ in types:
-            name = f"#internal_{next(self.internal_variable_count)}"
-            self._new_variable(name, typ, var_pos)
-            placeholders += (var_pos,)
-            var_pos += 32 * get_size_of_type(typ)
-
-        return placeholders
+        return self._new_variable(name, typ, var_size, True)
 
     def parse_type(self, ast_node, location):
         return self.global_ctx.parse_type(ast_node, location)

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -79,7 +79,7 @@ def parse_external_function(
         copier = ["pass"]
     elif sig.name == "__init__":
         copier = ["codecopy", MemoryPositions.RESERVED_MEMORY, "~codelen", sig.base_copy_size]
-        context.memory_allocator.allocate_memory(sig.max_copy_size)
+        context.memory_allocator.expand_memory(sig.max_copy_size)
     clampers.append(copier)
 
     if is_contract_payable and sig.mutability != "payable":
@@ -100,7 +100,7 @@ def parse_external_function(
                 )
             )
         if isinstance(arg.typ, ByteArrayLike):
-            mem_pos = context.memory_allocator.allocate_memory(32 * get_size_of_type(arg.typ))
+            mem_pos = context.memory_allocator.expand_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
             if sig.name == "__init__":
@@ -109,7 +109,7 @@ def parse_external_function(
                 )
             elif i >= default_args_start_pos:  # default args need to be allocated in memory.
                 type_size = get_size_of_type(arg.typ) * 32
-                default_arg_pos = context.memory_allocator.allocate_memory(type_size)
+                default_arg_pos = context.memory_allocator.expand_memory(type_size)
                 context.vars[arg.name] = VariableRecord(
                     name=arg.name, pos=default_arg_pos, typ=arg.typ, mutable=False,
                 )

--- a/vyper/parser/function_definitions/parse_function.py
+++ b/vyper/parser/function_definitions/parse_function.py
@@ -61,6 +61,6 @@ def parse_function(code, sigs, origcode, global_ctx, is_contract_payable, _vars=
         )
 
     o.context = context
-    o.total_gas = o.gas + calc_mem_gas(o.context.memory_allocator.get_next_memory_position())
+    o.total_gas = o.gas + calc_mem_gas(o.context.memory_allocator.size_of_mem)
     o.func_name = sig.name
     return o

--- a/vyper/parser/function_definitions/parse_function.py
+++ b/vyper/parser/function_definitions/parse_function.py
@@ -1,4 +1,6 @@
-from vyper.parser.context import Constancy, Context
+# can't use from [module] import [object] because it breaks mocks in testing
+from vyper.parser import context as ctx
+from vyper.parser.context import Constancy
 from vyper.parser.function_definitions.parse_external_function import (  # NOTE black/isort conflict
     parse_external_function,
 )
@@ -37,7 +39,7 @@ def parse_function(code, sigs, origcode, global_ctx, is_contract_payable, _vars=
 
     # Create a local (per function) context.
     memory_allocator = MemoryAllocator()
-    context = Context(
+    context = ctx.Context(
         vars=_vars,
         global_ctx=global_ctx,
         sigs=sigs,

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -62,7 +62,7 @@ def parse_internal_function(
     clampers: List[LLLnode] = []
 
     # Allocate variable space.
-    context.memory_allocator.allocate_memory(sig.max_copy_size)
+    context.memory_allocator.expand_memory(sig.max_copy_size)
 
     _post_callback_ptr = f"{sig.name}_{sig.method_id}_post_callback_ptr"
     context.callback_ptr = context.new_internal_variable(typ=BaseType("uint256"))
@@ -95,7 +95,7 @@ def parse_internal_function(
     # Fill variable positions
     for arg in sig.args:
         if isinstance(arg.typ, ByteArrayLike):
-            mem_pos = context.memory_allocator.allocate_memory(32 * get_size_of_type(arg.typ))
+            mem_pos = context.memory_allocator.expand_memory(32 * get_size_of_type(arg.typ))
             context.vars[arg.name] = VariableRecord(arg.name, mem_pos, arg.typ, False)
         else:
             context.vars[arg.name] = VariableRecord(

--- a/vyper/parser/memory_allocator.py
+++ b/vyper/parser/memory_allocator.py
@@ -57,6 +57,7 @@ class MemoryAllocator:
             prior to this value are considered permanently allocated.
         """
         self.next_mem = start_position
+        self.size_of_mem = start_position
         self.deallocated_mem: List[FreeMemory] = []
 
     # Get the next unused memory location
@@ -108,6 +109,7 @@ class MemoryAllocator:
 
         before_value = self.next_mem
         self.next_mem += size
+        self.size_of_mem = max(self.size_of_mem, self.next_mem)
         return before_value
 
     def deallocate_memory(self, pos: int, size: int) -> None:

--- a/vyper/parser/memory_allocator.py
+++ b/vyper/parser/memory_allocator.py
@@ -127,9 +127,8 @@ class MemoryAllocator:
         # releasing from the end of the allocated memory - reduce the free memory pointer
         if pos + size == self.next_mem:
             self.next_mem = pos
-            return
 
-        if not self.deallocated_mem or self.deallocated_mem[-1].position < pos:
+        elif not self.deallocated_mem or self.deallocated_mem[-1].position < pos:
             # no previously deallocated memory, or this is the highest position deallocated
             self.deallocated_mem.append(FreeMemory(position=pos, size=size))
         else:
@@ -138,6 +137,9 @@ class MemoryAllocator:
                 next(i for i in self.deallocated_mem if i.position > pos)
             )
             self.deallocated_mem.insert(idx, FreeMemory(position=pos, size=size))
+
+        if not self.deallocated_mem:
+            return
 
         # iterate over deallocated memory and merge slots where possible
         i = 1
@@ -150,3 +152,8 @@ class MemoryAllocator:
             else:
                 active = next_slot
                 i += 1
+
+        last = self.deallocated_mem[-1]
+        if last.position + last.size == self.next_mem:
+            self.next_mem = last.position
+            del self.deallocated_mem[-1]

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -38,7 +38,9 @@ class Stmt:
         if fn is None:
             raise TypeCheckFailure(f"Invalid statement node: {type(node).__name__}")
 
-        self.lll_node = fn()
+        with context.internal_memory_scope():
+            self.lll_node = fn()
+
         if self.lll_node is None:
             raise TypeCheckFailure("Statement node did not produce LLL")
 
@@ -98,14 +100,12 @@ class Stmt:
 
     def parse_If(self):
         if self.stmt.orelse:
-            block_scope_id = id(self.stmt.orelse)
-            with self.context.make_blockscope(block_scope_id):
+            with self.context.block_scope():
                 add_on = [parse_body(self.stmt.orelse, self.context)]
         else:
             add_on = []
 
-        block_scope_id = id(self.stmt)
-        with self.context.make_blockscope(block_scope_id):
+        with self.context.block_scope():
             test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
             body = ["if", test_expr, parse_body(self.stmt.body, self.context)] + add_on
             lll_node = LLLnode.from_list(body, typ=None, pos=getpos(self.stmt))
@@ -115,38 +115,37 @@ class Stmt:
         event = self.context.sigs["self"][self.stmt.value.func.id]
         expected_topics, topics = [], []
         expected_data, data = [], []
-        with self.context.internal_memory_scope(id(self.stmt)):
-            for pos, is_indexed in enumerate(event.indexed_list):
-                if is_indexed:
-                    expected_topics.append(event.args[pos])
-                    topics.append(self.stmt.value.args[pos])
-                else:
-                    expected_data.append(event.args[pos])
-                    data.append(self.stmt.value.args[pos])
-            topics = pack_logging_topics(
-                event.event_id, topics, expected_topics, self.context, pos=getpos(self.stmt),
-            )
-            inargs, inargsize, inargsize_node, inarg_start = pack_logging_data(
-                expected_data, data, self.context, pos=getpos(self.stmt),
-            )
-
-            if inargsize_node is None:
-                sz = inargsize
+        for pos, is_indexed in enumerate(event.indexed_list):
+            if is_indexed:
+                expected_topics.append(event.args[pos])
+                topics.append(self.stmt.value.args[pos])
             else:
-                sz = ["mload", inargsize_node]
+                expected_data.append(event.args[pos])
+                data.append(self.stmt.value.args[pos])
+        topics = pack_logging_topics(
+            event.event_id, topics, expected_topics, self.context, pos=getpos(self.stmt),
+        )
+        inargs, inargsize, inargsize_node, inarg_start = pack_logging_data(
+            expected_data, data, self.context, pos=getpos(self.stmt),
+        )
 
-            return LLLnode.from_list(
-                [
-                    "seq",
-                    inargs,
-                    LLLnode.from_list(
-                        ["log" + str(len(topics)), inarg_start, sz] + topics,
-                        add_gas_estimate=inargsize * 10,
-                    ),
-                ],
-                typ=None,
-                pos=getpos(self.stmt),
-            )
+        if inargsize_node is None:
+            sz = inargsize
+        else:
+            sz = ["mload", inargsize_node]
+
+        return LLLnode.from_list(
+            [
+                "seq",
+                inargs,
+                LLLnode.from_list(
+                    ["log" + str(len(topics)), inarg_start, sz] + topics,
+                    add_gas_estimate=inargsize * 10,
+                ),
+            ],
+            typ=None,
+            pos=getpos(self.stmt),
+        )
 
     def parse_Call(self):
         is_self_function = (
@@ -167,27 +166,26 @@ class Stmt:
         if isinstance(msg, vy_ast.Name) and msg.id == "UNREACHABLE":
             return LLLnode.from_list(["assert_unreachable", test_expr], typ=None, pos=getpos(msg))
 
-        with self.context.internal_memory_scope(id(self.stmt)):
-            reason_str = msg.s.strip()
-            sig_placeholder, arg_placeholder = self.context.new_sequential_vars(
-                BaseType(32), BaseType(32)
-            )
-            reason_str_type = ByteArrayType(len(reason_str))
-            placeholder_bytes = Expr(msg, self.context).lll_node
-            method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])
-            assert_reason = [
-                "seq",
-                ["mstore", sig_placeholder, method_id],
-                ["mstore", arg_placeholder, 32],
-                placeholder_bytes,
-                [
-                    "assert_reason",
-                    test_expr,
-                    int(sig_placeholder + 28),
-                    int(4 + get_size_of_type(reason_str_type) * 32),
-                ],
-            ]
-            return LLLnode.from_list(assert_reason, typ=None, pos=getpos(self.stmt))
+        reason_str_type = ByteArrayType(len(msg.value.strip()))
+
+        sig_placeholder = self.context.new_internal_variable(BaseType(32))
+        arg_placeholder = self.context.new_internal_variable(BaseType(32))
+        placeholder_bytes = Expr(msg, self.context).lll_node
+
+        method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])
+        assert_reason = [
+            "seq",
+            ["mstore", sig_placeholder, method_id],
+            ["mstore", arg_placeholder, 32],
+            placeholder_bytes,
+            [
+                "assert_reason",
+                test_expr,
+                int(sig_placeholder + 28),
+                int(4 + get_size_of_type(reason_str_type) * 32),
+            ],
+        ]
+        return LLLnode.from_list(assert_reason, typ=None, pos=getpos(self.stmt))
 
     def parse_Assert(self):
         test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
@@ -225,8 +223,7 @@ class Stmt:
         return arg_expr.value
 
     def parse_For(self):
-        block_scope_id = id(self.stmt)
-        with self.context.make_blockscope(block_scope_id):
+        with self.context.block_scope():
             if self.stmt.get("iter.func.id") == "range":
                 return self._parse_For_range()
             else:
@@ -489,9 +486,8 @@ class Stmt:
             # loop memory has to be allocated first.
             loop_memory_position = self.context.new_internal_variable(typ=BaseType("uint256"))
             # len & bytez placeholder have to be declared after each other at all times.
-            len_placeholder, bytez_placeholder = self.context.new_sequential_vars(
-                BaseType("uint256"), sub.typ
-            )
+            len_placeholder = self.context.new_internal_variable(BaseType("uint256"))
+            bytez_placeholder = self.context.new_internal_variable(sub.typ)
 
             if sub.location in ("storage", "memory"):
                 return LLLnode.from_list(

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -35,7 +35,16 @@ from vyper.utils import (
 # Function argument
 class VariableRecord:
     def __init__(
-        self, name, pos, typ, mutable, *, location="memory", blockscopes=None, defined_at=None
+        self,
+        name,
+        pos,
+        typ,
+        mutable,
+        *,
+        location="memory",
+        blockscopes=None,
+        defined_at=None,
+        is_internal=False,
     ):
         self.name = name
         self.pos = pos
@@ -44,6 +53,7 @@ class VariableRecord:
         self.location = location
         self.blockscopes = [] if blockscopes is None else blockscopes
         self.defined_at = defined_at  # source code location variable record was defined.
+        self.is_internal = is_internal
 
     @property
     def size(self):


### PR DESCRIPTION
### What I did
Deallocate internal memory variables between statements.

### How I did it
Upon exiting `internal_memory_scope`, all internal variables declared within the scope are deallocated. The scope is applied prior to parsing each statement node.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/95888776-3291dc80-0d8a-11eb-8447-cefb0941ec0b.png)
