### PR TITLE
Rename SizeLimits constants

### DIFF
--- a/tests/parser/functions/test_convert_to_int128.py
+++ b/tests/parser/functions/test_convert_to_int128.py
@@ -342,17 +342,17 @@ def conv_max_literal_alt() -> int128:
     assert c.conv_neg1_stor_alt() == -1
     assert c.conv_neg1_literal_alt() == -1
 
-    assert c.conv_min_stor() == SizeLimits.MINNUM
-    assert c.conv_min_literal() == SizeLimits.MINNUM
-    assert c.conv_min_stor_alt() == SizeLimits.MINNUM
-    assert c.conv_min_literal_alt() == SizeLimits.MINNUM
+    assert c.conv_min_stor() == SizeLimits.MIN_INT128
+    assert c.conv_min_literal() == SizeLimits.MIN_INT128
+    assert c.conv_min_stor_alt() == SizeLimits.MIN_INT128
+    assert c.conv_min_literal_alt() == SizeLimits.MIN_INT128
 
     assert c.conv_zero_stor() == 0
     assert c.conv_zero_literal() == 0
     assert c.conv_zero_stor_alt() == 0
     assert c.conv_zero_literal_alt() == 0
 
-    assert c.conv_max_stor() == SizeLimits.MAXNUM
-    assert c.conv_max_literal() == SizeLimits.MAXNUM
-    assert c.conv_max_stor_alt() == SizeLimits.MAXNUM
-    assert c.conv_max_literal_alt() == SizeLimits.MAXNUM
+    assert c.conv_max_stor() == SizeLimits.MAX_INT128
+    assert c.conv_max_literal() == SizeLimits.MAX_INT128
+    assert c.conv_max_stor_alt() == SizeLimits.MAX_INT128
+    assert c.conv_max_literal_alt() == SizeLimits.MAX_INT128

--- a/tests/parser/types/numbers/test_sqrt.py
+++ b/tests/parser/types/numbers/test_sqrt.py
@@ -131,7 +131,7 @@ def test(a: decimal) -> decimal:
     return c
 
 
-@pytest.mark.parametrize("value", [Decimal(0), Decimal(SizeLimits.MAXNUM)])
+@pytest.mark.parametrize("value", [Decimal(0), Decimal(SizeLimits.MAX_INT128)])
 def test_sqrt_bounds(sqrt_contract, value):
     vyper_sqrt = sqrt_contract.test(value)
     actual_sqrt = decimal_sqrt(value)
@@ -141,10 +141,10 @@ def test_sqrt_bounds(sqrt_contract, value):
 @pytest.mark.fuzzing
 @hypothesis.given(
     value=hypothesis.strategies.decimals(
-        min_value=Decimal(0), max_value=Decimal(SizeLimits.MAXNUM), places=DECIMAL_PLACES
+        min_value=Decimal(0), max_value=Decimal(SizeLimits.MAX_INT128), places=DECIMAL_PLACES
     )
 )
-@hypothesis.example(Decimal(SizeLimits.MAXNUM))
+@hypothesis.example(Decimal(SizeLimits.MAX_INT128))
 @hypothesis.example(Decimal(0))
 @hypothesis.settings(deadline=1000,)
 def test_sqrt_valid_range(sqrt_contract, value):
@@ -156,11 +156,11 @@ def test_sqrt_valid_range(sqrt_contract, value):
 @pytest.mark.fuzzing
 @hypothesis.given(
     value=hypothesis.strategies.decimals(
-        min_value=Decimal(SizeLimits.MINNUM), max_value=Decimal("-1E10"), places=DECIMAL_PLACES
+        min_value=Decimal(SizeLimits.MIN_INT128), max_value=Decimal("-1E10"), places=DECIMAL_PLACES
     )
 )
 @hypothesis.settings(deadline=400,)
-@hypothesis.example(Decimal(SizeLimits.MINNUM))
+@hypothesis.example(Decimal(SizeLimits.MIN_INT128))
 @hypothesis.example(Decimal("-1E10"))
 def test_sqrt_invalid_range(sqrt_contract, value):
     with pytest.raises(TransactionFailed):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -187,9 +187,9 @@ def _validate_numeric_bounds(
     node: Union["BinOp", "UnaryOp"], value: Union[decimal.Decimal, int]
 ) -> None:
     if isinstance(value, decimal.Decimal):
-        lower, upper = SizeLimits.MINNUM, SizeLimits.MAXNUM
+        lower, upper = SizeLimits.MIN_INT128, SizeLimits.MAX_INT128
     elif isinstance(value, int):
-        lower, upper = SizeLimits.MINNUM, SizeLimits.MAX_UINT256
+        lower, upper = SizeLimits.MIN_INT128, SizeLimits.MAX_UINT256
     else:
         raise CompilerPanic(f"Unexpected return type from {node._op}: {type(value)}")
     if not lower <= value <= upper:
@@ -711,7 +711,7 @@ class Num(Constant):
         return self.value
 
     def validate(self):
-        if self.value < SizeLimits.MINNUM:
+        if self.value < SizeLimits.MIN_INT128:
             raise OverflowException("Value is below lower bound for all numeric types", self)
         if self.value > SizeLimits.MAX_UINT256:
             raise OverflowException("Value exceeds upper bound for all numeric types", self)

--- a/vyper/functions/convert.py
+++ b/vyper/functions/convert.py
@@ -86,7 +86,7 @@ def to_int128(expr, args, kwargs, context):
 
         else:
             return LLLnode.from_list(
-                ["uclample", in_arg, ["mload", MemoryPositions.MAXNUM]],
+                ["uclample", in_arg, ["mload", MemoryPositions.MAX_INT128]],
                 typ=BaseType("int128"),
                 pos=getpos(expr),
             )

--- a/vyper/parser/arg_clamps.py
+++ b/vyper/parser/arg_clamps.py
@@ -145,7 +145,7 @@ def int128_clamp(lll_node):
     else:
         return [
             "clamp",
-            ["mload", MemoryPositions.MINNUM],
+            ["mload", MemoryPositions.MIN_INT128],
             lll_node,
-            ["mload", MemoryPositions.MAXNUM],
+            ["mload", MemoryPositions.MAX_INT128],
         ]

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -48,8 +48,8 @@ from vyper.utils import (
 BUILTIN_CONSTANTS = {
     "EMPTY_BYTES32": (0, "bytes32"),
     "ZERO_ADDRESS": (0, "address"),
-    "MAX_INT128": (SizeLimits.MAXNUM, "int128"),
-    "MIN_INT128": (SizeLimits.MINNUM, "int128"),
+    "MAX_INT128": (SizeLimits.MAX_INT128, "int128"),
+    "MIN_INT128": (SizeLimits.MIN_INT128, "int128"),
     "MAX_DECIMAL": (SizeLimits.MAXDECIMAL, "decimal"),
     "MIN_DECIMAL": (SizeLimits.MINDECIMAL, "decimal"),
     "MAX_UINT256": (SizeLimits.MAX_UINT256, "uint256"),
@@ -216,7 +216,7 @@ class Expr:
 
     def parse_Decimal(self):
         numstring, num, den = get_number_as_fraction(self.expr, self.context)
-        if not (SizeLimits.MINNUM * den <= num <= SizeLimits.MAXNUM * den):
+        if not (SizeLimits.MIN_INT128 * den <= num <= SizeLimits.MAX_INT128 * den):
             return
         if DECIMAL_DIVISOR % den:
             return

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -80,8 +80,8 @@ DECIMAL_DIVISOR = 10 ** MAX_DECIMAL_PLACES
 # Number of bytes in memory used for system purposes, not for variables
 class MemoryPositions:
     ADDRSIZE = 32
-    MAXNUM = 64
-    MINNUM = 96
+    MAX_INT128 = 64
+    MIN_INT128 = 96
     MAXDECIMAL = 128
     MINDECIMAL = 160
     FREE_VAR_SPACE = 192
@@ -94,8 +94,8 @@ class MemoryPositions:
 # Sizes of different data types. Used to clamp types.
 class SizeLimits:
     ADDRSIZE = 2 ** 160
-    MAXNUM = 2 ** 127 - 1
-    MINNUM = -(2 ** 127)
+    MAX_INT128 = 2 ** 127 - 1
+    MIN_INT128 = -(2 ** 127)
     MAXDECIMAL = (2 ** 127 - 1) * DECIMAL_DIVISOR
     MINDECIMAL = (-(2 ** 127)) * DECIMAL_DIVISOR
     MAX_UINT256 = 2 ** 256 - 1
@@ -108,7 +108,7 @@ class SizeLimits:
         if type_str == "uint256":
             return 0 <= value <= cls.MAX_UINT256
         elif type_str == "int128":
-            return cls.MINNUM <= value <= cls.MAXNUM
+            return cls.MIN_INT128 <= value <= cls.MAX_INT128
         else:
             raise Exception(f'Unknown type "{type_str}" supplied.')
 
@@ -117,8 +117,8 @@ class SizeLimits:
 # code.
 LOADED_LIMITS: Dict[int, int] = {
     MemoryPositions.ADDRSIZE: SizeLimits.ADDRSIZE,
-    MemoryPositions.MAXNUM: SizeLimits.MAXNUM,
-    MemoryPositions.MINNUM: SizeLimits.MINNUM,
+    MemoryPositions.MAX_INT128: SizeLimits.MAX_INT128,
+    MemoryPositions.MIN_INT128: SizeLimits.MIN_INT128,
     MemoryPositions.MAXDECIMAL: SizeLimits.MAXDECIMAL,
     MemoryPositions.MINDECIMAL: SizeLimits.MINDECIMAL,
 }


### PR DESCRIPTION
### What I did
Rename some of the `SizeLimits` enum attributes.  This smol PR lays groundwork for adding more number types (and reduces the complexity of the next PR's diff).

### How I did it
Grepping and copy-paste.

### How to verify it
Read the diff, verify that tests are still passing. If you're so motivated, you can also grep to check I didn't miss anything.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/114315239-1095ce80-9b0f-11eb-8628-8c941a21d38f.png)
