### PR TITLE
Lift restriction on calldata variables shadowing storage variables

### DIFF
--- a/tests/parser/exceptions/test_namespace_collision.py
+++ b/tests/parser/exceptions/test_namespace_collision.py
@@ -26,12 +26,6 @@ def foo():
     """,
     """
 x: int128
-
-@external
-def foo(x: int128): pass
-    """,
-    """
-x: int128
 x: int128
     """,
     """
@@ -60,3 +54,25 @@ int128: Bytes[3]
 def test_insufficient_arguments(bad_code):
     with pytest.raises(NamespaceCollision):
         compiler.compile_code(bad_code)
+
+
+pass_list = [
+    """
+x: int128
+
+@external
+def foo(x: int128): pass
+    """,
+    """
+x: int128
+
+@external
+def foo():
+    x: int128 = 1234
+    """,
+]
+
+
+@pytest.mark.parametrize("code", pass_list)
+def test_valid(code):
+    compiler.compile_code(code)

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -280,8 +280,6 @@ class ContractFunction(BaseTypeDefinition):
                 )
             if arg.arg in arguments:
                 raise ArgumentException(f"Function contains multiple inputs named {arg.arg}", arg)
-            if arg.arg in namespace["self"].members:
-                raise NamespaceCollision("Name shadows an existing storage-scoped value", arg)
             if arg.arg in namespace:
                 raise NamespaceCollision(arg.arg, arg)
 

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -45,14 +45,6 @@ def validate_external_function(
             "__init__ function may not have default parameters.", code
         )
 
-    # Check for duplicate variables with globals
-    for arg in sig.args:
-        if arg.name in global_ctx._globals:
-            raise FunctionDeclarationException(
-                "Variable name duplicated between " "function arguments and globals: " + arg.name,
-                code,
-            )
-
 
 def parse_external_function(
     code: ast.FunctionDef, sig: FunctionSignature, context: Context, is_contract_payable: bool


### PR DESCRIPTION
### What I did
Lift a restriction preventing calldata variable names from shadowing storage variable names.

Related to #2166 
Fixes #2219 

### How I did it
Remove the checks in `context` and `parser` subpackages.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100396667-5f126700-305f-11eb-92db-f6955d0a1ec8.png)
