### PR TITLE
fix: Var size when using new type objects

### DIFF
--- a/tests/parser/features/test_memory_dealloc.py
+++ b/tests/parser/features/test_memory_dealloc.py
@@ -1,0 +1,29 @@
+def test_memory_deallocation(get_contract):
+    code = """
+event Shimmy:
+    a: indexed(address)
+    b: uint256
+
+interface Other:
+    def sendit(): nonpayable
+
+@external
+def foo(target: address) -> uint256[2]:
+    log Shimmy(ZERO_ADDRESS, 3)
+    amount: uint256 = 1
+    flargen: uint256 = 42
+    Other(target).sendit()
+    return [amount, flargen]
+    """
+
+    code2 = """
+
+@external
+def sendit() -> bool:
+     return True
+    """
+
+    c = get_contract(code)
+    c2 = get_contract(code2)
+
+    assert c.foo(c2.address) == [1, 42]

--- a/vyper/signatures/function_signature.py
+++ b/vyper/signatures/function_signature.py
@@ -1,3 +1,4 @@
+import math
 from collections import Counter
 
 from vyper import ast as vy_ast
@@ -41,7 +42,9 @@ class VariableRecord:
     def size(self):
         if hasattr(self.typ, "size_in_bytes"):
             # temporary requirement to support both new and old type objects
-            return self.typ.size_in_bytes
+            # we divide by 32 here because the returned value is denominated
+            # in "slots" of 32 bytes each
+            return math.ceil(self.typ.size_in_bytes / 32)
         return get_size_of_type(self.typ)
 
 


### PR DESCRIPTION
### What I did
In `VariableRecord`, return the correct size when the related type object is one of the new `context` types.

This fixes an issue with memory corruption caused by excessive deallocation when releasing internal variables :(

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/108646586-14b65000-74bf-11eb-8c4a-7aed172ef73a.png)
