### PR TITLE
Remove `implements` statements after type checking

### DIFF
--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -49,20 +49,7 @@ class GlobalContext:
             # Statements of the form:
             # variable_name: type
             elif isinstance(item, vy_ast.AnnAssign):
-                is_implements_statement = (
-                    isinstance(item.target, vy_ast.Name) and item.target.id == "implements"
-                ) and item.annotation
-
-                # implements statement.
-                if is_implements_statement:
-                    interface_name = item.annotation.id  # type: ignore
-                    if interface_name not in global_ctx._interfaces:
-                        raise StructureException(
-                            f"Unknown interface specified: {interface_name}", item
-                        )
-                    global_ctx._implemented_interfaces.add(interface_name)
-                else:
-                    global_ctx.add_globals_and_events(item)
+                global_ctx.add_globals_and_events(item)
             # Function definitions
             elif isinstance(item, vy_ast.FunctionDef):
                 global_ctx._defs.append(item)


### PR DESCRIPTION
### What I did
Remove `implements` statements from the AST after type checking and prior to LLL gen.

All restrictions imposed by this statement are validated within the type checking pass. Removing it prior to heading into `parser` reduces the complexity as it's one less thing we have to think about.

### How I did it
* Add some logic to `ast/expansion.py`
* Remove references to `implements` within `GlobalContext` in parser.

### How to verify it
Run the tests.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/115474247-1fd2f580-a24e-11eb-8b29-5a2f6a2c7e78.png)
