### PR TITLE
Reorder functions within the bytecode

### DIFF
--- a/vyper/compiler/utils.py
+++ b/vyper/compiler/utils.py
@@ -9,10 +9,11 @@ def build_gas_estimates(lll_nodes: LLLnode) -> dict:
         if len(lll_nodes.args) > 0 and lll_nodes.args[-1].value == "return":
             lll_nodes = lll_nodes.args[-1].args[1].args[0]
 
-    assert lll_nodes.value == "seq"
-    for arg in lll_nodes.args:
-        if arg.func_name is not None:
-            gas_estimates[arg.func_name] = arg.total_gas
+    external_sub = next((i for i in lll_nodes.args if i.value == "with"), None)
+    if external_sub:
+        for func_lll in external_sub.args[-1].args:
+            if func_lll.func_name is not None:
+                gas_estimates[func_lll.func_name] = func_lll.total_gas
 
     return gas_estimates
 

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -193,23 +193,22 @@ def parse_external_function(
                 )
 
             # Function with default parameters.
+            function_jump_label = f"{sig.name}_{sig.method_id}_skip"
             o = LLLnode.from_list(
                 [
                     "seq",
                     sig_chain,
                     [
-                        "if",
-                        0,  # can only be jumped into
-                        [
-                            "seq",
-                            ["label", function_routine],
-                            ["seq"]
-                            + nonreentrant_pre
-                            + clampers
-                            + [parse_body(c, context) for c in code.body]
-                            + nonreentrant_post
-                            + [["stop"]],
-                        ],
+                        "seq",
+                        ["goto", function_jump_label],
+                        ["label", function_routine],
+                        ["seq"]
+                        + nonreentrant_pre
+                        + clampers
+                        + [parse_body(c, context) for c in code.body]
+                        + nonreentrant_post
+                        + [["stop"]],
+                        ["label", function_jump_label],
                     ],
                 ],
                 typ=None,

--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -106,7 +106,7 @@ def parse_external_function(
     # Is default function.
     elif sig.is_default_func():
         o = LLLnode.from_list(
-            ["seq"] + clampers + [parse_body(code.body, context)],  # type: ignore
+            ["seq"] + clampers + [parse_body(code.body, context)] + [["stop"]],  # type: ignore
             pos=getpos(code),
         )
     # Is a normal function.

--- a/vyper/parser/function_definitions/parse_internal_function.py
+++ b/vyper/parser/function_definitions/parse_internal_function.py
@@ -209,23 +209,16 @@ def parse_internal_function(
         _clampers = [["label", _post_callback_ptr]]
 
         # Function with default parameters.
-        o = LLLnode.from_list(
+        return LLLnode.from_list(
             [
                 "seq",
                 sig_chain,
-                [
-                    "if",
-                    0,  # can only be jumped into
-                    [
-                        "seq",
-                        ["seq"]
-                        + nonreentrant_pre
-                        + _clampers
-                        + [parse_body(c, context) for c in code.body]
-                        + nonreentrant_post
-                        + stop_func,
-                    ],
-                ],
+                ["seq"]
+                + nonreentrant_pre
+                + _clampers
+                + [parse_body(c, context) for c in code.body]
+                + nonreentrant_post
+                + stop_func,
             ],
             typ=None,
             pos=getpos(code),
@@ -234,21 +227,14 @@ def parse_internal_function(
     else:
         # Function without default parameters.
         sig_compare, internal_label = get_sig_statements(sig, getpos(code))
-        o = LLLnode.from_list(
-            [
-                "if",
-                sig_compare,
-                ["seq"]
-                + [internal_label]
-                + nonreentrant_pre
-                + clampers
-                + [parse_body(c, context) for c in code.body]
-                + nonreentrant_post
-                + stop_func,
-            ],
+        return LLLnode.from_list(
+            ["seq"]
+            + [internal_label]
+            + nonreentrant_pre
+            + clampers
+            + [parse_body(c, context) for c in code.body]
+            + nonreentrant_post
+            + stop_func,
             typ=None,
             pos=getpos(code),
         )
-        return o
-
-    return o

--- a/vyper/parser/function_definitions/utils.py
+++ b/vyper/parser/function_definitions/utils.py
@@ -10,7 +10,7 @@ def get_sig_statements(sig, pos):
             ["label", f"priv_{sig.method_id}"], pos=pos, annotation=f"{sig.sig}"
         )
     else:
-        sig_compare = ["eq", ["mload", 0], method_id_node]
+        sig_compare = ["eq", "_func_sig", method_id_node]
         private_label = ["pass"]
 
     return sig_compare, private_label

--- a/vyper/parser/parser.py
+++ b/vyper/parser/parser.py
@@ -89,34 +89,46 @@ def parse_external_interfaces(external_interfaces, global_ctx):
 def parse_other_functions(
     o, otherfuncs, sigs, external_interfaces, global_ctx, default_function, is_contract_payable,
 ):
-    func_sub = ["seq"]
-    main_seq = ["seq", func_init_lll(), ["with", "_func_sig", ["mload", 0], func_sub]]
+    # generate LLL for regular functions
+    external_func_sub = ["seq"]
+    internal_func_sub = ["seq"]
     add_gas = func_init_lll().gas
 
-    for _def in otherfuncs:
-        func_sub.append(
-            parse_function(
-                _def, {**{"self": sigs}, **external_interfaces}, global_ctx, is_contract_payable,
-            )
+    for func_node in otherfuncs:
+        func_lll = parse_function(
+            func_node, {**{"self": sigs}, **external_interfaces}, global_ctx, is_contract_payable,
         )
-        func_sub[-1].total_gas += add_gas
-        add_gas += 30
-        for sig in sig_utils.generate_default_arg_sigs(_def, external_interfaces, global_ctx):
-            sig.gas = func_sub[-1].total_gas
+        if func_lll.context.is_internal:
+            internal_func_sub.append(func_lll)
+        else:
+            external_func_sub.append(func_lll)
+            add_gas += 30
+        func_lll.total_gas += add_gas
+        for sig in sig_utils.generate_default_arg_sigs(func_node, external_interfaces, global_ctx):
+            sig.gas = func_lll.total_gas
             sigs[sig.sig] = sig
 
-    # Add fallback function
+    # generate LLL for fallback function
     if default_function:
-        default_func = parse_function(
+        fallback_lll = parse_function(
             default_function[0],
             {**{"self": sigs}, **external_interfaces},
             global_ctx,
             is_contract_payable,
         )
-        fallback = default_func
     else:
-        fallback = LLLnode.from_list(["revert", 0, 0], typ=None, annotation="Default function")
-    main_seq.append(["seq_unchecked", ["label", "fallback"], fallback])
+        fallback_lll = LLLnode.from_list(["revert", 0, 0], typ=None, annotation="Default function")
+
+    # bytecode is organized by: external functions, fallback fn, internal functions
+    # this way we save gas and reduce bytecode by not jumping over internal functions
+    main_seq = [
+        "seq",
+        func_init_lll(),
+        ["with", "_func_sig", ["mload", 0], external_func_sub],
+        ["seq_unchecked", ["label", "fallback"], fallback_lll],
+        internal_func_sub,
+    ]
+
     o.append(["return", 0, ["lll", main_seq, 0]])
     return o, main_seq
 


### PR DESCRIPTION
### What I did
Reorder functions within the bytecode and refactor how the function selector is checked.

### How I did it
Functions were previous sequenced in the same way as they are found in the source. Internal functions were jumped over following an inefficient `PUSH1 0x0 ISZEZO` check.

This PR places all internal functions __after__ the fallback, so they cannot be reached without being explicitely jumped to from an internal function. Thus, all the jumping logic can be removed and the bytecode size reduced.

The function selector itself was previous written to memory with offset 0, and loaded onto the stack for every comparison. This PR modifies the process so that the selector is kept on the stack and compared via `DUP` operations rather than repeated `MLOAD`. Less bytecode, less gas.

### How to verify it
Run the tests, see that nothing has broken.

### Cute Animal Picture
Coming soon