### PR TITLE
feat: add gaslimit and basefee env variables

### DIFF
--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -126,6 +126,7 @@ struct X:
 def add_record():
     a: X = X({x: block.timestamp})
     a.x = block.gaslimit
+    a.x = block.basefee
     a.x = 5
     """,
     """

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -87,6 +87,7 @@ OPCODES: OpcodeMap = {
     "GASLIMIT": (0x45, 0, 1, 2),
     "CHAINID": (0x46, 0, 1, (None, None, 2)),
     "SELFBALANCE": (0x47, 0, 1, (None, None, 5)),
+    "BASEFEE": (0x48, 0, 1, (None, None, None, 2)),
     "POP": (0x50, 1, 0, 2),
     "MLOAD": (0x51, 1, 1, 3),
     "MSTORE": (0x52, 2, 0, 3),

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -420,6 +420,8 @@ class Expr:
                 return LLLnode.from_list(["number"], typ="uint256", pos=getpos(self.expr))
             elif key == "block.gaslimit":
                 return LLLnode.from_list(["gaslimit"], typ="uint256", pos=getpos(self.expr))
+            elif key == "block.basefee":
+                return LLLnode.from_list(["basefee"], typ="uint256", pos=getpos(self.expr))
             elif key == "block.prevhash":
                 return LLLnode.from_list(
                     ["blockhash", ["sub", "number", 1]],

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -13,6 +13,7 @@ CONSTANT_ENVIRONMENT_VARS: Dict[str, Dict[str, type]] = {
         "difficulty": Uint256Definition,
         "number": Uint256Definition,
         "gaslimit": Uint256Definition,
+        "basefee": Uint256Definition,
         "prevhash": Bytes32Definition,
         "timestamp": Uint256Definition,
     },


### PR DESCRIPTION
### What I did
Add block.gaslimit and block.basefee (fixes https://github.com/vyperlang/vyper/issues/2415)

### How I did it

### How to verify it

### Description for the changelog
Add `block.gaslimit` and `block.basefee` environment variable

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
