### PR TITLE
Refactor function-level checks

### DIFF
--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -272,6 +272,12 @@ class ContractFunction(BaseTypeDefinition):
             # Assume nonpayable if not set at all (cannot accept Ether, but can modify state)
             kwargs["state_mutability"] = StateMutability.NONPAYABLE
 
+        if (
+            kwargs["state_mutability"] in (StateMutability.VIEW, StateMutability.PURE)
+            and "nonreentrant" in kwargs
+        ):
+            raise StructureException("Cannot use reentrancy guard on view or pure functions", node)
+
         # call arguments
         arg_count: Union[Tuple[int, int], int] = len(node.args.args)
         if node.args.defaults:


### PR DESCRIPTION
### What I did
Refactor and remove function-level checks out of `signatures`

### How I did it
The only missing check was for a reentrancy guard on a view/pure function. I've added it during type checking, and then removed all the checks from `FunctionSignature`.

### How to verify it
Confirm the test suite still passes

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106307101-37a66900-625f-11eb-977e-5dd14f4a9090.png)
