### PR TITLE
Use ContractFunction for reentrancy locks

### DIFF
--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -1,3 +1,4 @@
+from vyper import ast as vy_ast
 from vyper.parser.lll_node import LLLnode
 from vyper.parser.parser_utils import getpos
 from vyper.types import BaseType
@@ -11,7 +12,9 @@ from .abi import abi_encode, abi_type_of, ensure_tuple
 def make_return_stmt(stmt, context, begin_pos, _size, loop_memory_position=None):
     from vyper.parser.function_definitions.utils import get_nonreentrant_lock
 
-    _, nonreentrant_post = get_nonreentrant_lock(context.sig, context.global_ctx)
+    func_type = stmt.get_ancestor(vy_ast.FunctionDef)._metadata["type"]
+    _, nonreentrant_post = get_nonreentrant_lock(func_type, context.global_ctx)
+
     if context.is_internal:
         if loop_memory_position is None:
             loop_memory_position = context.new_internal_variable(BaseType("uint256"))

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -1,6 +1,6 @@
-import ast
 from typing import Any, List, Union
 
+from vyper import ast as vy_ast
 from vyper.parser.arg_clamps import make_arg_clamper
 from vyper.parser.context import Context, VariableRecord
 from vyper.parser.expr import Expr
@@ -33,7 +33,7 @@ def get_external_arg_copier(
 
 
 def parse_external_function(
-    code: ast.FunctionDef, sig: FunctionSignature, context: Context, is_contract_payable: bool
+    code: vy_ast.FunctionDef, sig: FunctionSignature, context: Context, is_contract_payable: bool
 ) -> LLLnode:
     """
     Parse a external function (FuncDef), and produce full function body.
@@ -44,7 +44,7 @@ def parse_external_function(
     :return: full sig compare & function body
     """
 
-    func_type = code._metadata['type']
+    func_type = code._metadata["type"]
 
     # Get nonreentrant lock
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_type, context.global_ctx)

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -44,8 +44,10 @@ def parse_external_function(
     :return: full sig compare & function body
     """
 
+    func_type = code._metadata['type']
+
     # Get nonreentrant lock
-    nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(sig, context.global_ctx)
+    nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_type, context.global_ctx)
 
     clampers = []
 

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -1,6 +1,6 @@
-import ast
 from typing import Any, List
 
+from vyper import ast as vy_ast
 from vyper.parser.context import Context
 from vyper.parser.expr import Expr
 from vyper.parser.function_definitions.utils import (
@@ -35,7 +35,7 @@ def get_internal_arg_copier(total_size: int, memory_dest: int) -> List[Any]:
 
 
 def parse_internal_function(
-    code: ast.FunctionDef, sig: FunctionSignature, context: Context
+    code: vy_ast.FunctionDef, sig: FunctionSignature, context: Context
 ) -> LLLnode:
     """
     Parse a internal function (FuncDef), and produce full function body.
@@ -45,7 +45,7 @@ def parse_internal_function(
     :return: full sig compare & function body
     """
 
-    func_type = code._metadata['type']
+    func_type = code._metadata["type"]
 
     # Get nonreentrant lock
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_type, context.global_ctx)

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -45,8 +45,10 @@ def parse_internal_function(
     :return: full sig compare & function body
     """
 
+    func_type = code._metadata['type']
+
     # Get nonreentrant lock
-    nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(sig, context.global_ctx)
+    nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_type, context.global_ctx)
 
     # Create callback_ptr, this stores a destination in the bytecode for a internal
     # function to jump to after a function has executed.

--- a/vyper/parser/function_definitions/utils.py
+++ b/vyper/parser/function_definitions/utils.py
@@ -40,11 +40,11 @@ def make_unpacker(ident, i_placeholder, begin_pos):
     ]
 
 
-def get_nonreentrant_lock(sig, global_ctx):
+def get_nonreentrant_lock(func_type, global_ctx):
     nonreentrant_pre = [["pass"]]
     nonreentrant_post = [["pass"]]
-    if sig.nonreentrant_key:
-        nkey = global_ctx.get_nonrentrant_counter(sig.nonreentrant_key)
+    if func_type.nonreentrant:
+        nkey = global_ctx.get_nonrentrant_counter(func_type.nonreentrant)
         nonreentrant_pre = [["seq", ["assert", ["iszero", ["sload", nkey]]], ["sstore", nkey, 1]]]
         nonreentrant_post = [["sstore", nkey, 0]]
     return nonreentrant_pre, nonreentrant_post


### PR DESCRIPTION
### What I did
Use `ContractFunction` for reentrancy locks

### How I did it
Of note: the function type is annotated onto return statements as `func_type`.

The rest is fairly straightforward.

### How to verify it
Check that tests are still passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106342220-655fd200-62a0-11eb-8fea-01b71cccb66c.png)
