### PR TITLE
Optimize calldataload

### DIFF
--- a/vyper/optimizer.py
+++ b/vyper/optimizer.py
@@ -59,57 +59,7 @@ def apply_general_optimizations(node: LLLnode) -> LLLnode:
     argz = [apply_general_optimizations(arg) for arg in node.args]
 
     if node.value == "seq":
-        # look for sequential mzero / calldatacopy operations that are zero'ing memory
-        # and merge them into a single calldatacopy
-        mzero_nodes: List = []
-        initial_offset = 0
-        total_length = 0
-        for lll_node in [i for i in argz if i.value != "pass"]:
-            if (
-                lll_node.value == "mstore"
-                and isinstance(lll_node.args[0].value, int)
-                and lll_node.args[1].value == 0
-            ):
-                # mstore of a zero value
-                offset = lll_node.args[0].value
-                if not mzero_nodes:
-                    initial_offset = offset
-                if initial_offset + total_length == offset:
-                    mzero_nodes.append(lll_node)
-                    total_length += 32
-                    continue
-
-            if (
-                lll_node.value == "calldatacopy"
-                and isinstance(lll_node.args[0].value, int)
-                and lll_node.args[1].value == "calldatasize"
-                and isinstance(lll_node.args[2].value, int)
-            ):
-                # calldatacopy from the end of calldata - efficient zero'ing via `empty()`
-                offset, length = lll_node.args[0].value, lll_node.args[2].value
-                if not mzero_nodes:
-                    initial_offset = offset
-                if initial_offset + total_length == offset:
-                    mzero_nodes.append(lll_node)
-                    total_length += length
-                    continue
-
-            # if we get this far, the current node is not a zero'ing operation
-            # it's time to apply the optimization if possible
-            if len(mzero_nodes) > 1:
-                new_lll = LLLnode.from_list(
-                    ["calldatacopy", initial_offset, "calldatasize", total_length],
-                    pos=mzero_nodes[0].pos,
-                )
-                # replace first zero'ing operation with optimized node and remove the rest
-                idx = argz.index(mzero_nodes[0])
-                argz[idx] = new_lll
-                for i in mzero_nodes[1:]:
-                    argz.remove(i)
-
-            initial_offset = 0
-            total_length = 0
-            mzero_nodes.clear()
+        _merge_memzero(argz)
 
     if node.value in arith and int_at(argz, 0) and int_at(argz, 1):
         left, right = get_int_at(argz, 0), get_int_at(argz, 1)
@@ -282,6 +232,60 @@ def apply_general_optimizations(node: LLLnode) -> LLLnode:
             add_gas_estimate=node.add_gas_estimate,
             valency=node.valency,
         )
+
+
+def _merge_memzero(argz):
+    # look for sequential mzero / calldatacopy operations that are zero'ing memory
+    # and merge them into a single calldatacopy
+    mstore_nodes: List = []
+    initial_offset = 0
+    total_length = 0
+    for lll_node in [i for i in argz if i.value != "pass"]:
+        if (
+            lll_node.value == "mstore"
+            and isinstance(lll_node.args[0].value, int)
+            and lll_node.args[1].value == 0
+        ):
+            # mstore of a zero value
+            offset = lll_node.args[0].value
+            if not mstore_nodes:
+                initial_offset = offset
+            if initial_offset + total_length == offset:
+                mstore_nodes.append(lll_node)
+                total_length += 32
+                continue
+
+        if (
+            lll_node.value == "calldatacopy"
+            and isinstance(lll_node.args[0].value, int)
+            and lll_node.args[1].value == "calldatasize"
+            and isinstance(lll_node.args[2].value, int)
+        ):
+            # calldatacopy from the end of calldata - efficient zero'ing via `empty()`
+            offset, length = lll_node.args[0].value, lll_node.args[2].value
+            if not mstore_nodes:
+                initial_offset = offset
+            if initial_offset + total_length == offset:
+                mstore_nodes.append(lll_node)
+                total_length += length
+                continue
+
+        # if we get this far, the current node is not a zero'ing operation
+        # it's time to apply the optimization if possible
+        if len(mstore_nodes) > 1:
+            new_lll = LLLnode.from_list(
+                ["calldatacopy", initial_offset, "calldatasize", total_length],
+                pos=mstore_nodes[0].pos,
+            )
+            # replace first zero'ing operation with optimized node and remove the rest
+            idx = argz.index(mstore_nodes[0])
+            argz[idx] = new_lll
+            for i in mstore_nodes[1:]:
+                argz.remove(i)
+
+        initial_offset = 0
+        total_length = 0
+        mstore_nodes.clear()
 
 
 def filter_unused_sizelimits(lll_node: LLLnode) -> LLLnode:


### PR DESCRIPTION
### What I did
Optimize how calldata is loaded into memory.

### How I did it
Within `optimizer.py`, look for sequential instructions of e.g.

```
[mstore, 864, [calldataload, 4]],
[mstore, 896, [calldataload, 36]],
[mstore, 928, [calldataload, 68]],
```

This can be optimized to:

```
[calldatacopy 864, 4, 32 * 3]
```

The optimization is applied with the same logic we use to optimize memory-zeroing actions:

1. Look for sequential `mstore` instructions that reference sequential calldata locations.
2. Merge them into a single `calldatacopy`

### How to verify it
Run the tests. I didn't add any new specific cases, but this optimization is applied anywhere multiple input args are taken by an external function so if it weren't working we'd see things failing everywhere.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/114725487-956e2b80-9d4d-11eb-9731-1fe45439e86d.png)
