### PR TITLE
Reduce code size by sharing code for clamps

### DIFF
--- a/vyper/compile_lll.py
+++ b/vyper/compile_lll.py
@@ -38,7 +38,7 @@ def mksymbol():
 
 
 def mkdebug(pc_debugger, pos):
-    i = instruction("DEBUG", pos)
+    i = Instruction("DEBUG", pos)
     i.pc_debugger = pc_debugger
     return [i]
 
@@ -74,7 +74,7 @@ def _add_postambles(asm_ops):
             _add_postambles(t)
 
 
-class instruction(str):
+class Instruction(str):
     def __new__(cls, sstr, *args, **kwargs):
         return super().__new__(cls, sstr)
 
@@ -92,7 +92,7 @@ def apply_line_numbers(func):
         code = args[0]
         ret = func(*args, **kwargs)
         new_ret = [
-            instruction(i, code.pos) if isinstance(i, str) and not isinstance(i, instruction) else i
+            Instruction(i, code.pos) if isinstance(i, str) and not isinstance(i, Instruction) else i
             for i in ret
         ]
         return new_ret
@@ -100,6 +100,7 @@ def apply_line_numbers(func):
     return apply_line_no_wrapper
 
 
+@apply_line_numbers
 def compile_to_assembly(code):
     res = _compile_to_assembly(code)
 
@@ -514,7 +515,7 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
 
 def note_line_num(line_number_map, item, pos):
     # Record line number attached to pos.
-    if isinstance(item, instruction):
+    if isinstance(item, Instruction):
         if item.lineno is not None:
             offsets = (item.lineno, item.col_offset, item.end_lineno, item.end_col_offset)
         else:


### PR DESCRIPTION
### What I did
See title

### How I did it

All clamps have the following code:
```
(assume condition is on the stack)
ISZERO _revert JUMPI # if not condition goto _revert
PUSH1 0 DUP REVERT
_revert
JUMPDEST
```

Since clamps are super common this code gets repeated. This reduces code
size by adding the PUSH1 0 DUP REVERT to each program's postamble, and
then clamps are simplified to the following

```
(assume condition is on the stack)
_revert JUMPI # if not condition goto _revert
-- cool now 5 opcodes are skipped
```

Then at the end of the contract, the following "postamble" is inserted:
```
_revert
JUMPDEST
PUSH1 0 DUP REVERT # repeated code is shared, yay
```
This commit also optimizes the following common "truthy" sequences:
```
ISZERO ISZERO ISZERO -> ISZERO
ISZERO ISZERO _jumpdest JUMPI -> _jumpdest JUMPI
```

### How to verify it
Tests pass. I compared with master (ba0676b9d9ea4) and compiling a couple large contracts resulted in nearly 10% codesize reduction:
```
vyper -f bytecode_runtime
```
|  | master (ba0676b9d9ea4)  | This branch (revert_codesize) |
| ---- | ------------- | ------------- |
| [curve-contract/StableSwapIB.vy](https://github.com/curvefi/curve-contract/blob/b0bbf77f8f93c9/contracts/pools/ib/StableSwapIB.vy) | 23792 bytes   | 21629 bytes |
| [yearn-vaults/Vault.vy](https://github.com/yearn/yearn-vaults/blob/b60d2ef876/contracts/Vault.vy) | 21816 bytes |  20243 bytes |


### Description for the changelog
Reduce code size by ~10% by sharing clamp code

### Cute Animal Picture
![photo_2021-07-16_07-36-32](https://user-images.githubusercontent.com/3867501/125964797-e5440801-c92a-49f1-9e45-87ab703272eb.jpg)

