### PR TITLE
fix trailing newline parse bug

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -218,7 +218,9 @@ def compile_files(
         except ValueError:
             file_str = file_path.as_posix()
         with file_path.open() as fh:
-            contract_sources[file_str] = fh.read()
+            # trailing newline fixes python parsing bug when source ends in a comment
+            # https://bugs.python.org/issue35107
+            contract_sources[file_str] = fh.read() + "\n"
 
     show_version = False
     if "combined_json" in output_formats:

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -85,9 +85,7 @@ def compile_codes(
 
     out: OrderedDict = OrderedDict()
     for source_id, contract_name in enumerate(sorted(contract_sources), start=initial_id):
-        # trailing newline fixes python parsing bug when source ends in a comment
-        # https://bugs.python.org/issue35107
-        source_code = f"{contract_sources[contract_name]}\n"
+        source_code = contract_sources[contract_name]
         interfaces: Any = interface_codes
         if (
             isinstance(interfaces, dict)


### PR DESCRIPTION
### What I did
Fix #2410 

The previous fix in #1720 stopped working because the modified source
code was only being provided to some compilation steps (compile_codes)
but not others (get_interface_codes).

### How I did it
Move the additional newline upstream

### How to verify it
Compile the code in the issue

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
