### PR TITLE
EIP2929 opcode repricing

### DIFF
--- a/tests/compiler/test_opcodes.py
+++ b/tests/compiler/test_opcodes.py
@@ -37,13 +37,16 @@ def test_version_check(evm_version):
     assert opcodes.version_check(begin=evm_version, end=evm_version)
     if evm_version not in ("byzantium", "atlantis"):
         assert not opcodes.version_check(end="byzantium")
-    if evm_version != "istanbul":
-        assert not opcodes.version_check(begin="istanbul")
+    istanbul_check = opcodes.version_check(begin="istanbul")
+    assert istanbul_check == (opcodes.EVM_VERSIONS[evm_version] >= opcodes.EVM_VERSIONS["istanbul"])
 
 
 def test_get_opcodes(evm_version):
     op = opcodes.get_opcodes()
-    if evm_version == "istanbul":
+    if evm_version == "berlin":
+        assert "CHAINID" in op
+        assert op["SLOAD"][-1] == 2100
+    elif evm_version == "istanbul":
         assert "CHAINID" in op
         assert op["SLOAD"][-1] == 800
     else:

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -186,7 +186,7 @@ def foo_call(_addr: address):
     outer_contract.foo_call(inner_contract.address)
 
     # manually specifying a sufficient amount should succeed
-    outer_contract = get_contract(outer_code.format(", gas=21000"))
+    outer_contract = get_contract(outer_code.format(", gas=50000"))
     outer_contract.foo_call(inner_contract.address)
 
     # manually specifying an insufficient amount should fail

--- a/tests/parser/syntax/test_self_balance.py
+++ b/tests/parser/syntax/test_self_balance.py
@@ -19,7 +19,7 @@ def __default__():
     pass
     """
     opcodes = compiler.compile_code(code, ["opcodes"], evm_version=evm_version)["opcodes"]
-    if evm_version == "istanbul":
+    if EVM_VERSIONS[evm_version] >= EVM_VERSIONS["istanbul"]:
         assert "SELFBALANCE" in opcodes
     else:
         assert "SELFBALANCE" not in opcodes

--- a/vyper/opcodes.py
+++ b/vyper/opcodes.py
@@ -29,17 +29,18 @@ EVM_VERSIONS: Dict[str, int] = {
     "constantinople": 1,
     "petersburg": 1,
     "istanbul": 2,
+    "berlin": 3,
     # ETC Forks
     "atlantis": 0,
     "agharta": 1,
 }
-DEFAULT_EVM_VERSION: str = "istanbul"
+DEFAULT_EVM_VERSION: str = "berlin"
 
 
 # opcode as hex value
 # number of values removed from stack
 # number of values added to stack
-# gas cost (byzantium, constantinople, istanbul)
+# gas cost (byzantium, constantinople, istanbul, berlin)
 OPCODES: OpcodeMap = {
     "STOP": (0x00, 0, 0, 0),
     "ADD": (0x01, 2, 1, 3),
@@ -79,11 +80,11 @@ OPCODES: OpcodeMap = {
     "CODESIZE": (0x38, 0, 1, 2),
     "CODECOPY": (0x39, 3, 0, 3),
     "GASPRICE": (0x3A, 0, 1, 2),
-    "EXTCODESIZE": (0x3B, 1, 1, 700),
-    "EXTCODECOPY": (0x3C, 4, 0, 700),
+    "EXTCODESIZE": (0x3B, 1, 1, (700, 700, 700, 2600)),
+    "EXTCODECOPY": (0x3C, 4, 0, (700, 700, 700, 2600)),
     "RETURNDATASIZE": (0x3D, 0, 1, 2),
     "RETURNDATACOPY": (0x3E, 3, 0, 3),
-    "EXTCODEHASH": (0x3F, 1, 1, (None, 400, 700)),
+    "EXTCODEHASH": (0x3F, 1, 1, (None, 400, 700, 2600)),
     "BLOCKHASH": (0x40, 1, 1, 20),
     "COINBASE": (0x41, 0, 1, 2),
     "TIMESTAMP": (0x42, 0, 1, 2),
@@ -96,7 +97,7 @@ OPCODES: OpcodeMap = {
     "MLOAD": (0x51, 1, 1, 3),
     "MSTORE": (0x52, 2, 0, 3),
     "MSTORE8": (0x53, 2, 0, 3),
-    "SLOAD": (0x54, 1, 1, (200, 200, 800)),
+    "SLOAD": (0x54, 1, 1, (200, 200, 800, 2100)),
     "SSTORE": (0x55, 2, 0, 20000),
     "JUMP": (0x56, 1, 0, 8),
     "JUMPI": (0x57, 2, 0, 10),
@@ -174,13 +175,13 @@ OPCODES: OpcodeMap = {
     "LOG3": (0xA3, 5, 0, 1500),
     "LOG4": (0xA4, 6, 0, 1875),
     "CREATE": (0xF0, 3, 1, 32000),
-    "CALL": (0xF1, 7, 1, 700),
-    "CALLCODE": (0xF2, 7, 1, 700),
+    "CALL": (0xF1, 7, 1, (700, 700, 700, 2100)),
+    "CALLCODE": (0xF2, 7, 1, (700, 700, 700, 2100)),
     "RETURN": (0xF3, 2, 0, 0),
-    "DELEGATECALL": (0xF4, 6, 1, 700),
+    "DELEGATECALL": (0xF4, 6, 1, (700, 700, 700, 2100)),
     "CREATE2": (0xF5, 4, 1, (None, 32000)),
     "SELFDESTRUCT": (0xFF, 1, 0, 25000),
-    "STATICCALL": (0xFA, 6, 1, 40),
+    "STATICCALL": (0xFA, 6, 1, (700, 700, 700, 2100)),
     "REVERT": (0xFD, 2, 0, 0),
     "INVALID": (0xFE, 0, 0, 0),
     "DEBUG": (0xA5, 1, 0, 0),


### PR DESCRIPTION
### What I did
* Add EIP2929 opcode repricings
* Set default evm version to `berlin`

### How I did it
I took the new pricings from the [EIP2929 spec](https://eips.ethereum.org/EIPS/eip-2929).  I didn't include any logic to account for hot-vs-cold access - in the same way that we always assume an SSTORE to cost 20,000 these values just give an upper-bound estimate.

I also bumped the default evm target to `berlin`. This has no effect aside from the gas estimates, as there are no new opcodes introduced.

All of this is required to make the test suite pass, because the latest release of `eth-tester` now uses berlin as the default ruleset.

### How to verify it
Verify that the test suite is passing in the CI.  I had to tweak a few tests, I tried to do so in a way such that we won't have to adjust them again for the next hardfork.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/114549079-a184bb00-9c71-11eb-8cd4-fa75a264908b.png)
