### PR TITLE
Fixes for bytearrays as hashmap key

### DIFF
--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -348,9 +348,11 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
                         ]
                     )
                 else:
-                    sub = LLLnode.from_list(
-                        ["sha3", ["add", key.args[0].value, 32], ["mload", key.args[0].value]]
-                    )
+                    value = key.args[0].value
+                    if value == "add":
+                        # special case, key is a bytes array within a tuple/struct
+                        value = key.args[0]
+                    sub = LLLnode.from_list(["sha3", ["add", value, 32], key])
         else:
             subtype = typ.valuetype
             sub = base_type_conversion(key, key.typ, typ.keytype, pos=pos)


### PR DESCRIPTION
### What I did
Fix two compile-time issues related to bytearray types as `HashMap` keys:

* bytearrays that are part of a struct
* bytearrays in storage

Closes #2237

### How I did it
1. In `vyper/parser/parser_utils.py`, do not assume that the key is a memory offset. This allows the use of structs.
2. In `vyper/parser/expr.py`, add a special case when the key is a bytearray in storage. Because `sha3` only works on memory, we must first copy the bytearray to memory.

### How to verify it
Run the tests.  I've added several new cases to target this (and related) behavior.


### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/101053856-eea0a400-3590-11eb-8a3c-6b3f0f02a1d0.png)
