### PR TITLE
Fix: allow use of `slice` with `bytes32` in calldata

### DIFF
--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -22,24 +22,19 @@ def bar(inp1: Bytes[10]) -> int128:
 
     assert c.bar(b"badminton") == 35
 
-    print("Passed slice test")
-
 
 def test_test_slice2(get_contract_with_gas_estimation):
-    # TODO once parser is refactored so that `i` is `uint256`, remove call to `convert`
     test_slice2 = """
 @external
 def slice_tower_test(inp1: Bytes[50]) -> Bytes[50]:
     inp: Bytes[50] = inp1
     for i in range(1, 11):
-        inp = slice(inp, 1, convert(30 - i * 2, uint256))
+        inp = slice(inp, 1, 30 - i * 2)
     return inp
     """
     c = get_contract_with_gas_estimation(test_slice2)
     x = c.slice_tower_test(b"abcdefghijklmnopqrstuvwxyz1234")
     assert x == b"klmnopqrst", x
-
-    print("Passed advanced slice test")
 
 
 def test_test_slice3(get_contract_with_gas_estimation):
@@ -68,8 +63,6 @@ def bar(inp1: Bytes[50]) -> int128:
 
     assert c.bar(b"badminton") == 35
 
-    print("Passed storage slice test")
-
 
 def test_test_slice4(get_contract_with_gas_estimation, assert_tx_failed):
     test_slice4 = """
@@ -90,8 +83,6 @@ def foo(inp: Bytes[10], start: uint256, _len: uint256) -> Bytes[10]:
     assert_tx_failed(lambda: c.foo(b"badminton", 1, 9))
     assert_tx_failed(lambda: c.foo(b"badminton", 9, 1))
     assert_tx_failed(lambda: c.foo(b"badminton", 10, 0))
-
-    print("Passed slice edge case test")
 
 
 def test_slice_at_end(get_contract):

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -174,6 +174,11 @@ def make_byte_slice_copier(destination, source, length, max_length, pos=None):
         loader = ["mload", ["add", "_pos", ["mul", 32, ["mload", MemoryPositions.FREE_LOOP_INDEX]]]]
     elif source.location == "storage":
         loader = ["sload", ["add", "_pos", ["mload", MemoryPositions.FREE_LOOP_INDEX]]]
+    elif source.location == "calldata":
+        loader = [
+            "calldataload",
+            ["add", "_pos", ["mul", 32, ["mload", MemoryPositions.FREE_LOOP_INDEX]]],
+        ]
     else:
         raise CompilerPanic(f"Unsupported location: {source.location}")
     # Where to paste it?


### PR DESCRIPTION
### What I did
Allow slicing `bytes32` calldata variables.

Fixes #2200 

### How I did it
In `vyper/parser/parser_utils.py::make_byte_slice_copier`, added `calldata` as a valid source location.

### How to verify it
Run the tests.  I've added some new cases for this functionality.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100439812-741de300-30bd-11eb-96b0-3de399a000fd.png)
