### PR TITLE
Optimize nonpayable assertion

### DIFF
--- a/vyper/parser/function_definitions/parse_external_function.py
+++ b/vyper/parser/function_definitions/parse_external_function.py
@@ -33,14 +33,15 @@ def get_external_arg_copier(
 
 
 def parse_external_function(
-    code: vy_ast.FunctionDef, sig: FunctionSignature, context: Context, is_contract_payable: bool
+    code: vy_ast.FunctionDef, sig: FunctionSignature, context: Context, check_nonpayable: bool,
 ) -> LLLnode:
     """
     Parse a external function (FuncDef), and produce full function body.
 
     :param sig: the FuntionSignature
     :param code: ast of function
-    :param is_contract_payable: bool - does this contract contain payable functions?
+    :param check_nonpayable: if True, include a check that `msg.value == 0`
+                             at the beginning of the function
     :return: full sig compare & function body
     """
 
@@ -60,7 +61,7 @@ def parse_external_function(
         context.memory_allocator.expand_memory(sig.max_copy_size)
     clampers.append(copier)
 
-    if is_contract_payable and sig.mutability != "payable":
+    if check_nonpayable and sig.mutability != "payable":
         # if the contract contains payable functions, but this is not one of them
         # add an assertion that the value of the call is zero
         clampers.append(["assert", ["iszero", "callvalue"]])

--- a/vyper/parser/function_definitions/parse_function.py
+++ b/vyper/parser/function_definitions/parse_function.py
@@ -22,7 +22,7 @@ def is_default_func(code):
     return code.name == "__default__"
 
 
-def parse_function(code, sigs, global_ctx, is_contract_payable, _vars=None):
+def parse_function(code, sigs, global_ctx, check_nonpayable, _vars=None):
     """
     Parses a function and produces LLL code for the function, includes:
         - Signature method if statement
@@ -56,7 +56,7 @@ def parse_function(code, sigs, global_ctx, is_contract_payable, _vars=None):
         o = parse_internal_function(code=code, sig=sig, context=context,)
     else:
         o = parse_external_function(
-            code=code, sig=sig, context=context, is_contract_payable=is_contract_payable
+            code=code, sig=sig, context=context, check_nonpayable=check_nonpayable
         )
 
     o.context = context


### PR DESCRIPTION
### What I did
Optimize how the nonpayable check is applied within the bytecode

### How I did it
Where possible, external functions are now organized by [payable], [nonpayable] and a single assertion that `msg.value == 0` is placed in between the two sections.

When a contract contains a payable default function, and nonpayable functions, this optimization is not possible and the check is still applied per-function.

### How to verify it
Run the tests.  I expanded the testing around the `@payable` decorator to handle all the different possible permutations based on this optimization.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/108108150-842bda00-7090-11eb-92a4-aaca1f8e87d6.png)
