### PR TITLE
relax an assertion in packing external call args

### DIFF
--- a/vyper/old_codegen/external_call.py
+++ b/vyper/old_codegen/external_call.py
@@ -121,7 +121,7 @@ def _external_call_helper(
         gas = "gas"
 
     # sanity check
-    assert len(contract_sig.args) == len(args_lll)
+    assert len(contract_sig.base_args) <= len(args_lll) <= len(contract_sig.args)
 
     if context.is_constant() and contract_sig.mutability not in ("view", "pure"):
         # TODO is this already done in type checker?


### PR DESCRIPTION
the number of args passed could be somewhere in between
base args + 0 kwargs and
base args + all kwargs

### What I did
Fix #2520 and #2374 

### How I did it
An assertion introduced in #2447 was too aggressive. The rest of the code works.

### How to verify it
`vyper -f ir` of the code in the issues

### Description for the changelog
Fix calls to external functions involving kwargs

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/3867501/140558503-5d93afb2-6a12-4b97-9509-b5b39a4a0198.png)