### PR TITLE
Add builtin function `abs`

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -97,7 +97,7 @@ Chain Interaction
 .. py:function:: create_forwarder_to(target: address, value: uint256 = 0) -> address
 
     Deploys a small contract that duplicates the logic of the contract at ``target``, but has it's own state since every call to ``target`` is made using ``DELEGATECALL`` to ``target``. To the end user, this should be indistinguishable from an independantly deployed contract with the same code as ``target``.
-    
+
 .. note::
 
   It is very important that the deployed contract at ``target`` is code you know and trust, and does not implement the ``selfdestruct`` opcode as this will affect the operation of the forwarder contract.
@@ -357,6 +357,24 @@ Data Manipulation
 
 Math
 ====
+
+.. py:function:: abs(value: int256) -> int256
+
+    Return the absolute value of a signed integer.
+
+    * ``value``: Integer to return the absolute value of
+
+    .. code-block:: python
+
+        @external
+        @view
+        def foo(value: int256) -> int256:
+            return abs(value)
+
+    .. code-block:: python
+
+        >>> ExampleContract.foo(-31337)
+        31337
 
 .. py:function:: ceil(value: decimal) -> int128
 

--- a/tests/functions/folding/test_abs.py
+++ b/tests/functions/folding/test_abs.py
@@ -1,0 +1,60 @@
+import pytest
+from hypothesis import example, given, settings
+from hypothesis import strategies as st
+
+from vyper import ast as vy_ast
+from vyper import functions as vy_fn
+from vyper.exceptions import OverflowException
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(a=st.integers(min_value=-(2 ** 255) + 1, max_value=2 ** 255 - 1))
+@example(a=0)
+def test_abs(get_contract, a):
+    source = """
+@external
+def foo(a: int256) -> int256:
+    return abs(a)
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"abs({a})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE["abs"].evaluate(old_node)
+
+    assert contract.foo(a) == new_node.value == abs(a)
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50, deadline=1000)
+@given(a=st.integers(min_value=2 ** 255, max_value=2 ** 256 - 1))
+def test_abs_upper_bound_folding(get_contract, a):
+    source = f"""
+@external
+def foo(a: int256) -> int256:
+    return abs({a})
+    """
+    with pytest.raises(OverflowException):
+        get_contract(source)
+
+
+def test_abs_lower_bound(get_contract, assert_tx_failed):
+    source = """
+@external
+def foo(a: int256) -> int256:
+    return abs(a)
+    """
+    contract = get_contract(source)
+
+    assert_tx_failed(lambda: contract.foo(-(2 ** 255)))
+
+
+def test_abs_lower_bound_folded(get_contract, assert_tx_failed):
+    source = """
+@external
+def foo() -> int256:
+    return abs(-2**255)
+    """
+    with pytest.raises(OverflowException):
+        get_contract(source)


### PR DESCRIPTION
### What I did
Add `abs` as a builtin function to get the absolute value of an `int256`.

### How I did it
Add `Abs` within `vyper/functions/functions.py`. The logic is fairly straightforward - the only possible overflow is with `-2**255` where we end up with the same value, so I do a check that the result is != the original value.

### How to verify it
Run the tests. I've added hypothesis tests to verify both the runtime and compile-time behaviour, including the happy path and the reverting path.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/115447235-4df20e80-a229-11eb-8d05-558ac0181e0d.png)
