### PR TITLE
Fix/disallow nonreentrant decorator on constructor

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -223,6 +223,7 @@ class ContractFunction(BaseTypeDefinition):
                             f"{kwargs['nonreentrant']}",
                             node,
                         )
+
                     if decorator.get("func.id") != "nonreentrant":
                         raise StructureException("Decorator is not callable", decorator)
                     if len(decorator.args) != 1 or not isinstance(decorator.args[0], vy_ast.Str):
@@ -230,6 +231,11 @@ class ContractFunction(BaseTypeDefinition):
                             "@nonreentrant name must be given as a single string literal",
                             decorator,
                         )
+
+                    if node.name == "__init__":
+                        msg = "Nonreentrant decorator disallowed on `__init__`"
+                        raise FunctionDeclarationException(msg, decorator)
+
                     kwargs["nonreentrant"] = decorator.args[0].value
 
                 elif isinstance(decorator, vy_ast.Name):

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -214,6 +214,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
 
     def visit_FunctionDef(self, node):
         func = ContractFunction.from_FunctionDef(node)
+
         try:
             self.namespace["self"].add_member(func.name, func)
             node._metadata["type"] = func


### PR DESCRIPTION
### What I did

Simple fix in module level validation. When visiting all the functions, just check if the constructor has the nonreentrant attribute set to a value other than `None`.

Fix: #1755 

### How I did it

Added a check in the module validation stage.

### How to verify it

- Check the test + the line change

### Description for the changelog

- fix: disallow nonreentrant decorator on constructor

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTz9RSTls4-XXz-3_Le0d4ZBSVI_TwCBwKTBw&usqp=CAU)
