### PR TITLE
Remove unused context managers

### DIFF
--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -49,10 +49,6 @@ class Context:
         self.is_payable = is_payable
         # In Loop status. Whether body is currently evaluating within a for-loop or not.
         self.in_for_loop = set()
-        # Count returns in function
-        self.function_return_count = 0
-        # In assignment. Whether expression is currently evaluating an assignment expression.
-        self.in_assignment = False
         # List of custom structs that have been defined.
         self.structs = global_ctx._structs
         # Callback pointer to jump back to, used in internal functions.
@@ -87,12 +83,6 @@ class Context:
         self.in_for_loop.add(name_of_list)
         yield
         self.in_for_loop.remove(name_of_list)
-
-    @contextlib.contextmanager
-    def assignment_scope(self):
-        self.in_assignment = True
-        yield
-        self.in_assignment = False
 
     @contextlib.contextmanager
     def range_scope(self):

--- a/vyper/parser/context.py
+++ b/vyper/parser/context.py
@@ -47,8 +47,6 @@ class Context:
         self.in_range_expr = False
         # Is the function payable?
         self.is_payable = is_payable
-        # In Loop status. Whether body is currently evaluating within a for-loop or not.
-        self.in_for_loop = set()
         # List of custom structs that have been defined.
         self.structs = global_ctx._structs
         # Callback pointer to jump back to, used in internal functions.
@@ -77,12 +75,6 @@ class Context:
     #
     # Context Managers
     # - Context managers are used to ensure proper wrapping of scopes and context states.
-
-    @contextlib.contextmanager
-    def in_for_loop_scope(self, name_of_list):
-        self.in_for_loop.add(name_of_list)
-        yield
-        self.in_for_loop.remove(name_of_list)
 
     @contextlib.contextmanager
     def range_scope(self):


### PR DESCRIPTION
### What I did
Remove unused context managers.

### How I did it
In `parser/context.py` there are several context managers that have been made redundant thanks to the new type checking pass.  I've removed them and confirmed that nothing breaks.  It's one less piece to consider as we refactor.

### How to verify it
Confirm that the test suite is still passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/105615723-00553980-5dd3-11eb-9f8f-369c980d57e2.png)
