### PR TITLE
Explicitly disallow iteration of list of structs

### DIFF
--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -69,6 +69,21 @@ def foo() -> int128[3]:
     """,
         StructureException,
     ),
+    (
+        """
+# for loops only allowed on base types
+struct Baz:
+    a: uint256
+bar: Baz[3]
+
+@external
+def foo():
+    for x in self.bar:
+        pass
+
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/vyper/context/validation/local.py
+++ b/vyper/context/validation/local.py
@@ -20,6 +20,7 @@ from vyper.context.types.indexable.sequence import (
     TupleDefinition,
 )
 from vyper.context.types.meta.event import Event
+from vyper.context.types.meta.struct import StructDefinition
 from vyper.context.types.utils import get_type_from_annotation
 from vyper.context.types.value.boolean import BoolDefinition
 from vyper.context.types.value.numeric import Uint256Definition
@@ -322,6 +323,9 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
         if next((i for i in type_list if isinstance(i, ArrayDefinition)), False):
             raise StructureException("Cannot iterate over a nested list", node.iter)
+
+        if next((i for i in type_list if isinstance(i, StructDefinition)), False):
+            raise StructureException("Cannot iterate over a list of structs", node.iter)
 
         if isinstance(node.iter, (vy_ast.Name, vy_ast.Attribute)):
             # check for references to the iterated value within the body of the loop


### PR DESCRIPTION
### What I did
Explicitly disallow iteration of a list of structs

Fixes #2223 

### How I did it
Add a check within the type checking pass. This behaviour is disallowed in parser, but without the exception in type checking it raises a `CompilerPanic`

### How to verify it
Run the tests. I added a new test to verify this behavior.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100446075-987ebd00-30c7-11eb-8287-82862a61a262.png)
