### PR TITLE
Add py39 configs and prepare to drop py36

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,15 +135,6 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: Install Rustup
-      run: sudo snap install rustup --classic
-
-    - name: Install nightly Rust
-      run: rustup toolchain install nightly
-
-    - name: Use nightly Rust as default
-      run: rustup default nightly
-
     - name: Install Tox
       run: pip install tox
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Install Tox
       run: pip install tox
@@ -27,10 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install Tox
         run: pip install tox
@@ -44,10 +44,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Install Tox
       run: pip install tox
@@ -117,6 +117,38 @@ jobs:
 
     - name: Run Tox
       run: TOXENV=py38-core tox -r
+
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+
+  py39-core:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install Rustup
+      run: sudo snap install rustup --classic
+
+    - name: Install nightly Rust
+      run: rustup toolchain install nightly
+
+    - name: Use nightly Rust as default
+      run: rustup default nightly
+
+    - name: Install Tox
+      run: pip install tox
+
+    - name: Run Tox
+      run: TOXENV=py39-core tox -r
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-core
+    py{36,37,38,39}-core
     lint
     mypy
     docs
@@ -13,12 +13,13 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 extras =
     test
 whitelist_externals = make
 
 [testenv:docs]
-basepython=python3.6
+basepython=python3.8
 deps =
     sphinx
     sphinx_rtd_theme
@@ -43,15 +44,15 @@ extras =
 whitelist_externals = make
 
 [testenv:lint]
-basepython = python
+basepython = python3.8
 extras = lint
 commands =
-    black --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
+    black -t py38 --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
     flake8 {toxinidir}/vyper {toxinidir}/tests
     isort --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
 
 [testenv:mypy]
-basepython = python
+basepython = python3.8
 extras = lint
 commands =
     mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p vyper


### PR DESCRIPTION
Hey.

This is my first PR here. :tada: 

### What I did
1. Create a new action to run `py39` in GitHub Actions;
2. Replace `py36` by `py38` for all CI actions;
3. Force `black` to use `py38`.

#### Why I didn't drop 3.6?

Well, I'm not sure if we really need to. My suggestion is to keep an isolated GitHub action for this version until it becomes obsolete.

### How to verify it

Check GitHub Actions. :trollface: 

### Why this build is :red_circle:?

Python 3.9 build is breaking due to davesque/blake2b-py installation.

> The requirement to install Rust is related to davesque/blake2b-py#2 - as soon as this is fixed upstream we plan to roll out official support for Python 3.9.

We must wait davesque/blake2b-py#2 to rebuild.

### Related issue

#2182

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/1095412/112056688-119e9600-8b37-11eb-8a9b-4065568a0a55.png)
