### PR TITLE
refactor: remove origcode member from Context

### DIFF
--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -94,7 +94,7 @@ class CompilerData:
 
     def _gen_lll(self) -> None:
         # fetch both deployment and runtime LLL
-        self._lll_nodes, self._lll_runtime = generate_lll_nodes(self.source_code, self.global_ctx)
+        self._lll_nodes, self._lll_runtime = generate_lll_nodes(self.global_ctx)
 
     @property
     def lll_nodes(self) -> parser.LLLnode:
@@ -197,9 +197,7 @@ def generate_global_context(
     return GlobalContext.get_global_context(vyper_module, interface_codes=interface_codes)
 
 
-def generate_lll_nodes(
-    source_code: str, global_ctx: GlobalContext
-) -> Tuple[parser.LLLnode, parser.LLLnode]:
+def generate_lll_nodes(global_ctx: GlobalContext) -> Tuple[parser.LLLnode, parser.LLLnode]:
     """
     Generate the intermediate representation (LLL) from the contextualized AST.
 
@@ -211,8 +209,6 @@ def generate_lll_nodes(
 
     Arguments
     ---------
-    source_code : str
-        Vyper source code.
     global_ctx : GlobalContext
         Contextualized Vyper AST
 
@@ -222,7 +218,7 @@ def generate_lll_nodes(
         LLL to generate deployment bytecode
         LLL to generate runtime bytecode
     """
-    lll_nodes, lll_runtime = parser.parse_tree_to_lll(source_code, global_ctx)
+    lll_nodes, lll_runtime = parser.parse_tree_to_lll(global_ctx)
     lll_nodes = optimizer.optimize(lll_nodes)
     lll_runtime = optimizer.optimize(lll_runtime)
     return lll_nodes, lll_runtime

--- a/vyper/functions/utils.py
+++ b/vyper/functions/utils.py
@@ -7,7 +7,7 @@ from vyper.parser.stmt import parse_body
 def generate_inline_function(code, variables, memory_allocator):
     ast_code = parse_to_ast(code)
     new_context = Context(
-        vars=variables, global_ctx=GlobalContext(), memory_allocator=memory_allocator, origcode=code
+        vars=variables, global_ctx=GlobalContext(), memory_allocator=memory_allocator
     )
     generated_lll = parse_body(ast_code.body, new_context)
     return new_context, generated_lll

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -26,7 +26,6 @@ class Context:
         constancy=Constancy.Mutable,
         is_internal=False,
         is_payable=False,
-        origcode="",
         method_id="",
         sig=None,
     ):
@@ -48,8 +47,6 @@ class Context:
         self.in_range_expr = False
         # Is the function payable?
         self.is_payable = is_payable
-        # Original code (for error pretty-printing purposes)
-        self.origcode = origcode
         # In Loop status. Whether body is currently evaluating within a for-loop or not.
         self.in_for_loop = set()
         # Count returns in function

--- a/vyper/parser/function_definitions/parse_function.py
+++ b/vyper/parser/function_definitions/parse_function.py
@@ -22,7 +22,7 @@ def is_default_func(code):
     return code.name == "__default__"
 
 
-def parse_function(code, sigs, origcode, global_ctx, is_contract_payable, _vars=None):
+def parse_function(code, sigs, global_ctx, is_contract_payable, _vars=None):
     """
     Parses a function and produces LLL code for the function, includes:
         - Signature method if statement
@@ -47,7 +47,6 @@ def parse_function(code, sigs, origcode, global_ctx, is_contract_payable, _vars=
         return_type=sig.output_type,
         constancy=Constancy.Constant if sig.mutability in ("view", "pure") else Constancy.Mutable,
         is_payable=sig.mutability == "payable",
-        origcode=origcode,
         is_internal=sig.internal,
         method_id=sig.method_id,
         sig=sig,

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -95,14 +95,7 @@ def parse_external_interfaces(external_interfaces, global_ctx):
 
 
 def parse_other_functions(
-    o,
-    otherfuncs,
-    sigs,
-    external_interfaces,
-    origcode,
-    global_ctx,
-    default_function,
-    is_contract_payable,
+    o, otherfuncs, sigs, external_interfaces, global_ctx, default_function, is_contract_payable,
 ):
     sub = ["seq", func_init_lll()]
     add_gas = func_init_lll().gas
@@ -110,11 +103,7 @@ def parse_other_functions(
     for _def in otherfuncs:
         sub.append(
             parse_function(
-                _def,
-                {**{"self": sigs}, **external_interfaces},
-                origcode,
-                global_ctx,
-                is_contract_payable,
+                _def, {**{"self": sigs}, **external_interfaces}, global_ctx, is_contract_payable,
             )
         )
         sub[-1].total_gas += add_gas
@@ -128,7 +117,6 @@ def parse_other_functions(
         default_func = parse_function(
             default_function[0],
             {**{"self": sigs}, **external_interfaces},
-            origcode,
             global_ctx,
             is_contract_payable,
         )
@@ -141,7 +129,7 @@ def parse_other_functions(
 
 
 # Main python parse tree => LLL method
-def parse_tree_to_lll(source_code: str, global_ctx: GlobalContext) -> Tuple[LLLnode, LLLnode]:
+def parse_tree_to_lll(global_ctx: GlobalContext) -> Tuple[LLLnode, LLLnode]:
     _names_def = [_def.name for _def in global_ctx._defs]
     # Checks for duplicate function names
     if len(set(_names_def)) < len(_names_def):
@@ -191,25 +179,14 @@ def parse_tree_to_lll(source_code: str, global_ctx: GlobalContext) -> Tuple[LLLn
         o.append(init_func_init_lll())
         o.append(
             parse_function(
-                initfunc[0],
-                {**{"self": sigs}, **external_interfaces},
-                source_code,
-                global_ctx,
-                False,
+                initfunc[0], {**{"self": sigs}, **external_interfaces}, global_ctx, False,
             )
         )
 
     # If there are regular functions...
     if otherfuncs or defaultfunc:
         o, runtime = parse_other_functions(
-            o,
-            otherfuncs,
-            sigs,
-            external_interfaces,
-            source_code,
-            global_ctx,
-            defaultfunc,
-            is_contract_payable,
+            o, otherfuncs, sigs, external_interfaces, global_ctx, defaultfunc, is_contract_payable,
         )
     else:
         runtime = o.copy()
@@ -230,7 +207,7 @@ def parse_to_lll(
 ) -> LLLnode:
     vyper_module = vy_ast.parse_to_ast(source_code)
     global_ctx = GlobalContext.get_global_context(vyper_module, interface_codes=interface_codes)
-    lll_nodes, lll_runtime = parse_tree_to_lll(source_code, global_ctx)
+    lll_nodes, lll_runtime = parse_tree_to_lll(global_ctx)
 
     if runtime_only:
         return lll_runtime


### PR DESCRIPTION
### What I did
Remove the `origcode` attribute from the `Context` object.

This attribute was not in use anywhere. Removing it helps to reduce the size of the input arguments in several `parser` functions - a small step toward refactoring,

### How I did it
See diff.

### How to verify it
Confirm that the existing test suite still passes.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/101520261-e4194c80-398c-11eb-93f6-dade572ffbcc.png)
