### PR TITLE
Refactor method identifier and natspec outputs

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -10,7 +10,6 @@ from vyper.compiler.phases import CompilerData
 from vyper.compiler.utils import build_gas_estimates
 from vyper.context.types.function import FunctionVisibility, StateMutability
 from vyper.parser.lll_node import LLLnode
-from vyper.signatures import sig_utils
 from vyper.warnings import ContractSizeLimitWarning
 
 
@@ -77,7 +76,10 @@ def build_ir_output(compiler_data: CompilerData) -> LLLnode:
 
 
 def build_method_identifiers_output(compiler_data: CompilerData) -> dict:
-    return sig_utils.mk_method_identifiers(compiler_data.global_ctx)
+    interface = compiler_data.vyper_module_folded._metadata["type"]
+    functions = interface.members.values()
+
+    return {k: hex(v) for func in functions for k, v in func.method_ids.items()}
 
 
 def build_abi_output(compiler_data: CompilerData) -> list:

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -22,12 +22,12 @@ def build_ast_dict(compiler_data: CompilerData) -> dict:
 
 
 def build_devdoc(compiler_data: CompilerData) -> dict:
-    userdoc, devdoc = parse_natspec(compiler_data.vyper_module_folded, compiler_data.global_ctx)
+    userdoc, devdoc = parse_natspec(compiler_data.vyper_module_folded)
     return devdoc
 
 
 def build_userdoc(compiler_data: CompilerData) -> dict:
-    userdoc, devdoc = parse_natspec(compiler_data.vyper_module_folded, compiler_data.global_ctx)
+    userdoc, devdoc = parse_natspec(compiler_data.vyper_module_folded)
     return userdoc
 
 

--- a/vyper/context/validation/utils.py
+++ b/vyper/context/validation/utils.py
@@ -453,7 +453,7 @@ def validate_unique_method_ids(functions: List) -> None:
     functions : List[ContractFunction]
         A list of ContractFunction objects.
     """
-    method_ids = [x for i in functions for x in i.method_ids]
+    method_ids = [x for i in functions for x in i.method_ids.values()]
     collision = next((i for i in method_ids if method_ids.count(i) > 1), None)
     if collision:
         collision_str = ", ".join(i.name for i in functions if collision in i.method_ids)

--- a/vyper/signatures/sig_utils.py
+++ b/vyper/signatures/sig_utils.py
@@ -56,25 +56,3 @@ def mk_full_signature(global_ctx, sig_formatter):
             for s in default_sigs:
                 o.append(sig_formatter(s))
     return o
-
-
-def mk_method_identifiers(global_ctx):
-    identifiers = {}
-
-    for code in global_ctx._defs:
-        identifiers.update(mk_single_method_identifier(code, global_ctx))
-
-    return identifiers
-
-
-def mk_single_method_identifier(code, global_ctx):
-    identifiers = {}
-    sig = FunctionSignature.from_definition(
-        code, sigs=global_ctx._contracts, custom_structs=global_ctx._structs,
-    )
-    if not sig.internal:
-        default_sigs = generate_default_arg_sigs(code, global_ctx._contracts, global_ctx)
-        for s in default_sigs:
-            identifiers[s.sig] = hex(s.method_id)
-
-    return identifiers


### PR DESCRIPTION
### What I did
Refactor how the method_identifier and natspec outputs are generated to eliminate dependency on the `signatures` subpackage.

### How I did it
* Modify `ContractFunction.method_ids` to return a dict rather than a list. Not sure why I did it as a list initially :grimacing:  but it wasn't in use in many places
* Use the new dict format for generating the refactored outputs, eliminating a need to generate `FunctionSignature` objects.
* Remove now-unused functions within `signatures`
* Fix failing tests related to natspec

### How to verify it
Run the test suite.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106313204-1d24bd80-6268-11eb-9dee-b6e41729af3d.png)
