### PR TITLE
Adapted Simple auction test assertion

### DIFF
--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -38,7 +38,7 @@ def test_bid(w3, tester, auction_contract, assert_tx_failed):
     assert auction_contract.highestBidder() == k1
     assert auction_contract.highestBid() == 1
     # Bidder bid cannot equal current highest bid
-    assert_tx_failed(lambda: auction_contract.bid(transact={"value": 0, "from": k1}))
+    assert_tx_failed(lambda: auction_contract.bid(transact={"value": 1, "from": k1}))
     # Higher bid can replace current highest bid
     auction_contract.bid(transact={"value": 2, "from": k2})
     # Check that highest bidder and highest bid have changed accordingly


### PR DESCRIPTION
Current highest bid is 1
(I think, assertion still fails because 0 quantity bid is also not allowed)

### What I did
Adapted a test with correct assertions
### How I did it
-
### How to verify it
Assertion result doesn't change, so it boils down to code review
### Description for the changelog
Adapted a test with correct assertions about bids same as current highest bid are not allowed
### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://image.shutterstock.com/z/stock-photo-cute-portrait-of-baby-tortoise-hatching-africa-spurred-tortoise-birth-of-new-life-closeup-of-a-1273311703.jpg)
