### PR TITLE
Implement abi_encode builtin

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -627,18 +627,18 @@ Utilities
 
     BETA, USE WITH CARE.
     Takes a variable number of args as input, and returns the ABIv2-encoded bytestring. Used for packing arguments to raw_call, EIP712 and other cases where a consistent and efficient serialization method is needed.
-    Once this function has seen more use we provisionally plan to put it into the ethereum.abi namespace.
+    Once this function has seen more use we provisionally plan to put it into the ``ethereum.abi`` namespace.
 
     * ``*args``: Arbitrary arguments
-    * ``ensure_tuple``: If set to True, ensures that even a single argument is encoded as a tuple. In other words, `bytes` gets encoded as `(bytes)`. This is the calling convention for Vyper and Solidity functions. Except for very specific use cases, this should be set to True. Must be a literal.
+    * ``ensure_tuple``: If set to True, ensures that even a single argument is encoded as a tuple. In other words, ``bytes`` gets encoded as ``(bytes,)``. This is the calling convention for Vyper and Solidity functions. Except for very specific use cases, this should be set to True. Must be a literal.
 
-    Returns a bytestring whose max length is determined by the arguments. For example, encoding a Bytes[32] results in a Bytes[64] (first word is the length of the bytestring).
+    Returns a bytestring whose max length is determined by the arguments. For example, encoding a ``Bytes[32]`` results in a ``Bytes[64]`` (first word is the length of the bytestring variable).
 
     .. code-block:: python
 
         @external
         @view
-        def foo() -> Bytes[4]:
+        def foo() -> Bytes[128]:
             x: uint256 = 1
             y: Bytes[32] = "234"
             return _abi_encode(x, y)

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -622,4 +622,28 @@ Utilities
     .. code-block:: python
 
         >>> ExampleContract.foo()
-        b"\xa9\x05\x9c\xbb"
+
+.. py:function:: _abi_encode(\*args, ensure_tuple: bool = True) -> Bytes[<depends on input>]
+
+    BETA, USE WITH CARE.
+    Takes a variable number of args as input, and returns the ABIv2-encoded bytestring. Used for packing arguments to raw_call, EIP712 and other cases where a consistent and efficient serialization method is needed.
+    Once this function has seen more use we provisionally plan to put it into the ethereum.abi namespace.
+
+    * ``*args``: Arbitrary arguments
+    * ``ensure_tuple``: If set to True, ensures that even a single argument is encoded as a tuple. In other words, `bytes` gets encoded as `(bytes)`. This is the calling convention for Vyper and Solidity functions. Except for very specific use cases, this should be set to True. Must be a literal.
+
+    Returns a bytestring whose max length is determined by the arguments. For example, encoding a Bytes[32] results in a Bytes[64] (first word is the length of the bytestring).
+
+    .. code-block:: python
+
+        @external
+        @view
+        def foo() -> Bytes[4]:
+            x: uint256 = 1
+            y: Bytes[32] = "234"
+            return _abi_encode(x, y)
+
+    .. code-block:: python
+
+        >>> ExampleContract.foo().hex()
+        "0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000033233340000000000000000000000000000000000000000000000000000000000"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,14 @@ def keccak():
 
 
 @pytest.fixture
+def abi_encode(w3):
+    def f(abi_t, py_val):
+        return w3.codec.encode_single(abi_t, py_val)
+
+    return f
+
+
+@pytest.fixture
 def bytes_helper():
     def bytes_helper(str, length):
         return bytes(str, "utf-8") + bytearray(length - len(str))

--- a/tests/functional/codegen/test_abi_encode.py
+++ b/tests/functional/codegen/test_abi_encode.py
@@ -1,0 +1,73 @@
+# import pytest
+from decimal import Decimal
+
+
+# @pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
+def test_abi_encode(get_contract, abi_encode):
+    code = """
+struct Animal:
+  name: String[64]
+  id_: int128
+  price: decimal
+
+struct Human:
+  name: String[32]
+  pet: Animal
+
+@external
+# TODO accept struct input once the functionality is available
+def abi_encode(
+    name: String[32],
+    pet_name: String[64],
+    pet_id: int128,
+    pet_price: decimal,
+    ensure_tuple: bool=True
+) -> Bytes[256]:
+    human: Human = Human({
+      name: name,
+      pet: Animal({
+        name: pet_name,
+        id_: pet_id,
+        price: pet_price
+      })
+    })
+    if ensure_tuple:
+        return _abi_encode(human, ensure_tuple=True)
+    else:
+        return _abi_encode(human, ensure_tuple=False)
+@external
+def abi_encode2(name: String[32], ensure_tuple: bool = True) -> Bytes[96]:
+    if ensure_tuple:
+        return _abi_encode(name, ensure_tuple=True)
+    else:
+        return _abi_encode(name, ensure_tuple=False)
+@external
+def abi_encode3(x: uint256, ensure_tuple: bool = True) -> Bytes[32]:
+    if ensure_tuple:
+        return _abi_encode(x, ensure_tuple=True)
+    else:
+        return _abi_encode(x, ensure_tuple=False)
+    """
+    c = get_contract(code)
+
+    # test each method once each with ensure_tuple set to True and False
+
+    arg = 123
+    assert c.abi_encode3(arg, False).hex() == abi_encode("uint256", arg).hex()
+    assert c.abi_encode3(arg, True).hex() == abi_encode("(uint256)", (arg,)).hex()
+
+    arg = "some string"
+    assert c.abi_encode2(arg, False).hex() == abi_encode("string", arg).hex()
+    assert c.abi_encode2(arg, True).hex() == abi_encode("(string)", (arg,)).hex()
+
+    args = ("foobar", "vyper", 123, Decimal("123.4"))
+    human_tuple = (
+        "foobar",
+        ("vyper", 123, Decimal("123.4")),
+    )  # TODO use convenience method to convert from human
+    human_t = "(string,(string,int128,fixed168x10))"
+    human_encoded = abi_encode(human_t, human_tuple)
+    assert c.abi_encode(*args, False).hex() == human_encoded.hex()
+
+    human_encoded = abi_encode(f"({human_t})", (human_tuple,))
+    assert c.abi_encode(*args, True).hex() == human_encoded.hex()

--- a/tests/functional/codegen/test_abi_encode.py
+++ b/tests/functional/codegen/test_abi_encode.py
@@ -29,7 +29,7 @@ def abi_encode(
     pet_price: decimal,
     pet_data: uint256[3],
     pet_metadata: bytes32,
-    ensure_tuple: bool=True
+    ensure_tuple: bool
 ) -> Bytes[256]:
     human: Human = Human({
       name: name,
@@ -44,19 +44,19 @@ def abi_encode(
       }),
     })
     if ensure_tuple:
-        return _abi_encode(human, ensure_tuple=True)
+        return _abi_encode(human) # default ensure_tuple=True
     else:
         return _abi_encode(human, ensure_tuple=False)
 @external
-def abi_encode2(name: String[32], ensure_tuple: bool = True) -> Bytes[96]:
+def abi_encode2(name: String[32], ensure_tuple: bool) -> Bytes[96]:
     if ensure_tuple:
-        return _abi_encode(name, ensure_tuple=True)
+        return _abi_encode(name) # default ensure_tuple=True
     else:
         return _abi_encode(name, ensure_tuple=False)
 @external
-def abi_encode3(x: uint256, ensure_tuple: bool = True) -> Bytes[32]:
+def abi_encode3(x: uint256, ensure_tuple: bool) -> Bytes[32]:
     if ensure_tuple:
-        return _abi_encode(x, ensure_tuple=True)
+        return _abi_encode(x) # default ensure_tuple=True
     else:
         return _abi_encode(x, ensure_tuple=False)
     """

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -21,7 +21,12 @@ from vyper.exceptions import (
     VyperException,
     ZeroDivisionException,
 )
-from vyper.old_codegen.abi import abi_encode, abi_type_of, abi_type_of2
+from vyper.old_codegen.abi import (
+    ABI_Tuple,
+    abi_encode,
+    abi_type_of,
+    abi_type_of2,
+)
 from vyper.old_codegen.arg_clamps import int128_clamp
 from vyper.old_codegen.expr import Expr
 from vyper.old_codegen.keccak256_helper import keccak256_helper
@@ -68,6 +73,7 @@ from vyper.semantics.types.value.numeric import (
 )
 from vyper.semantics.validation.utils import (
     get_common_types,
+    get_exact_type_from_node,
     get_possible_types_from_node,
     validate_expected_type,
 )
@@ -987,6 +993,7 @@ class AsWeiValue:
 
 zero_value = LLLnode.from_list(0, typ=BaseType("uint256"))
 false_value = LLLnode.from_list(0, typ=BaseType("bool", is_literal=True))
+true_value = LLLnode.from_list(1, typ=BaseType("bool", is_literal=True))
 
 
 class RawCall(_SimpleBuiltinFunction):
@@ -1714,37 +1721,74 @@ class Empty:
 
 class ABIEncode(_SimpleBuiltinFunction):
     _id = "_abi_encode"  # TODO prettier to rename this to abi.encode
-    _inputs = ["*"]
-    _kwargs = {"output_type": Optional("name_literal", "bytes")}
+    # signature: *, ensure_tuple=<literal_bool> -> Bytes[<calculated len>]
+    # (check the signature manually since we have no utility methods
+    # to handle varargs.)
+    # explanation of ensure_tuple:
+    # default is to force even a single value into a tuple,
+    # e.g. _abi_encode(bytes) -> abi_encode((bytes,))
+    # this follows the encoding convention for functions:
+    # ://docs.soliditylang.org/en/v0.8.6/abi-spec.html#function-selector-and-argument-encoding
+    # if this is turned off, then bytes will be encoded as bytes.
 
     @staticmethod
     # this should probably be a utility function
     def _exactly_one(xs):
         return len(set(xs)) == 1
 
+    @staticmethod
+    def _ensure_tuple(node):
+        # figure out if we need to encode single values as tuples
+        ensure_tuple = next((i.value for i in node.keywords if i.arg == "ensure_tuple"), None)
+        if ensure_tuple is None:
+            # default to True.
+            return True
+
+        elif not isinstance(ensure_tuple, vy_ast.NameConstant) or not isinstance(
+            ensure_tuple.value, bool
+        ):
+            raise TypeMismatch(
+                "The `ensure_tuple` parameter must be a static/literal boolean value", node
+            )
+        else:
+            return ensure_tuple.value
+
     def fetch_call_return(self, node):
-        maxlen = 0
+        # figure out the output type by converting
+        # the types to ABI_Types and calling size_bound API
+        arg_abi_types = []
         for arg in node.args:
-            argtys = get_possible_types_from_node(arg)
-            possible_lengths = [abi_type_of2(t).size_bound() for t in argtys]
-            if not self._exactly_one(possible_lengths):
-                raise StructureException("Can't figure out an ABI type", arg)
-            maxlen += possible_lengths[0]
+            arg_t = get_exact_type_from_node(arg)
+            arg_abi_types.append(abi_type_of2(arg_t))
+
+        # special case, no tuple
+        if len(arg_abi_types) == 1 and not self._ensure_tuple(node):
+            arg_abi_t = arg_abi_types[0]
+        else:
+            arg_abi_t = ABI_Tuple(arg_abi_types)
+
+        maxlen = arg_abi_t.size_bound()
 
         ret = BytesArrayDefinition()
         ret.set_length(maxlen)
         return ret
 
     def build_LLL(self, expr, context):
+
         args = [Expr(arg, context).lll_node for arg in expr.args]
         if len(args) < 1:
             raise StructureException("abi_encode expects at least one argument", expr)
 
-        args_tuple_t = TupleType([x.typ for x in args])
-        args_as_tuple = LLLnode.from_list(["multi"] + [x for x in args], typ=args_tuple_t)
-        args_abi_t = abi_type_of(args_tuple_t)
+        # figure out the required length for the output buffer
+        if len(args) == 1 and not self._ensure_tuple(expr):
+            # special case, no tuple
+            encode_input = args[0]
+        else:
+            args_tuple_t = TupleType([x.typ for x in args])
+            encode_input = LLLnode.from_list(["multi"] + [x for x in args], typ=args_tuple_t)
 
-        maxlen = args_abi_t.size_bound()
+        input_abi_t = abi_type_of(encode_input.typ)
+        maxlen = input_abi_t.size_bound()
 
         buf_t = ByteArrayType(maxlen=maxlen)
         buf = context.new_internal_variable(buf_t)
@@ -1752,11 +1796,17 @@ class ABIEncode(_SimpleBuiltinFunction):
         pos = getpos(expr)
 
         return LLLnode.from_list(
-            ["seq", abi_encode(buf, args_as_tuple, pos), buf],
+            [
+                "seq",
+                # write the output length to where bytestring stores its length
+                ["mstore", buf, abi_encode(buf + 32, encode_input, pos, returns_len=True)],
+                # return the buf location
+                buf,
+            ],
             location="memory",
             typ=buf_t,
             pos=pos,
-            annotation="abi_encode builtin",
+            annotation=f"abi_encode builtin ensure_tuple={self._ensure_tuple(expr)}",
         )
 
 

--- a/vyper/old_codegen/abi.py
+++ b/vyper/old_codegen/abi.py
@@ -1,3 +1,4 @@
+import vyper.semantics.types as vy
 from vyper.exceptions import CompilerPanic
 from vyper.old_codegen.lll_node import LLLnode
 from vyper.old_codegen.parser_utils import (
@@ -35,6 +36,9 @@ class ABIType:
     # max size (in bytes) in the dynamic section (aka 'tail')
     def dynamic_size_bound(self):
         return 0
+
+    def size_bound(self):
+        return self.static_size() + self.dynamic_size_bound()
 
     # The canonical name of the type for calculating the function selector
     def selector_name(self):
@@ -280,6 +284,32 @@ def abi_type_of(lll_typ):
         raise CompilerPanic(f"Unrecognized type {lll_typ}")
 
 
+# the new type system
+# TODO consider moving these into properties of the type itself
+def abi_type_of2(t: vy.BasePrimitive) -> ABIType:
+    if isinstance(t, vy.AbstractNumericDefinition):
+        return ABI_GIntM(t._bits, t._signed)
+    if isinstance(t, vy.AddressDefinition):
+        return ABI_Address()
+    if isinstance(t, vy.Bytes32Definition):
+        return ABI_BytesM(t.length)
+    if isinstance(t, vy.BoolDefinition):
+        return ABI_Bool()
+    if isinstance(t, vy.DecimalDefinition):
+        return ABI_FixedMxN(t._bits, t._decimal_places, True)
+    if isinstance(t, vy.BytesArrayDefinition):
+        return ABI_Bytes(t._length)
+    if isinstance(t, vy.StringDefinition):
+        return ABI_String(t._length)
+    if isinstance(t, vy.TupleDefinition):
+        return ABI_Tuple([abi_type_of2(t) for t in t.value_type])
+    if isinstance(t, vy.StructDefinition):
+        return ABI_Tuple([abi_type_of2(t) for t in t.members.values()])
+    if isinstance(t, vy.ArrayDefinition):
+        return ABI_StaticArray(abi_type_of2(t.value_type, t.length))
+    raise CompilerPanic(f"Unrecognized type {t}")
+
+
 # there are a lot of places in the calling convention where a tuple
 # must be passed, so here's a convenience function for that.
 def ensure_tuple(abi_typ):
@@ -338,7 +368,7 @@ def o_list(lll_node, pos=None):
 # that users will provide deeply nested data.
 def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
     parent_abi_t = abi_type_of(lll_node.typ)
-    size_bound = parent_abi_t.static_size() + parent_abi_t.dynamic_size_bound()
+    size_bound = parent_abi_t.size_bound()
     if bufsz is not None and bufsz < 32 * size_bound:
         raise CompilerPanic("buffer provided to abi_encode not large enough")
 
@@ -402,7 +432,7 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns=False):
 
     lll_ret = ["with", dst_begin, dst, ["with", dst_loc, dst_begin, lll_ret]]
 
-    return LLLnode.from_list(lll_ret)
+    return LLLnode.from_list(lll_ret, pos=pos)
 
 
 # lll_node is the destination LLL item, src is the input buffer.

--- a/vyper/old_codegen/abi.py
+++ b/vyper/old_codegen/abi.py
@@ -306,7 +306,7 @@ def abi_type_of2(t: vy.BasePrimitive) -> ABIType:
     if isinstance(t, vy.StructDefinition):
         return ABI_Tuple([abi_type_of2(t) for t in t.members.values()])
     if isinstance(t, vy.ArrayDefinition):
-        return ABI_StaticArray(abi_type_of2(t.value_type, t.length))
+        return ABI_StaticArray(abi_type_of2(t.value_type), t.length)
     raise CompilerPanic(f"Unrecognized type {t}")
 
 

--- a/vyper/old_codegen/global_context.py
+++ b/vyper/old_codegen/global_context.py
@@ -120,7 +120,7 @@ class GlobalContext:
                 # A struct must be defined before it is referenced.
                 # This feels like a semantic step and maybe should be pushed
                 # to a later compilation stage.
-                self.parse_type( member_type, "storage")
+                self.parse_type(member_type, "storage")
                 members.append((member_name, member_type))
             else:
                 raise StructureException("Structs can only contain variables", item)

--- a/vyper/old_codegen/return_.py
+++ b/vyper/old_codegen/return_.py
@@ -115,7 +115,7 @@ def gen_tuple_return(stmt, context, sub):
 
         # in case of multi we can't create a variable to store location of the return expression
         # as multi can have data from multiple location like store, calldata etc
-        encode_out = abi_encode(return_buffer, sub, pos=getpos(stmt), returns=True)
+        encode_out = abi_encode(return_buffer, sub, pos=getpos(stmt), returns_len=True)
         load_return_len = ["mload", MemoryPositions.FREE_VAR_SPACE]
         os = [
             "seq",
@@ -127,7 +127,7 @@ def gen_tuple_return(stmt, context, sub):
     # for tuple return types where a function is called inside the tuple, we
     # process the calls prior to encoding the return data
     if sub.value == "seq_unchecked" and sub.args[-1].value == "multi":
-        encode_out = abi_encode(return_buffer, sub.args[-1], pos=getpos(stmt), returns=True)
+        encode_out = abi_encode(return_buffer, sub.args[-1], pos=getpos(stmt), returns_len=True)
         load_return_len = ["mload", MemoryPositions.FREE_VAR_SPACE]
         os = (
             ["seq"]
@@ -143,7 +143,7 @@ def gen_tuple_return(stmt, context, sub):
     # of the return expression. This is done so that the return expression does not get evaluated
     # abi-encode uses a function named o_list which evaluate the expression multiple times
     sub_loc = LLLnode("sub_loc", typ=sub.typ, location=sub.location)
-    encode_out = abi_encode(return_buffer, sub_loc, pos=getpos(stmt), returns=True)
+    encode_out = abi_encode(return_buffer, sub_loc, pos=getpos(stmt), returns_len=True)
     load_return_len = ["mload", MemoryPositions.FREE_VAR_SPACE]
     os = [
         "with",

--- a/vyper/old_codegen/types/types.py
+++ b/vyper/old_codegen/types/types.py
@@ -204,7 +204,9 @@ def parse_type(item, location, sigs=None, custom_structs=None):
         elif (sigs is not None) and item.id in sigs:
             return InterfaceType(item.id)
         elif (custom_structs is not None) and (item.id in custom_structs):
-            return make_struct_type(item.id, location, sigs, custom_structs[item.id], custom_structs,)
+            return make_struct_type(
+                item.id, location, sigs, custom_structs[item.id], custom_structs,
+            )
         else:
             raise InvalidType("Invalid base type: " + item.id, item)
     # Units, e.g. num (1/sec) or contracts
@@ -215,7 +217,9 @@ def parse_type(item, location, sigs=None, custom_structs=None):
                 return InterfaceType(item.args[0].id)
         # Struct types
         if (custom_structs is not None) and (item.func.id in custom_structs):
-            return make_struct_type(item.id, location, sigs, custom_structs[item.id], custom_structs,)
+            return make_struct_type(
+                item.id, location, sigs, custom_structs[item.id], custom_structs,
+            )
         raise InvalidType("Units are no longer supported", item)
     # Subscripts
     elif isinstance(item, vy_ast.Subscript):
@@ -238,10 +242,14 @@ def parse_type(item, location, sigs=None, custom_structs=None):
                     parse_type(item.value, location, sigs, custom_structs=custom_structs,), n_val,
                 )
         elif item.value.id in ("HashMap",) and isinstance(item.slice.value, vy_ast.Tuple):
-            keytype = parse_type(item.slice.value.elements[0], None, sigs, custom_structs=custom_structs,)
+            keytype = parse_type(
+                item.slice.value.elements[0], None, sigs, custom_structs=custom_structs,
+            )
             return MappingType(
                 keytype,
-                parse_type(item.slice.value.elements[1], location, sigs, custom_structs=custom_structs,),
+                parse_type(
+                    item.slice.value.elements[1], location, sigs, custom_structs=custom_structs,
+                ),
             )
         # Mappings, e.g. num[address]
         else:

--- a/vyper/semantics/types/__init__.py
+++ b/vyper/semantics/types/__init__.py
@@ -8,10 +8,10 @@ from .value.array_value import BytesArrayDefinition, StringDefinition
 from .value.boolean import BoolDefinition
 from .value.bytes_fixed import Bytes32Definition
 from .value.numeric import (
+    AbstractNumericDefinition,
     DecimalDefinition,
     Int128Definition,
     Uint256Definition,
-    AbstractNumericDefinition,
 )
 
 # any more?

--- a/vyper/semantics/types/__init__.py
+++ b/vyper/semantics/types/__init__.py
@@ -1,5 +1,20 @@
 from . import indexable, user, value
+from .abstract import SignedIntegerAbstractType, UnsignedIntegerAbstractType
 from .bases import BasePrimitive
+from .indexable.sequence import ArrayDefinition, TupleDefinition
+from .user.struct import StructDefinition
+from .value.address import AddressDefinition
+from .value.array_value import BytesArrayDefinition, StringDefinition
+from .value.boolean import BoolDefinition
+from .value.bytes_fixed import Bytes32Definition
+from .value.numeric import (
+    DecimalDefinition,
+    Int128Definition,
+    Uint256Definition,
+    AbstractNumericDefinition,
+)
+
+# any more?
 
 
 def get_primitive_types():

--- a/vyper/semantics/types/value/numeric.py
+++ b/vyper/semantics/types/value/numeric.py
@@ -16,7 +16,7 @@ from ..bases import (
 )
 
 
-class _NumericDefinition(ValueTypeDefinition):
+class AbstractNumericDefinition(ValueTypeDefinition):
     """
     Private base class for numeric definitions.
 
@@ -85,7 +85,7 @@ class _NumericDefinition(ValueTypeDefinition):
         return
 
 
-class _SignedIntegerDefinition(_NumericDefinition):
+class _SignedIntegerDefinition(AbstractNumericDefinition):
     """
     Private base class for signed integer definitions.
     """
@@ -97,7 +97,7 @@ class _SignedIntegerDefinition(_NumericDefinition):
         return f"int{self._bits}"
 
 
-class _UnsignedIntegerDefinition(_NumericDefinition):
+class _UnsignedIntegerDefinition(AbstractNumericDefinition):
     """
     Private base class for unsigned integer definitions.
     """
@@ -141,15 +141,16 @@ class Uint256Definition(UnsignedIntegerAbstractType, _UnsignedIntegerDefinition)
     _invalid_op = vy_ast.USub
 
 
-class DecimalDefinition(FixedAbstractType, _NumericDefinition):
-    _bits = 168
+class DecimalDefinition(FixedAbstractType, AbstractNumericDefinition):
+    _bits = 168  # TODO generalize
+    _decimal_places = 10  # TODO generalize
     _id = "decimal"
     _is_signed = True
     _invalid_op = vy_ast.Pow
 
     @property
     def canonical_type(self) -> str:
-        return "fixed168x10"
+        return f"fixed{self._bits}x{self._decimal_places}"
 
 
 # primitives


### PR DESCRIPTION
### What I did
Implement user-facing abi encode function
    
This exposes abi_encode to the user. The returned bytestring has a
length of the size bound on the ABI encoded data (size_bound was
refactored in this commit to a convenience function) and the provided
buffer must be large enough to accept the data.

### How I did it

### How to verify it
Compile the following example contract:
```python
struct Foo:
  a: String[64]
  b: int128
  c: decimal
@internal
def foo():
  x: uint256 = 1
  r1: Bytes[32] = abi_encode(x)
  y: Foo = Foo({a: "123", b: 234, c: 50.0})
  z: Bytes[32] = b"678"
  r2: Bytes[288] = abi_encode(x, y, z)
```

To test:
- arrays

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
