### PR TITLE
Fix return optimization for nested tuple

### DIFF
--- a/tests/functional/codegen/test_struct_return.py
+++ b/tests/functional/codegen/test_struct_return.py
@@ -1,6 +1,39 @@
 import pytest
 
 
+def test_nested_tuple(get_contract):
+    code = """
+struct Animal:
+    location: address
+    fur: uint256
+
+struct Human:
+    location: address
+    height: uint256
+
+@external
+def return_nested_tuple() -> (Animal, Human):
+    animal: Animal = Animal({
+        location: 0x1234567890123456789012345678901234567890,
+        fur: 123
+    })
+    human: Human = Human({
+        location: 0x1234567890123456789012345678900000000000,
+        height: 456
+    })
+
+    # do stuff, edit the structs
+    animal.fur += 1
+    human.height += 1
+
+    return animal, human
+    """
+    c = get_contract(code)
+    addr1 = "0x1234567890123456789012345678901234567890"
+    addr2 = "0x1234567890123456789012345678900000000000"
+    assert c.return_nested_tuple() == [(addr1, 124), (addr2, 457)]
+
+
 @pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
 def test_string_inside_tuple(get_contract, string):
     code = f"""

--- a/vyper/old_codegen/return_.py
+++ b/vyper/old_codegen/return_.py
@@ -1,12 +1,7 @@
 from vyper import ast as vy_ast
 from vyper.old_codegen.lll_node import LLLnode
 from vyper.old_codegen.parser_utils import getpos, make_setter
-from vyper.old_codegen.types import (
-    BaseType,
-    ListType,
-    TupleType,
-    get_size_of_type,
-)
+from vyper.old_codegen.types import BaseType, TupleType, get_size_of_type
 from vyper.old_codegen.types.check import check_assign
 from vyper.utils import MemoryPositions
 
@@ -100,31 +95,26 @@ def gen_tuple_return(stmt, context, sub):
 
         if isinstance(context.return_type, TupleType) and not abi_typ.dynamic_size_bound():
             # for tuples where every value is of the same type and a fixed length,
-            # we can simplify the encoding by treating it as though it were an array
-            base_types = set()
-            for typ in context.return_type.members:
-                while isinstance(typ, ListType):
-                    typ = typ.subtype
-                base_types.add(typ.typ)
-
-            if len(base_types) == 1:
-                new_sub = LLLnode.from_list(
-                    context.new_internal_variable(context.return_type),
-                    typ=context.return_type,
-                    location="memory",
-                )
-                setter = make_setter(new_sub, sub, "memory", pos=getpos(stmt))
-                return LLLnode.from_list(
-                    [
-                        "seq",
-                        setter,
-                        make_return_stmt(
-                            stmt, context, new_sub, get_size_of_type(context.return_type) * 32,
-                        ),
-                    ],
-                    typ=None,
-                    pos=getpos(stmt),
-                )
+            # we can simplify the encoding by using make_setter, since
+            # our memory encoding happens to be identical to the ABI
+            # encoding.
+            new_sub = LLLnode.from_list(
+                context.new_internal_variable(context.return_type),
+                typ=context.return_type,
+                location="memory",
+            )
+            setter = make_setter(new_sub, sub, "memory", pos=getpos(stmt))
+            return LLLnode.from_list(
+                [
+                    "seq",
+                    setter,
+                    make_return_stmt(
+                        stmt, context, new_sub, get_size_of_type(context.return_type) * 32,
+                    ),
+                ],
+                typ=None,
+                pos=getpos(stmt),
+            )
 
         # in case of multi we can't create a variable to store location of the return expression
         # as multi can have data from multiple location like store, calldata etc


### PR DESCRIPTION
The optimization for tuples of base types expected anything inside a
tuple to be an int, but that's not always the case.

Luckily logic introduced in 0605abbe9 can actually be generalized to any
tuple type which has no dynamic data in the ABI encoding, so we just
remove the constraints on the child types.

### What I did
Fixes #2390 

### How I did it

### How to verify it
Compile the example in #2390.

### Description for the changelog
Fix type error when returning nested tuples.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
