### PR TITLE
Fixed typo in comments

### DIFF
--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -14,7 +14,7 @@ def auction_contract(w3, get_contract):
 def test_initial_state(w3, tester, auction_contract):
     # Check beneficiary is correct
     assert auction_contract.beneficiary() == w3.eth.accounts[0]
-    # Check bidding time is 5 days
+    # Check bidding time is `EXPIRY` seconds
     assert (
         auction_contract.auctionEnd() == tester.get_block_by_number("latest")["timestamp"] + EXPIRY
     )  # noqa: E501


### PR DESCRIPTION
EXPIRY variable is 16, implying 16 seconds, however, the comment says 5 days.

In order to avoid comments being missed, removed the hardcoded value

### What I did
edited comment
### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i2-prod.mirror.co.uk/incoming/article7262984.ece/ALTERNATES/s1200c/Pay-penguins_0712.jpg)
