### PR TITLE
add test for bytes constant creation (gh-1538)

### DIFF
--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -192,6 +192,9 @@ MY_DECIMAL: constant(decimal) = 1e-10
     """
 MY_DECIMAL: constant(decimal) = -1e38
     """,
+    """
+CONST_BYTES: constant(Bytes[4]) = b'1234'
+    """,
 ]
 
 


### PR DESCRIPTION
### What I did
Add a test for #1538 (bytes constant creation fails when the length of the constant is equal to max length of the type)
I assumes`bytes` has been renamed to `Bytes` since that issue was created

Fixes #1538 
### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.luvbat.com/uploads/cute_baby_chimp_walking_on_two_legs__5602641329.jpg)
