### PR TITLE
Drop python3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,29 +55,6 @@ jobs:
     - name: Run Tox
       run: TOXENV=mypy tox -r
 
-  py36-core:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.6
-
-    - name: Install Tox
-      run: pip install tox
-
-    - name: Run Tox
-      run: TOXENV=py36-core tox -r
-
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-
   py37-core:
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-core
+    py{37,38,39}-core
     lint
     mypy
     docs
@@ -10,7 +10,6 @@ usedevelop = True
 commands =
     core: pytest -m "not fuzzing" --showlocals {posargs:tests/}
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -5,9 +5,9 @@ import pkg_resources as _pkg_resources
 
 from vyper.compiler import compile_code, compile_codes  # noqa: F401
 
-if (_sys.version_info.major, _sys.version_info.minor) < (3, 6):
+if (_sys.version_info.major, _sys.version_info.minor) < (3, 7):
     # Can't be tested, as our test harness is using python3.6.
-    raise Exception("Requires python3.6+")  # pragma: no cover
+    raise Exception("Requires python3.7+")  # pragma: no cover
 
 
 _version_file = _Path(__file__).parent.joinpath("vyper_git_version.txt")


### PR DESCRIPTION
Major operating systems (Ubuntu, MacOS) have already moved on, plus it
doesn't have dataclasses.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
