### PR TITLE
fix handling of structs in imported modules

### DIFF
--- a/vyper/ast/signatures/interface.py
+++ b/vyper/ast/signatures/interface.py
@@ -99,8 +99,20 @@ def extract_sigs(sig_code, interface_name=None):
         interface_ast = [
             i
             for i in vy_ast.parse_to_ast(sig_code["code"], contract_name=interface_name)
-            if isinstance(i, vy_ast.FunctionDef)
-            or isinstance(i, vy_ast.EventDef)
+            # all the nodes visited by ModuleNodeVisitor.
+            if isinstance(
+                i,
+                (
+                    vy_ast.FunctionDef,
+                    vy_ast.EventDef,
+                    vy_ast.StructDef,
+                    vy_ast.InterfaceDef,
+                    # parsing import statements at this stage
+                    # causes issues with recursive imports
+                    # vy_ast.Import,
+                    # vy_ast.ImportFrom,
+                ),
+            )
             or (isinstance(i, vy_ast.AnnAssign) and i.target.id != "implements")
         ]
         global_ctx = GlobalContext.get_global_context(interface_ast)


### PR DESCRIPTION
### What I did
expand parsing to all AST types which might need to be parsed to
semantically understand the top-level items in a module.

Fixes #2359

### How I did it

### How to verify it
Compile the example in the issue

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.npr.org/assets/img/2015/01/06/bluefin-tuna-2_custom-808feafef2fcb638e46945e81c26827fd39a25d9-s1600-c85.webp)
