### PR TITLE
Expand AST type annotation

### DIFF
--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -31,7 +31,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
     """
 
     for node in vyper_module.get_children(vy_ast.AnnAssign, {"annotation.func.id": "public"}):
-        func_type = node._metadata["type"]
+        func_type = node._metadata["func_type"]
         input_types, return_type = func_type.get_signature()
         input_nodes = []
 
@@ -44,6 +44,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
         return_stmt: vy_ast.VyperNode = vy_ast.Attribute(
             value=vy_ast.Name(id="self"), attr=func_type.name
         )
+        return_stmt._metadata["type"] = node._metadata["type"]
 
         for i, type_ in enumerate(input_types):
             if not isinstance(annotation, vy_ast.Subscript):

--- a/vyper/context/validation/annotation.py
+++ b/vyper/context/validation/annotation.py
@@ -46,10 +46,9 @@ class StatementAnnotationVisitor(_AnnotationVisitorBase):
     )
 
     def __init__(self, fn_node: vy_ast.FunctionDef, namespace: dict) -> None:
-        self.func = namespace["self"].get_member(fn_node.name, fn_node)
+        self.func = fn_node._metadata["type"]
         self.namespace = namespace
         self.expr_visitor = ExpressionAnnotationVisitor()
-        fn_node._metadata["type"] = self.func
 
     def visit(self, node):
         super().visit(node)

--- a/vyper/context/validation/base.py
+++ b/vyper/context/validation/base.py
@@ -11,9 +11,10 @@ class VyperNodeVisitorBase:
     def visit(self, node):
         if isinstance(node, self.ignored_types):
             return
-        visitor_fn = getattr(self, f"visit_{node.ast_type}", None)
+        node_type = type(node).__name__
+        visitor_fn = getattr(self, f"visit_{node_type}", None)
         if visitor_fn is None:
             raise StructureException(
-                f"Unsupported syntax for {self.scope_name} namespace: {node.ast_type}", node,
+                f"Unsupported syntax for {self.scope_name} namespace: {node_type}", node,
             )
         visitor_fn(node)

--- a/vyper/context/validation/local.py
+++ b/vyper/context/validation/local.py
@@ -131,7 +131,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         self.vyper_module = vyper_module
         self.fn_node = fn_node
         self.namespace = namespace
-        self.func = namespace["self"].get_member(fn_node.name, fn_node)
+        self.func = fn_node._metadata["type"]
         self.annotation_visitor = StatementAnnotationVisitor(fn_node, namespace)
         namespace.update(self.func.arguments)
 

--- a/vyper/context/validation/module.py
+++ b/vyper/context/validation/module.py
@@ -165,7 +165,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
 
                     # generate function type and add to metadata
                     # we need this when builing the public getter
-                    node._metadata["type"] = ContractFunction.from_AnnAssign(node)
+                    node._metadata["func_type"] = ContractFunction.from_AnnAssign(node)
 
                 # remove the outer call node, to handle cases such as `public(map(..))`
                 annotation = annotation.args[0]

--- a/vyper/context/validation/module.py
+++ b/vyper/context/validation/module.py
@@ -173,6 +173,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
         type_definition = get_type_from_annotation(
             annotation, DataLocation.STORAGE, is_immutable, is_public
         )
+        node._metadata["type"] = type_definition
 
         if is_immutable:
             if not node.value:
@@ -198,6 +199,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
             raise exc.with_annotation(node) from None
         try:
             self.namespace["self"].add_member(name, type_definition)
+            node.target._metadata["type"] = type_definition
         except NamespaceCollision:
             raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
         except VyperException as exc:
@@ -214,6 +216,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
         func = ContractFunction.from_FunctionDef(node)
         try:
             self.namespace["self"].add_member(func.name, func)
+            node._metadata["type"] = func
         except VyperException as exc:
             raise exc.with_annotation(node) from None
 


### PR DESCRIPTION
### What I did
Expand the AST annotation logic to cover more node types, notably:

* module-scoped `AnnAssign` nodes (storage variables)
* For loops
* structs
* builtin functions

This is more groundwork for eventually removing types from `parser`.

### How to verify it
Confirm that the test suite is still passing.  Nothing in this PR has any effect on compilation, so there is nothing new to test at this point.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/116129658-2d73f980-a6ec-11eb-89d6-3de6a73eecad.png)
