### PR TITLE
Change guidance for bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,7 +8,6 @@ about: Any general feedback or bug reports about the Vyper Compiler. No new feat
 * vyper Version (output of `vyper --version`): x.x.x
 * OS: osx/linux/win
 * Python Version (output of `python --version`):
-* Environment (output of `pip freeze`):
 
 ### What's your issue about?
 
@@ -17,6 +16,7 @@ Please include information like:
 * full output of the error you received
 * what command you ran
 * the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
+* please try running your example with the --debug flag turned on
 
 
 ### How can it be fixed?

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -90,6 +90,13 @@ def _parse_args(argv):
         type=int,
     )
     parser.add_argument(
+        "--debug",
+        help="Turn on compiler debug information. "
+        "Currently an alias for --traceback-limit but "
+        "may add more information in the future",
+        action="store_true",
+    )
+    parser.add_argument(
         "--standard-json",
         help="Switch to standard JSON mode. Use `--standard-json -h` for available options.",
         action="store_true",
@@ -104,6 +111,8 @@ def _parse_args(argv):
         sys.tracebacklimit = args.traceback_limit
     elif VYPER_TRACEBACK_LIMIT is not None:
         sys.tracebacklimit = VYPER_TRACEBACK_LIMIT
+    elif args.debug:
+        sys.tracebacklimit = 1000
     else:
         # Python usually defaults sys.tracebacklimit to 1000.  We use a default
         # setting of zero so error printouts only include information about where


### PR DESCRIPTION
I have never ever EVER seen a bug report where the output of `pip
freeze` made a difference. It only ever takes up space.

This commit also brings back the --debug flag, so it's easy for users
to submit the debug info for their bug.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
