### PR TITLE
Reduce stack operations in make_setter

### DIFF
--- a/vyper/old_codegen/abi.py
+++ b/vyper/old_codegen/abi.py
@@ -498,6 +498,7 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns_len=False):
     return LLLnode.from_list(lll_ret, pos=pos, annotation=f"abi_encode {lll_node.typ}")
 
 
+# CMC 20211002 this is probably dead code because make_setter does this.
 # lll_node is the destination LLL item, src is the input buffer.
 # recursively copy the buffer items into lll_node, based on its type.
 # src: pointer to beginning of buffer

--- a/vyper/old_codegen/abi.py
+++ b/vyper/old_codegen/abi.py
@@ -414,7 +414,7 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns_len=False):
     if not parent_abi_t.is_dynamic():
         # cast the output buffer to something that make_setter accepts
         dst = LLLnode(dst, typ=lll_node.typ, location="memory")
-        lll_ret = ["seq", make_setter(dst, lll_node, "memory", pos)]
+        lll_ret = ["seq", make_setter(dst, lll_node, pos)]
         if returns_len:
             lll_ret.append(parent_abi_t.embedded_static_size())
         return LLLnode.from_list(lll_ret, pos=pos, annotation=f"abi_encode {lll_node.typ}")
@@ -457,11 +457,11 @@ def abi_encode(dst, lll_node, pos=None, bufsz=None, returns_len=False):
         elif isinstance(o.typ, BaseType):
             d = LLLnode(dst_loc, typ=o.typ, location="memory")
             # call into make_setter routine
-            lll_ret.append(make_setter(d, o, location=d.location, pos=pos))
+            lll_ret.append(make_setter(d, o, pos=pos))
         elif isinstance(o.typ, ByteArrayLike):
             d = LLLnode.from_list(dst_loc, typ=o.typ, location="memory")
-            # call into make_setter routinme
-            lll_ret.append(["seq", make_setter(d, o, location=d.location, pos=pos), zero_pad(d)])
+            # call into make_setter routine
+            lll_ret.append(["seq", make_setter(d, o, pos=pos), zero_pad(d)])
         else:
             raise CompilerPanic(f"unreachable type: {o.typ}")
 
@@ -531,7 +531,7 @@ def abi_decode(lll_node, src, clamp=True, pos=None):
             else:
                 pass
 
-            lll_ret.append(make_setter(o, src_loc, location=o.location, pos=pos))
+            lll_ret.append(make_setter(o, src_loc, pos=pos))
 
         if i + 1 == len(os):
             pass  # optimize out the last pointer increment

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -715,7 +715,7 @@ class Expr:
                 typ=ListType(right.typ.subtype, right.typ.count),
                 location="memory",
             )
-            setter = make_setter(tmp_list, right, "memory", pos=getpos(self.expr))
+            setter = make_setter(tmp_list, right, pos=getpos(self.expr))
             load_i_from_list = [
                 "mload",
                 ["add", tmp_list, ["mul", 32, ["mload", MemoryPositions.FREE_LOOP_INDEX]]],

--- a/vyper/old_codegen/parser_utils.py
+++ b/vyper/old_codegen/parser_utils.py
@@ -434,32 +434,8 @@ def get_element_ptr(parent, key, pos, array_bounds_check=True):
             )
 
     elif isinstance(typ, MappingType):
-        sub = None
-        if isinstance(key.typ, ByteArrayLike):
-            # CMC 20210916 pretty sure this is dead code. TODO double check
-            if isinstance(typ.keytype, ByteArrayLike) and (typ.keytype.maxlen >= key.typ.maxlen):
-                subtype = typ.valuetype
-                if len(key.args[0].args) >= 3:  # handle bytes literal.
-                    sub = LLLnode.from_list(
-                        [
-                            "seq",
-                            key,
-                            [
-                                "sha3",
-                                ["add", key.args[0].args[-1], 32],
-                                ["mload", key.args[0].args[-1]],
-                            ],
-                        ]
-                    )
-                else:
-                    value = key.args[0].value
-                    if value == "add":
-                        # special case, key is a bytes array within a tuple/struct
-                        value = key.args[0]
-                    sub = LLLnode.from_list(["sha3", ["add", value, 32], key])
-        else:
-            subtype = typ.valuetype
-            sub = unwrap_location(key)
+        subtype = typ.valuetype
+        sub = unwrap_location(key)
 
         if sub is not None and location == "storage":
             return LLLnode.from_list(["sha3_64", parent, sub], typ=subtype, location="storage")

--- a/vyper/old_codegen/return_.py
+++ b/vyper/old_codegen/return_.py
@@ -52,7 +52,7 @@ def make_return_stmt(lll_val: LLLnode, stmt: Any, context: Context) -> Optional[
             "with",
             dst,
             "pass",  # return_buffer is passed on the stack by caller
-            make_setter(dst, lll_val, location="memory", pos=_pos),
+            make_setter(dst, lll_val, pos=_pos),
         ]
 
         return finalize(fill_return_buffer)

--- a/vyper/old_codegen/self_call.py
+++ b/vyper/old_codegen/self_call.py
@@ -80,13 +80,13 @@ def lll_for_self_call(stmt_expr, context):
         )
         copy_args.append(
             # --> args evaluate here <--
-            make_setter(tmp_args_buf, args_as_tuple, "memory", pos)
+            make_setter(tmp_args_buf, args_as_tuple, pos)
         )
 
-        copy_args.append(make_setter(args_dst, tmp_args_buf, "memory", pos))
+        copy_args.append(make_setter(args_dst, tmp_args_buf, pos))
 
     else:
-        copy_args = make_setter(args_dst, args_as_tuple, "memory", pos)
+        copy_args = make_setter(args_dst, args_as_tuple, pos)
 
     call_sequence = [
         "seq",

--- a/vyper/old_codegen/stmt.py
+++ b/vyper/old_codegen/stmt.py
@@ -77,7 +77,7 @@ class Stmt:
 
         variable_loc = LLLnode.from_list(pos, typ=typ, location="memory", pos=getpos(self.stmt),)
 
-        lll_node = make_setter(variable_loc, sub, "memory", pos=getpos(self.stmt))
+        lll_node = make_setter(variable_loc, sub, pos=getpos(self.stmt))
         lll_node.annotation = self.stmt.get("node_source_code")
 
         return lll_node
@@ -87,7 +87,7 @@ class Stmt:
         sub = Expr(self.stmt.value, self.context).lll_node
         target = self._get_target(self.stmt.target)
 
-        lll_node = make_setter(target, sub, target.location, pos=getpos(self.stmt))
+        lll_node = make_setter(target, sub, pos=getpos(self.stmt))
         lll_node.pos = getpos(self.stmt)
         lll_node.annotation = self.stmt.get("node_source_code")
         return lll_node
@@ -315,7 +315,7 @@ class Stmt:
                 typ=ListType(subtype, count),
                 location="memory",
             )
-            setter = make_setter(tmp_list, iter_list_node, "memory", pos=getpos(self.stmt))
+            setter = make_setter(tmp_list, iter_list_node, pos=getpos(self.stmt))
             body = [
                 "seq",
                 ["mstore", value_pos, ["mload", ["add", tmp_list, ["mul", ["mload", i_pos], 32]]]],

--- a/vyper/old_codegen/types/check.py
+++ b/vyper/old_codegen/types/check.py
@@ -7,5 +7,5 @@ from vyper.old_codegen.parser_utils import make_setter
 # Check assignment from rhs to lhs.
 # For now use make_setter for its typechecking side effects
 def check_assign(lhs, rhs, pos):
-    make_setter(lhs, rhs, location="memory", pos=pos)
+    make_setter(lhs, rhs, pos=pos)
     # TODO Refactor into an actual type-checking function


### PR DESCRIPTION
### What I did
Optimize and simplify make_setter, cleaning out some inefficient bytecode that was introduced in https://github.com/vyperlang/vyper/pull/2447

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/135742272-96757104-d5fe-4f80-b72f-0cd6d8df7041.png)
