### PR TITLE
fix: allow interfaces in lists,structs,maps

### DIFF
--- a/vyper/old_codegen/global_context.py
+++ b/vyper/old_codegen/global_context.py
@@ -120,9 +120,7 @@ class GlobalContext:
                 # A struct must be defined before it is referenced.
                 # This feels like a semantic step and maybe should be pushed
                 # to a later compilation stage.
-                parse_type(
-                    member_type, "storage", custom_structs=self._structs,
-                )
+                self.parse_type( member_type, "storage")
                 members.append((member_name, member_type))
             else:
                 raise StructureException("Structs can only contain variables", item)
@@ -206,7 +204,7 @@ class GlobalContext:
             if isinstance(item.annotation.args[0], vy_ast.Name) and item_name in self._contracts:
                 typ = InterfaceType(item_name)
             else:
-                typ = parse_type(item.annotation.args[0], "storage", custom_structs=self._structs,)
+                typ = self.parse_type(item.annotation.args[0], "storage")
             self._globals[item.target.id] = VariableRecord(
                 item.target.id, len(self._globals), typ, True,
             )
@@ -215,7 +213,7 @@ class GlobalContext:
             self._globals[item.target.id] = VariableRecord(
                 item.target.id,
                 len(self._globals),
-                parse_type(item.annotation, "storage", custom_structs=self._structs,),
+                self.parse_type(item.annotation, "storage"),
                 True,
             )
         else:

--- a/vyper/old_codegen/types/types.py
+++ b/vyper/old_codegen/types/types.py
@@ -181,7 +181,7 @@ def canonicalize_type(t, is_indexed=False):
     raise InvalidType(f"Invalid or unsupported type: {repr(t)}")
 
 
-def make_struct_type(name, location, members, custom_structs):
+def make_struct_type(name, location, sigs, members, custom_structs):
     o = OrderedDict()
 
     for key, value in members:
@@ -189,7 +189,7 @@ def make_struct_type(name, location, members, custom_structs):
             raise InvalidType(
                 f"Invalid member variable for struct {key.id}, expected a name.", key,
             )
-        o[key.id] = parse_type(value, location, custom_structs=custom_structs)
+        o[key.id] = parse_type(value, location, sigs=sigs, custom_structs=custom_structs)
 
     return StructType(o, name)
 
@@ -201,8 +201,10 @@ def parse_type(item, location, sigs=None, custom_structs=None):
     if isinstance(item, vy_ast.Name):
         if item.id in BASE_TYPES:
             return BaseType(item.id)
+        elif (sigs is not None) and item.id in sigs:
+            return InterfaceType(item.id)
         elif (custom_structs is not None) and (item.id in custom_structs):
-            return make_struct_type(item.id, location, custom_structs[item.id], custom_structs,)
+            return make_struct_type(item.id, location, sigs, custom_structs[item.id], custom_structs,)
         else:
             raise InvalidType("Invalid base type: " + item.id, item)
     # Units, e.g. num (1/sec) or contracts
@@ -213,7 +215,7 @@ def parse_type(item, location, sigs=None, custom_structs=None):
                 return InterfaceType(item.args[0].id)
         # Struct types
         if (custom_structs is not None) and (item.func.id in custom_structs):
-            return make_struct_type(item.id, location, custom_structs[item.id], custom_structs,)
+            return make_struct_type(item.id, location, sigs, custom_structs[item.id], custom_structs,)
         raise InvalidType("Units are no longer supported", item)
     # Subscripts
     elif isinstance(item, vy_ast.Subscript):
@@ -233,13 +235,13 @@ def parse_type(item, location, sigs=None, custom_structs=None):
             # List
             else:
                 return ListType(
-                    parse_type(item.value, location, custom_structs=custom_structs,), n_val,
+                    parse_type(item.value, location, sigs, custom_structs=custom_structs,), n_val,
                 )
         elif item.value.id in ("HashMap",) and isinstance(item.slice.value, vy_ast.Tuple):
-            keytype = parse_type(item.slice.value.elements[0], None, custom_structs=custom_structs,)
+            keytype = parse_type(item.slice.value.elements[0], None, sigs, custom_structs=custom_structs,)
             return MappingType(
                 keytype,
-                parse_type(item.slice.value.elements[1], location, custom_structs=custom_structs,),
+                parse_type(item.slice.value.elements[1], location, sigs, custom_structs=custom_structs,),
             )
         # Mappings, e.g. num[address]
         else:


### PR DESCRIPTION
The dict of interfaces was not being passed around correctly during
parse_type, resulting in variables like the following not type-checking:
```
interface Foo:
  ...
foos: HashMap[..., Foo] # didn't type check
```
Fixes #1824

### What I did

### How I did it

### How to verify it
Compile the above example

### Description for the changelog
Allow interfaces in lists, structs and maps

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
