### PR TITLE
Remove redundant type-check logic in event LLL-gen

### DIFF
--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -122,9 +122,7 @@ class Stmt:
             else:
                 expected_data.append(event.args[pos])
                 data.append(self.stmt.value.args[pos])
-        topics = pack_logging_topics(
-            event.event_id, topics, expected_topics, self.context, pos=getpos(self.stmt),
-        )
+        topics = pack_logging_topics(event.event_id, topics, expected_topics, self.context)
         inargs, inargsize, inargsize_node, inarg_start = pack_logging_data(
             expected_data, data, self.context, pos=getpos(self.stmt),
         )


### PR DESCRIPTION
### What I did
Remove redundant type checks when generating LLL for events.

### How I did it
Mostly should be self explanatory. All of the raised exceptions were dead code, because the checks happen in the new type checking pass.

Of note is line 84 in `parser/events.py` - the call to `base_type_conversion` was not actually performing a conversion, this was just a way to validating the argument type prior to generating the logging topic.

### How to verify it
Confirm that the test sutie is still passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/105358115-080bb700-5bf6-11eb-8d2f-d8dc915ccac2.png)
