### PR TITLE
Add `size_in_bytes` to new type objects

### DIFF
--- a/tests/functional/context/types/test_size_in_bytes.py
+++ b/tests/functional/context/types/test_size_in_bytes.py
@@ -1,0 +1,49 @@
+import pytest
+
+from vyper.context.types.bases import DataLocation
+from vyper.context.types.utils import get_type_from_annotation
+
+BASE_TYPES = ["int128", "uint256", "bool", "address", "bytes32"]
+ARRAY_VALUE_TYPES = ["String", "Bytes"]
+LOCATIONS = [DataLocation.STORAGE, DataLocation.MEMORY, DataLocation.STORAGE]
+
+
+@pytest.mark.parametrize("type_str", BASE_TYPES)
+@pytest.mark.parametrize("location", LOCATIONS)
+def test_base_types(build_node, type_str, location):
+    node = build_node(type_str)
+    type_definition = get_type_from_annotation(node, location)
+
+    assert type_definition.size_in_bytes == 32
+
+
+@pytest.mark.parametrize("type_str", ARRAY_VALUE_TYPES)
+@pytest.mark.parametrize("location", LOCATIONS)
+@pytest.mark.parametrize("length,size", [(1, 64), (32, 64), (33, 96), (86, 128)])
+def test_array_value_types(build_node, type_str, location, length, size):
+    node = build_node(f"{type_str}[{length}]")
+    type_definition = get_type_from_annotation(node, location)
+
+    assert type_definition.size_in_bytes == size
+
+
+@pytest.mark.parametrize("type_str", BASE_TYPES)
+@pytest.mark.parametrize("location", LOCATIONS)
+@pytest.mark.parametrize("length", range(1, 4))
+def test_base_types_as_arrays(build_node, type_str, location, length):
+    node = build_node(f"{type_str}[{length}]")
+    type_definition = get_type_from_annotation(node, location)
+
+    assert type_definition.size_in_bytes == length * 32
+
+
+@pytest.mark.parametrize("type_str", BASE_TYPES)
+@pytest.mark.parametrize("location", LOCATIONS)
+@pytest.mark.parametrize("first", range(1, 4))
+@pytest.mark.parametrize("second", range(1, 4))
+def test_base_types_as_multidimensional_arrays(build_node, type_str, location, first, second):
+    node = build_node(f"{type_str}[{first}][{second}]")
+
+    type_definition = get_type_from_annotation(node, location)
+
+    assert type_definition.size_in_bytes == first * second * 32

--- a/vyper/context/types/bases.py
+++ b/vyper/context/types/bases.py
@@ -185,9 +185,12 @@ class BaseTypeDefinition:
     -----------------
     is_immutable : bool, optional
         If `True`, the value of this object cannot be modified after assignment.
+    size_in_bytes: int
+        The number of bytes that are required to store this type.
     """
 
     is_dynamic_size = False
+    size_in_bytes = 32
     _id: str
 
     def __init__(

--- a/vyper/context/types/indexable/sequence.py
+++ b/vyper/context/types/indexable/sequence.py
@@ -117,7 +117,7 @@ class TupleDefinition(_SequenceDefinition):
 
     @property
     def is_dynamic_size(self):
-        return any(i for i in self.self.value_type if i.is_dynamic_size)
+        return any(i for i in self.value_type if i.is_dynamic_size)
 
     @property
     def size_in_bytes(self):

--- a/vyper/context/types/indexable/sequence.py
+++ b/vyper/context/types/indexable/sequence.py
@@ -70,6 +70,10 @@ class ArrayDefinition(_SequenceDefinition):
     def is_dynamic_size(self):
         return self.value_type.is_dynamic_size
 
+    @property
+    def size_in_bytes(self):
+        return self.value_type.size_in_bytes * self.length
+
     def get_index_type(self, node):
         if isinstance(node, vy_ast.Int):
             if node.value < 0:
@@ -114,6 +118,10 @@ class TupleDefinition(_SequenceDefinition):
     @property
     def is_dynamic_size(self):
         return any(i for i in self.self.value_type if i.is_dynamic_size)
+
+    @property
+    def size_in_bytes(self):
+        return sum(i.size_in_bytes for i in self.value_type)
 
     def get_index_type(self, node):
         if not isinstance(node, vy_ast.Int):

--- a/vyper/context/types/meta/struct.py
+++ b/vyper/context/types/meta/struct.py
@@ -32,6 +32,10 @@ class StructDefinition(MemberTypeDefinition):
     def is_dynamic_size(self):
         return any(i for i in self.members.values() if i.is_dynamic_size)
 
+    @property
+    def size_in_bytes(self):
+        return sum(i.size_in_bytes for i in self.members.values())
+
     def compare_type(self, other):
         return super().compare_type(other) and self._id == other._id
 

--- a/vyper/context/types/value/array_value.py
+++ b/vyper/context/types/value/array_value.py
@@ -1,3 +1,4 @@
+import math
 from typing import Type
 
 from vyper import ast as vy_ast
@@ -58,6 +59,14 @@ class _ArrayValueDefinition(ValueTypeDefinition):
         if self._length:
             return self._length
         return self._min_length
+
+    @property
+    def size_in_bytes(self):
+        # the first slot (32 bytes) stores the actual length, and then we reserve
+        # enough additional slots to store the data if it uses the max available length
+        # because this data type is single-bytes, we make it so it takes the max 32 byte
+        # boundary as it's size, instead of giving it a size that is not cleanly divisble by 32
+        return 32 + math.ceil(self.length / 32) * 32
 
     @property
     def canonical_type(self) -> str:


### PR DESCRIPTION
### What I did
Add a `size_in_bytes` attribute to each of the new type objects within `vyper.context`

This is a small but significant piece required to phase out the old type objects in favor of the new.

### How I did it
Self explanatory.

### How to verify it
Run the test suite.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/104977305-82beb180-59ff-11eb-977b-3d8571e5db5a.png)
