### PR TITLE
Fix/msg data

### DIFF
--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -266,6 +266,7 @@ class Slice:
             # if we are slicing msg.data, the length should
             # be a constant, since msg.data can be of dynamic length
             # we can't use it's length as the maxlen
+            assert isinstance(length.value, int) # sanity check
             sub_typ_maxlen = length.value
         else:
             sub_typ_maxlen = sub.typ.maxlen

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -262,6 +262,9 @@ class Slice:
                     "Invalid start / length values needs to be between 0 and 32.", expr,
                 )
             sub_typ_maxlen = 32
+        elif sub.location == "calldata":
+            # msg.data
+            sub_typ_maxlen = length.value
         else:
             sub_typ_maxlen = sub.typ.maxlen
 
@@ -280,6 +283,16 @@ class Slice:
             adj_sub = LLLnode.from_list(
                 ["add", sub, ["add", ["div", "_start", 32], 1]], typ=sub.typ, location=sub.location,
             )
+        elif sub.location == "calldata":
+            node = [
+                "seq",
+                ["assert", ["le", start.value + length.value, "calldatasize"]],  # runtime bounds check
+                ["mstore", np, length],
+                ["calldatacopy", np + 32, start, length],
+                np,
+            ]
+            return LLLnode.from_list(node, typ=ByteArrayType(length.value), location="memory")
+        
         else:
             adj_sub = LLLnode.from_list(
                 ["add", sub, ["add", ["sub", "_start", ["mod", "_start", 32]], 32]],

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -351,6 +351,10 @@ class Len(_SimpleBuiltinFunction):
         return vy_ast.Int.from_node(node, value=length)
 
     def build_LLL(self, node, context):
+        if isinstance(node.args[0], vy_ast.Attribute):
+            key = f"{node.args[0].value.id}.{node.args[0].attr}"
+            if key == "msg.data":
+                return LLLnode.from_list(["calldatasize"], typ="uint256")
         arg = Expr(node.args[0], context).lll_node
         return get_bytearray_length(arg)
 

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -375,25 +375,7 @@ class Expr:
             if key == "msg.sender" and not self.context.is_internal:
                 return LLLnode.from_list(["caller"], typ="address", pos=getpos(self.expr))
             elif key == "msg.data" and not self.context.is_internal:
-                is_len = self.expr._metadata.get("is_len")
-                if is_len is True:
-                    typ = ByteArrayType(32)
-                    pos = self.context.new_internal_variable(typ)
-                    node = ["seq", ["mstore", pos, "calldatasize"], pos]
-                    return LLLnode.from_list(
-                        node, typ=typ, pos=getpos(self.expr), location="memory"
-                    )
-                size = self.expr._metadata.get("size")
-                typ = ByteArrayType(size + 32)
-                pos = self.context.new_internal_variable(typ)
-                node = [
-                    "seq",
-                    ["assert", ["le", size, "calldatasize"]],
-                    ["mstore", pos, size],
-                    ["calldatacopy", pos + 32, 0, size],
-                    pos,
-                ]
-                return LLLnode.from_list(node, typ=typ, pos=getpos(self.expr), location="memory")
+                return LLLnode(None, typ=ByteArrayType(0), location="calldata")
             elif key == "msg.value" and self.context.is_payable:
                 return LLLnode.from_list(
                     ["callvalue"], typ=BaseType("uint256"), pos=getpos(self.expr),

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -375,7 +375,7 @@ class Expr:
             if key == "msg.sender" and not self.context.is_internal:
                 return LLLnode.from_list(["caller"], typ="address", pos=getpos(self.expr))
             elif key == "msg.data" and not self.context.is_internal:
-                return LLLnode(None, typ=ByteArrayType(0), location="calldata")
+                return LLLnode(0, typ=ByteArrayType(0), location="calldata")
             elif key == "msg.value" and self.context.is_payable:
                 return LLLnode.from_list(
                     ["callvalue"], typ=BaseType("uint256"), pos=getpos(self.expr),

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -55,12 +55,7 @@ class StatementAnnotationVisitor(_AnnotationVisitorBase):
         super().visit(node)
 
     def visit_Attribute(self, node):
-        if node.get("value.id") == "msg" and node.attr == "data":
-            parent = node.get_ancestor()
-            if parent.get("func.id") == "slice":
-                node._metadata["size"] = parent.args[1].value + parent.args[2].value
-            elif parent.get("func.id") == "len":
-                node._metadata["is_len"] = True
+        pass
 
     def visit_AnnAssign(self, node):
         type_ = get_exact_type_from_node(node.target)

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -55,6 +55,8 @@ class StatementAnnotationVisitor(_AnnotationVisitorBase):
         super().visit(node)
 
     def visit_Attribute(self, node):
+        # NOTE: required for msg.data node, removing borks and results in
+        # vyper.exceptions.StructureException: Cannot annotate: Attribute
         pass
 
     def visit_AnnAssign(self, node):

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -186,9 +186,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
     def visit_Attribute(self, node):
         if node.get("value.id") == "msg" and node.attr == "data":
             parent = node.get_ancestor()
-            is_slice = parent.get("func.id") == "slice"
-            is_len = parent.get("func.id") == "len"
-            if not is_slice and not is_len:
+            if parent.get("func.id") not in ["slice", "len"]:
                 raise SyntaxException(
                     "msg.data is only allowed inside of the slice or len functions",
                     node.node_source_code,

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -186,7 +186,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
     def visit_Attribute(self, node):
         if node.get("value.id") == "msg" and node.attr == "data":
             parent = node.get_ancestor()
-            if parent.get("func.id") not in ["slice", "len"]:
+            if parent.get("func.id") not in ("slice", "len"):
                 raise SyntaxException(
                     "msg.data is only allowed inside of the slice or len functions",
                     node.node_source_code,


### PR DESCRIPTION
### What I did

Refactored the msg.data environment variable. Instead of handling each distinctive use case in `expr.py`, uses are handled in the respective functions which operate on `msg.data`.

- Len builtin simply returns calldatasize
- Slice builtin returns a bytes array containing the sliced portion of calldata
  - The length argument to slice should be a compile time literal as calldatasize is unbounded, and we need a maxsize
  on the return type of the slice function instead of defaulting to the maxsize of msg.data

### How I did it

Followed charles' guidance. Mainly just made `msg.data` return an empty LLLnode with `location='calldata'`, and then handled it in the builtin functions

### How to verify it

The test suite for `msg.data` is unchanged, so passing tests verify this refactoring worked.

### Description for the changelog

- Fix: msg.data memory allocation removed in favor of builtin function handling

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.glamour.com/photos/56964cd993ef4b095210515b/16:9/w_1280,c_limit/fashion-2015-10-cute-baby-turtles-main.jpg)
