### PR TITLE
WIP: bytes4 type

### DIFF
--- a/vyper/old_codegen/abi.py
+++ b/vyper/old_codegen/abi.py
@@ -307,6 +307,8 @@ def abi_type_of(lll_typ):
             return ABI_GIntM(256, True)
         elif "address" == t:
             return ABI_Address()
+        elif "bytes4" == t:
+            return ABI_BytesM(4)
         elif "bytes32" == t:
             return ABI_BytesM(32)
         elif "bool" == t:

--- a/vyper/old_codegen/parser_utils.py
+++ b/vyper/old_codegen/parser_utils.py
@@ -677,6 +677,12 @@ def shr(x, bits):
     return ["div", x, ["exp", 2, bits]]
 
 
+def shl(x, bits):
+    if version_check(begin="constantinople"):
+        return ["shl", bits, x]
+    return ["mul", x, ["exp", 2, bits]]
+
+
 def sar(x, bits):
     if version_check(begin="constantinople"):
         return ["sar", bits, x]

--- a/vyper/old_codegen/types/types.py
+++ b/vyper/old_codegen/types/types.py
@@ -173,7 +173,7 @@ def canonicalize_type(t, is_indexed=False):
         raise InvalidType(f"Cannot canonicalize non-base type: {t}")
 
     t = t.typ
-    if t in ("int128", "int256", "uint8", "uint256", "bool", "address", "bytes32"):
+    if t in ("int128", "int256", "uint8", "uint256", "bool", "address", "bytes4", "bytes32"):
         return t
     elif t == "decimal":
         return "fixed168x10"

--- a/vyper/semantics/types/value/bytes_fixed.py
+++ b/vyper/semantics/types/value/bytes_fixed.py
@@ -4,6 +4,32 @@ from vyper.semantics.types.abstract import BytesAbstractType
 from vyper.semantics.types.bases import BasePrimitive, BaseTypeDefinition, ValueTypeDefinition
 
 
+class Bytes4Definition(BytesAbstractType, ValueTypeDefinition):
+
+    # included for compatibility with bytes array methods
+    _id = "bytes4"
+    length = 4
+    _length = 4
+    _min_length = 4
+
+
+class Bytes4Primitive(BasePrimitive):
+
+    _as_array = True
+    _type = Bytes4Definition
+    _id = "bytes4"
+    _valid_literal = (vy_ast.Bytes, vy_ast.Hex)
+
+    @classmethod
+    def from_literal(cls, node: vy_ast.Constant) -> BaseTypeDefinition:
+        obj = super().from_literal(node)
+        if isinstance(node, vy_ast.Bytes) and len(node.value.hex()) != 8:
+            raise InvalidLiteral("Invalid literal for type bytes4", node)
+        if isinstance(node, vy_ast.Hex) and len(node.value) != 10:
+            raise InvalidLiteral("Invalid literal for type bytes4", node)
+        return obj
+
+
 class Bytes32Definition(BytesAbstractType, ValueTypeDefinition):
 
     # included for compatibility with bytes array methods

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -204,7 +204,17 @@ VALID_LLL_MACROS = {
 }
 
 # Available base types
-BASE_TYPES = {"int128", "int256", "decimal", "bytes32", "uint8", "uint256", "bool", "address"}
+BASE_TYPES = {
+    "int128",
+    "int256",
+    "decimal",
+    "bytes4",
+    "bytes32",
+    "uint8",
+    "uint256",
+    "bool",
+    "address",
+}
 
 
 def is_instances(instances, instance_type):


### PR DESCRIPTION
### What I did

Add `bytes4` type.

Fixes: #1575 

### How I did it

tldr: Looked at stack traces ... 

Added in the definition and primitive classes, modified a few functions such as `clamp_basetype`, `abi_type_of`, to make sure the resulting `IR` was as I expected it to be.

TODO:

- Allow bytes4 literals without breaking `Bytes[4]` (if that's even possible)
- Test cases
- Fix ERC721 token example
- Docs
- conversions in vyper/builtin_functions/convert.py
- MethodID builtin compatibility

### How to verify it

*Test cases to be added*

### Description for the changelog

- Add bytes4 base type

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/AQLs36FT8Sg/maxresdefault.jpg)

> I think this'll be the last base type I add manually ... pretty sure moving to some more robust way to port all valid solidity types would be better :) (but I wanted this and uint8 sooner than later) 