### PR TITLE
fix: convert bytes to hex when generating ast dict

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -763,11 +763,13 @@ class Bytes(Constant):
     def __init__(self, parent: Optional["VyperNode"] = None, **kwargs: dict):
         super().__init__(parent, **kwargs)
         if isinstance(self.value, str):
-            self.value = self.value.encode("utf8")
+            # convert hex string to bytes
+            length = len(self.value) // 2 - 1
+            self.value = int(self.value, 16).to_bytes(length, "big")
 
     def to_dict(self):
         ast_dict = super().to_dict()
-        ast_dict["value"] = self.value.decode("utf8")
+        ast_dict["value"] = f"0x{self.value.hex()}"
         return ast_dict
 
     @property


### PR DESCRIPTION
### What I did
Represent bytes as hex in the AST output. This fixes an issue where some bytestrings produce compilable code, but cannot be serialized as the AST dict.

Closes #2163 

### How I did it
See code, pretty self explanatory.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100472483-c2e76f00-30f5-11eb-8289-6184ffdf12b1.png)
