### PR TITLE
Expand `method_ids`

### DIFF
--- a/vyper/ast/natspec.py
+++ b/vyper/ast/natspec.py
@@ -57,7 +57,7 @@ def parse_natspec(vyper_module_folded: vy_ast.Module) -> Tuple[dict, dict]:
         args = tuple(i.arg for i in node.args.args)
         invalid_fields = ("title", "license")
         fn_natspec = _parse_docstring(source, docstring, invalid_fields, args, ret_len)
-        for method_id in func_type.method_ids:
+        for method_id in func_type.get_method_id_dict():
             if "notice" in fn_natspec:
                 userdoc.setdefault("methods", {})[method_id] = {"notice": fn_natspec.pop("notice")}
             if fn_natspec:

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -79,7 +79,7 @@ def build_method_identifiers_output(compiler_data: CompilerData) -> dict:
     interface = compiler_data.vyper_module_folded._metadata["type"]
     functions = interface.members.values()
 
-    return {k: hex(v) for func in functions for k, v in func.method_ids.items()}
+    return {k: hex(v) for func in functions for k, v in func.get_method_id_dict().items()}
 
 
 def build_abi_output(compiler_data: CompilerData) -> list:

--- a/vyper/context/validation/utils.py
+++ b/vyper/context/validation/utils.py
@@ -453,8 +453,8 @@ def validate_unique_method_ids(functions: List) -> None:
     functions : List[ContractFunction]
         A list of ContractFunction objects.
     """
-    method_ids = [x for i in functions for x in i.method_ids.values()]
+    method_ids = [x for i in functions for x in i.get_method_id_dict().values()]
     collision = next((i for i in method_ids if method_ids.count(i) > 1), None)
     if collision:
-        collision_str = ", ".join(i.name for i in functions if collision in i.method_ids)
-        raise StructureException(f"Methods have conflicting IDs: {collision_str}")
+        func_names = [i.name for i in functions if collision in i.get_method_id_dict().values()]
+        raise StructureException(f"Methods have conflicting IDs: {', '.join(func_names)}")


### PR DESCRIPTION
### What I did
Rename `method_ids` to `get_method_id_dict` and add a property method for `method_id`.

The dict for all method IDs is a requirement for certain compiler outputs, however a single "primary" method id is required internally during the IR, to reference the method regardless of default args.  Having this available as a property method is more readable than continually referencing e.g. `list(func.method_ids.values())[-1]`

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/106344523-84636180-62aa-11eb-8cb7-db97aadd5e36.png)
