### PR TITLE
Assertion/revert optimizations

### DIFF
--- a/tests/compiler/LLL/test_optimize_lll.py
+++ b/tests/compiler/LLL/test_optimize_lll.py
@@ -7,7 +7,6 @@ optimize_list = [
     (["ne", 1, 0], ["ne", 1, 0]),  # noop
     (["if", ["ne", 1, 0], "pass"], ["if", ["xor", 1, 0], "pass"]),
     (["assert", ["ne", 1, 0]], ["assert", ["xor", 1, 0]]),
-    (["assert_reason", ["ne", 1, 0], 0, 0], ["assert_reason", ["xor", 1, 0], 0, 0]),
     (["mstore", 0, ["ne", 1, 0]], ["mstore", 0, ["ne", 1, 0]]),  # noop
 ]
 

--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -286,12 +286,6 @@ def compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=No
         o = compile_to_assembly(code.args[0], withargs, existing_labels, break_dest, height)
         o.extend(get_revert())
         return o
-    elif code.value == "assert_reason":
-        o = compile_to_assembly(code.args[0], withargs, existing_labels, break_dest, height)
-        mem_start = compile_to_assembly(code.args[1], withargs, existing_labels, break_dest, height)
-        mem_len = compile_to_assembly(code.args[2], withargs, existing_labels, break_dest, height)
-        o.extend(get_revert(mem_start, mem_len))
-        return o
     # Unsigned/signed clamp, check less-than
     elif code.value in CLAMP_OP_NAMES:
         if isinstance(code.args[0].value, int) and isinstance(code.args[1].value, int):

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -192,7 +192,6 @@ PSEUDO_OPCODES: OpcodeMap = {
     "UCLAMPLE": (None, 2, 1, 30),
     "CLAMP_NONZERO": (None, 1, 1, 19),
     "ASSERT": (None, 1, 0, 85),
-    "ASSERT_REASON": (None, 3, 0, 85),
     "ASSERT_UNREACHABLE": (None, 1, 0, 17),
     "PASS": (None, 0, 0, 0),
     "BREAK": (None, 0, 0, 20),

--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -47,10 +47,6 @@ def _is_constant_add(node: LLLnode, args: List[LLLnode]) -> bool:
     )
 
 
-def has_cond_arg(node):
-    return node.value in ["if", "if_unchecked", "assert", "assert_reason"]
-
-
 def optimize(lll_node: LLLnode) -> LLLnode:
     lll_node = apply_general_optimizations(lll_node)
     lll_node = filter_unused_sizelimits(lll_node)
@@ -234,7 +230,7 @@ def apply_general_optimizations(node: LLLnode) -> LLLnode:
         )
     # [ne, x, y] has the same truthyness as [xor, x, y]
     # rewrite 'ne' as 'xor' in places where truthy is accepted.
-    elif has_cond_arg(node) and argz[0].value == "ne":
+    elif node.value in ("if", "if_unchecked", "assert") and argz[0].value == "ne":
         argz[0] = LLLnode.from_list(["xor"] + argz[0].args)  # type: ignore
         return LLLnode.from_list(
             [node.value] + argz,  # type: ignore

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -174,15 +174,19 @@ class Stmt:
 
         method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])
         assert_reason = [
-            "seq",
-            ["mstore", sig_placeholder, method_id],
-            ["mstore", arg_placeholder, 32],
-            placeholder_bytes,
+            "if",
+            ["iszero", test_expr],
             [
-                "assert_reason",
-                test_expr,
-                int(sig_placeholder + 28),
-                int(4 + get_size_of_type(reason_str_type) * 32),
+                "seq",
+                ["mstore", sig_placeholder, method_id],
+                ["mstore", arg_placeholder, 32],
+                placeholder_bytes,
+                [
+                    "assert_reason",
+                    0,
+                    sig_placeholder + 28,
+                    int(4 + get_size_of_type(reason_str_type) * 32),
+                ],
             ],
         ]
         return LLLnode.from_list(assert_reason, typ=None, pos=getpos(self.stmt))

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -173,26 +173,29 @@ class Stmt:
         placeholder_bytes = Expr(msg, self.context).lll_node
 
         method_id = fourbytes_to_int(keccak256(b"Error(string)")[:4])
-        assert_reason = [
-            "if",
-            ["iszero", test_expr],
-            [
-                "seq",
-                ["mstore", sig_placeholder, method_id],
-                ["mstore", arg_placeholder, 32],
-                placeholder_bytes,
-                [
-                    "assert_reason",
-                    0,
-                    sig_placeholder + 28,
-                    int(4 + get_size_of_type(reason_str_type) * 32),
-                ],
-            ],
+
+        revert_seq = [
+            "seq",
+            ["mstore", sig_placeholder, method_id],
+            ["mstore", arg_placeholder, 32],
+            placeholder_bytes,
+            ["revert", sig_placeholder + 28, int(4 + get_size_of_type(reason_str_type) * 32)],
         ]
-        return LLLnode.from_list(assert_reason, typ=None, pos=getpos(self.stmt))
+        if test_expr:
+            lll_node = ["if", ["iszero", test_expr], revert_seq]
+        else:
+            lll_node = revert_seq
+
+        return LLLnode.from_list(lll_node, typ=None, pos=getpos(self.stmt))
 
     def parse_Assert(self):
         test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
+        if test_expr.typ.is_literal:
+            if test_expr.value == 1:
+                # skip literal assertions that always pass
+                return LLLnode.from_list(["pass"], typ=None, pos=getpos(self.stmt))
+            else:
+                test_expr = test_expr.value
 
         if self.stmt.msg:
             return self._assert_reason(test_expr, self.stmt.msg)
@@ -203,7 +206,7 @@ class Stmt:
         if self.stmt.exc:
             return self._assert_reason(0, self.stmt.exc)
         else:
-            return LLLnode.from_list(["assert", 0], typ=None, pos=getpos(self.stmt))
+            return LLLnode.from_list(["revert", 0, 0], typ=None, pos=getpos(self.stmt))
 
     def _check_valid_range_constant(self, arg_ast_node, raise_exception=True):
         with self.context.range_scope():


### PR DESCRIPTION
### What I did
LLL-level optimizations around assertions and reverts.

### How I did it
* check the assertion before storing the error string in memory
* use `revert` macro instead of `assert` where possible
* avoid assert check if test statement is a literal

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/96059535-e08aad00-0e96-11eb-9958-f1e7697d9fc3.png)
