### PR TITLE
Bump isort dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,9 @@
 repos:
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    -   id: seed-isort-config
-
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+-   repo: https://github.com/pycqa/isort
+    rev: 5.7.0
     hooks:
       - id: isort
+        name: isort
 
 -   repo: https://github.com/psf/black
     rev: 19.10b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,18 +6,17 @@ test = pytest
 
 [flake8]
 max-line-length = 100
-exclude = 
+exclude =
 	venv*
 	.tox
 	docs
 	build
-per-file-ignores = 
+per-file-ignores =
 	*/__init__.py: F401
 
 [tool:isort]
 force_grid_wrap = 0
 include_trailing_comma = True
-known_third_party = asttokens,eth_abi,eth_account,eth_keys,eth_tester,eth_utils,hypothesis,lark,pkg_resources,pytest,recommonmark,semantic_version,setuptools,web3
 known_first_party = vyper
 multi_line_output = 3
 use_parentheses = True
@@ -32,5 +31,5 @@ addopts = -n auto
 	--hypothesis-show-statistics
 python_files = test_*.py
 testpaths = tests
-markers = 
+markers =
 	fuzzing: Run Hypothesis fuzz test suite (deselect with '-m "not fuzzing"')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {
         "flake8==3.8.3",
         "flake8-bugbear==20.1.4",
         "flake8-use-fstring==1.1",
-        "isort==4.3.21",
+        "isort==5.7.0",
         "mypy==0.780",
     ],
     "docs": ["recommonmark", "sphinx>=3.0,<4.0", "sphinx_rtd_theme>=0.5,<0.6"],

--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -5,7 +5,7 @@ EXPIRY = 16
 
 @pytest.fixture
 def auction_start(w3):
-    return w3.eth.getBlock('latest').timestamp + 1
+    return w3.eth.getBlock("latest").timestamp + 1
 
 
 @pytest.fixture

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -1,6 +1,6 @@
 import pytest
-
 from hexbytes import HexBytes
+
 from vyper import compiler
 from vyper.exceptions import ArgumentException, StateAccessViolation
 from vyper.functions import get_create_forwarder_to_bytecode

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,9 @@ whitelist_externals = make
 basepython = python
 extras = lint
 commands =
-    black .
+    black --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
     flake8 {toxinidir}/vyper {toxinidir}/tests
-    isort --recursive --check-only --diff {toxinidir}/vyper {toxinidir}/tests
+    isort --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
 
 [testenv:mypy]
 basepython = python


### PR DESCRIPTION
### What I did
* Bump `isort` to `v5.7.0` in `setup.py` and `.pre-commit-config.yaml`
* Remove now-redundant `known_third_party` field within `setup.cfg`
* Update tox lint job
* Apply linter rules

### How to verify it
Check that the lint job in the CI is passing

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/108105568-13cf8980-708d-11eb-9f94-92d1a97e98de.png)
