### PR TITLE
Change forwarder proxy bytecode to ERC-1167

### DIFF
--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -1,5 +1,6 @@
 import pytest
 
+from hexbytes import HexBytes
 from vyper import compiler
 from vyper.exceptions import ArgumentException, StateAccessViolation
 from vyper.functions import get_create_forwarder_to_bytecode
@@ -63,15 +64,15 @@ def create_and_return_forwarder(inp: address) -> address:
     assert c2.create_and_call_returnten(c.address) == 10
     c2.create_and_call_returnten(c.address, transact={})
 
-    expected_forwarder_code_mask = get_create_forwarder_to_bytecode()[12:]
+    _, preamble, callcode = get_create_forwarder_to_bytecode()
 
     c3 = c2.create_and_return_forwarder(c.address, call={})
     c2.create_and_return_forwarder(c.address, transact={})
 
     c3_contract_code = w3.toBytes(w3.eth.getCode(c3))
 
-    assert c3_contract_code[:14] == expected_forwarder_code_mask[:14]
-    assert c3_contract_code[35:] == expected_forwarder_code_mask[35:]
+    assert c3_contract_code[:10] == HexBytes(preamble)
+    assert c3_contract_code[-15:] == HexBytes(callcode)
 
     print("Passed forwarder test")
     # TODO: This one is special

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -1426,51 +1426,35 @@ class PowMod256(_SimpleBuiltinFunction):
 
 
 def get_create_forwarder_to_bytecode():
-    from vyper.compile_lll import assembly_to_evm, num_to_bytearray
+    from vyper.compile_lll import assembly_to_evm
 
     code_a = [
-        "PUSH1",
-        0x33,
-        "PUSH1",
-        0x0C,
-        "PUSH1",
-        0x00,
-        "CODECOPY",
-        "PUSH1",
-        0x33,
-        "PUSH1",
-        0x00,
-        "RETURN",
         "CALLDATASIZE",
-        "PUSH1",
-        0x00,
-        "PUSH1",
-        0x00,
+        "RETURNDATASIZE",
+        "RETURNDATASIZE",
         "CALLDATACOPY",
-        "PUSH2",
-        num_to_bytearray(0x1000),
-        "PUSH1",
-        0x00,
+        "RETURNDATASIZE",
+        "RETURNDATASIZE",
+        "RETURNDATASIZE",
         "CALLDATASIZE",
-        "PUSH1",
-        0x00,
+        "RETURNDATASIZE",
         "PUSH20",  # [address to delegate to]
     ]
     code_b = [
         "GAS",
         "DELEGATECALL",
-        "PUSH1",
-        0x2C,  # jumpdest of whole program.
-        "JUMPI",
-        "PUSH1",
-        0x0,
+        "RETURNDATASIZE",
+        "DUP3",
         "DUP1",
+        "RETURNDATACOPY",
+        "SWAP1",
+        "RETURNDATASIZE",
+        "SWAP2",
+        "PUSH1",
+        0x2B,  # jumpdest of whole program.
+        "JUMPI",
         "REVERT",
         "JUMPDEST",
-        "PUSH2",
-        num_to_bytearray(0x1000),
-        "PUSH1",
-        0x00,
         "RETURN",
     ]
     return assembly_to_evm(code_a)[0] + (b"\x00" * 20) + assembly_to_evm(code_b)[0]


### PR DESCRIPTION
### What I did
fixes: #2269 

### How I did it
Copy some stuff

### How to verify it
- Manual inspection
- Deploy to Etherscan and verify proxy working

### Description for the changelog
Updated forwarder proxy bytecode to ERC-1167 compliance

### Cute Animal Picture
![cute kitty](http://gobrandgo.com/wp-content/uploads/2013/10/surprised-cat-eric-hacke.jpg)