### PR TITLE
Linter fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,9 @@ whitelist_externals = make
 basepython = python3.8
 extras = lint
 commands =
-    black -t py38 --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
+    black -t py38 {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
     flake8 {toxinidir}/vyper {toxinidir}/tests
-    isort --check {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
+    isort {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
 
 [testenv:mypy]
 basepython = python3.8


### PR DESCRIPTION
### What I did
* remove `py39` as a version target in the black conf
* remove the `--check` flag when running black and isort in tox

