### PR TITLE
Fix broken link

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -37,7 +37,7 @@ State variables are accessed via the :ref:`self<constants-self>` object.
 
     self.storedData = 123
 
-See the documentation on :ref:`Types <types>` or `Scoping and Declarations <scoping>`_ for more information.
+See the documentation on :ref:`Types<types>` or :ref:`Scoping and Declarations<scoping>` for more information.
 
 .. _structure-functions:
 


### PR DESCRIPTION
### What I did
Fix a broken link based on issue: #2213 

### How I did it
add ``:ref:`` syntax behind the link

### How to verify it
Click on the link?

### Description for the changelog
Fix the link in structure-of-a-contract.rst that suppose to direct the user to Scoping and Declarations page

### Cute Animal Picture
# NOPE
