### PR TITLE
feat: deterministic proxies with CREATE2 and EIP1167

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -94,7 +94,7 @@ Bitwise Operations
 Chain Interaction
 =================
 
-.. py:function:: create_forwarder_to(target: address, value: uint256 = 0) -> address
+.. py:function:: create_forwarder_to(target: address, value: uint256 = 0[, salt: bytes32]) -> address
 
     Deploys a small contract that duplicates the logic of the contract at ``target``, but has it's own state since every call to ``target`` is made using ``DELEGATECALL`` to ``target``. To the end user, this should be indistinguishable from an independantly deployed contract with the same code as ``target``.
 
@@ -104,6 +104,7 @@ Chain Interaction
 
     * ``target``: Address of the contract to duplicate
     * ``value``: The wei value to send to the new contract address (Optional, default 0)
+    * ``salt``: A ``bytes32`` value utilized by the ``CREATE2`` opcode (Optional, if supplied deterministic deployment is done via ``CREATE2``)
 
     Returns the address of the duplicated contract.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 import pytest
 from eth_tester import EthereumTester
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 
@@ -173,3 +174,15 @@ def search_for_sublist():
         return False
 
     return search_for_sublist
+
+
+@pytest.fixture
+def create2(keccak):
+    def _create2(_addr, _salt, _initcode):
+        prefix = HexBytes("0xff")
+        addr = HexBytes(_addr)
+        salt = HexBytes(_salt)
+        initcode = HexBytes(_initcode)
+        return keccak(prefix + addr + salt + keccak(initcode))[12:]
+
+    return _create2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,12 +177,12 @@ def search_for_sublist():
 
 
 @pytest.fixture
-def create2(keccak):
-    def _create2(_addr, _salt, _initcode):
+def create2_address_of(keccak):
+    def _f(_addr, _salt, _initcode):
         prefix = HexBytes("0xff")
         addr = HexBytes(_addr)
         salt = HexBytes(_salt)
         initcode = HexBytes(_initcode)
         return keccak(prefix + addr + salt + keccak(initcode))[12:]
 
-    return _create2
+    return _f

--- a/tests/parser/functions/test_create_with_code_of.py
+++ b/tests/parser/functions/test_create_with_code_of.py
@@ -109,7 +109,7 @@ main: address
 
 @external
 def test(_salt: bytes32) -> address:
-    self.main = create_forwarder_to(self, salt=_salt, is_deterministic=True)
+    self.main = create_forwarder_to(self, salt=_salt)
     return self.main
     """
 

--- a/tests/parser/functions/test_create_with_code_of.py
+++ b/tests/parser/functions/test_create_with_code_of.py
@@ -1,3 +1,13 @@
+from hexbytes import HexBytes
+
+
+def initcode(_addr):
+    addr = HexBytes(_addr)
+    pre = HexBytes("0x602D3D8160093D39F3363d3d373d3d3d363d73")
+    post = HexBytes("0x5af43d82803e903d91602b57fd5bf3")
+    return HexBytes(pre + (addr + HexBytes(0) * (20 - len(addr))) + post)
+
+
 def test_create_forwarder_to_create(get_contract):
     code = """
 main: address
@@ -91,3 +101,19 @@ def test2(a: uint256) -> Bytes[100]:
 
     assert receipt["status"] == 0
     assert receipt["gasUsed"] < GAS_SENT
+
+
+def test_create2_forwarder_to_create(get_contract, create2, keccak):
+    code = """
+main: address
+
+@external
+def test(_salt: bytes32) -> address:
+    self.main = create_forwarder_to(self, salt=_salt, is_deterministic=True)
+    return self.main
+    """
+
+    c = get_contract(code)
+
+    salt = keccak(b"vyper")
+    assert HexBytes(c.test(salt)) == create2(c.address, salt, initcode(c.address))

--- a/tests/parser/functions/test_create_with_code_of.py
+++ b/tests/parser/functions/test_create_with_code_of.py
@@ -103,7 +103,7 @@ def test2(a: uint256) -> Bytes[100]:
     assert receipt["gasUsed"] < GAS_SENT
 
 
-def test_create2_forwarder_to_create(get_contract, create2, keccak):
+def test_create2_forwarder_to_create(get_contract, create2_address_of, keccak):
     code = """
 main: address
 
@@ -116,4 +116,4 @@ def test(_salt: bytes32) -> address:
     c = get_contract(code)
 
     salt = keccak(b"vyper")
-    assert HexBytes(c.test(salt)) == create2(c.address, salt, initcode(c.address))
+    assert HexBytes(c.test(salt)) == create2_address_of(c.address, salt, initcode(c.address))

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -9,7 +9,7 @@ fail_list = [
 @external
 def foo():
     x: address = create_forwarder_to(0x1234567890123456789012345678901234567890, value=4, value=9)
-    """
+    """,
     """
 @external
 def foo():

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -10,6 +10,22 @@ fail_list = [
 def foo():
     x: address = create_forwarder_to(0x1234567890123456789012345678901234567890, value=4, value=9)
     """
+    """
+@external
+def foo():
+    x: address = create_forwarder_to(
+        0x1234567890123456789012345678901234567890, salt=keccak256(b"Vyper Rocks!")
+    )
+    """,
+    """
+@external
+def foo(_is_deterministic: bool):
+    x: address = create_forwarder_to(
+        0x1234567890123456789012345678901234567890,
+        salt=keccak256(b"Vyper Rocks!"),
+        is_deterministic=_is_deterministic
+    )
+    """,
 ]
 
 
@@ -37,6 +53,22 @@ def foo():
 @external
 def foo():
     x: address = create_forwarder_to(0x1234567890123456789012345678901234567890, value=9)
+    """,
+    """
+@external
+def foo():
+    x: address = create_forwarder_to(
+        0x1234567890123456789012345678901234567890,
+        salt=keccak256(b"Vyper Rocks!"),
+        is_deterministic=True
+    )
+    """,
+    """
+@external
+def foo(_salt: bytes32):
+    x: address = create_forwarder_to(
+        0x1234567890123456789012345678901234567890, salt=_salt, is_deterministic=True
+    )
     """,
 ]
 

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -12,18 +12,9 @@ def foo():
     """,
     """
 @external
-def foo():
+def foo(_salt: bytes32):
     x: address = create_forwarder_to(
-        0x1234567890123456789012345678901234567890, salt=keccak256(b"Vyper Rocks!")
-    )
-    """,
-    """
-@external
-def foo(_is_deterministic: bool):
-    x: address = create_forwarder_to(
-        0x1234567890123456789012345678901234567890,
-        salt=keccak256(b"Vyper Rocks!"),
-        is_deterministic=_is_deterministic
+        0x1234567890123456789012345678901234567890, salt=keccak256(b"Vyper Rocks!"), salt=_salt
     )
     """,
 ]
@@ -59,16 +50,13 @@ def foo():
 def foo():
     x: address = create_forwarder_to(
         0x1234567890123456789012345678901234567890,
-        salt=keccak256(b"Vyper Rocks!"),
-        is_deterministic=True
+        salt=keccak256(b"Vyper Rocks!")
     )
     """,
     """
 @external
 def foo(_salt: bytes32):
-    x: address = create_forwarder_to(
-        0x1234567890123456789012345678901234567890, salt=_salt, is_deterministic=True
-    )
+    x: address = create_forwarder_to(0x1234567890123456789012345678901234567890, salt=_salt)
     """,
 ]
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1553,7 +1553,7 @@ class CreateForwarderTo(_SimpleBuiltinFunction):
     def build_LLL(self, expr, args, kwargs, context):
         value = kwargs["value"]
         salt = kwargs["salt"]
-        is_deterministic = "salt" in [kwarg.arg for kwarg in expr.keywords]
+        should_use_create2 = "salt" in [kwarg.arg for kwarg in expr.keywords]
 
         if context.is_constant():
             raise StateAccessViolation(
@@ -1579,7 +1579,7 @@ class CreateForwarderTo(_SimpleBuiltinFunction):
         op = "create"
         op_args = [value, placeholder, preamble_length + 20 + len(forwarder_post_evm)]
 
-        if is_deterministic:
+        if should_use_create2:
             op = "create2"
             op_args.append(salt)
 


### PR DESCRIPTION
### What I did

Extended the `create_forwarder_to` built-in by adding functionality to deploy minimal proxies using the `CREATE2` opcode.

The following is now possible:

```python

@external
def foo(_target: address, _salt: bytes32) -> address:
    return create_forwarder_to(_target, salt=_salt)
```

The deployment address of the proxy can be determined with the following:

```python
keccak256(0xff ++ deployingAddr ++ salt ++ keccak256(bytecode))[12:]
```

where `bytecode` is equal to:

```python
pre = "0x602D3D8160093D39F3363d3d373d3d3d363d73"
post = "0x5af43d82803e903d91602b57fd5bf3"
bytecode = pre ++ target ++ post
```

### How I did it

Modified the built-in to accept and handle new keyword `salt`.

### How to verify it

Check the new tests added. A set of tests verifying syntax, and a test verifying runtime execution.

### Description for the changelog

Added support for deterministic deployment of minimal proxies 

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ebayimg.com/images/g/3WUAAOSwfR5fvCMG/s-l300.jpg)
