### PR TITLE
Consider events during type-check "implements:"

### DIFF
--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -145,6 +145,57 @@ def foo() -> uint256:
     )
 
 
+def test_missing_event(assert_compile_failed):
+    interface_code = """
+event Foo:
+    a: uint256
+    """
+
+    interface_codes = {"FooBarInterface": {"type": "vyper", "code": interface_code}}
+
+    not_implemented_code = """
+import a as FooBarInterface
+
+implements: FooBarInterface
+
+@external
+def bar() -> uint256:
+    return 1
+    """
+
+    assert_compile_failed(
+        lambda: compile_code(not_implemented_code, interface_codes=interface_codes),
+        InterfaceViolation,
+    )
+
+
+def test_malformed_event(assert_compile_failed):
+    interface_code = """
+event Foo:
+    a: uint256
+    """
+
+    interface_codes = {"FooBarInterface": {"type": "vyper", "code": interface_code}}
+
+    not_implemented_code = """
+import a as FooBarInterface
+
+implements: FooBarInterface
+
+event Foo:
+    a: int128
+
+@external
+def bar() -> uint256:
+    return 1
+    """
+
+    assert_compile_failed(
+        lambda: compile_code(not_implemented_code, interface_codes=interface_codes),
+        InterfaceViolation,
+    )
+
+
 VALID_IMPORT_CODE = [
     # import statement, import path without suffix
     ("import a as Foo", "a"),


### PR DESCRIPTION
### What I did
During type checking. consider events when validating the `implements` statement.

### How I did it
Expand the existing code for `implements` - most of the logic is just ported over from how we check functions.

### How to verify it
Verify the test suite is still passing. This is already very well tested so I have not added further cases.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/105615789-91c4ab80-5dd3-11eb-9ba2-a869fa52a7c0.png)
