### PR TITLE
Fix code-block directive in struct docs

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -416,7 +416,7 @@ Struct types can be used inside mappings and arrays. Structs can contain arrays 
 
 Struct members can be accessed via ``struct.argname``.
 
-.. code-block::
+.. code-block:: python
 
     # Defining a struct
     struct MyStruct:


### PR DESCRIPTION
The documentation is currently [missing a code example on how to define structs](https://vyper.readthedocs.io/en/stable/types.html#structs). That's because the `code-block` RST directive is missing a language argument. This PR fixes it.

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/56/0b/d4/560bd4906ba70342b6acd901756720a7.jpg)
