### PR TITLE
Add a function to change the minter identity

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -341,6 +341,18 @@ def mint(_to: address, _tokenId: uint256) -> bool:
     self._addTokenTo(_to, _tokenId)
     log Transfer(ZERO_ADDRESS, _to, _tokenId)
     return True
+    
+    
+@external transferMinterRole(_newMinter: address):
+    """
+    @dev Function to transfer the minter position to a new address
+         Throws if `msg.sender` is not the minter.
+    @param _newMinter The new minter address for the contract.
+    """
+    # Throws if `msg.sender` is not the current minter
+    assert msg.sender == self.minter
+    self.minter = _newMinter
+   
 
 
 @external


### PR DESCRIPTION
It could be useful to transfer the privilege to somebody else, for example when the minter leaves a job with the organization that owns the ERC-721 contract. This could also be accomplished by giving the private key for the address to the next person, but if a person created multiple ERC-721 contracts and didn't think about it beforehand they might have to give all of them or none. With this function they can decide to transfer only some contracts.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
