### PR TITLE
add machine readable ir_json format

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -34,6 +34,7 @@ external_interface - External interface of a contract, used for outside contract
 opcodes            - List of opcodes as a string
 opcodes_runtime    - List of runtime opcodes as a string
 ir                 - Intermediate representation in LLL
+ir_json            - Intermediate LLL representation in JSON format
 """
 
 combined_json_outputs = [
@@ -254,7 +255,7 @@ def compile_files(
         output_formats = combined_json_outputs
         show_version = True
 
-    translate_map = {"abi_python": "abi", "json": "abi", "ast": "ast_dict"}
+    translate_map = {"abi_python": "abi", "json": "abi", "ast": "ast_dict", "ir_json": "ir_dict"}
     final_formats = [translate_map.get(i, i) for i in output_formats]
 
     compiler_data = vyper.compile_codes(

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -17,6 +17,7 @@ OUTPUT_FORMATS = {
     "external_interface": output.build_external_interface_output,
     "interface": output.build_interface_output,
     "ir": output.build_ir_output,
+    "ir_dict": output.build_ir_dict_output,
     "method_identifiers": output.build_method_identifiers_output,
     # requires assembly
     "abi": output.build_abi_output,

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -77,6 +77,18 @@ def build_ir_output(compiler_data: CompilerData) -> LLLnode:
     return compiler_data.lll_nodes
 
 
+def build_ir_dict_output(compiler_data: CompilerData) -> LLLnode:
+    lll = compiler_data.lll_nodes
+
+    def _to_dict(lll_node):
+        args = lll_node.args
+        if len(args) > 0:
+            return {lll_node.value: [_to_dict(x) for x in args]}
+        return lll_node.value
+
+    return _to_dict(lll)
+
+
 def build_method_identifiers_output(compiler_data: CompilerData) -> dict:
     interface = compiler_data.vyper_module_folded._metadata["type"]
     functions = interface.members.values()


### PR DESCRIPTION
### What I did
Add JSON format for IR output. Makes it easier for tools to integrate our IR.

### How I did it
Map LLL nodes with no args to JSON number or string, LLL nodes with args map to `{"instruction": *args}`.

### How to verify it
Try it out

### Description for the changelog
Add machine-readable JSON format for IR output

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
