### PR TITLE
allow variable access on constant/literal arrays

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -395,3 +395,18 @@ def bar(_baz: Foo[3]) -> String[96]:
     c = get_contract(code)
     c_input = [[i, msg] for i, msg in enumerate(("Hello ", "world", "!!!!"))]
     assert c.bar(c_input) == "Hello world!!!!"
+
+
+def test_constant_list(get_contract, assert_tx_failed):
+    some_good_primes = [5.0, 11.0, 17.0, 29.0, 37.0, 41.0]
+    code = f"""
+MY_LIST: constant(decimal[6]) = {some_good_primes}
+@external
+def ix(i: uint256) -> decimal:
+    return MY_LIST[i]
+    """
+    c = get_contract(code)
+    for i, p in enumerate(some_good_primes):
+        assert c.ix(i) == p
+    # assert oob
+    assert_tx_failed(lambda: c.ix(len(some_good_primes) + 1))

--- a/vyper/old_codegen/expr.py
+++ b/vyper/old_codegen/expr.py
@@ -446,7 +446,15 @@ class Expr:
                 return get_element_ptr(sub, self.expr.attr, pos=getpos(self.expr))
 
     def parse_Subscript(self):
-        sub = Expr.parse_variable_location(self.expr.value, self.context)
+        sub = Expr(self.expr.value, self.context).lll_node
+        if sub.value == "multi":
+            # force literal to memory
+            t = LLLnode(self.context.new_internal_variable(sub.typ), typ=sub.typ, location="memory")
+            sub = LLLnode.from_list(
+                ["seq", make_setter(t, sub, pos=getpos(self.expr)), t],
+                typ=sub.typ,
+                location="memory",
+            )
 
         if isinstance(sub.typ, MappingType):
             # TODO sanity check we are in a self.my_map[i] situation
@@ -465,6 +473,7 @@ class Expr:
                 return
         else:
             return
+
         lll_node = get_element_ptr(sub, index, pos=getpos(self.expr))
         lll_node.mutable = sub.mutable
         return lll_node


### PR DESCRIPTION
### What I did
Fix #2156 and #2130 

Note that a bug similar to #2130 can still be triggered with a list of ambiguous type. For instance, `MY_LIST: constant(uint256[1]) = [1]`. I used a `decimal` in the test to demonstrate that the array literals pass but the type checker issue still needs to be addressed.

### How I did it
Expand the logic in `Expr.parse_Subscript` to handle constants/literals

### How to verify it
See test

### Description for the changelog
Allow variable access on constant/literal arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
