### PR TITLE
refactor: abstract `ensure_in_memory` pattern

### DIFF
--- a/tests/parser/features/test_immutable.py
+++ b/tests/parser/features/test_immutable.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.parametrize(
     "typ,value",
     [

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -18,6 +18,18 @@ def foo() -> Bytes[7]:
     assert c.foo() == b"moose"
 
 
+def test_raw_call_non_memory(get_contract):
+    source_code = """
+_foo: Bytes[5]
+@external
+def foo() -> Bytes[5]:
+    self._foo = b"moose"
+    return raw_call(0x0000000000000000000000000000000000000004, self._foo, max_outsize=5)
+    """
+    c = get_contract(source_code)
+    assert c.foo() == b"moose"
+
+
 def test_returndatasize_exceeds_max_outsize(get_contract):
     source_code = """
 @external

--- a/tests/parser/syntax/test_immutables.py
+++ b/tests/parser/syntax/test_immutables.py
@@ -48,8 +48,7 @@ VALUE: immutable(uint256)
 def __init__(_value: uint256):
     VALUE = _value * 3
     VALUE = VALUE + 1
-    """
-
+    """,
 ]
 
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1263,38 +1263,19 @@ class RawLog:
                 typ=None,
                 pos=getpos(expr),
             )
-        if args[1].location == "memory":
-            return LLLnode.from_list(
-                [
-                    "with",
-                    "_arr",
-                    args[1],
-                    ["log" + str(len(topics)), ["add", "_arr", 32], ["mload", "_arr"]] + topics,
-                ],
-                typ=None,
-                pos=getpos(expr),
-            )
-        placeholder = context.new_internal_variable(args[1].typ)
-        placeholder_node = LLLnode.from_list(placeholder, typ=args[1].typ, location="memory")
-        copier = make_byte_array_copier(
-            placeholder_node,
-            LLLnode.from_list("_sub", typ=args[1].typ, location=args[1].location),
-            pos=getpos(expr),
-        )
+
+        input_buf = ensure_in_memory(args[1])
+
         return LLLnode.from_list(
             [
                 "with",
                 "_sub",
-                args[1],
+                input_buf
                 [
-                    "seq",
-                    copier,
-                    [
-                        "log" + str(len(topics)),
-                        ["add", placeholder_node, 32],
-                        ["mload", placeholder_node],
-                    ]
-                    + topics,
+                    "log" + str(len(topics)),
+                    ["add", "_sub", 32],
+                    ["mload", "_sub"],
+                    *topics,
                 ],
             ],
             typ=None,

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1257,14 +1257,14 @@ class RawLog:
             return LLLnode.from_list(
                 [
                     "seq",
+                    # TODO use make_setter
                     ["mstore", placeholder, unwrap_location(args[1])],
                     ["log" + str(len(topics)), placeholder, 32] + topics,
                 ],
-                typ=None,
                 pos=getpos(expr),
             )
 
-        input_buf = ensure_in_memory(args[1])
+        input_buf = ensure_in_memory(args[1], context, pos=getpos(expr))
 
         return LLLnode.from_list(
             [

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -36,7 +36,6 @@ from vyper.old_codegen.parser_utils import (
     getpos,
     lll_tuple_from_args,
     load_op,
-    make_byte_array_copier,
     make_byte_slice_copier,
     unwrap_location,
 )
@@ -638,6 +637,7 @@ class Sha256(_SimpleBuiltinFunction):
                 "_sub",
                 sub,
                 [
+                    "seq",
                     _make_sha256_call(
                         # TODO use add_ofst if sub is statically known
                         inp_start=["add", "_sub", 32],
@@ -1270,15 +1270,9 @@ class RawLog:
             [
                 "with",
                 "_sub",
-                input_buf
-                [
-                    "log" + str(len(topics)),
-                    ["add", "_sub", 32],
-                    ["mload", "_sub"],
-                    *topics,
-                ],
+                input_buf,
+                ["log" + str(len(topics)), ["add", "_sub", 32], ["mload", "_sub"], *topics],
             ],
-            typ=None,
             pos=getpos(expr),
         )
 

--- a/vyper/old_codegen/events.py
+++ b/vyper/old_codegen/events.py
@@ -19,7 +19,7 @@ def _encode_log_topics(expr, event_id, arg_nodes, context):
             value = unwrap_location(arg)
 
         elif isinstance(arg.typ, ByteArrayLike):
-            value = keccak256_helper(expr, [arg], kwargs=None, context=context)
+            value = keccak256_helper(expr, arg, context=context)
         else:
             # TODO block at higher level
             raise TypeMismatch("Event indexes may only be value types", expr)

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -493,9 +493,9 @@ class Expr:
             # TODO sanity check we are in a self.my_map[i] situation
             index = Expr.parse_value_expr(self.expr.slice.value, self.context)
             if isinstance(index.typ, ByteArrayLike):
-                # special case,
                 # we have to hash the key to get a storage location
-                index = keccak256_helper(self.expr.slice.value, index.args, None, self.context)
+                assert len(index.args) == 1
+                index = keccak256_helper(self.expr.slice.value, index.args[0], self.context)
 
         elif isinstance(sub.typ, ListType):
             index = Expr.parse_value_expr(self.expr.slice.value, self.context)
@@ -905,8 +905,8 @@ class Expr:
             left_over_32 = left.typ.maxlen > 32
             right_over_32 = right.typ.maxlen > 32
             if length_mismatch or left_over_32 or right_over_32:
-                left_keccak = keccak256_helper(self.expr, [left], None, self.context)
-                right_keccak = keccak256_helper(self.expr, [right], None, self.context)
+                left_keccak = keccak256_helper(self.expr, left, self.context)
+                right_keccak = keccak256_helper(self.expr, right, self.context)
 
                 if op == "eq" or op == "ne":
                     return LLLnode.from_list(

--- a/vyper/old_codegen/keccak256_helper.py
+++ b/vyper/old_codegen/keccak256_helper.py
@@ -2,7 +2,7 @@ from math import ceil
 
 from vyper.exceptions import CompilerPanic
 from vyper.old_codegen.lll_node import LLLnode
-from vyper.old_codegen.parser_utils import getpos, ensure_in_memory
+from vyper.old_codegen.parser_utils import ensure_in_memory, getpos
 from vyper.old_codegen.types import BaseType, ByteArrayLike, is_base_type
 from vyper.utils import MemoryPositions, bytes_to_int, keccak256
 
@@ -21,13 +21,8 @@ def _gas_bound(num_words):
     return SHA3_BASE + num_words * SHA3_PER_WORD
 
 
-# TODO kwargs is dead argument
-def keccak256_helper(expr, lll_args, kwargs, context):
-    if len(lll_args) != 1:
-        # NOTE this may be checked at a higher level, but just be safe
-        raise CompilerPanic("keccak256 must be called with exactly 1 argument", expr)
-
-    sub = lll_args[0]
+def keccak256_helper(expr, lll_arg, context):
+    sub = lll_args  # TODO get rid of useless variable
     _check_byteslike(sub.typ, expr)
 
     # Can hash literals
@@ -48,8 +43,6 @@ def keccak256_helper(expr, lll_args, kwargs, context):
             pos=getpos(expr),
             add_gas_estimate=_gas_bound(1),
         )
-
-    # type is ByteArrayLike.
 
     sub = ensure_in_memory(sub, context, pos=getpos(expr))
 

--- a/vyper/old_codegen/keccak256_helper.py
+++ b/vyper/old_codegen/keccak256_helper.py
@@ -2,7 +2,7 @@ from math import ceil
 
 from vyper.exceptions import CompilerPanic
 from vyper.old_codegen.lll_node import LLLnode
-from vyper.old_codegen.parser_utils import getpos, make_byte_array_copier
+from vyper.old_codegen.parser_utils import getpos, ensure_in_memory
 from vyper.old_codegen.types import BaseType, ByteArrayLike, is_base_type
 from vyper.utils import MemoryPositions, bytes_to_int, keccak256
 
@@ -51,40 +51,14 @@ def keccak256_helper(expr, lll_args, kwargs, context):
 
     # type is ByteArrayLike.
 
-    # Otherwise, copy the data to an in-memory buffer
-    # TODO refactor the following logic into a function, ensure_in_memory,
-    # which elides the byte array copy if the bytes are already in memory.
-    if sub.location == "memory":
-        # If we are hashing a value in memory, no need to copy it, just hash in-place
-        return LLLnode.from_list(
-            [
-                "with",
-                "_buf",
-                sub,
-                ["with", "_len", ["mload", "_buf"], ["sha3", ["add", "_buf", 32], "_len"]],
-            ],
-            typ=BaseType("bytes32"),
-            pos=getpos(expr),
-            add_gas_estimate=_gas_bound(ceil(sub.typ.maxlen / 32)),
-        )
+    sub = ensure_in_memory(sub, context, pos=getpos(expr))
 
-    placeholder = context.new_internal_variable(sub.typ)
-    placeholder_node = LLLnode.from_list(placeholder, typ=sub.typ, location="memory")
-    copier = make_byte_array_copier(
-        placeholder_node,
-        LLLnode.from_list("_src", typ=sub.typ, location=sub.location),
-    )
     return LLLnode.from_list(
         [
             "with",
-            "_src",
+            "_buf",
             sub,
-            [
-                "with",
-                "_dst",
-                placeholder_node,
-                ["seq", copier, ["sha3", ["add", "_dst", 32], ["mload", "_dst"]]],
-            ],
+            ["sha3", ["add", "_buf", 32], ["mload", "_buf"]],
         ],
         typ=BaseType("bytes32"),
         pos=getpos(expr),

--- a/vyper/old_codegen/keccak256_helper.py
+++ b/vyper/old_codegen/keccak256_helper.py
@@ -22,10 +22,11 @@ def _gas_bound(num_words):
 
 
 def keccak256_helper(expr, lll_arg, context):
-    sub = lll_args  # TODO get rid of useless variable
+    sub = lll_arg  # TODO get rid of useless variable
     _check_byteslike(sub.typ, expr)
 
     # Can hash literals
+    # TODO this is dead code.
     if isinstance(sub, bytes):
         return LLLnode.from_list(
             bytes_to_int(keccak256(sub)), typ=BaseType("bytes32"), pos=getpos(expr)

--- a/vyper/old_codegen/parser_utils.py
+++ b/vyper/old_codegen/parser_utils.py
@@ -624,9 +624,7 @@ def ensure_in_memory(lll_var, context, pos=None):
         return lll_var
 
     typ = lll_var.typ
-    buf = LLLnode.from_list(
-        context.new_internal_variable(typ), typ=typ, location="memory"
-    )
+    buf = LLLnode.from_list(context.new_internal_variable(typ), typ=typ, location="memory")
     do_copy = make_setter(buf, lll_var, pos=pos)
 
     return LLLnode.from_list(["seq", do_copy, buf], typ=typ, location="memory")

--- a/vyper/old_codegen/stmt.py
+++ b/vyper/old_codegen/stmt.py
@@ -158,11 +158,13 @@ class Stmt:
             self.context.constancy = tmp
 
         # TODO this is probably useful in parser_utils
+        # compare with eval_seq.
         def _get_last(lll):
             if len(lll.args) == 0:
                 return lll.value
             return _get_last(lll.args[-1])
 
+        # TODO maybe use ensure_in_memory
         if msg_lll.location != "memory":
             buf = self.context.new_internal_variable(msg_lll.typ)
             instantiate_msg = make_byte_array_copier(buf, msg_lll)


### PR DESCRIPTION
There is a common pattern in the codebase which checks if a bytestring is in memory and copies if not. This abstracts the pattern into a function, and additionally applies it to the `raw_call` function for about 20 bytes savings per usage of raw_call (when the input is already in memory).

### How to verify it
See code is cleaner, new tests pass

### Description for the changelog
Optimize raw_call

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/d/d3/Fischotter%2C_Lutra_Lutra.JPG)
