### PR TITLE
fix: allow constant structs

### DIFF
--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -22,7 +22,7 @@ from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.bases import DataLocation
 from vyper.semantics.types.function import ContractFunction
 from vyper.semantics.types.user.event import Event
-from vyper.semantics.types.utils import check_literal, get_type_from_annotation
+from vyper.semantics.types.utils import check_constant, get_type_from_annotation
 from vyper.semantics.validation.base import VyperNodeVisitorBase
 from vyper.semantics.validation.utils import (
     validate_expected_type,
@@ -178,8 +178,8 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
         if is_immutable:
             if not node.value:
                 raise VariableDeclarationException("Constant must be declared with a value", node)
-            if not check_literal(node.value):
-                raise StateAccessViolation("Value must be a literal", node.value)
+            if not check_constant(node.value):
+                raise StateAccessViolation("Value must be a constant", node.value)
 
             validate_expected_type(node.value, type_definition)
             try:


### PR DESCRIPTION
the constant check was not passing any structs because it did not have
any logic to handle it.

### What I did
Fix https://github.com/vyperlang/vyper/issues/1430

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
