### PR TITLE
fix: add RETURN when looking for unreachable code

### DIFF
--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -510,7 +510,7 @@ def assembly_to_evm(assembly, start_pos=0):
     # to avoid unnecessary bytecode bloat.
     i = 0
     while i < len(assembly) - 1:
-        if assembly[i] in ("JUMP", "STOP", "REVERT") and not (
+        if assembly[i] in ("JUMP", "RETURN", "REVERT", "STOP") and not (
             is_symbol(assembly[i + 1]) or assembly[i + 1] == "JUMPDEST"
         ):
             del assembly[i + 1]


### PR DESCRIPTION
### What I did
Consider `RETURN` when searching for unreachable bytecode. An extension of #2304 

### How I did it
Self explanatory - see diff.

### How to verify it
Run tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/108003185-3e203900-6ff2-11eb-8918-dc801f134394.png)
