### PR TITLE
Refactor ContractFunction

### DIFF
--- a/vyper/ast/validation.py
+++ b/vyper/ast/validation.py
@@ -39,6 +39,9 @@ def validate_call_args(
     if not isinstance(arg_count, (int, tuple)):
         raise CompilerPanic(f"Invalid type for arg_count: {type(arg_count).__name__}")
 
+    if isinstance(arg_count, tuple) and arg_count[0] == arg_count[1]:
+        arg_count == arg_count[0]
+
     if isinstance(node.func, vy_ast.Attribute):
         msg = f" for call to '{node.func.attr}'"
     elif isinstance(node.func, vy_ast.Name):

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -392,6 +392,14 @@ class ContractFunction(BaseTypeDefinition):
             method_ids.update(_generate_method_id(self.name, arg_types[:i]))
         return method_ids
 
+    @property
+    def is_constructor(self) -> bool:
+        return self.name == "__init__"
+
+    @property
+    def is_fallback(self) -> bool:
+        return self.name == "__default__"
+
     def get_signature(self) -> Tuple[Tuple, Optional[BaseTypeDefinition]]:
         return tuple(self.arguments.values()), self.return_type
 
@@ -424,11 +432,11 @@ class ContractFunction(BaseTypeDefinition):
     def to_abi_dict(self) -> List[Dict]:
         abi_dict: Dict = {"stateMutability": self.mutability.value}
 
-        if self.name == "__default__":
+        if self.is_fallback:
             abi_dict["type"] = "fallback"
             return [abi_dict]
 
-        if self.name == "__init__":
+        if self.is_constructor:
             abi_dict["type"] = "constructor"
         else:
             abi_dict["type"] = "function"


### PR DESCRIPTION
### What I did
Adjustments to the `ContractFunction` api to aid readability as I refactor out `FunctionSignature`.

### How I did it
* Add `is_constructor` and `is_fallback` property methods. This replaces `func.name == "__init__"`  comparisons.  More readable and makes it easier to refactor in the future.
* Replace `arg_count` with `min_arg_count` and `max_arg_count`.  The prior was a sometimes-int, sometimes-tuple and led to repeated `if isinstance(arg_count, tuple)` checks which aren't immediately obvious to the reader what's happening.
* Add `has_default_args` property method to check if max args > min args

### How to verify it
Check that tests are passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106333129-4fdeae00-6288-11eb-9fee-700545e78421.png)
