### PR TITLE
Move method_id collision check into type checker

### DIFF
--- a/vyper/context/types/meta/interface.py
+++ b/vyper/context/types/meta/interface.py
@@ -8,7 +8,10 @@ from vyper.context.types.bases import DataLocation, MemberTypeDefinition
 from vyper.context.types.function import ContractFunction
 from vyper.context.types.meta.event import Event
 from vyper.context.types.value.address import AddressDefinition
-from vyper.context.validation.utils import validate_expected_type
+from vyper.context.validation.utils import (
+    validate_expected_type,
+    validate_unique_method_ids,
+)
 from vyper.exceptions import (
     InterfaceViolation,
     NamespaceCollision,
@@ -41,6 +44,7 @@ class InterfacePrimitive:
     _as_array = True
 
     def __init__(self, _id, members, events):
+        validate_unique_method_ids(members.values())
         self._id = _id
         self.members = members
         self.events = events

--- a/vyper/context/validation/utils.py
+++ b/vyper/context/validation/utils.py
@@ -441,3 +441,20 @@ def get_index_value(node: vy_ast.Index) -> int:
         raise ArrayIndexException("Subscript must be greater than 0", node)
 
     return node.value.value
+
+
+def validate_unique_method_ids(functions: List) -> None:
+    """
+    Check for collisions between the 4byte function selectors
+    of each function within a contract.
+
+    Arguments
+    ---------
+    functions : List[ContractFunction]
+        A list of ContractFunction objects.
+    """
+    method_ids = [x for i in functions for x in i.method_ids]
+    collision = next((i for i in method_ids if method_ids.count(i) > 1), None)
+    if collision:
+        collision_str = ", ".join(i.name for i in functions if collision in i.method_ids)
+        raise StructureException(f"Methods have conflicting IDs: {collision_str}")


### PR DESCRIPTION
### What I did
Move the logic for checking for unique method IDs into the type checker.

### How I did it
* expand `ContractFunction.method_id` to return a list of method IDs (required when a function uses default values)
* add `validate_unique_method_ids` to the validation utils, to perform the actual check.  This is called during the module-level type check, and when generating `InterfacePrimitive` objects.
* remove the now-ded logic in `signatures`

### How to verify it
Run the tests. The behaviour is already well tested so I did not add any new tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106148492-63e7ba00-6179-11eb-88f1-8ceed00377ae.png)
