### PR TITLE
Public getter fixes

### DIFF
--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -30,6 +30,8 @@ x: public(uint256)
 y: public(int128[5])
 z: public(Bytes[100])
 w: public(HashMap[int128, W])
+a: public(uint256[10][10])
+b: public(HashMap[uint256, HashMap[address, uint256[4]]])
 
 @external
 def __init__():
@@ -42,6 +44,8 @@ def __init__():
     self.w[2].e[1][2] = 17
     self.w[3].f = 750
     self.w[3].g = 751
+    self.a[1][4] = 666
+    self.b[42][self] = [5,6,7,8]
     """
 
     c = get_contract_with_gas_estimation_for_constants(getter_code)
@@ -54,3 +58,20 @@ def __init__():
     assert c.w(2)[3][1][2] == 17  # W.e[1][2]
     assert c.w(3)[4] == 750  # W.f
     assert c.w(3)[5] == 751  # W.g
+    assert c.a(1, 4) == 666
+    assert c.b(42, c.address, 2) == 7
+
+
+def test_getter_mutability(get_contract):
+    code = """
+foo: public(uint256)
+goo: public(String[69])
+bar: public(uint256[4][5])
+baz: public(HashMap[address, Bytes[100]])
+potatoes: public(HashMap[uint256, HashMap[bytes32, uint256[4]]])
+"""
+
+    contract = get_contract(code)
+
+    for item in contract._classic_contract.abi:
+        assert item["stateMutability"] == "view"

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -78,7 +78,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
             name=func_type.name,
             args=vy_ast.arguments(args=input_nodes, defaults=[],),
             body=[vy_ast.Return(value=return_stmt)],
-            decorator_list=[vy_ast.Name(id="external")],
+            decorator_list=[vy_ast.Name(id="external"), vy_ast.Name(id="view")],
             returns=return_node,
         )
         expanded._metadata["type"] = func_type

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -49,7 +49,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
             if not isinstance(annotation, vy_ast.Subscript):
                 # if we get here something has failed in type checking
                 raise CompilerPanic("Mismatch between node and input type while building getter")
-            if annotation.value.id == "HashMap":  # type: ignore
+            if annotation.value.get("id") == "HashMap":  # type: ignore
                 # for a HashMap, split the key/value types and use the key type as the next arg
                 arg, annotation = annotation.slice.value.elements  # type: ignore
             else:

--- a/vyper/context/types/function.py
+++ b/vyper/context/types/function.py
@@ -372,7 +372,7 @@ class ContractFunction(BaseTypeDefinition):
             len(arguments),
             return_type,
             function_visibility=FunctionVisibility.EXTERNAL,
-            state_mutability=StateMutability.NONPAYABLE,
+            state_mutability=StateMutability.VIEW,
         )
 
     @property


### PR DESCRIPTION
### What I did
Fix some issues with public getters:

* incorrect `stateMutability` within the ABI
* compile-time error when declaring a multidimensional array as public

### How I did it
See diff. Both fixes are fairly straightforward.

### How to verify it
Run the tests. I added some cases to cover the behaviours where the issue existed. This initially made it to master in #2295, I had assumed that public getters were better covered in the test suite than they actually are :grimacing: 

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/108211446-fd790a80-712c-11eb-866d-6cfbf64f4feb.png)
