### PR TITLE
feat: call internal functions from constructor

### DIFF
--- a/examples/stock/company.vy
+++ b/examples/stock/company.vy
@@ -39,12 +39,6 @@ def __init__(_company: address, _total_shares: uint256, initial_price: uint256):
     # The company holds all the shares at first, but can sell them all.
     self.holdings[self.company] = _total_shares
 
-# Find out how much stock the company holds
-@view
-@internal
-def _stockAvailable() -> uint256:
-    return self.holdings[self.company]
-
 # Public function to allow external access to _stockAvailable
 @view
 @external
@@ -68,12 +62,6 @@ def buyStock():
 
     # Log the buy event.
     log Buy(msg.sender, buy_order)
-
-# Find out how much stock any address (that's owned by someone) has.
-@view
-@internal
-def _getHolding(_stockholder: address) -> uint256:
-    return self.holdings[_stockholder]
 
 # Public function to allow external access to _getHolding
 @view
@@ -135,12 +123,6 @@ def payBill(vendor: address, amount: uint256):
     # Log the payment event.
     log Pay(vendor, amount)
 
-# Return the amount in wei that a company has raised in stock offerings.
-@view
-@internal
-def _debt() -> uint256:
-    return (self.totalShares - self._stockAvailable()) * self.price
-
 # Public function to allow external access to _debt
 @view
 @external
@@ -154,3 +136,21 @@ def debt() -> uint256:
 @external
 def worth() -> uint256:
     return self.balance - self._debt()
+
+# Return the amount in wei that a company has raised in stock offerings.
+@view
+@internal
+def _debt() -> uint256:
+    return (self.totalShares - self._stockAvailable()) * self.price
+
+# Find out how much stock the company holds
+@view
+@internal
+def _stockAvailable() -> uint256:
+    return self.holdings[self.company]
+
+# Find out how much stock any address (that's owned by someone) has.
+@view
+@internal
+def _getHolding(_stockholder: address) -> uint256:
+    return self.holdings[_stockholder]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,11 +114,11 @@ def get_contract_module(no_optimize):
 
 
 def get_compiler_gas_estimate(code, func):
-    ir_runtime = compiler.phases.CompilerData(code).ir_runtime
+    sigs = compiler.phases.CompilerData(code).function_signatures
     if func:
-        return compiler.utils.build_gas_estimates(ir_runtime)[func] + 22000
+        return compiler.utils.build_gas_estimates(sigs)[func] + 22000
     else:
-        return sum(compiler.utils.build_gas_estimates(ir_runtime).values()) + 22000
+        return sum(compiler.utils.build_gas_estimates(sigs).values()) + 22000
 
 
 def check_gas_on_chain(w3, tester, code, func=None, res=None):

--- a/tests/parser/features/test_immutable.py
+++ b/tests/parser/features/test_immutable.py
@@ -212,3 +212,30 @@ def get_idx_two() -> int128:
     c = get_contract(code, *values)
     assert c.get_my_list() == expected_values
     assert c.get_idx_two() == expected_values[2][2][2]
+
+
+@pytest.mark.parametrize("n", range(5))
+def test_internal_function_with_immutables(get_contract, n):
+    code = """
+@internal
+def foo() -> uint256:
+    self.counter += 1
+    return self.counter
+
+counter: uint256
+VALUE: immutable(uint256)
+
+@external
+def __init__(x: uint256):
+    self.counter = x
+    self.foo()
+    VALUE = self.foo()
+    self.foo()
+
+@external
+def get_immutable() -> uint256:
+    return VALUE
+    """
+
+    c = get_contract(code, n)
+    assert c.get_immutable() == n + 2

--- a/tests/parser/features/test_init.py
+++ b/tests/parser/features/test_init.py
@@ -21,3 +21,34 @@ def __init__(a: uint256):
     assert "CALLDATALOAD" in opcodes
     assert "CALLDATACOPY" not in opcodes[:ir_return_idx]
     assert "CALLDATALOAD" not in opcodes[:ir_return_idx]
+
+
+def test_init_calls_internal(get_contract, assert_compile_failed, assert_tx_failed):
+    code = """
+foo: public(uint8)
+@internal
+def bar(x: uint256) -> uint8:
+    return convert(x, uint8) * 7
+@external
+def __init__(a: uint256):
+    self.foo = self.bar(a)
+
+@external
+def baz() -> uint8:
+    return self.bar(convert(self.foo, uint256))
+    """
+    n = 5
+    c = get_contract(code, n)
+    assert c.foo() == n * 7
+    assert c.baz() == 245  # 5*7*7
+
+    n = 6
+    c = get_contract(code, n)
+    assert c.foo() == n * 7
+    assert_tx_failed(lambda: c.baz())
+
+    n = 255
+    assert_compile_failed(lambda: get_contract(code, n))
+
+    n = 256
+    assert_compile_failed(lambda: get_contract(code, n))

--- a/vyper/ast/signatures/__init__.py
+++ b/vyper/ast/signatures/__init__.py
@@ -1,1 +1,1 @@
-from .function_signature import FunctionSignature, VariableRecord
+from .function_signature import FrameInfo, FunctionSignature, VariableRecord

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -94,7 +94,7 @@ class FunctionSignature:
         self.return_type = return_type
         self.mutability = mutability
         self.internal = internal
-        self.gas = None
+        self.gas_estimate = None
         self.nonreentrant_key = nonreentrant_key
         self.func_ast_code = func_ast_code
         self.is_from_json = is_from_json

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -7,7 +7,7 @@ from vyper.address_space import MEMORY
 from vyper.codegen.ir_node import Encoding
 from vyper.codegen.types import NodeType, parse_type
 from vyper.exceptions import StructureException
-from vyper.utils import cached_property, mkalphanum
+from vyper.utils import MemoryPositions, cached_property, mkalphanum
 
 # dict from function names to signatures
 FunctionSignatures = Dict[str, "FunctionSignature"]
@@ -66,6 +66,16 @@ class FunctionArg:
     ast_source: vy_ast.VyperNode
 
 
+@dataclass
+class FrameInfo:
+    frame_start: int
+    frame_size: int
+
+    @property
+    def mem_used(self):
+        return self.frame_size + MemoryPositions.RESERVED_MEMORY
+
+
 # Function signature object
 class FunctionSignature:
     def __init__(
@@ -91,11 +101,17 @@ class FunctionSignature:
 
         self.set_default_args()
 
+        # frame info is metadata that will be generated during codegen.
+        self.frame_info: Optional[FrameInfo] = None
+
     def __str__(self):
         input_name = "def " + self.name + "(" + ",".join([str(arg.typ) for arg in self.args]) + ")"
         if self.return_type:
             return input_name + " -> " + str(self.return_type) + ":"
         return input_name + ":"
+
+    def set_frame_info(self, frame_info):
+        self.frame_info = frame_info
 
     @cached_property
     def _ir_identifier(self) -> str:
@@ -228,3 +244,7 @@ class FunctionSignature:
     @property
     def is_init_func(self):
         return self.name == "__init__"
+
+    @property
+    def is_regular_function(self):
+        return not self.is_default_func and not self.is_init_func

--- a/vyper/ast/signatures/interface.py
+++ b/vyper/ast/signatures/interface.py
@@ -130,7 +130,7 @@ def extract_sigs(sig_code, interface_name=None):
             )
             or (isinstance(i, vy_ast.AnnAssign) and i.target.id != "implements")
         ]
-        global_ctx = GlobalContext.get_global_context(interface_ast, should_topsort=False)
+        global_ctx = GlobalContext.get_global_context(interface_ast)
         return _get_external_signatures(global_ctx)
     elif sig_code["type"] == "json":
         return mk_full_signature_from_json(sig_code["code"])

--- a/vyper/ast/signatures/interface.py
+++ b/vyper/ast/signatures/interface.py
@@ -98,9 +98,9 @@ def mk_full_signature_from_json(abi):
 def _get_external_signatures(global_ctx, sig_formatter=lambda x: x):
     ret = []
 
-    for code in global_ctx._defs:
+    for func_ast in global_ctx._function_defs:
         sig = FunctionSignature.from_definition(
-            code,
+            func_ast,
             sigs=global_ctx._contracts,
             custom_structs=global_ctx._structs,
         )
@@ -130,7 +130,7 @@ def extract_sigs(sig_code, interface_name=None):
             )
             or (isinstance(i, vy_ast.AnnAssign) and i.target.id != "implements")
         ]
-        global_ctx = GlobalContext.get_global_context(interface_ast)
+        global_ctx = GlobalContext.get_global_context(interface_ast, should_topsort=False)
         return _get_external_signatures(global_ctx)
     elif sig_code["type"] == "json":
         return mk_full_signature_from_json(sig_code["code"])

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -5,7 +5,7 @@ from typing import Optional
 from vyper.ast import VyperNode
 from vyper.ast.signatures.function_signature import VariableRecord
 from vyper.codegen.types import NodeType
-from vyper.exceptions import CompilerPanic, FunctionDeclarationException
+from vyper.exceptions import CompilerPanic
 
 
 class Constancy(enum.Enum):

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -82,15 +82,6 @@ class Context:
     def is_constant(self):
         return self.constancy is Constancy.Constant or self.in_assertion or self.in_range_expr
 
-    def register_callee(self, frame_size):
-        self._callee_frame_sizes.append(frame_size)
-
-    @property
-    def max_callee_frame_size(self):
-        if len(self._callee_frame_sizes) == 0:
-            return 0
-        return max(self._callee_frame_sizes)
-
     #
     # Context Managers
     # - Context managers are used to ensure proper wrapping of scopes and context states.

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -22,11 +22,7 @@ class Context:
         vars_=None,
         sigs=None,
         forvars=None,
-        return_type=None,
         constancy=Constancy.Mutable,
-        is_internal=False,
-        is_payable=False,
-        # method_id="",
         sig=None,
     ):
         # In-memory variables, in the form (name, memory location, type)
@@ -41,9 +37,6 @@ class Context:
         # Variables defined in for loops, e.g. for i in range(6): ...
         self.forvars = forvars or {}
 
-        # Return type of the function
-        self.return_type = return_type
-
         # Is the function constant?
         self.constancy = constancy
 
@@ -53,13 +46,8 @@ class Context:
         # Whether we are currently parsing a range expression
         self.in_range_expr = False
 
-        # Is the function payable?
-        self.is_payable = is_payable
-
         # List of custom structs that have been defined.
         self.structs = global_ctx._structs
-
-        self.is_internal = is_internal
 
         # store global context
         self.global_ctx = global_ctx
@@ -73,14 +61,25 @@ class Context:
         # Not intended to be accessed directly
         self.memory_allocator = memory_allocator
 
-        self._callee_frame_sizes = []
-
-        # Intermented values, used for internal IDs
+        # Incremented values, used for internal IDs
         self._internal_var_iter = 0
         self._scope_id_iter = 0
 
     def is_constant(self):
         return self.constancy is Constancy.Constant or self.in_assertion or self.in_range_expr
+
+    # convenience propreties
+    @property
+    def is_payable(self):
+        return self.sig.mutability == "payable"
+
+    @property
+    def is_internal(self):
+        return self.sig.internal
+
+    @property
+    def return_type(self):
+        return self.sig.return_type
 
     #
     # Context Managers

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -238,19 +238,15 @@ class Context:
         the kwargs which need to be filled in by the compiler
         """
 
+        sig = self.sigs["self"].get(method_name, None)
+
         def _check(cond, s="Unreachable"):
             if not cond:
                 raise CompilerPanic(s)
-
-        sig = self.sigs["self"].get(method_name, None)
-        if sig is None:
-            err_msg = f"Function self.{method_name} does not exist"
-            raise FunctionDeclarationException(err_msg, ast_source)
-
-        _check(sig.internal)  # sanity check
-        # should have been caught during type checking, sanity check anyway
+        # these should have been caught during type checking; sanity check
+        _check(sig is not None)
+        _check(sig.internal)
         _check(len(sig.base_args) <= len(args_ir) <= len(sig.args))
-
         # more sanity check, that the types match
         # _check(all(l.typ == r.typ for (l, r) in zip(args_ir, sig.args))
 

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -244,12 +244,8 @@ class Context:
 
         sig = self.sigs["self"].get(method_name, None)
         if sig is None:
-            raise FunctionDeclarationException(
-                "Function does not exist or has not been declared yet "
-                "(reminder: functions cannot call functions later in code "
-                "than themselves)",
-                ast_source,
-            )
+            err_msg = f"Function self.{method_name} does not exist"
+            raise FunctionDeclarationException(err_msg, ast_source)
 
         _check(sig.internal)  # sanity check
         # should have been caught during type checking, sanity check anyway

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -243,6 +243,7 @@ class Context:
         def _check(cond, s="Unreachable"):
             if not cond:
                 raise CompilerPanic(s)
+
         # these should have been caught during type checking; sanity check
         _check(sig is not None)
         _check(sig.internal)

--- a/vyper/codegen/function_definitions/__init__.py
+++ b/vyper/codegen/function_definitions/__init__.py
@@ -1,1 +1,1 @@
-from .common import generate_ir_for_function, is_default_func, is_initializer  # noqa
+from .common import generate_ir_for_function  # noqa

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -57,7 +57,7 @@ def generate_ir_for_function(
         assert skip_nonpayable_check is False
         o = generate_ir_for_internal_function(code, sig, context)
     else:
-        if sig.mutability == "payable" and not sig.is_default_func:
+        if sig.mutability == "payable":
             assert skip_nonpayable_check is False  # nonsense
         o = generate_ir_for_external_function(code, sig, context, skip_nonpayable_check)
 

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -62,7 +62,7 @@ def generate_ir_for_function(
     o.source_pos = getpos(code)
 
     frame_size = context.memory_allocator.size_of_mem - MemoryPositions.RESERVED_MEMORY
-    sig.gas = o.total_gas
+
     sig.set_frame_info(FrameInfo(allocate_start, frame_size))
 
     if not sig.internal:
@@ -73,5 +73,7 @@ def generate_ir_for_function(
         # note: internal functions do not need to adjust gas estimate since
         # it is already accounted for by the caller.
         pass
+
+    sig.gas_estimate = o.total_gas
 
     return o

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -1,5 +1,5 @@
 # can't use from [module] import [object] because it breaks mocks in testing
-from typing import Dict, Tuple
+from typing import Dict
 
 import vyper.ast as vy_ast
 from vyper.ast.signatures import FrameInfo, FunctionSignature
@@ -38,9 +38,7 @@ def generate_ir_for_function(
     for c in callees:
         frame_info = sigs["self"][c.name].frame_info
         assert frame_info is not None  # make mypy happy
-        max_callee_frame_size = max(
-            max_callee_frame_size, frame_info.frame_size
-        )
+        max_callee_frame_size = max(max_callee_frame_size, frame_info.frame_size)
 
     allocate_start = max_callee_frame_size + MemoryPositions.RESERVED_MEMORY
 

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -17,7 +17,7 @@ def generate_ir_for_function(
     code: vy_ast.FunctionDef,
     sigs: Dict[str, Dict[str, FunctionSignature]],  # all signatures in all namespaces
     global_ctx: GlobalContext,
-    check_nonpayable: bool,
+    skip_nonpayable_check: bool,
 ) -> IRnode:
     """
     Parse a function and produce IR code for the function, includes:
@@ -54,10 +54,12 @@ def generate_ir_for_function(
     )
 
     if sig.internal:
-        assert check_nonpayable is False
+        assert skip_nonpayable_check is False
         o = generate_ir_for_internal_function(code, sig, context)
     else:
-        o = generate_ir_for_external_function(code, sig, context, check_nonpayable)
+        if sig.mutability == "payable":
+            assert skip_nonpayable_check is False  # nonsense
+        o = generate_ir_for_external_function(code, sig, context, skip_nonpayable_check)
 
     o.source_pos = getpos(code)
 

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -57,7 +57,7 @@ def generate_ir_for_function(
         assert skip_nonpayable_check is False
         o = generate_ir_for_internal_function(code, sig, context)
     else:
-        if sig.mutability == "payable":
+        if sig.mutability == "payable" and not sig.is_default_func:
             assert skip_nonpayable_check is False  # nonsense
         o = generate_ir_for_external_function(code, sig, context, skip_nonpayable_check)
 

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -48,14 +48,15 @@ def generate_ir_for_function(
     callees = code._metadata["type"].called_functions
 
     if len(callees) == 0:
-        allocate_start = 0
+        max_callee_frame_size = 0
     else:
 
         def get_frame_size(name):
             return sigs["self"][name].frame_size  # type: ignore
 
         max_callee_frame_size = max(get_frame_size(c.name) for c in callees)
-        allocate_start = max_callee_frame_size + MemoryPositions.RESERVED_MEMORY
+
+    allocate_start = max_callee_frame_size + MemoryPositions.RESERVED_MEMORY
 
     memory_allocator = MemoryAllocator(allocate_start)
 

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -64,6 +64,7 @@ def generate_ir_for_function(
     o.source_pos = getpos(code)
 
     frame_size = context.memory_allocator.size_of_mem - MemoryPositions.RESERVED_MEMORY
+    sig.gas = o.total_gas
     sig.set_frame_info(FrameInfo(allocate_start, frame_size))
 
     if not sig.internal:

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -76,6 +76,6 @@ def generate_ir_for_function(
         # it is already accounted for by the caller.
         pass
 
-    sig.gas_estimate = o.total_gas
+    sig.gas_estimate = o.gas
 
     return o

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -70,11 +70,9 @@ def generate_ir_for_function(
     if not sig.internal:
         # adjust gas estimate to include cost of mem expansion
         # frame_size of external function includes all private functions called
+        # (note: internal functions do not need to adjust gas estimate since
+        # it is already accounted for by the caller.)
         o.add_gas_estimate += calc_mem_gas(sig.frame_info.mem_used)
-    else:
-        # note: internal functions do not need to adjust gas estimate since
-        # it is already accounted for by the caller.
-        pass
 
     sig.gas_estimate = o.gas
 

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -2,7 +2,7 @@
 from typing import Dict, Tuple
 
 import vyper.ast as vy_ast
-from vyper.ast.signatures import FunctionSignature
+from vyper.ast.signatures import FrameInfo, FunctionSignature
 from vyper.codegen.context import Constancy, Context
 from vyper.codegen.core import check_single_exit, getpos
 from vyper.codegen.function_definitions.external_function import generate_ir_for_external_function
@@ -13,22 +13,12 @@ from vyper.codegen.memory_allocator import MemoryAllocator
 from vyper.utils import MemoryPositions, calc_mem_gas
 
 
-# Is a function the initializer?
-def is_initializer(code: vy_ast.FunctionDef) -> bool:
-    return code.name == "__init__"
-
-
-# Is a function the default function?
-def is_default_func(code: vy_ast.FunctionDef) -> bool:
-    return code.name == "__default__"
-
-
 def generate_ir_for_function(
     code: vy_ast.FunctionDef,
-    sigs: Dict[str, Dict[str, FunctionSignature]],
+    sigs: Dict[str, Dict[str, FunctionSignature]],  # all signatures in all namespaces
     global_ctx: GlobalContext,
     check_nonpayable: bool,
-) -> Tuple[IRnode, int, int]:
+) -> IRnode:
     """
     Parse a function and produce IR code for the function, includes:
         - Signature method if statement
@@ -36,25 +26,21 @@ def generate_ir_for_function(
         - Clamping and copying of arguments
         - Function body
     """
-    sig = FunctionSignature.from_definition(
-        code,
-        sigs=sigs,
-        custom_structs=global_ctx._structs,
-    )
+    sig = code._metadata["signature"]
 
     # Validate return statements.
     check_single_exit(code)
 
     callees = code._metadata["type"].called_functions
 
-    if len(callees) == 0:
-        max_callee_frame_size = 0
-    else:
-
-        def get_frame_size(name):
-            return sigs["self"][name].frame_size  # type: ignore
-
-        max_callee_frame_size = max(get_frame_size(c.name) for c in callees)
+    # we start our function frame from the largest callee frame
+    max_callee_frame_size = 0
+    for c in callees:
+        frame_info = sigs["self"][c.name].frame_info
+        assert frame_info is not None  # make mypy happy
+        max_callee_frame_size = max(
+            max_callee_frame_size, frame_info.frame_size
+        )
 
     allocate_start = max_callee_frame_size + MemoryPositions.RESERVED_MEMORY
 
@@ -65,14 +51,12 @@ def generate_ir_for_function(
         global_ctx=global_ctx,
         sigs=sigs,
         memory_allocator=memory_allocator,
-        return_type=sig.return_type,
         constancy=Constancy.Constant if sig.mutability in ("view", "pure") else Constancy.Mutable,
-        is_payable=sig.mutability == "payable",
-        is_internal=sig.internal,
         sig=sig,
     )
 
     if sig.internal:
+        assert check_nonpayable is False
         o = generate_ir_for_internal_function(code, sig, context)
     else:
         o = generate_ir_for_external_function(code, sig, context, check_nonpayable)
@@ -80,15 +64,15 @@ def generate_ir_for_function(
     o.source_pos = getpos(code)
 
     frame_size = context.memory_allocator.size_of_mem - MemoryPositions.RESERVED_MEMORY
+    sig.set_frame_info(FrameInfo(allocate_start, frame_size))
 
     if not sig.internal:
+        # adjust gas estimate to include cost of mem expansion
         # frame_size of external function includes all private functions called
-        o.total_gas = o.gas + calc_mem_gas(frame_size)
+        o.add_gas_estimate += calc_mem_gas(sig.frame_info.mem_used)
     else:
-        # frame size for internal function does not need to be adjusted
-        # since it is already accounted for by the caller
-        o.total_gas = o.gas  # type: ignore
+        # note: internal functions do not need to adjust gas estimate since
+        # it is already accounted for by the caller.
+        pass
 
-    o.context = context  # type: ignore
-    o.func_name = sig.name
-    return o, allocate_start, frame_size
+    return o

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -143,7 +143,7 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature) -> List[A
 # TODO it would be nice if this returned a data structure which were
 # amenable to generating a jump table instead of the linear search for
 # method_id we have now.
-def generate_ir_for_external_function(code, sig, context, check_nonpayable):
+def generate_ir_for_external_function(code, sig, context, skip_nonpayable_check):
     # TODO type hints:
     # def generate_ir_for_external_function(
     #    code: vy_ast.FunctionDef, sig: FunctionSignature, context: Context, check_nonpayable: bool,
@@ -167,7 +167,7 @@ def generate_ir_for_external_function(code, sig, context, check_nonpayable):
     # generate the main body of the function
     body += handle_base_args
 
-    if check_nonpayable and sig.mutability != "payable":
+    if sig.mutability != "payable" and not skip_nonpayable_check:
         # if the contract contains payable functions, but this is not one of them
         # add an assertion that the value of the call is zero
         body += [["assert", ["iszero", "callvalue"]]]

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -115,7 +115,6 @@ class GlobalContext:
                         func_sig.defined_in_interface = interface_name
                         global_ctx._interface[func_sig.sig] = func_sig
 
-
         global_ctx._function_defs = _topsort(global_ctx._function_defs)
 
         return global_ctx

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -47,7 +47,7 @@ class GlobalContext:
     # Parse top-level functions and variables
     @classmethod
     def get_global_context(
-        cls, vyper_module: "vy_ast.Module", interface_codes: Optional[InterfaceImports] = None
+        cls, vyper_module: "vy_ast.Module", interface_codes: Optional[InterfaceImports] = None, should_topsort=True
     ) -> "GlobalContext":
         # TODO is this a cyclic import?
         from vyper.ast.signatures.interface import extract_sigs, get_builtin_interfaces
@@ -113,7 +113,9 @@ class GlobalContext:
                         func_sig.defined_in_interface = interface_name
                         global_ctx._interface[func_sig.sig] = func_sig
 
-        global_ctx._function_defs = _topsort(global_ctx._function_defs)
+        # relies on annotation phase having been run.
+        if should_topsort:
+            global_ctx._function_defs = _topsort(global_ctx._function_defs)
 
         return global_ctx
 

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -8,26 +8,24 @@ from vyper.typing import InterfaceImports
 from vyper.utils import cached_property
 
 
-def _topsort_helper(functions):
+def _topsort_helper(functions, lookup):
     #  single pass to get a topsort of functions, but may have duplicates
-    _lookup = {f.name: f for f in functions}
 
     ret = []
     for f in functions:
         # called_functions is a list of ContractFunctions, need to map
         # back to FunctionDefs.
-        callees = [_lookup[t.name] for t in f._metadata["type"].called_functions]
-        ret.extend(_topsort(callees))
+        callees = [lookup[t.name] for t in f._metadata["type"].called_functions]
+        ret.extend(_topsort_helper(callees, lookup))
         ret.append(f)
 
     return ret
 
 
 def _topsort(functions):
+    lookup = {f.name: f for f in functions}
     # strip duplicates
-    ret = list(dict.fromkeys(_topsort_helper(functions)))
-
-    return ret
+    return list(dict.fromkeys(_topsort_helper(functions, lookup)))
 
 
 # Datatype to store all global context information.

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -47,7 +47,10 @@ class GlobalContext:
     # Parse top-level functions and variables
     @classmethod
     def get_global_context(
-        cls, vyper_module: "vy_ast.Module", interface_codes: Optional[InterfaceImports] = None, should_topsort=True
+        cls,
+        vyper_module: "vy_ast.Module",
+        interface_codes: Optional[InterfaceImports] = None,
+        should_topsort: bool = True,
     ) -> "GlobalContext":
         # TODO is this a cyclic import?
         from vyper.ast.signatures.interface import extract_sigs, get_builtin_interfaces

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -100,7 +100,7 @@ class IRnode:
         if isinstance(self.value, int):
             _check(len(self.args) == 0, "int can't have arguments")
             self.valency = 1
-            self.gas = 5
+            self._gas = 5
         elif isinstance(self.value, str):
             # Opcodes and pseudo-opcodes (e.g. clamp)
             if self.value.upper() in get_ir_opcodes():
@@ -112,7 +112,7 @@ class IRnode:
                 )
                 # We add 2 per stack height at push time and take it back
                 # at pop time; this makes `break` easier to handle
-                self.gas = gas + 2 * (outs - ins)
+                self._gas = gas + 2 * (outs - ins)
                 for arg in self.args:
                     # pop and pass are used to push/pop values on the stack to be
                     # consumed for internal functions, therefore we whitelist this as a zero valency
@@ -122,16 +122,16 @@ class IRnode:
                         arg.valency == 1 or arg.value in zero_valency_whitelist,
                         f"invalid argument to `{self.value}`: {arg}",
                     )
-                    self.gas += arg.gas
+                    self._gas += arg.gas
                 # Dynamic gas cost: 8 gas for each byte of logging data
                 if self.value.upper()[0:3] == "LOG" and isinstance(self.args[1].value, int):
-                    self.gas += self.args[1].value * 8
+                    self._gas += self.args[1].value * 8
                 # Dynamic gas cost: non-zero-valued call
                 if self.value.upper() == "CALL" and self.args[2].value != 0:
-                    self.gas += 34000
+                    self._gas += 34000
                 # Dynamic gas cost: filling sstore (ie. not clearing)
                 elif self.value.upper() == "SSTORE" and self.args[1].value != 0:
-                    self.gas += 15000
+                    self._gas += 15000
                 # Dynamic gas cost: calldatacopy
                 elif self.value.upper() in ("CALLDATACOPY", "CODECOPY", "EXTCODECOPY"):
                     size = 34000
@@ -139,16 +139,16 @@ class IRnode:
                     size_arg = self.args[size_arg_index]
                     if isinstance(size_arg.value, int):
                         size = size_arg.value
-                    self.gas += ceil32(size) // 32 * 3
+                    self._gas += ceil32(size) // 32 * 3
                 # Gas limits in call
                 if self.value.upper() == "CALL" and isinstance(self.args[0].value, int):
-                    self.gas += self.args[0].value
+                    self._gas += self.args[0].value
             # If statements
             elif self.value == "if":
                 if len(self.args) == 3:
-                    self.gas = self.args[0].gas + max(self.args[1].gas, self.args[2].gas) + 3
+                    self._gas = self.args[0].gas + max(self.args[1].gas, self.args[2].gas) + 3
                 if len(self.args) == 2:
-                    self.gas = self.args[0].gas + self.args[1].gas + 17
+                    self._gas = self.args[0].gas + self.args[1].gas + 17
                 _check(
                     self.args[0].valency > 0,
                     f"zerovalent argument as a test to an if statement: {self.args[0]}",
@@ -167,7 +167,7 @@ class IRnode:
                     f"zerovalent argument to with statement: {self.args[1]}",
                 )
                 self.valency = self.args[2].valency
-                self.gas = sum([arg.gas for arg in self.args]) + 5
+                self._gas = sum([arg.gas for arg in self.args]) + 5
             # Repeat statements: repeat <index_name> <startval> <rounds> <rounds_bound> <body>
             elif self.value == "repeat":
                 _check(
@@ -190,19 +190,19 @@ class IRnode:
 
                 self.valency = 0
 
-                self.gas = counter_ptr.gas + start.gas
-                self.gas += 3  # gas for repeat_bound
+                self._gas = counter_ptr.gas + start.gas
+                self._gas += 3  # gas for repeat_bound
                 int_bound = int(repeat_bound.value)
-                self.gas += int_bound * (body.gas + 50) + 30
+                self._gas += int_bound * (body.gas + 50) + 30
 
                 if repeat_count != repeat_bound:
                     # gas for assert(repeat_count <= repeat_bound)
-                    self.gas += 18
+                    self._gas += 18
 
             # Seq statements: seq <statement> <statement> ...
             elif self.value == "seq":
                 self.valency = self.args[-1].valency if self.args else 0
-                self.gas = sum([arg.gas for arg in self.args]) + 30
+                self._gas = sum([arg.gas for arg in self.args]) + 30
 
             # GOTO is a jump with args
             # e.g. (goto my_label x y z) will push x y and z onto the stack,
@@ -215,19 +215,19 @@ class IRnode:
                     )
 
                 self.valency = 0
-                self.gas = sum([arg.gas for arg in self.args])
+                self._gas = sum([arg.gas for arg in self.args])
             elif self.value == "label":
                 if not self.args[1].value == "var_list":
                     raise CodegenPanic(f"2nd argument to label must be var_list, {self}")
                 self.valency = 0
-                self.gas = 1 + sum(t.gas for t in self.args)
+                self._gas = 1 + sum(t.gas for t in self.args)
             # var_list names a variable number stack variables
             elif self.value == "var_list":
                 for arg in self.args:
                     if not isinstance(arg.value, str) or len(arg.args) > 0:
                         raise CodegenPanic(f"var_list only takes strings: {self.args}")
                 self.valency = 0
-                self.gas = 0
+                self._gas = 0
 
             # Multi statements: multi <expr> <expr> ...
             elif self.value == "multi":
@@ -236,19 +236,19 @@ class IRnode:
                         arg.valency > 0, f"Multi expects all children to not be zerovalent: {arg}"
                     )
                 self.valency = sum([arg.valency for arg in self.args])
-                self.gas = sum([arg.gas for arg in self.args])
+                self._gas = sum([arg.gas for arg in self.args])
             elif self.value == "deploy":
                 self.valency = 0
-                self.gas = NullAttractor()  # unknown
+                self._gas = NullAttractor()  # unknown
             # Stack variables
             else:
                 self.valency = 1
-                self.gas = 3
+                self._gas = 3
         elif self.value is None:
             self.valency = 1
             # None IRnodes always get compiled into something else, e.g.
             # mzero or PUSH1 0, and the gas will get re-estimated then.
-            self.gas = 3
+            self._gas = 3
         else:
             raise CompilerPanic(f"Invalid value for IR AST node: {self.value}")
         assert isinstance(self.args, list)
@@ -256,11 +256,10 @@ class IRnode:
         if valency is not None:
             self.valency = valency
 
-        self.gas
-
+    # TODO would be nice to rename to `gas_estimate` or `gas_bound`
     @property
-    def total_gas(self):
-        return self.gas + self.add_gas_estimate
+    def gas(self):
+        return self._gas + self.add_gas_estimate
 
     # the IR should be cached.
     # TODO make this private. turns out usages are all for the caching

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -53,7 +53,7 @@ class Encoding(Enum):
 # Data structure for IR parse tree
 class IRnode:
     repr_show_gas = False
-    gas: int
+    _gas: int
     valency: int
     args: List["IRnode"]
     value: Union[str, int]

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -87,10 +87,6 @@ class IRnode:
         self.encoding = encoding
         self.as_hex = AS_HEX_DEFAULT
 
-        # Optional annotation properties for gas estimation
-        self.total_gas = None
-        self.func_name = None
-
         def _check(condition, err):
             if not condition:
                 raise CompilerPanic(str(err))
@@ -260,7 +256,11 @@ class IRnode:
         if valency is not None:
             self.valency = valency
 
-        self.gas += self.add_gas_estimate
+        self.gas
+
+    @property
+    def total_gas(self):
+        return self.gas + self.add_gas_estimate
 
     # the IR should be cached.
     # TODO make this private. turns out usages are all for the caching

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -183,14 +183,12 @@ def parse_tree_to_ir(global_ctx: GlobalContext) -> Tuple[IRnode, IRnode, Functio
             {[name for name in _names_events if _names_events.count(name) > 1][0]}"""
         )
     # Initialization function
-    init_function = next((_def for _def in global_ctx._function_defs if is_initializer(_def)), None)
+    init_function = next((f for f in global_ctx._function_defs if is_initializer(f)), None)
     # Default function
-    default_function = next((i for i in global_ctx._function_defs if is_default_func(i)), None)
+    default_function = next((f for f in global_ctx._function_defs if is_default_func(f)), None)
 
     regular_functions = [
-        _def
-        for _def in global_ctx._function_defs
-        if not is_initializer(_def) and not is_default_func(_def)
+        f for f in global_ctx._function_defs if not is_initializer(f) and not is_default_func(f)
     ]
 
     sigs: dict = {}

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -174,8 +174,6 @@ def parse_regular_functions(
 
 # Main python parse tree => IR method
 def parse_tree_to_ir(global_ctx: GlobalContext) -> Tuple[IRnode, IRnode, FunctionSignatures]:
-    _func_lookup = {f.name: f for f in global_ctx._function_defs}
-
     # CMC 2022-05-05 TODO this is probably dead code.
     _names_events = [_event.name for _event in global_ctx._events]
     # Checks for duplicate event names
@@ -190,7 +188,9 @@ def parse_tree_to_ir(global_ctx: GlobalContext) -> Tuple[IRnode, IRnode, Functio
     default_function = next((i for i in global_ctx._function_defs if is_default_func(i)), None)
 
     regular_functions = [
-        _def for _def in global_ctx._function_defs if not is_initializer(_def) and not is_default_func(_def)
+        _def
+        for _def in global_ctx._function_defs
+        if not is_initializer(_def) and not is_default_func(_def)
     ]
 
     sigs: dict = {}

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -126,6 +126,8 @@ def _runtime_ir(runtime_functions, all_sigs, global_ctx):
         # TODO: prune internal functions in this case?
         return ["seq"] + list(internal_functions_map.values()), internal_functions_map
 
+    # note: if the user does not provide one, the default fallback function
+    # reverts anyway. so it does not hurt to batch the payable check.
     is_default_payable = (
         default_function is not None
         and default_function._metadata["type"].mutability == StateMutability.PAYABLE

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -128,14 +128,11 @@ def _runtime_ir(runtime_functions, all_sigs, global_ctx):
 
     # note: if the user does not provide one, the default fallback function
     # reverts anyway. so it does not hurt to batch the payable check.
-    is_default_payable = (
-        default_function is not None
-        and default_function._metadata["type"].mutability == StateMutability.PAYABLE
-    )
+    default_is_nonpayable = default_function is None or not _is_payable(default_function)
 
     # when a contract has a nonpayable default function,
     # we can do a single check for all nonpayable functions
-    batch_payable_check = len(nonpayables) > 0 or not is_default_payable
+    batch_payable_check = len(nonpayables) > 0 and default_is_nonpayable
     skip_nonpayable_check = batch_payable_check
 
     selector_section = ["seq"]

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -124,7 +124,8 @@ def _runtime_ir(runtime_functions, all_sigs, global_ctx):
     # contains immutables
     if len(external_functions) == 0:
         # TODO: prune internal functions in this case?
-        return ["seq"] + list(internal_functions_map.values()), internal_functions_map
+        runtime = ["seq"] + list(internal_functions_map.values())
+        return runtime, internal_functions_map
 
     # note: if the user does not provide one, the default fallback function
     # reverts anyway. so it does not hurt to batch the payable check.

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -1,6 +1,6 @@
 # a contract.vy -- all functions and constructor
 
-from typing import Dict, List, Optional, Tuple, Union, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 from vyper import ast as vy_ast
 from vyper.ast.signatures.function_signature import FunctionSignature, FunctionSignatures

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -38,9 +38,6 @@ def ir_for_self_call(stmt_expr, context):
     args_tuple_t = TupleType([x.typ for x in args_ir])
     args_as_tuple = IRnode.from_list(["multi"] + [x for x in args_ir], typ=args_tuple_t)
 
-    # register callee to help calculate our starting frame offset
-    context.register_callee(sig.frame_size)
-
     if context.is_constant() and sig.mutability not in ("view", "pure"):
         raise StateAccessViolation(
             f"May not call state modifying function "

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -108,7 +108,7 @@ def ir_for_self_call(stmt_expr, context):
         typ=sig.return_type,
         location=MEMORY,
         annotation=stmt_expr.get("node_source_code"),
-        add_gas_estimate=sig.gas,
+        add_gas_estimate=sig.gas_estimate,
     )
     o.is_self_call = True
     return o

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -62,7 +62,7 @@ def ir_for_self_call(stmt_expr, context):
 
     # note: dst_tuple_t != args_tuple_t
     dst_tuple_t = TupleType([arg.typ for arg in sig.args])
-    args_dst = IRnode(sig.frame_start, typ=dst_tuple_t, location=MEMORY)
+    args_dst = IRnode(sig.frame_info.frame_start, typ=dst_tuple_t, location=MEMORY)
 
     # if one of the arguments is a self call, the argument
     # buffer could get borked. to prevent against that,

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -132,7 +132,7 @@ def build_abi_output(compiler_data: CompilerData) -> list:
     abi = compiler_data.vyper_module_folded._metadata["type"].to_abi_dict()
     if compiler_data.show_gas_estimates:
         # Add gas estimates for each function to ABI
-        gas_estimates = build_gas_estimates(compiler_data.ir_runtime)
+        gas_estimates = build_gas_estimates(compiler_data.function_signatures)
         for func in abi:
             try:
                 func_signature = func["name"]
@@ -143,7 +143,6 @@ def build_abi_output(compiler_data: CompilerData) -> list:
             func_name, _, _ = func_signature.partition("(")
             # This check ensures we skip __init__ since it has no estimate
             if func_name in gas_estimates:
-                # TODO: mutation
                 func["gas"] = gas_estimates[func_name]
     return abi
 

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -108,7 +108,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
         ret = vars(sig)
         ret["return_type"] = str(ret["return_type"])
         ret["_ir_identifier"] = sig._ir_identifier
-        for attr in ("gas", "func_ast_code"):
+        for attr in ("gas_estimate", "func_ast_code"):
             del ret[attr]
         for attr in ("args", "base_args", "default_args"):
             if attr in ret:

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -259,7 +259,7 @@ def generate_ir_nodes(
         IR to generate deployment bytecode
         IR to generate runtime bytecode
     """
-    ir_nodes, ir_runtime, function_sigs = module.parse_tree_to_ir(global_ctx)
+    ir_nodes, ir_runtime, function_sigs = module.generate_ir_for_module(global_ctx)
     if not no_optimize:
         ir_nodes = optimizer.optimize(ir_nodes)
         ir_runtime = optimizer.optimize(ir_runtime)

--- a/vyper/compiler/utils.py
+++ b/vyper/compiler/utils.py
@@ -1,16 +1,11 @@
-from vyper.codegen.ir_node import IRnode
+from typing import Dict
+
+from vyper.ast.signatures import FunctionSignature
 
 
-def build_gas_estimates(ir_runtime: IRnode) -> dict:
-    gas_estimates: dict = {}
-
-    external_sub = next((i for i in ir_runtime.args if i.value == "with"), None)
-    if external_sub:
-        for func_ir in external_sub.args[-1].args:
-            if func_ir.func_name is not None:
-                gas_estimates[func_ir.func_name] = func_ir.total_gas
-
-    return gas_estimates
+def build_gas_estimates(function_sigs: Dict[str, FunctionSignature]) -> dict:
+    # note: `.gas` is added to FunctionSignature in vyper/codegen/module.py
+    return {k: v.gas for (k, v) in function_sigs.items()}
 
 
 def expand_source_map(compressed_map: str) -> list:

--- a/vyper/compiler/utils.py
+++ b/vyper/compiler/utils.py
@@ -4,8 +4,9 @@ from vyper.ast.signatures import FunctionSignature
 
 
 def build_gas_estimates(function_sigs: Dict[str, FunctionSignature]) -> dict:
-    # note: `.gas` is added to FunctionSignature in vyper/codegen/module.py
-    return {k: v.gas for (k, v) in function_sigs.items()}
+    # note: `.gas_estimate` is added to FunctionSignature
+    # in vyper/codegen/function_definitions/common.py
+    return {k: v.gas_estimate for (k, v) in function_sigs.items()}
 
 
 def expand_source_map(compressed_map: str) -> list:

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -510,7 +510,7 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
         assert isinstance(padding, int), "non-int padding"
 
         begincode = mksymbol("runtime_begin")
-        subcode = _compile_to_assembly(ir, {}, existing_labels, None, 0)
+        subcode = _compile_to_assembly(ir, {}, None, None, 0)
 
         o = []
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -510,7 +510,8 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
         assert isinstance(padding, int), "non-int padding"
 
         begincode = mksymbol("runtime_begin")
-        subcode = _compile_to_assembly(ir, {}, None, None, 0)
+
+        subcode = _compile_to_assembly(ir)
 
         o = []
 

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -182,9 +182,6 @@ def optimize(node: IRnode) -> IRnode:
         add_gas_estimate=add_gas_estimate,
         valency=valency,
     )
-    if node.total_gas is not None:
-        ret.total_gas = node.total_gas - node.gas + ret.gas
-        ret.func_name = node.func_name
 
     return ret
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -1,7 +1,7 @@
 import re
 import warnings
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from vyper import ast as vy_ast
 from vyper.ast.validation import validate_call_args
@@ -123,7 +123,7 @@ class ContractFunction(BaseTypeDefinition):
         self.nonreentrant = nonreentrant
 
         # a list of internal functions this function calls
-        self.called_functions = set()
+        self.called_functions: Set["ContractFunction"] = set()
 
     def __repr__(self):
         return f"contract function '{self.name}'"

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -400,6 +400,14 @@ class ContractFunction(BaseTypeDefinition):
         )
 
     @property
+    def is_external(self) -> bool:
+        return self.visibility == FunctionVisibility.EXTERNAL
+
+    @property
+    def is_internal(self) -> bool:
+        return self.visibility == FunctionVisibility.INTERNAL
+
+    @property
     def method_ids(self) -> Dict[str, int]:
         """
         Dict of `{signature: four byte selector}` for this function.

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -122,6 +122,9 @@ class ContractFunction(BaseTypeDefinition):
         self.mutability = state_mutability
         self.nonreentrant = nonreentrant
 
+        # a list of internal functions this function calls
+        self.called_functions = set()
+
     def __repr__(self):
         return f"contract function '{self.name}'"
 

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -2,7 +2,11 @@ from vyper import ast as vy_ast
 from vyper.exceptions import StructureException
 from vyper.semantics.types import ArrayDefinition
 from vyper.semantics.types.bases import BaseTypeDefinition
-from vyper.semantics.types.function import ContractFunction, MemberFunctionDefinition
+from vyper.semantics.types.function import (
+    ContractFunction,
+    MemberFunctionDefinition,
+    FunctionVisibility,
+)
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.user.struct import StructPrimitive
 from vyper.semantics.validation.utils import (
@@ -132,11 +136,14 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         node._metadata["type"] = node_type
         self.visit(node.func)
 
-        if isinstance(call_type, ContractFunction):
+        if (
+            isinstance(call_type, ContractFunction)
+            and call_type.visibility == FunctionVisibility.INTERNAL
+        ):
             self.func.called_functions.add(call_type)
 
         if isinstance(call_type, (Event, ContractFunction)):
-            # events and internal function calls
+            # events and function calls
             for arg, arg_type in zip(node.args, list(call_type.arguments.values())):
                 self.visit(arg, arg_type)
         elif isinstance(call_type, StructPrimitive):

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -4,8 +4,8 @@ from vyper.semantics.types import ArrayDefinition
 from vyper.semantics.types.bases import BaseTypeDefinition
 from vyper.semantics.types.function import (
     ContractFunction,
-    MemberFunctionDefinition,
     FunctionVisibility,
+    MemberFunctionDefinition,
 )
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.user.struct import StructPrimitive

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -50,7 +50,7 @@ class StatementAnnotationVisitor(_AnnotationVisitorBase):
     def __init__(self, fn_node: vy_ast.FunctionDef, namespace: dict) -> None:
         self.func = fn_node._metadata["type"]
         self.namespace = namespace
-        self.expr_visitor = ExpressionAnnotationVisitor()
+        self.expr_visitor = ExpressionAnnotationVisitor(self.func)
 
     def visit(self, node):
         super().visit(node)
@@ -101,6 +101,9 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
 
     ignored_types = ()
 
+    def __init__(self, fn_node: ContractFunction):
+        self.func = fn_node
+
     def visit(self, node, type_=None):
         # the statement visitor sometimes passes type information about expressions
         super().visit(node, type_)
@@ -128,6 +131,10 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         node_type = type_ or call_type.fetch_call_return(node)
         node._metadata["type"] = node_type
         self.visit(node.func)
+
+        if isinstance(call_type, ContractFunction):
+            self.func.called_functions.add(call_type)
+
         if isinstance(call_type, (Event, ContractFunction)):
             # events and internal function calls
             for arg, arg_type in zip(node.args, list(call_type.arguments.values())):

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -2,11 +2,7 @@ from vyper import ast as vy_ast
 from vyper.exceptions import StructureException
 from vyper.semantics.types import ArrayDefinition
 from vyper.semantics.types.bases import BaseTypeDefinition
-from vyper.semantics.types.function import (
-    ContractFunction,
-    FunctionVisibility,
-    MemberFunctionDefinition,
-)
+from vyper.semantics.types.function import ContractFunction, MemberFunctionDefinition
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.user.struct import StructPrimitive
 from vyper.semantics.validation.utils import (
@@ -136,10 +132,7 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         node._metadata["type"] = node_type
         self.visit(node.func)
 
-        if (
-            isinstance(call_type, ContractFunction)
-            and call_type.visibility == FunctionVisibility.INTERNAL
-        ):
+        if isinstance(call_type, ContractFunction) and call_type.is_internal:
             self.func.called_functions.add(call_type)
 
         if isinstance(call_type, (Event, ContractFunction)):


### PR DESCRIPTION
### What I did
allow calling internal functions from constructor. fixes https://github.com/vyperlang/vyper/issues/1631 and https://github.com/vyperlang/vyper/issues/2318

### How I did it

### Commit message
```
this commit allows the user to call internal functions from the     
`__init__` function. it does this by generating a call graph during the
annotation phase and then generating code for the functions called from
the init function for during deploy code generation                 
          
this also has a performance benefit (compiler time) because we can get
rid of the two-pass method for tracing frame size.                  
          
now that we have a call graph, this commit also introduces a topsort of
functions based on the call dependency tree. this ensures we can compile
functions that call functions that occur after them in the source code.
          
lastly, this commit also refactors vyper/codegen/module.py so that the
payable logic is cleaner, it uses properties instead of calculations
more, and cleans up properties on IRnode, FunctionSignature and Context.
```

### How to verify it

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/167010862-e6cb0375-6cd9-454c-9c14-88e74ad7201b.png)
