### PR TITLE
Refactor: function-level type checks

### DIFF
--- a/tests/parser/exceptions/test_function_declaration_exception.py
+++ b/tests/parser/exceptions/test_function_declaration_exception.py
@@ -33,6 +33,11 @@ def foo() -> int128:
 def test_func() -> int128:
     return (1, 2)
     """,
+    """
+@external
+def __init__(a: int128 = 12):
+    pass
+    """,
 ]
 
 

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -273,6 +273,10 @@ class ContractFunction(BaseTypeDefinition):
         # call arguments
         arg_count: Union[Tuple[int, int], int] = len(node.args.args)
         if node.args.defaults:
+            if node.name == "__init__":
+                raise FunctionDeclarationException(
+                    "Constructor may not use default arguments", node.args.defaults[0]
+                )
             arg_count = (
                 len(node.args.args) - len(node.args.defaults),
                 len(node.args.args),

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -258,6 +258,14 @@ class ContractFunction(BaseTypeDefinition):
                 f"Visibility must be set to one of: {', '.join(FunctionVisibility.values())}", node
             )
 
+        if (
+            node.name == "__default__"
+            and kwargs["function_visibility"] != FunctionVisibility.EXTERNAL
+        ):
+            raise FunctionDeclarationException(
+                "Default function must be marked as `@external`", node
+            )
+
         if "state_mutability" not in kwargs:
             # Assume nonpayable if not set at all (cannot accept Ether, but can modify state)
             kwargs["state_mutability"] = StateMutability.NONPAYABLE

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -258,13 +258,15 @@ class ContractFunction(BaseTypeDefinition):
                 f"Visibility must be set to one of: {', '.join(FunctionVisibility.values())}", node
             )
 
-        if (
-            node.name == "__default__"
-            and kwargs["function_visibility"] != FunctionVisibility.EXTERNAL
-        ):
-            raise FunctionDeclarationException(
-                "Default function must be marked as `@external`", node
-            )
+        if node.name == "__default__":
+            if kwargs["function_visibility"] != FunctionVisibility.EXTERNAL:
+                raise FunctionDeclarationException(
+                    "Default function must be marked as `@external`", node
+                )
+            if node.args.args:
+                raise FunctionDeclarationException(
+                    "Default function may not receive any arguments", node.args.args[0]
+                )
 
         if "state_mutability" not in kwargs:
             # Assume nonpayable if not set at all (cannot accept Ether, but can modify state)

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -10,7 +10,6 @@ from vyper.parser.function_definitions.utils import (
     get_nonreentrant_lock,
     get_sig_statements,
 )
-from vyper.parser.global_context import GlobalContext
 from vyper.parser.lll_node import LLLnode
 from vyper.parser.parser_utils import getpos, make_setter
 from vyper.parser.stmt import parse_body
@@ -34,18 +33,6 @@ def get_external_arg_copier(
     return copier
 
 
-def validate_external_function(
-    code: ast.FunctionDef, sig: FunctionSignature, global_ctx: GlobalContext
-) -> None:
-    """ Validate external function definition. """
-
-    # __init__ function may not have defaults.
-    if sig.is_initializer() and sig.total_default_args > 0:
-        raise FunctionDeclarationException(
-            "__init__ function may not have default parameters.", code
-        )
-
-
 def parse_external_function(
     code: ast.FunctionDef, sig: FunctionSignature, context: Context, is_contract_payable: bool
 ) -> LLLnode:
@@ -57,8 +44,6 @@ def parse_external_function(
     :param is_contract_payable: bool - does this contract contain payable functions?
     :return: full sig compare & function body
     """
-
-    validate_external_function(code, sig, context.global_ctx)
 
     # Get nonreentrant lock
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(sig, context.global_ctx)

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -1,7 +1,6 @@
 import ast
 from typing import Any, List, Union
 
-from vyper.exceptions import FunctionDeclarationException
 from vyper.parser.arg_clamps import make_arg_clamper
 from vyper.parser.context import Context, VariableRecord
 from vyper.parser.expr import Expr
@@ -104,10 +103,6 @@ def parse_external_function(
         )
     # Is default function.
     elif sig.is_default_func():
-        if len(sig.args) > 0:
-            raise FunctionDeclarationException(
-                "Default function may not receive any arguments.", code
-            )
         o = LLLnode.from_list(
             ["seq"] + clampers + [parse_body(code.body, context)],  # type: ignore
             pos=getpos(code),

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -1,7 +1,6 @@
 import ast
 from typing import Any, List
 
-from vyper.exceptions import FunctionDeclarationException
 from vyper.parser.context import Context
 from vyper.parser.expr import Expr
 from vyper.parser.function_definitions.utils import (
@@ -35,12 +34,6 @@ def get_internal_arg_copier(total_size: int, memory_dest: int) -> List[Any]:
     return copier
 
 
-def validate_internal_function(code: ast.FunctionDef, sig: FunctionSignature) -> None:
-    """ Validate internal function defintion """
-    if sig.is_default_func():
-        raise FunctionDeclarationException("Default function may only be external.", code)
-
-
 def parse_internal_function(
     code: ast.FunctionDef, sig: FunctionSignature, context: Context
 ) -> LLLnode:
@@ -51,8 +44,6 @@ def parse_internal_function(
     :param code: ast of function
     :return: full sig compare & function body
     """
-
-    validate_internal_function(code, sig)
 
     # Get nonreentrant lock
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(sig, context.global_ctx)


### PR DESCRIPTION
### What I did
Move several function-level type checks out of `parser` and into `context`:

* Visibility of `__default__`
* Use of args in `__default__`
* Use of default values in `__init__`

### How I did it
Copy-paste, mostly.  See the diff - it's fairly self explanatory.

### How to verify it
Run the test suite.  Two of these behaviors were already well tested, I've added a test case for the 3rd.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/101417879-3575fd00-38f5-11eb-98ff-0a51606736e9.png)
