### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -82,7 +82,7 @@ Interfaces
 
 An interface is a set of function definitions used to enable calls between smart contracts. A contract interface defines all of that contract's externally available functions. By importing the interface, your contract now knows how to call these functions in other contracts.
 
-Interfaces can be added to contracts either through inline definition, or by importing them from a seperate file.
+Interfaces can be added to contracts either through inline definition, or by importing them from a separate file.
 
 .. code-block:: python
 


### PR DESCRIPTION
### What I did
I fixed a small typo in the documentation

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture



![Put a link to a cute animal picture inside the parenthesis-->](![photo167895181204498500](https://user-images.githubusercontent.com/6214688/97607319-1e4c1180-1a11-11eb-826a-160074fe42e9.jpg))
