### PR TITLE
Add canonical_type to ArrayDefinition

### DIFF
--- a/tests/functional/context/types/test_event.py
+++ b/tests/functional/context/types/test_event.py
@@ -69,6 +69,21 @@ EVENT_ID_TESTS = [
         # Nonsense(bytes,int128[4][38],address[3],uint256,string)
         0xEE1C420D3504F8A563AA99C8341A41C4C2A1A7F35665EE2F5F341CB8F451B5FC,
     ),
+    (
+        """event Bar:
+    a: decimal[4]""",
+        # Bar(fixed168x10[4])
+        0x7F5D3D77DC11EED2D256D513EF1916FBA342AD13DD629E3C2FF3BD1BAEADF932,
+    ),
+    (
+        """event Rtadr:
+    a: indexed(decimal)
+    b: decimal[2][5]
+    c: Bytes[4]
+    d: decimal[666]""",
+        # Rtadr(fixed168x10,fixed168x10[2][5],bytes,fixed168x10[666])
+        0x20B4E04949A8E3B03C8DECC09D8B18B271D42E66F83B9FAA7B75EA7E22E27177,
+    ),
 ]
 
 

--- a/vyper/context/types/indexable/sequence.py
+++ b/vyper/context/types/indexable/sequence.py
@@ -67,6 +67,10 @@ class ArrayDefinition(_SequenceDefinition):
         return f"{self.value_type}[{self.length}]"
 
     @property
+    def canonical_type(self):
+        return f"{self.value_type.canonical_type}[{self.length}]"
+
+    @property
     def is_dynamic_size(self):
         return self.value_type.is_dynamic_size
 


### PR DESCRIPTION
### What I did
Add the `canonical_type` property method to `ArrayDefinition`.

### How I did it
See code.

### How to verify it
Run the tests.  I've added some new cases related to event IDs - an incorrect event ID for decimal arrays is how I found this issue.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/105565480-448b0000-5d27-11eb-97cf-bd44671c26c9.png)
