### PR TITLE
Fix: memory corruption from nested internal function calls

### DIFF
--- a/vyper/parser/parser_utils.py
+++ b/vyper/parser/parser_utils.py
@@ -534,8 +534,14 @@ def make_setter(left, right, location, pos, in_function_call=False):
             left = LLLnode.from_list(["sha3_32", left], typ=left.typ, location="storage_prehashed")
             left_token.location = "storage_prehashed"
         # If the right side is a literal
-        if right.value == "multi":
-            subs = []
+        if right.value in ["multi", "seq_unchecked"] and right.typ.is_literal:
+            if right.value == "seq_unchecked":
+                # when the LLL is `seq_unchecked`, this is a literal where one or
+                # more values must be pre-processed to avoid memory corruption
+                subs = right.args[:-1]
+                right = right.args[-1]
+            else:
+                subs = []
             for i in range(left.typ.count):
                 lhs_setter = _make_array_index_setter(left, left_token, pos, location, i)
                 subs.append(make_setter(lhs_setter, right.args[i], location, pos=pos,))


### PR DESCRIPTION
### What I did
Fix a runtime bug allowing for memory corruption when making an internal function call inside a literal array or another function call.

The issue is the same as the one outlined in https://github.com/vyperlang/vyper/security/advisories/GHSA-2r3x-4mrv-mcxf and fixed in https://github.com/vyperlang/vyper/pull/2186. In my previous fix I did not fully comprehend the scope of the issue, and so the bug was still present when making a private function call inside a literal array, or when accessing a single indexed value from a private function call returning a list or tuple.

### How I did it
Expand the logic added in #2186, applying it also to `Subscript` and `List` nodes.  I have refactored the check into it's own new function, `parse_sequence`, which is applied on all lists, tuples, and private function calls. There is some recursive logic to account for multidimensional arrays.

### How to verify it
Run the tests.  I've included some new cases - awful code that nobody should ever write, that would cause the bug to appear in very many varieties (if it were still around).

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/114286611-703d9c80-9a71-11eb-97e3-5434fae14d13.png)
