### PR TITLE
msg.data extract32 usage

### DIFF
--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -33,7 +33,7 @@ Name                 Type             Value
 
 .. note::
 
-    ``msg.data`` requires the usage of :func:`slice <slice>` to explicitly extract a section of calldata. If the extracted section exceeds the bounds of calldata, this will throw. You can check the size of ``msg.data`` using :func:`len <len>`.   
+    ``msg.data`` requires the usage of :func:`slice <slice>` or :func:`extract32 <extract32>` to explicitly extract a section of calldata. If the extracted section exceeds the bounds of calldata, this will throw. You can check the size of ``msg.data`` using :func:`len <len>`.   
 
 .. _constants-self:
 

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -36,6 +36,21 @@ def foo(_value: uint256) -> uint256:
     assert contract.foo(42) == 42
 
 
+@pytest.mark.parametrize("index", [4, -32])
+def test_extract_32_usage_variable_assignment_alt_datatype(get_contract, index, w3):
+    code = f"""
+@external
+def foo(_value: address) -> address:
+    bar: address = extract32(msg.data, {index}, output_type=address)
+    return bar
+"""
+
+    contract = get_contract(code)
+    acct = w3.eth.accounts[0]
+
+    assert contract.foo(acct) == acct
+
+
 def test_slicing_start_index_other_than_zero(get_contract):
     code = """
 @external
@@ -94,6 +109,22 @@ def foo():
 
     contract.foo(transact={"from": acct})
     assert contract.cache() == bytes(keccak(text="foo()")[:4])
+
+
+@pytest.mark.parametrize("index", [4, -32])
+def test_extract32_assignment_to_storage(w3, get_contract, index):
+    code = f"""
+cache: public(uint256)
+
+@external
+def foo(_value: uint256):
+    self.cache = extract32(msg.data, {index}, output_type=uint256)
+"""
+    acct = w3.eth.accounts[0]
+    contract = get_contract(code)
+
+    contract.foo(42, transact={"from": acct})
+    assert contract.cache() == 42
 
 
 def test_get_len(get_contract):

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -22,6 +22,19 @@ def foo() -> Bytes[4]:
     assert contract.foo() == bytes(keccak(text="foo()")[:4])
 
 
+def test_extract_32_usage_variable_assignment(get_contract):
+    code = """
+@external
+def foo(_value: uint256) -> uint256:
+    bar: bytes32 = extract32(msg.data, 4)
+    return convert(bar, uint256)
+"""
+
+    contract = get_contract(code)
+
+    assert contract.foo(42) == 42
+
+
 def test_slicing_start_index_other_than_zero(get_contract):
     code = """
 @external

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -22,11 +22,12 @@ def foo() -> Bytes[4]:
     assert contract.foo() == bytes(keccak(text="foo()")[:4])
 
 
-def test_extract_32_usage_variable_assignment(get_contract):
-    code = """
+@pytest.mark.parametrize("index", [4, -32])
+def test_extract_32_usage_variable_assignment(get_contract, index):
+    code = f"""
 @external
 def foo(_value: uint256) -> uint256:
-    bar: bytes32 = extract32(msg.data, 4)
+    bar: bytes32 = extract32(msg.data, {index})
     return convert(bar, uint256)
 """
 

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -395,6 +395,18 @@ class Expr:
                         pos,
                     ]
                     return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
+                elif parent.get("func.id") == "extract32":
+                    size = parent.args[1].value + 32
+                    typ = ByteArrayType(size)
+                    pos = self.context.new_internal_variable(typ)
+                    node = [
+                        "seq",
+                        ["mstore", pos, size],
+                        ["calldatacopy", pos + 32, 0, size],
+                        pos,
+                    ]
+                    return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
+
             elif key == "msg.value" and self.context.is_payable:
                 return LLLnode.from_list(
                     ["callvalue"], typ=BaseType("uint256"), pos=getpos(self.expr),

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -396,7 +396,7 @@ class Expr:
                     ]
                     return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
                 elif parent.get("func.id") == "extract32":
-                    start = parent.args[1].value 
+                    start = parent.args[1].value
                     if start >= 0:
                         size = start + 32
                         typ = ByteArrayType(size + 32)
@@ -410,15 +410,18 @@ class Expr:
                     else:
                         # negative start index so our size is really just abs(start)
                         # because we are going to grab just the end chunk
-                        size = abs(start)
-                        typ = ByteArrayType(size + 32)
+                        array_size = abs(start)
+                        typ = ByteArrayType(array_size + 32)
                         pos = self.context.new_internal_variable(typ)
                         node = [
                             "seq",
-                            ["mstore", pos, size],
-                            ["calldatacopy", pos + 32, ["sub", "calldatasize", size], size],
+                            ["mstore", pos, array_size],
+                            ["calldatacopy", pos + 32, ["sub", "calldatasize", array_size], array_size],
                             pos,
                         ]
+                        # overwrite the user supplied negative value to be 0
+                        # since we are just grabbing the beginning of the chunk we took at the end
+                        parent.args[1].value = 0
 
                     return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
 

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -396,15 +396,30 @@ class Expr:
                     ]
                     return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
                 elif parent.get("func.id") == "extract32":
-                    size = parent.args[1].value + 32
-                    typ = ByteArrayType(size)
-                    pos = self.context.new_internal_variable(typ)
-                    node = [
-                        "seq",
-                        ["mstore", pos, size],
-                        ["calldatacopy", pos + 32, 0, size],
-                        pos,
-                    ]
+                    start = parent.args[1].value 
+                    if start >= 0:
+                        size = start + 32
+                        typ = ByteArrayType(size + 32)
+                        pos = self.context.new_internal_variable(typ)
+                        node = [
+                            "seq",
+                            ["mstore", pos, size],
+                            ["calldatacopy", pos + 32, 0, size],
+                            pos,
+                        ]
+                    else:
+                        # negative start index so our size is really just abs(start)
+                        # because we are going to grab just the end chunk
+                        size = abs(start)
+                        typ = ByteArrayType(size + 32)
+                        pos = self.context.new_internal_variable(typ)
+                        node = [
+                            "seq",
+                            ["mstore", pos, size],
+                            ["calldatacopy", pos + 32, ["sub", "calldatasize", size], size],
+                            pos,
+                        ]
+
                     return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
 
             elif key == "msg.value" and self.context.is_payable:

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -55,12 +55,7 @@ class StatementAnnotationVisitor(_AnnotationVisitorBase):
         super().visit(node)
 
     def visit_Attribute(self, node):
-        if node.get("value.id") == "msg" and node.attr == "data":
-            parent = node.get_ancestor()
-            if parent.get("func.id") == "slice":
-                node._metadata["size"] = parent.args[1].value + parent.args[2].value
-            elif parent.get("func.id") == "len":
-                node._metadata["is_len"] = True
+        pass
 
     def visit_AnnAssign(self, node):
         type_ = get_exact_type_from_node(node.target)

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -186,9 +186,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
     def visit_Attribute(self, node):
         if node.get("value.id") == "msg" and node.attr == "data":
             parent = node.get_ancestor()
-            is_slice = parent.get("func.id") == "slice"
-            is_len = parent.get("func.id") == "len"
-            if not is_slice and not is_len:
+            if parent.get("func.id") not in ("slice", "len", "extract32"):
                 raise SyntaxException(
                     "msg.data is only allowed inside of the slice or len functions",
                     node.node_source_code,


### PR DESCRIPTION
### What I did

Allow `msg.data` to be used as an argument in `extract32` 

Fix: #2413 

### How I did it

- Modified the function level validation, and added `extract32` as a valid function to use msg.data with
- Modified the expr.py file, with an additional branch for `extract32`. Here we simply do the same as `slice`, and return a memory variable with size equal to start index + 32, unless the user supplies a negative value in which case we only need the last chunk of calldata, so the array's memory size is really just abs(start_index).

Note: for negative value start indexes, I'm not sure if it ever worked in the past, but the docs seems to portray that you can supply a negative value as the start index in extract32. Currently this borks so new issue will be added. But to circumvent that, I simply overwrote the node's start index to be 0, when the start index was negative.

### How to verify it

I added 3 more test cases, 1 verifying extract32 usage assignment to memory, 1 verifying assignment to storage, and 1 verifying extracting an address instead of the standard bytes32.

### Description for the changelog

- feat: allow `msg.data` to be supplied as an argument to `extract32`

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/tuna-animals-to-follow-on-instagram-1568322831.jpg)
