### PR TITLE
Remove base_type_conversion

### DIFF
--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -90,6 +90,11 @@ def foo():
     assert self.foobar == ZERO_ADDRESS
     assert bar == ZERO_ADDRESS
     """,
+        """
+@external
+def foo() -> bool:
+    return empty(bool)
+    """,
     ],
 )
 def test_empty_basic_type(contract, get_contract_with_gas_estimation):
@@ -230,11 +235,6 @@ def test_empty_basic_type_lists(contract, get_contract_with_gas_estimation):
 @external
 def foo() -> uint256:
     return empty(1)
-    """,
-        """
-@external
-def foo() -> bool:
-    return empty(bool)
     """,
         """
 @external

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -6,7 +6,6 @@ from vyper.exceptions import StructureException
 from vyper.parser.expr import Expr
 from vyper.parser.lll_node import LLLnode
 from vyper.parser.parser_utils import (
-    base_type_conversion,
     getpos,
     make_byte_array_copier,
     make_setter,
@@ -99,7 +98,7 @@ def pack_args_by_32(
             value = unwrap_location(arg)
         else:
             value = Expr(arg, context).lll_node
-            value = base_type_conversion(value, value.typ, value.typ, pos)
+            value = unwrap_location(value)
         holder.append(LLLnode.from_list(["mstore", placeholder, value], location="memory"))
     elif isinstance(typ, ArrayValueAbstractType):
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -380,6 +380,9 @@ def unwrap_location(orig):
     elif orig.location == "calldata":
         return LLLnode.from_list(["calldataload", orig], typ=orig.typ)
     else:
+        # handle None value inserted by `empty`
+        if orig.value is None:
+            return LLLnode.from_list(0, typ=orig.typ)
         return orig
 
 

--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -24,14 +24,7 @@ from vyper.types import (
     has_dynamic_data,
     is_base_type,
 )
-from vyper.types.types import InterfaceType
-from vyper.utils import (
-    DECIMAL_DIVISOR,
-    GAS_IDENTITY,
-    GAS_IDENTITYWORD,
-    MemoryPositions,
-    SizeLimits,
-)
+from vyper.utils import GAS_IDENTITY, GAS_IDENTITYWORD, MemoryPositions
 
 getcontext().prec = 78  # MAX_UINT256 < 1e78
 
@@ -342,7 +335,7 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
                     sub = LLLnode.from_list(["sha3", ["add", value, 32], key])
         else:
             subtype = typ.valuetype
-            sub = base_type_conversion(key, key.typ, typ.keytype, pos=pos)
+            sub = unwrap_location(key)
 
         if sub is not None and location == "storage":
             return LLLnode.from_list(["sha3_64", parent, sub], typ=subtype, location="storage")
@@ -376,42 +369,6 @@ def add_variable_offset(parent, key, pos, array_bounds_check=True):
             return LLLnode.from_list(
                 ["add", ["mul", offset, sub], parent], typ=subtype, location=location, pos=pos
             )
-
-
-# Convert from one base type to another
-@type_check_wrapper
-def base_type_conversion(orig, frm, to, pos, in_function_call=False):
-    orig = unwrap_location(orig)
-
-    # do the base type check so we can use BaseType attributes
-    if not isinstance(frm, BaseType) or not isinstance(to, BaseType):
-        return
-
-    if getattr(frm, "is_literal", False):
-        for typ in (frm.typ, to.typ):
-            if typ in ("int128", "uint256") and not SizeLimits.in_bounds(typ, orig.value):
-                return
-
-    is_decimal_int128_conversion = frm.typ == "int128" and to.typ == "decimal"
-    is_same_type = frm.typ == to.typ
-    is_literal_conversion = frm.is_literal and (frm.typ, to.typ) == ("int128", "uint256")
-    is_address_conversion = isinstance(frm, InterfaceType) and to.typ == "address"
-    if not (
-        is_same_type
-        or is_literal_conversion
-        or is_address_conversion
-        or is_decimal_int128_conversion
-    ):
-        return
-
-    # handle None value inserted by `empty()`
-    if orig.value is None:
-        return LLLnode.from_list(0, typ=to)
-
-    if is_decimal_int128_conversion:
-        return LLLnode.from_list(["mul", orig, DECIMAL_DIVISOR], typ=BaseType("decimal"),)
-
-    return LLLnode(orig.value, orig.args, typ=to, add_gas_estimate=orig.add_gas_estimate)
 
 
 # Unwrap location
@@ -548,9 +505,7 @@ def _make_array_index_setter(target, target_token, pos, location, offset):
 def make_setter(left, right, location, pos, in_function_call=False):
     # Basic types
     if isinstance(left.typ, BaseType):
-        right = base_type_conversion(
-            right, right.typ, left.typ, pos, in_function_call=in_function_call,
-        )
+        right = unwrap_location(right)
         if location == "storage":
             return LLLnode.from_list(["sstore", left, right], typ=None)
         elif location == "memory":

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -8,7 +8,6 @@ from vyper.parser.events import pack_logging_data, pack_logging_topics
 from vyper.parser.expr import Expr
 from vyper.parser.parser_utils import (
     LLLnode,
-    base_type_conversion,
     getpos,
     make_byte_array_copier,
     make_setter,
@@ -377,18 +376,7 @@ class Stmt:
                 self.context,
             )
             return LLLnode.from_list(
-                [
-                    "with",
-                    "_stloc",
-                    target,
-                    [
-                        "sstore",
-                        "_stloc",
-                        base_type_conversion(
-                            lll_node, lll_node.typ, target.typ, pos=getpos(self.stmt)
-                        ),
-                    ],
-                ],
+                ["with", "_stloc", target, ["sstore", "_stloc", unwrap_location(lll_node)]],
                 typ=None,
                 pos=getpos(self.stmt),
             )
@@ -406,18 +394,7 @@ class Stmt:
                 self.context,
             )
             return LLLnode.from_list(
-                [
-                    "with",
-                    "_mloc",
-                    target,
-                    [
-                        "mstore",
-                        "_mloc",
-                        base_type_conversion(
-                            lll_node, lll_node.typ, target.typ, pos=getpos(self.stmt)
-                        ),
-                    ],
-                ],
+                ["with", "_mloc", target, ["mstore", "_mloc", unwrap_location(lll_node)]],
                 typ=None,
                 pos=getpos(self.stmt),
             )


### PR DESCRIPTION
### What I did
Remove `base_type_conversion` from `parser_utils`

At one point this method did stuff, but now that type checking handles all the unhappy paths it's mostly just a roundabout way to call `unwrap_location`.

### How I did it
1. Replaced calls to `base_type_conversion` with `unwrap_location`.
1. Added a new branch in `unwrap_location` to support `empty`.

The `is_decimal_int128_conversion` is a relic from when we allowed implicit conversions between decimals and integers - you can check recent code coverage, this is now unreachable.

### How to verify it
Run the tests. See that nothing is broke'd.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/107838538-98c55500-6da6-11eb-9b41-273e8e9d94bf.png)
