### PR TITLE
Fix: storage corruption from re-entrancy locks

### DIFF
--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -185,6 +185,9 @@ class GlobalContext:
 
         item_name, item_attributes = self.get_item_name_and_attributes(item, item_attributes)
 
+        # references to `len(self._globals)` are remnants of deprecated code, retained
+        # to preserve existing interfaces while we complete a larger refactor. location
+        # and size of storage vars is handled in `vyper.context.validation.data_positions`
         if item_name in self._contracts or item_name in self._interfaces:
             if self.get_call_func_name(item) == "address":
                 raise StructureException(
@@ -221,14 +224,12 @@ class GlobalContext:
         """
         Nonrentrant locks use a prefix with a counter to minimise deployment cost of a contract.
 
-        All storage variables are allocated exactly one slot, incrementing from 0.
-        For types that require >1 slot the actual location is determined from a keccak
-        https://github.com/vyperlang/vyper/issues/769
-
-        We're able to set the initial re-entrant counter using `len(self._globals)`
-        because all storage slots are allocated while parsing the module-scope,
-        and re-entrancy locks aren't allocated until later when parsing individual
-        function scopes.
+        We're able to set the initial re-entrant counter using the sum of the sizes
+        of all the storage slots because all storage slots are allocated while parsing
+        the module-scope, and re-entrancy locks aren't allocated until later when parsing
+        individual function scopes. This relies on the deprecated _globals attribute
+        because the new way of doing things (set_data_positions) doesn't expose the
+        next unallocated storage location.
         """
         if key in self._nonrentrant_keys:
             return self._nonrentrant_keys[key]

--- a/vyper/parser/global_context.py
+++ b/vyper/parser/global_context.py
@@ -3,7 +3,7 @@ from typing import Optional
 from vyper import ast as vy_ast
 from vyper.exceptions import CompilerPanic, InvalidType, StructureException
 from vyper.signatures.function_signature import ContractRecord, VariableRecord
-from vyper.types import InterfaceType, parse_type
+from vyper.types import InterfaceType, MappingType, parse_type
 from vyper.typing import InterfaceImports
 
 
@@ -233,7 +233,10 @@ class GlobalContext:
         if key in self._nonrentrant_keys:
             return self._nonrentrant_keys[key]
         else:
-            counter = len(self._globals) + self._nonrentrant_counter
+            counter = (
+                sum(v.size for v in self._globals.values() if not isinstance(v.typ, MappingType))
+                + self._nonrentrant_counter
+            )
             self._nonrentrant_keys[key] = counter
             self._nonrentrant_counter += 1
             return counter


### PR DESCRIPTION
### What I did
Fix an issue allowing corruption of storage by re-entrancy locks.

In #2308, the location of re-entrancy locks was moved to the first unused storage slot. This worked fine as long as all multiple-slot types were stored using a sha3, but after #2361 this created a potential overlap between the lock slot and regular storage when the contract contains at least one storage value that occupies multiple slots.

### How I did it
In `vyper/parser/global_context.py`, when calculating the offset for re-entrancy locks, correctly consider the size of each type.

### How to verify it
Run the tests. I expanded a test that I'd added in #2361 that focuses on checking the layout of storage - it now also includes checks involving re-entrancy locks.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/124840433-7e209200-df7a-11eb-92a8-360a9c92b0f2.png)
