### PR TITLE
Fix: `empty` static-sized arrays within log statement

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -67,6 +67,14 @@ x: Bytes <= wei
     """
 x: String <= 33
     """,
+    """
+event Foo:
+    a: Bytes[4]
+
+@external
+def foo():
+    log Foo(empty(Bytes[4]))
+    """,
 ]
 
 

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -1,5 +1,5 @@
 from vyper import ast as vy_ast
-from vyper.exceptions import TypeMismatch
+from vyper.exceptions import StructureException, TypeMismatch
 from vyper.parser.expr import Expr
 from vyper.parser.lll_node import LLLnode
 from vyper.parser.parser_utils import (
@@ -301,6 +301,11 @@ def pack_logging_data(expected_data, args, context, pos):
     for i, (arg, data) in enumerate(zip(args, expected_data)):
         typ = data.typ
         if isinstance(typ, ByteArrayLike):
+            if isinstance(arg, vy_ast.Call) and arg.func.get("id") == "empty":
+                # TODO add support for this
+                raise StructureException(
+                    "Cannot use `empty` on Bytes or String types within an event log", arg
+                )
             pack_args_by_32(
                 holder=holder,
                 maxlen=maxlen,


### PR DESCRIPTION
### What I did
Allow use of `empty` with static-sized arrays, inside an event logging statement.

Closes #2158 

### How I did it
Expanded logic in `parser.events` - this is very similar to logic in #2234 

### How to verify it
Run tests.  I added some cases.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/100554028-b0f30100-329a-11eb-9e7f-3c848c75f668.png)
