### PR TITLE
Remove redundant checks in parser/signatures

### DIFF
--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -16,7 +16,6 @@ from vyper.parser.lll_node import LLLnode
 from vyper.signatures import sig_utils
 from vyper.signatures.event_signature import EventSignature
 from vyper.signatures.function_signature import FunctionSignature
-from vyper.signatures.interface import check_valid_contract_interface
 from vyper.typing import InterfaceImports
 from vyper.utils import LOADED_LIMITS
 
@@ -195,9 +194,6 @@ def parse_tree_to_lll(global_ctx: GlobalContext) -> Tuple[LLLnode, LLLnode]:
         # if no functions in the contract are payable, assert that callvalue is
         # zero at the beginning of the bytecode
         runtime.insert(1, ["assert", ["iszero", "callvalue"]])
-
-    # Check if interface of contract is correct.
-    check_valid_contract_interface(global_ctx, sigs)
 
     return LLLnode.from_list(o, typ=None), LLLnode.from_list(runtime, typ=None)
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -775,15 +775,6 @@ def _check_return_body(node, node_list):
             )
 
 
-def check_unmatched_return(fn_node):
-    if fn_node.returns and not _return_check(fn_node.body):
-        raise StructureException(
-            f'Missing or Unmatched return statements in function "{fn_node.name}". '
-            "All control flow statements (like if) need balanced return statements.",
-            fn_node,
-        )
-
-
 def _return_check(node):
     if is_return_from_function(node):
         return True


### PR DESCRIPTION
### What I did
Remove redundant checks within the `parser` and `signatures` submodules.  All of these checks are now handled within type checking and all of this is unreachable code.

### How I did it
Delete!

### How to verify it
1. Confirm the tests are still passing.
2. Check the latest coverage report on master to verify that all of the deleted code is unreachable.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106199705-2c4b3300-61b6-11eb-82d7-d7bb3df74689.png)
