### PR TITLE
Fixes struct example

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -424,7 +424,7 @@ Struct members can be accessed via ``struct.argname``.
         value2: decimal
 
     # Declaring a struct variable
-    exampleStruct: MyStruct = MyStruct({value1: 1, value2: 2})
+    exampleStruct: MyStruct = MyStruct({value1: 1, value2: 2.0})
 
     # Accessing a value
     exampleStruct.value1 = 1


### PR DESCRIPTION
### What I did

As mentioned #2422, the struct example in the docs is slightly wrong. Here's the fix.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2017/04/cute-baby-elephants-26-5900b6257ccea__700.jpg)
