### PR TITLE
Fix: incorrect `TypeMismatch` when dealing with literals in lists

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -1,4 +1,4 @@
-from vyper.exceptions import ArrayIndexException, TypeMismatch
+from vyper.exceptions import ArrayIndexException, OverflowException
 
 
 def test_list_tester_code(get_contract_with_gas_estimation):
@@ -252,10 +252,10 @@ def test_compile_time_bounds_check(get_contract_with_gas_estimation, assert_comp
     code = """
 @external
 def parse_list_fail():
-    xs: uint256[3] = [2**255, 1, 3]
+    xs: uint256[3] = [2**256, 1, 3]
     pass
     """
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatch)
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), OverflowException)
 
 
 def test_2d_array_input_1(get_contract):

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -938,20 +938,15 @@ class Expr:
             return lll_node.typ
 
         lll_node = []
-        previous_type = None
         out_type = None
 
         for elt in self.expr.elements:
             current_lll_node = Expr(elt, self.context).lll_node
-            if not out_type:
+            if not out_type or not current_lll_node.typ.is_literal:
+                # prefer to use a non-literal type here, because literals can be ambiguous
+                # this should be removed altogether as we refactor types out of parser
                 out_type = current_lll_node.typ
-
-            current_type = get_out_type(current_lll_node)
-            if len(lll_node) > 0 and previous_type != current_type:
-                raise TypeMismatch("Lists may only contain one type", self.expr)
-            else:
-                lll_node.append(current_lll_node)
-                previous_type = current_type
+            lll_node.append(current_lll_node)
 
         return LLLnode.from_list(
             ["multi"] + lll_node, typ=ListType(out_type, len(lll_node)), pos=getpos(self.expr),


### PR DESCRIPTION
### What I did
Fix an issue preventing literal lists where some members are literals and others are not.  For example:

```
@external
def foo() -> uint256[2]:
    a: uint256 = 123
    return [a, 2]
```

This would fail because in `parser/stmt.py` the literal `2` is interpreted as an `int128`. However, we know this to be incorrect because we have already completed the type checking pass.

### How I did it
Remove the now-redundant check that was blocking this at compile-time.  I did some minor voodoo to retain the type information within `parser` so that nothing else breaks later down the line, and left a comment to prevent confusion later when we refactor types out altogether.

### How to verify it
Check that tests are passing.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/108127408-7f285400-70ab-11eb-9ee0-3334807d3057.png)
