### PR TITLE
fix: annotated kwargs for builtins

### DIFF
--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -87,6 +87,16 @@ def foo():
 def foo():
     raw_call(0x1234567890123456789012345678901234567890, b"cow")
     """,
+    """
+balances: HashMap[uint256,uint256]
+@external
+def foo():
+    raw_call(
+        0x1234567890123456789012345678901234567890,
+        b"cow",
+        value=self.balance - self.balances[0]
+    )
+    """,
 ]
 
 

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -142,6 +142,8 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
             # builtin functions
             for arg in node.args:
                 self.visit(arg, None)
+            for kwarg in node.keywords:
+                self.visit(kwarg.value, None)
 
     def visit_Compare(self, node, type_):
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):


### PR DESCRIPTION
This is a regression in v0.2.14, the way function calls got annotated
was changed but kwargs didn't get the update.

Test case:
```
balances: HashMap[uint256, uint256]
@external
def foo(receiver: address):
  raw_call(receiver, b"", value=self.balance - self.balances[0])
```

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
