### PR TITLE
Address checksum validation

### DIFF
--- a/tests/ast/nodes/test_hex.py
+++ b/tests/ast/nodes/test_hex.py
@@ -1,0 +1,37 @@
+import pytest
+
+from vyper import ast as vy_ast
+from vyper.exceptions import InvalidLiteral
+
+code_invalid_checksum = [
+    """
+foo: constant(address) = 0x6b175474e89094c44da98b954eedeac495271d0f
+    """,
+    """
+foo: constant(address[1]) = [0x6b175474e89094c44da98b954eedeac495271d0f]
+    """,
+    """
+@external
+def foo():
+    bar: address = 0x6b175474e89094c44da98b954eedeac495271d0f
+    """,
+    """
+@external
+def foo():
+    bar: address[1] = [0x6b175474e89094c44da98b954eedeac495271d0f]
+    """,
+    """
+@external
+def foo():
+    for i in [0x6b175474e89094c44da98b954eedeac495271d0f]:
+        pass
+    """,
+]
+
+
+@pytest.mark.parametrize("code", code_invalid_checksum)
+def test_invalid_checksum(code):
+    vyper_module = vy_ast.parse_to_ast(code)
+
+    with pytest.raises(InvalidLiteral):
+        vy_ast.validation.validate_literal_nodes(vyper_module)

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -717,7 +717,7 @@ class Decimal(Num):
         super().validate()
 
 
-class Hex(Num):
+class Hex(Constant):
     """
     A hexadecimal value, e.g. `0xFF`
 
@@ -728,6 +728,7 @@ class Hex(Num):
     """
 
     __slots__ = ()
+    _translated_fields = {"n": "value"}
 
     def validate(self):
         if len(self.value) % 2:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -15,7 +15,12 @@ from vyper.exceptions import (
     ZeroDivisionException,
 )
 from vyper.settings import VYPER_ERROR_CONTEXT_LINES, VYPER_ERROR_LINE_NUMBERS
-from vyper.utils import MAX_DECIMAL_PLACES, SizeLimits, annotate_source_code
+from vyper.utils import (
+    MAX_DECIMAL_PLACES,
+    SizeLimits,
+    annotate_source_code,
+    checksum_encode,
+)
 
 NODE_BASE_ATTRIBUTES = (
     "_children",
@@ -727,6 +732,12 @@ class Hex(Num):
     def validate(self):
         if len(self.value) % 2:
             raise InvalidLiteral("Hex notation requires an even number of digits", self)
+        if len(self.value) == 42 and checksum_encode(self.value) != self.value:
+            raise InvalidLiteral(
+                "Address checksum mismatch. If you are sure this is the right "
+                f"address, the correct checksummed form is: {checksum_encode(self.value)}",
+                self,
+            )
 
 
 class Str(Constant):

--- a/vyper/context/types/value/address.py
+++ b/vyper/context/types/value/address.py
@@ -3,7 +3,7 @@ from vyper.context.types.bases import BasePrimitive, MemberTypeDefinition
 from vyper.context.types.value.boolean import BoolDefinition
 from vyper.context.types.value.bytes_fixed import Bytes32Definition
 from vyper.context.types.value.numeric import Uint256Definition
-from vyper.exceptions import InvalidLiteral
+from vyper.exceptions import CompilerPanic, InvalidLiteral
 from vyper.utils import checksum_encode
 
 
@@ -30,9 +30,6 @@ class AddressPrimitive(BasePrimitive):
         if len(addr) != 42:
             raise InvalidLiteral("Invalid literal for type 'address'", node)
         if checksum_encode(addr) != addr:
-            raise InvalidLiteral(
-                "Address checksum mismatch. If you are sure this is the right "
-                f"address, the correct checksummed form is: {checksum_encode(addr)}",
-                node,
-            )
+            # this should have been caught in `vyper.ast.nodes.Hex.validate`
+            raise CompilerPanic("Address checksum mismatch")
         return AddressDefinition()


### PR DESCRIPTION
### What I did
Validate address checksums during AST generation.

Closes #2216

### How I did it
Since we only use `Hex` for `address` and `bytes32`, I've moved the checksum validation into `Hex.validate`. This is the earliest point we can catch the issue, and ensures it can't be missed in one of several spots within type checking.

### How to verify it
Run the tests.  I've added some cases to verify this.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100465848-6e3df700-30e9-11eb-9f25-fe3e4477e5ce.png)
