### PR TITLE
Assign storage locations prior to LLL gen / place arrays sequentially in storage

### DIFF
--- a/tests/functional/context/types/test_size_in_bytes.py
+++ b/tests/functional/context/types/test_size_in_bytes.py
@@ -24,7 +24,8 @@ def test_array_value_types(build_node, type_str, location, length, size):
     node = build_node(f"{type_str}[{length}]")
     type_definition = get_type_from_annotation(node, location)
 
-    assert type_definition.size_in_bytes == size
+    # TODO once storage of bytes is optimized, remove the +32
+    assert type_definition.size_in_bytes == size + 32
 
 
 @pytest.mark.parametrize("type_str", BASE_TYPES)

--- a/tests/functional/test_storage_slots.py
+++ b/tests/functional/test_storage_slots.py
@@ -1,0 +1,59 @@
+code = """
+
+struct StructOne:
+    a: String[33]
+    b: uint256[3]
+
+struct StructTwo:
+    a: Bytes[5]
+    b: int128[2]
+    c: String[64]
+
+a: public(StructOne)
+b: public(uint256[2])
+c: public(Bytes[32])
+d: public(int128[4])
+foo: public(HashMap[uint256, uint256[3]])
+e: public(String[47])
+f: public(int256[1])
+g: public(StructTwo[2])
+h: public(bytes32[5])
+
+
+@external
+def __init__():
+    self.a = StructOne({a: "ok", b: [4,5,6]})
+    self.b = [7, 8]
+    self.c = b"thisisthirtytwobytesokhowdoyoudo"
+    self.d = [-1, -2, -3, -4]
+    self.e = "A realllllly long string but we wont use it all"
+    self.f = [33]
+    self.g = [
+        StructTwo({a: b"hello", b: [-66, 420], c: "another string"}),
+        StructTwo({
+            a: b"gbye",
+            b: [1337, 888],
+            c: "whatifthisstringtakesuptheentirelengthwouldthatbesobadidothinkso"
+        })
+    ]
+    self.foo[0] = [987, 654, 321]
+    self.foo[1] = [123, 456, 789]
+"""
+
+
+def test_storage_slots(get_contract):
+    c = get_contract(code)
+    assert c.a() == ["ok", [4, 5, 6]]
+    assert [c.b(i) for i in range(2)] == [7, 8]
+    assert c.c() == b"thisisthirtytwobytesokhowdoyoudo"
+    assert [c.d(i) for i in range(4)] == [-1, -2, -3, -4]
+    assert c.e() == "A realllllly long string but we wont use it all"
+    assert c.f(0) == 33
+    assert c.g(0) == [b"hello", [-66, 420], "another string"]
+    assert c.g(1) == [
+        b"gbye",
+        [1337, 888],
+        "whatifthisstringtakesuptheentirelengthwouldthatbesobadidothinkso",
+    ]
+    assert [c.foo(0, i) for i in range(3)] == [987, 654, 321]
+    assert [c.foo(1, i) for i in range(3)] == [123, 456, 789]

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 
 from vyper import ast as vy_ast
 from vyper import compile_lll, optimizer
-from vyper.context import validate_semantics
+from vyper.context import set_data_positions, validate_semantics
 from vyper.parser import parser
 from vyper.parser.global_context import GlobalContext
 from vyper.typing import InterfaceImports
@@ -175,6 +175,7 @@ def generate_folded_ast(
     vy_ast.folding.fold(vyper_module_folded)
     validate_semantics(vyper_module_folded, interface_codes)
     vy_ast.expansion.expand_annotated_ast(vyper_module_folded)
+    set_data_positions(vyper_module_folded)
 
     return vyper_module_folded
 

--- a/vyper/context/__init__.py
+++ b/vyper/context/__init__.py
@@ -1,1 +1,2 @@
 from vyper.context.validation import validate_semantics
+from vyper.context.validation.data_positions import set_data_positions

--- a/vyper/context/types/value/array_value.py
+++ b/vyper/context/types/value/array_value.py
@@ -66,7 +66,9 @@ class _ArrayValueDefinition(ValueTypeDefinition):
         # enough additional slots to store the data if it uses the max available length
         # because this data type is single-bytes, we make it so it takes the max 32 byte
         # boundary as it's size, instead of giving it a size that is not cleanly divisble by 32
-        return 32 + math.ceil(self.length / 32) * 32
+
+        # TODO adding 64 here instead of 32 to be compatible with parser - fix this!
+        return 64 + math.ceil(self.length / 32) * 32
 
     @property
     def canonical_type(self) -> str:

--- a/vyper/context/validation/data_positions.py
+++ b/vyper/context/validation/data_positions.py
@@ -1,0 +1,36 @@
+import math
+
+from vyper import ast as vy_ast
+from vyper.context.types.bases import StorageSlot
+
+
+def set_data_positions(vyper_module: vy_ast.Module) -> None:
+    """
+    Parse the annotated Vyper AST, determine data positions for all variables,
+    and annotate the AST nodes with the position data.
+
+    Arguments
+    ---------
+    vyper_module : vy_ast.Module
+        Top-level Vyper AST node that has already been annotated with type data.
+    """
+    set_storage_slots(vyper_module)
+
+
+def set_storage_slots(vyper_module: vy_ast.Module) -> None:
+    """
+    Parse module-level Vyper AST to calculate the layout of storage variables.
+    """
+    available_slot = 0
+    for node in vyper_module.get_children(vy_ast.AnnAssign):
+        type_ = node.target._metadata["type"]
+        type_.set_position(StorageSlot(available_slot))
+        available_slot += math.ceil(type_.size_in_bytes / 32)
+
+
+def set_calldata_offsets(fn_node: vy_ast.FunctionDef) -> None:
+    pass
+
+
+def set_memory_offsets(fn_node: vy_ast.FunctionDef) -> None:
+    pass

--- a/vyper/functions/convert.py
+++ b/vyper/functions/convert.py
@@ -323,9 +323,7 @@ def to_bytes32(expr, args, kwargs, context):
         if in_arg.location == "memory":
             return LLLnode.from_list(["mload", ["add", in_arg, 32]], typ=BaseType("bytes32"))
         elif in_arg.location == "storage":
-            return LLLnode.from_list(
-                ["sload", ["add", ["sha3_32", in_arg], 1]], typ=BaseType("bytes32")
-            )
+            return LLLnode.from_list(["sload", ["add", in_arg, 1]], typ=BaseType("bytes32"))
 
     else:
         return LLLnode(

--- a/vyper/functions/functions.py
+++ b/vyper/functions/functions.py
@@ -265,9 +265,7 @@ class Slice:
         # Copies over bytearray data
         if sub.location == "storage":
             adj_sub = LLLnode.from_list(
-                ["add", ["sha3_32", sub], ["add", ["div", "_start", 32], 1]],
-                typ=sub.typ,
-                location=sub.location,
+                ["add", sub, ["add", ["div", "_start", 32], 1]], typ=sub.typ, location=sub.location,
             )
         else:
             adj_sub = LLLnode.from_list(
@@ -441,11 +439,9 @@ class Concat:
                         ["add", "_arg", 32], typ=arg.typ, location=arg.location,
                     )
                 elif arg.location == "storage":
-                    length = LLLnode.from_list(
-                        ["sload", ["sha3_32", "_arg"]], typ=BaseType("int128")
-                    )
+                    length = LLLnode.from_list(["sload", "_arg"], typ=BaseType("int128"))
                     argstart = LLLnode.from_list(
-                        ["add", ["sha3_32", "_arg"], 1], typ=arg.typ, location=arg.location,
+                        ["add", "_arg", 1], typ=arg.typ, location=arg.location,
                     )
                 # Make a copier to copy over data from that argument
                 seq.append(
@@ -789,9 +785,7 @@ def _memory_element_getter(index):
 
 
 def _storage_element_getter(index):
-    return LLLnode.from_list(
-        ["sload", ["add", ["sha3_32", "_sub"], ["add", 1, index]]], typ=BaseType("int128"),
-    )
+    return LLLnode.from_list(["sload", ["add", "_sub", ["add", 1, index]]], typ=BaseType("int128"),)
 
 
 class Extract32(_SimpleBuiltinFunction):
@@ -823,7 +817,7 @@ class Extract32(_SimpleBuiltinFunction):
             lengetter = LLLnode.from_list(["mload", "_sub"], typ=BaseType("int128"))
             elementgetter = _memory_element_getter
         elif sub.location == "storage":
-            lengetter = LLLnode.from_list(["sload", ["sha3_32", "_sub"]], typ=BaseType("int128"))
+            lengetter = LLLnode.from_list(["sload", "_sub"], typ=BaseType("int128"))
             elementgetter = _storage_element_getter
         # TODO: unclosed if/elif clause.  Undefined behavior if `sub.location`
         # isn't one of `memory`/`storage`

--- a/vyper/parser/events.py
+++ b/vyper/parser/events.py
@@ -163,7 +163,7 @@ def pack_args_by_32(
             for i in range(0, size):
                 storage_offset = i
                 arg2 = LLLnode.from_list(
-                    ["sload", ["add", ["sha3_32", Expr(arg, context).lll_node], storage_offset]],
+                    ["sload", ["add", Expr(arg, context).lll_node, storage_offset]],
                 )
                 holder, maxlen = pack_args_by_32(
                     holder, maxlen, arg2, typ, context, placeholder + mem_offset, pos=pos,

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -358,9 +358,10 @@ class Expr:
                 )
         # self.x: global attribute
         elif isinstance(self.expr.value, vy_ast.Name) and self.expr.value.id == "self":
+            type_ = self.expr._metadata["type"]
             var = self.context.globals[self.expr.attr]
             return LLLnode.from_list(
-                var.pos,
+                type_.position.position,
                 typ=var.typ,
                 location="storage",
                 pos=getpos(self.expr),

--- a/vyper/parser/expr.py
+++ b/vyper/parser/expr.py
@@ -753,7 +753,7 @@ class Expr:
         elif right.location == "storage":
             load_i_from_list = [
                 "sload",
-                ["add", ["sha3_32", right], ["mload", MemoryPositions.FREE_LOOP_INDEX]],
+                ["add", right, ["mload", MemoryPositions.FREE_LOOP_INDEX]],
             ]
         else:
             load_operation = "mload" if right.location == "memory" else "calldataload"
@@ -870,7 +870,7 @@ class Expr:
                     if side.location == "memory":
                         return ["mload", ["add", 32, side]]
                     elif side.location == "storage":
-                        return ["sload", ["add", 1, ["sha3_32", side]]]
+                        return ["sload", ["add", 1, side]]
 
                 return LLLnode.from_list(
                     [op, load_bytearray(left), load_bytearray(right)],

--- a/vyper/parser/external_call.py
+++ b/vyper/parser/external_call.py
@@ -192,10 +192,11 @@ def make_external_call(stmt_expr, context):
         and stmt_expr.func.value.attr in context.sigs
     ):  # noqa: E501
         contract_name = stmt_expr.func.value.attr
+        type_ = stmt_expr.func.value._metadata["type"]
         var = context.globals[stmt_expr.func.value.attr]
         contract_address = unwrap_location(
             LLLnode.from_list(
-                var.pos,
+                type_.position.position,
                 typ=var.typ,
                 location="storage",
                 pos=getpos(stmt_expr),
@@ -220,10 +221,11 @@ def make_external_call(stmt_expr, context):
     ):
 
         contract_name = context.globals[stmt_expr.func.value.attr].typ.name
+        type_ = stmt_expr.func.value._metadata["type"]
         var = context.globals[stmt_expr.func.value.attr]
         contract_address = unwrap_location(
             LLLnode.from_list(
-                var.pos,
+                type_.position.position,
                 typ=var.typ,
                 location="storage",
                 pos=getpos(stmt_expr),

--- a/vyper/parser/keccak256_helper.py
+++ b/vyper/parser/keccak256_helper.py
@@ -31,7 +31,7 @@ def keccak256_helper(expr, args, kwargs, context):
             pos=getpos(expr),
         )
     elif sub.location == "storage":
-        lengetter = LLLnode.from_list(["sload", ["sha3_32", "_sub"]], typ=BaseType("int128"))
+        lengetter = LLLnode.from_list(["sload", "_sub"], typ=BaseType("int128"))
     else:
         # This should never happen, but just left here for future compiler-writers.
         raise Exception(f"Unsupported location: {sub.location}")  # pragma: no test

--- a/vyper/parser/stmt.py
+++ b/vyper/parser/stmt.py
@@ -341,11 +341,7 @@ class Stmt:
             count = iter_list_node.typ.count
             body = [
                 "seq",
-                [
-                    "mstore",
-                    value_pos,
-                    ["sload", ["add", ["sha3_32", iter_list_node], ["mload", i_pos]]],
-                ],
+                ["mstore", value_pos, ["sload", ["add", iter_list_node, ["mload", i_pos]]]],
                 parse_body(self.stmt.body, self.context),
             ]
             lll_node = LLLnode.from_list(


### PR DESCRIPTION
### What I did
* Add the start of an expansion pass that assigns variable positions prior to generating the LLL
* Use this new pass to refactor the layout of storage variables

### How I did it
Currently, whenever dealing with a type that requires >1 storage slot, we calculate the storage location in the same way as that of a mapping (using a keccak).  This is inefficient for both gas costs and bytecode size. Because Vyper does not support dynamically-sized variables without a limit on their length, it is possible to calculate the maximum required number of slots for all storage variables and instead place them sequentially to avoid the expensive `SHA3` operation.

To do this, I've added the `DataPosition` class, and related child classes, to represent positions within storage/memory/calldata. After type checking is completed, the AST is parsed once more and these objects applied to each previously assigned type. Handling this as a separate pass is imo a cleaner approach, making it easier to understand where and how this happens.

Armed with this information and the new storage layout, I've then removed various references to `sha_32` within `parser`. I had to do a couple hacky things to make the new play well with the old, but mostly it was a reductive operation so I think this is a net win in terms of the bigger refactor goal.

I have more logic ready to go re: assigning locations for memory and calldata, but for the scope of this PR all I've included is the eventual API to show my idea for the bigger picture without doing too much in a single chunk.

### How to verify it
Run the tests.  I added a lovely (awful?) new test case that assigns to and reads from a variety of storage slots to check for corruption. I also ran the Curve test suite against this PR, everything passes.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/116139944-6d40de00-a6f8-11eb-9c97-d4a58f59a6e2.png)
