### PR TITLE
`canonical_type` and `method_id`

### DIFF
--- a/vyper/context/types/bases.py
+++ b/vyper/context/types/bases.py
@@ -188,6 +188,7 @@ class BaseTypeDefinition:
     """
 
     is_dynamic_size = False
+    _id: str
 
     def __init__(
         self,
@@ -198,6 +199,13 @@ class BaseTypeDefinition:
         self.location = location
         self.is_immutable = is_immutable
         self.is_public = is_public
+
+    @property
+    def canonical_type(self) -> str:
+        """
+        The canonical name of this type. Used for ABI types and generating function signatures.
+        """
+        return self._id
 
     def from_annotation(self, node: vy_ast.VyperNode, **kwargs: Any) -> None:
         # always raises, user should have used a primitive

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -352,6 +352,13 @@ class ContractFunction(BaseTypeDefinition):
             state_mutability=StateMutability.NONPAYABLE,
         )
 
+    @property
+    def canonical_type(self) -> str:
+        """
+        The canonical signature of this function.
+        """
+        return f"{self.name}({','.join(i.canonical_type for i in self.arguments.values())})"
+
     def get_signature(self) -> Tuple[Tuple, Optional[BaseTypeDefinition]]:
         return tuple(self.arguments.values()), self.return_type
 

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -354,18 +354,12 @@ class ContractFunction(BaseTypeDefinition):
         )
 
     @property
-    def canonical_type(self) -> str:
-        """
-        The canonical signature of this function.
-        """
-        return f"{self.name}({','.join(i.canonical_type for i in self.arguments.values())})"
-
-    @property
     def method_id(self) -> int:
         """
         Four byte selector for this function.
         """
-        selector = keccak256(self.canonical_type.encode())[:4].hex()
+        function_sig = f"{self.name}({','.join(i.canonical_type for i in self.arguments.values())})"
+        selector = keccak256(function_sig.encode())[:4].hex()
         return int(selector, 16)
 
     def get_signature(self) -> Tuple[Tuple, Optional[BaseTypeDefinition]]:

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -26,6 +26,7 @@ from vyper.exceptions import (
     StateAccessViolation,
     StructureException,
 )
+from vyper.utils import keccak256
 
 
 class FunctionVisibility(StringEnum):
@@ -358,6 +359,14 @@ class ContractFunction(BaseTypeDefinition):
         The canonical signature of this function.
         """
         return f"{self.name}({','.join(i.canonical_type for i in self.arguments.values())})"
+
+    @property
+    def method_id(self) -> int:
+        """
+        Four byte selector for this function.
+        """
+        selector = keccak256(self.canonical_type.encode())[:4].hex()
+        return int(selector, 16)
 
     def get_signature(self) -> Tuple[Tuple, Optional[BaseTypeDefinition]]:
         return tuple(self.arguments.values()), self.return_type

--- a/vyper/context/types/meta/struct.py
+++ b/vyper/context/types/meta/struct.py
@@ -35,6 +35,10 @@ class StructDefinition(MemberTypeDefinition):
     def compare_type(self, other):
         return super().compare_type(other) and self._id == other._id
 
+    @property
+    def canonical_type(self) -> str:
+        return f"({','.join(i.canonical_type for i in self.members.values())})"
+
 
 class StructPrimitive:
 

--- a/vyper/context/types/value/array_value.py
+++ b/vyper/context/types/value/array_value.py
@@ -59,6 +59,10 @@ class _ArrayValueDefinition(ValueTypeDefinition):
             return self._length
         return self._min_length
 
+    @property
+    def canonical_type(self) -> str:
+        return self._id.lower()
+
     def set_length(self, length):
         """
         Sets the exact length of the type.

--- a/vyper/context/types/value/numeric.py
+++ b/vyper/context/types/value/numeric.py
@@ -138,6 +138,10 @@ class DecimalDefinition(FixedAbstractType, _NumericDefinition):
     _is_signed = True
     _invalid_op = vy_ast.Pow
 
+    @property
+    def canonical_type(self) -> str:
+        return "fixed168x10"
+
 
 # primitives
 


### PR DESCRIPTION
### What I did
Add `canonical_type` and `method_id` property methods to type objects within `vyper.context`

This is a small step toward annotating the AST prior to LLL generation.

### How I did it
Fairly self explanatory, see code.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/101407630-d0fe7200-38e3-11eb-9e3a-874dc58b38fa.png)
