### PR TITLE
Fix/msg data extract32 usage

### DIFF
--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -33,7 +33,7 @@ Name                 Type             Value
 
 .. note::
 
-    ``msg.data`` requires the usage of :func:`slice <slice>` to explicitly extract a section of calldata. If the extracted section exceeds the bounds of calldata, this will throw. You can check the size of ``msg.data`` using :func:`len <len>`.   
+    ``msg.data`` requires the usage of :func:`slice <slice>` or :func:`extract32 <extract32>` to explicitly extract a section of calldata. If the extracted section exceeds the bounds of calldata, this will throw. You can check the size of ``msg.data`` using :func:`len <len>`.   
 
 .. _constants-self:
 

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -93,6 +93,29 @@ def foo(bar: uint256) -> uint256:
     assert contract.foo(42) == 36
 
 
+def test_extract32_msg_data(get_contract):
+    code = """
+@external
+def foo(bar: uint256) -> uint256:
+    return extract32(msg.data, 4, output_type=uint256)
+"""
+    contract = get_contract(code)
+
+    assert contract.foo(42) == 42
+
+
+def test_extract32_msg_data_address(get_contract, w3):
+    code = """
+@external
+def foo(bar: address) -> address:
+    return extract32(msg.data, 4, output_type=address)
+"""
+    contract = get_contract(code)
+    acct = w3.eth.accounts[0]
+
+    assert contract.foo(acct) == acct
+
+
 fail_list = [
     (
         """

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -266,7 +266,7 @@ class Slice:
             # if we are slicing msg.data, the length should
             # be a constant, since msg.data can be of dynamic length
             # we can't use it's length as the maxlen
-            assert isinstance(length.value, int) # sanity check
+            assert isinstance(length.value, int)  # sanity check
             sub_typ_maxlen = length.value
         else:
             sub_typ_maxlen = sub.typ.maxlen
@@ -820,6 +820,10 @@ def _storage_element_getter(index):
     return LLLnode.from_list(["sload", ["add", "_sub", ["add", 1, index]]], typ=BaseType("int128"),)
 
 
+def _calldata_element_getter(index):
+    return LLLnode.from_list(["calldataload", ["mul", 32, index]], typ=BaseType("int128"))
+
+
 class Extract32(_SimpleBuiltinFunction):
 
     _id = "extract32"
@@ -851,6 +855,9 @@ class Extract32(_SimpleBuiltinFunction):
         elif sub.location == "storage":
             lengetter = LLLnode.from_list(["sload", "_sub"], typ=BaseType("int128"))
             elementgetter = _storage_element_getter
+        elif sub.location == "calldata":
+            lengetter = LLLnode.from_list(["calldatasize"], typ="uint256")
+            elementgetter = _calldata_element_getter
         # TODO: unclosed if/elif clause.  Undefined behavior if `sub.location`
         # isn't one of `memory`/`storage`
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -858,8 +858,9 @@ class Extract32(_SimpleBuiltinFunction):
         elif sub.location == "calldata":
             lengetter = LLLnode.from_list(["calldatasize"], typ="uint256")
             elementgetter = _calldata_element_getter
-        # TODO: unclosed if/elif clause.  Undefined behavior if `sub.location`
-        # isn't one of `memory`/`storage`
+        else:
+            # sub.location should be one of calldata, memory, storage
+            raise CompilerPanic(f"Invalid element location {sub.location}")
 
         # Special case: index known to be a multiple of 32
         if isinstance(index.value, int) and not index.value % 32:

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -856,7 +856,7 @@ class Extract32(_SimpleBuiltinFunction):
             lengetter = LLLnode.from_list(["sload", "_sub"], typ=BaseType("int128"))
             elementgetter = _storage_element_getter
         elif sub.location == "calldata":
-            lengetter = LLLnode.from_list(["calldatasize"], typ="uint256")
+            lengetter = LLLnode.from_list(["add", "calldatasize", 32], typ="uint256")
             elementgetter = _calldata_element_getter
         else:
             # sub.location should be one of calldata, memory, storage

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -821,7 +821,7 @@ def _storage_element_getter(index):
 
 
 def _calldata_element_getter(index):
-    return LLLnode.from_list(["calldataload", ["mul", 32, index]], typ=BaseType("int128"))
+    return LLLnode.from_list(["calldataload", ["mul", 32, index]], typ=BaseType("uint256"))
 
 
 class Extract32(_SimpleBuiltinFunction):

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -186,7 +186,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
     def visit_Attribute(self, node):
         if node.get("value.id") == "msg" and node.attr == "data":
             parent = node.get_ancestor()
-            if parent.get("func.id") not in ("slice", "len"):
+            if parent.get("func.id") not in ("slice", "len", "extract32"):
                 raise SyntaxException(
                     "msg.data is only allowed inside of the slice or len functions",
                     node.node_source_code,


### PR DESCRIPTION
### What I did

Simply added a length getter and an element getter for calldata extract32 usage. 

Fixes: #2423 

### How I did it

Length is simple, we just use the `calldatasize` op, for getting  an element, we simply use `calldataload`

### How to verify it

I added two additional test cases, where I load  a uint256 and an address.
- Some other corner cases may be requested if needed

### Description for the changelog

- feat: allow extract32 usage with msg.data

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT16pd51vEk2T1Faf8zOuzHm7DCHp4Z_l5LHQ&usqp=CAU)
