### PR TITLE
refactor: enable limited LLL subroutines

### DIFF
--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -195,6 +195,7 @@ PSEUDO_OPCODES: OpcodeMap = {
     "ASSERT": (None, 1, 0, 85),
     "ASSERT_UNREACHABLE": (None, 1, 0, 17),
     "PASS": (None, 0, 0, 0),
+    "DUMMY": (None, 0, 1, 0), # tell LLL that no, there really is a stack item here
     "BREAK": (None, 0, 0, 20),
     "CONTINUE": (None, 0, 0, 20),
     "SHA3_32": (None, 1, 1, 72),

--- a/vyper/lll/compile_lll.py
+++ b/vyper/lll/compile_lll.py
@@ -306,8 +306,7 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
         o = []
         for arg in code.args:
             o.extend(_compile_to_assembly(arg, withargs, existing_labels, break_dest, height))
-            # if arg.valency == 1 and arg != code.args[-1]:
-            #     o.append('POP')
+            height += arg.valency
         return o
     # Assure (if false, invalid opcode)
     elif code.value == "assert_unreachable":

--- a/vyper/lll/compile_lll.py
+++ b/vyper/lll/compile_lll.py
@@ -151,7 +151,7 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
             "POP",
         ]
     # Pass statements
-    elif code.value == "pass":
+    elif code.value in ("pass", "dummy"):
         return []
     # Code length
     elif code.value == "~codelen":

--- a/vyper/lll/compile_lll.py
+++ b/vyper/lll/compile_lll.py
@@ -489,8 +489,8 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
     # # jump to a symbol
     elif code.value == "goto":
         return ["_sym_" + str(code.args[0]), "JUMP"]
-    elif isinstance(code.value, str) and code.value.startswith("_sym_"):
-        return code.value
+    elif isinstance(code.value, str) and is_symbol(code.value):
+        return [code.value]
     # set a symbol as a location.
     elif code.value == "label":
         label_name = str(code.args[0])

--- a/vyper/old_codegen/arg_clamps.py
+++ b/vyper/old_codegen/arg_clamps.py
@@ -135,16 +135,17 @@ def int128_clamp(lll_node):
             "with",
             "_val",
             lll_node,
-            ["seq",
+            [
+                "seq",
                 # if _val is in bounds,
                 # _val >>> 127 == 0 for positive _val
                 # _val >>> 127 == -1 for negative _val
                 # -1 and 0 are the only numbers which are unchanged by sar,
                 # so sar'ing (_val>>>127) one more bit should leave it unchanged.
                 ["assert", ["eq", ["sar", 128, "_val"], ["sar", 127, "_val"]]],
-                "_val"
-            ]
-            ]
+                "_val",
+            ],
+        ]
     else:
         return [
             "clamp",

--- a/vyper/old_codegen/lll_node.py
+++ b/vyper/old_codegen/lll_node.py
@@ -139,7 +139,7 @@ class LLLnode:
                     raise CompilerPanic("With statement must have 3 arguments")
                 if len(self.args[0].args) or not isinstance(self.args[0].value, str):
                     raise CompilerPanic("First argument to with statement must be a variable")
-                if not self.args[1].valency:
+                if not self.args[1].valency and self.args[1].value != "pass":
                     raise CompilerPanic(
                         (
                             "Second argument to with statement (initial value) "


### PR DESCRIPTION
In https://github.com/vyperlang/vyper/pull/2416 I implemented some LLL features to make it easier to recover LLL variables at an arbitrary jumpdest. This PR pulls out that functionality so the OVM PR is a bit smaller.

### What I did
Enable a limited subroutine architecture in LLL, although the functionality is very basic (even more basic than parametrized labels) and mostly relies on convention. The convention is basically
```
(seq_unchecked
 _sym__exit ; push exit label onto the stack
 arg3 ; push label args reverse order because the stack is LIFO
 arg2
 arg1
 goto my_subroutine
 label _exit
 dummy ; my_subroutine returns a stack item, this marks it for LLL
)
...
(seq
 label my_subroutine
 (with arg1 pass (with arg2 pass (with arg3 pass) ... ))
 ...
 _return_value
 swap1
 jump ; _sym__exit
)
```

In the future this could be more formalized but this is all I needed at this stage.

### Description for the changelog
Refactor LLL subroutines

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
