### PR TITLE
fix: add license to wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_files = LICENSE
+
 [aliases]
 test = pytest
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     author="Vyper Team",
     author_email="",
     url="https://github.com/vyperlang/vyper",
-    license="MIT",
+    license="Apache License 2.0",
     keywords="ethereum evm smart contract language",
     include_package_data=True,
     packages=find_packages(exclude=("tests", "docs")),
@@ -77,7 +77,7 @@ setup(
     },
     classifiers=[
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.6",
     ],
     data_files=[("", [hash_file_rel_path])],


### PR DESCRIPTION
### What I did
Add the license file to the wheels, this will make working on https://github.com/vyperlang/vyper/issues/2214 easier.
Also saw that `MIT` was still mentioned in setup.py instead of Apache, fixed that
### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.zmescience.com/wp-content/uploads/2018/02/9861752254_8ec9df2cd1_b.jpg)
