### PR TITLE
feat: add artifact generation CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Artifacts
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  unix-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Pip Packages
+        run: pip install . && pip install pyinstaller
+
+      - name: Generate Binary
+        run: make freeze
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/vyper.*commit.*
+
+  windows-build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Pip Packages
+        run: pip install . && pip install pyinstaller
+
+      - name: Generate Binary
+        run: ./make.cmd freeze
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/vyper.*commit.*


### PR DESCRIPTION
### What I did

Add automatic artifact generation to the CI when a new release is created.

Note: This doesn't automatically attach the artifacts to the release. Before the release is published, the artifacts would have to be retrieved and then attached.

Fixes: #2491

### How I did it

Googling, reading docs, debugging etc ...

### How to verify it

You can see an example of the CI result here: https://github.com/skellet0r/vyper/actions/runs/1371314450

Simply scroll to the bottom and download the `artifact.zip` archive, which will include binaries for all 3 platforms

### Description for the changelog

- Add automatic artifact generation for releases

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2014/12/cutest-baby-animals-22__605.jpg)
