### PR TITLE
optimize call to identity precompile

### DIFF
--- a/vyper/old_codegen/parser_utils.py
+++ b/vyper/old_codegen/parser_utils.py
@@ -92,7 +92,7 @@ def make_byte_array_copier(destination, source, pos=None):
                     "with",
                     "_sz",
                     ["add", 32, ["mload", "_source"]],
-                    ["assert", ["call", ["gas"], 4, 0, "_source", "_sz", destination, "_sz"]],
+                    ["pop", ["call", ["gas"], 4, 0, "_source", "_sz", destination, "_sz"]],
                 ],
             ],  # noqa: E501
             typ=None,


### PR DESCRIPTION
a call to the identity only ever fails with OOG (YP), so if you call it
with all remaining gas and it fails it's already too late to revert.

### How to verify it
see if tests pass

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
