### PR TITLE
propagate revert data when external call fails

### DIFF
--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -155,6 +155,7 @@ def assert_tx_failed(tester):
             function_to_test()
         tester.revert_to_snapshot(snapshot_id)
         if exc_text:
-            assert exc_text in str(excinfo.value)
+            # TODO test equality
+            assert exc_text in str(excinfo.value), (exc_text, excinfo.value)
 
     return assert_tx_failed

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -114,7 +114,9 @@ def get_array(arg1: address) -> Bytes[3]:
     assert_tx_failed(lambda: c2.get_array(c.address))
 
 
-@pytest.mark.parametrize("revert_string", ["Mayday, mayday!", "A very long revert string" + "."*512])
+@pytest.mark.parametrize(
+    "revert_string", ["Mayday, mayday!", "A very long revert string" + "." * 512]
+)
 def test_revert_propagation(get_contract, assert_tx_failed, revert_string):
     raiser = f"""
 @external

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -4,6 +4,7 @@ from eth_tester.exceptions import TransactionFailed
 
 
 # web3 returns f"execution reverted: {err_str}"
+# TODO move exception string parsing logic into assert_tx_failed
 def _fixup_err_str(s):
     return s.replace("execution reverted: ", "")
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -26,6 +26,7 @@ from vyper.old_codegen.expr import Expr
 from vyper.old_codegen.keccak256_helper import keccak256_helper
 from vyper.old_codegen.parser_utils import (
     LLLnode,
+    check_external_call,
     clamp_basetype,
     get_bytearray_length,
     get_element_ptr,
@@ -1172,7 +1173,7 @@ class RawCall(_SimpleBuiltinFunction):
 
             if revert_on_failure:
                 typ = bytes_ty
-                ret_lll = ["seq", ["assert", call_lll], store_output_size]
+                ret_lll = ["seq", check_external_call(call_lll), store_output_size]
             else:
                 typ = TupleType([bool_ty, bytes_ty])
                 ret_lll = [
@@ -1186,7 +1187,7 @@ class RawCall(_SimpleBuiltinFunction):
         else:
             if revert_on_failure:
                 typ = None
-                ret_lll = ["assert", call_lll]
+                ret_lll = check_external_call(call_lll)
             else:
                 typ = bool_ty
                 ret_lll = call_lll

--- a/vyper/old_codegen/external_call.py
+++ b/vyper/old_codegen/external_call.py
@@ -5,6 +5,7 @@ from vyper.old_codegen.abi import abi_encode, abi_type_of
 from vyper.old_codegen.lll_node import Encoding, LLLnode
 from vyper.old_codegen.parser_utils import (
     calculate_type_for_external_return,
+    check_external_call,
     get_element_ptr,
     getpos,
     unwrap_location,
@@ -153,7 +154,7 @@ def _external_call_helper(
     else:
         call_op = ["call", gas, contract_address, value, args_ofst, args_len, ret_ofst, ret_len]
 
-    sub.append(["assert", call_op])
+    sub.append(check_external_call(call_op))
 
     if contract_sig.return_type is not None:
         sub += ret_unpacker

--- a/vyper/old_codegen/parser_utils.py
+++ b/vyper/old_codegen/parser_utils.py
@@ -44,7 +44,7 @@ setcontext(DecimalContextOverride(prec=78))
 
 # propagate revert message when calls to external contracts fail
 def check_external_call(call_lll):
-    copy_revertdata = ["returndatacopy", 0, "returndatasize"]
+    copy_revertdata = ["returndatacopy", 0, 0, "returndatasize"]
     revert = ["revert", 0, "returndatasize"]
 
     propagate_revert_lll = ["seq", copy_revertdata, revert]

--- a/vyper/old_codegen/parser_utils.py
+++ b/vyper/old_codegen/parser_utils.py
@@ -42,6 +42,15 @@ class DecimalContextOverride(Context):
 setcontext(DecimalContextOverride(prec=78))
 
 
+# propagate revert message when calls to external contracts fail
+def check_external_call(call_lll):
+    copy_revertdata = ["returndatacopy", 0, "returndatasize"]
+    revert = ["revert", 0, "returndatasize"]
+
+    propagate_revert_lll = ["seq", copy_revertdata, revert]
+    return ["if", ["iszero", call_lll], propagate_revert_lll]
+
+
 def type_check_wrapper(fn):
     def _wrapped(*args, **kwargs):
         return_value = fn(*args, **kwargs)


### PR DESCRIPTION
### What I did
Fix #2529 

### How I did it
Change straight `assert (call ...)` to
 ```
 if !(call ...) (seq
 (returndatacopy 0 0 returndatasize)
(revert 0 returndatasize)
))
```

### How to verify it
Check out tests

### Description for the changelog
Propagate revert data when external call fails

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
