### PR TITLE
Updates to support python 3.9 AST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     packages=find_packages(exclude=("tests", "docs")),
     python_requires=">=3.6",
     py_modules=["vyper"],
-    install_requires=["asttokens==2.0.3", "pycryptodome>=3.5.1,<4", "semantic-version==2.8.5"],
+    install_requires=["asttokens==2.0.4", "pycryptodome>=3.5.1,<4", "semantic-version==2.8.5"],
     setup_requires=["pytest-runner"],
     tests_require=extras_require["test"],
     extras_require=extras_require,

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import raises
 
 from vyper import compiler
-from vyper.exceptions import SyntaxException
+from vyper.exceptions import ArgumentException, SyntaxException
 
 fail_list = [
     """
@@ -15,7 +15,7 @@ def foo():
 
 @pytest.mark.parametrize("bad_code", fail_list)
 def test_type_mismatch_exception(bad_code):
-    with raises(SyntaxException):
+    with raises((SyntaxException, ArgumentException)):
         compiler.compile_code(bad_code)
 
 

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, SyntaxException
+from vyper.exceptions import ArgumentException, InvalidType, SyntaxException
 
 fail_list = [
     (
@@ -12,7 +12,7 @@ def foo():
         0x1234567890123456789012345678901234567890, b"cow", max_outsize=4, max_outsize=9
     )
     """,
-        SyntaxException,
+        (SyntaxException, ArgumentException),
     ),
     (
         """

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -127,6 +127,24 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         return node
 
+    def visit_Subscript(self, node):
+        """
+        Maintain consistency of `Subscript.slice` across python versions.
+
+        Starting from python 3.9, the `Index` node type has been deprecated,
+        and made impossible to instantiate via regular means. Here we do awful
+        hacky black magic to create an `Index` node. We need our own parser.
+        """
+        self.generic_visit(node)
+
+        if not isinstance(node.slice, python_ast.Index):
+            index = python_ast.Constant(value=node.slice, ast_type="Index")
+            index.__class__ = python_ast.Index
+            self.generic_visit(index)
+            node.slice = index
+
+        return node
+
     def visit_Constant(self, node):
         """
         Handle `Constant` when using Python >=3.8


### PR DESCRIPTION
### What I did
Update the `vyper.ast` subpackage to handle changes introduced in the python AST in version 3.9.

Related to #2182 
Closes #2205 
Closes #2206

### How I did it
The only change in 3.9 relevant to Vyper was the deprecation of the [`Index`](https://greentreesnakes.readthedocs.io/en/latest/nodes.html#Index) node class:

> Deprecated since version 3.9: Old classes `ast.Index` and `ast.ExtSlice` are still available, but they will be removed in future Python releases. In the meantime, instantiating them will return an instance of a different class.

This node is exclusively used within `slice` attribute of the `Subscript` node - starting in 3.9, `slice` now contains `Index.value` directly.

I had to get hacky to sidestep the logic that prevents direct instantiation of `Index`. It works, I've explained it in the docstring, but this is a great example of why we really need our own parser.

### How to verify it
We're unable to run the test suite against python 3.9 in the CI, because of a lack of support from an upstream dependency: https://github.com/davesque/blake2b-py/issues/2

I've run the tests locally and verified that everything is passing.  I think we should merge this PR now, and once our test deps support 3.9 we can announce official support.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100395868-17d6a700-305c-11eb-9d7e-cebee331230b.png)
