### PR TITLE
docs: fix simple typo, unknow -> unknown

### DIFF
--- a/tests/parser/types/test_node_types.py
+++ b/tests/parser/types/test_node_types.py
@@ -70,7 +70,7 @@ def test_get_size_of_type():
     _struct = StructType({"a": BaseType("int128"), "b": BaseType("decimal")}, "Foo")
     assert get_size_of_type(_struct) == 2
 
-    # Don't allow unknow types.
+    # Don't allow unknown types.
     with raises(Exception):
         get_size_of_type(int)
 


### PR DESCRIPTION
There is a small typo in tests/parser/types/test_node_types.py.

Should read `unknown` rather than `unknow`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md