### PR TITLE
Add support for `not in` comparator

### DIFF
--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -230,6 +230,7 @@ _IN: "in"
            | comparator _LE atom ->  le
            | comparator _GE atom ->  ge
            | comparator _IN atom ->  in
+           | comparator _NOT _IN atom ->  in
 
 // NOTE: Must end recursive cycle like this (with `atom` calling `operation`)
 ?atom: variable_access

--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -80,6 +80,24 @@ def in_test(x: int128) -> bool:
     assert c.in_test(7) is True
 
 
+def test_cmp_not_in_list(get_contract_with_gas_estimation):
+    code = """
+@external
+def in_test(x: int128) -> bool:
+    if x not in [9, 7, 6, 5]:
+        return True
+    return False
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.in_test(1) is True
+    assert c.in_test(-7) is True
+    assert c.in_test(-9) is True
+    assert c.in_test(5) is False
+    assert c.in_test(7) is False
+
+
 def test_mixed_in_list(assert_compile_failed, get_contract_with_gas_estimation):
     code = """
 @external

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1090,6 +1090,14 @@ class In(VyperNode):
         return left in right
 
 
+class NotIn(VyperNode):
+    __slots__ = ()
+    _description = "exclusion"
+
+    def _op(self, left, right):
+        return left not in right
+
+
 class Call(VyperNode):
     __slots__ = ("func", "args", "keywords", "keyword")
 

--- a/vyper/context/validation/utils.py
+++ b/vyper/context/validation/utils.py
@@ -162,7 +162,7 @@ class _ExprTypeChecker:
 
     def types_from_Compare(self, node):
         # comparison: `x < y`
-        if isinstance(node.op, vy_ast.In):
+        if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
             left = self.get_possible_types_from_node(node.left)
             right = self.get_possible_types_from_node(node.right)

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -675,12 +675,11 @@ class Expr:
         else:
             compare_sequence = ["seq"] + for_loop_sequence
 
-        # Compare the result of the repeat loop to 1, to know if a match was found.
-        lll_node = LLLnode.from_list(
-            ["eq", 1, compare_sequence], typ="bool", annotation="in comporator"
-        )
+        if isinstance(self.expr.op, vy_ast.NotIn):
+            # for `not in`, invert the result
+            compare_sequence = ["iszero", compare_sequence]
 
-        return lll_node
+        return LLLnode.from_list(compare_sequence, typ="bool", annotation="in comparator")
 
     @staticmethod
     def _signed_to_unsigned_comparision_op(op):
@@ -706,7 +705,9 @@ class Expr:
             # TODO: Can this if branch be removed ^
             pass
 
-        elif isinstance(self.expr.op, vy_ast.In) and isinstance(right.typ, ListType):
+        elif isinstance(self.expr.op, (vy_ast.In, vy_ast.NotIn)) and isinstance(
+            right.typ, ListType
+        ):
             if left.typ != right.typ.subtype:
                 return
             return self.build_in_comparator()


### PR DESCRIPTION
### What I did
Add support for the `not in` comparator

Closes #2218 

### How I did it
* Added the `NotIn` ast node
* Expand the list comparator logic in `parser` to support `not in`

### How to verify it
Run the tests. I added some new cases to test this behaviour.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100485556-f0deaa80-3119-11eb-8780-ea01b2e91813.png)
