### PR TITLE
Assembly-level optimizations

### DIFF
--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -517,6 +517,19 @@ def assembly_to_evm(assembly, start_pos=0):
         else:
             i += 1
 
+    # When a nested subroutine finishes and is the final action within it's
+    # parent subroutine, we end up with multiple simultaneous JUMPDEST
+    # instructions that can be merged to reduce the bytecode size.
+    i = 0
+    while i < len(assembly) - 3:
+        if is_symbol(assembly[i]) and assembly[i + 1] == "JUMPDEST":
+            if is_symbol(assembly[i + 2]) and assembly[i + 3] == "JUMPDEST":
+                to_replace = assembly[i + 2]
+                assembly = assembly[: i + 2] + assembly[i + 4 :]  # noqa: E203
+                assembly = [x if x != to_replace else assembly[i] for x in assembly]
+                continue
+        i += 1
+
     line_number_map = {
         "breakpoints": set(),
         "pc_breakpoints": set(),


### PR DESCRIPTION
### What I did
* find and remove unreachable instructions within the assembly
* merge sequential jumpdests

### How I did it
Added some logic in `assembly_to_evm` within `compile_lll.py`

Both of these situations occur as a result of LLL generation happening in small chunks that don't see the "bigger picture" around them. There is likely a more elegant solution here, but this is effective and simple to implement. I've left comments about what's happening, we can try to address this properly as we refactor out `parser` in the future and give ourselves more effective data structures to catch and fix this as it happens rather than after the fact.

### How to verify it
Run tests, confirm that nothing broke.  If this created any issues we'd see tests failing everywhere, especially within the e2e tests of the examples.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/107960241-aea06900-6fa4-11eb-9f19-d926b3283445.png)
Notice me senpai!