### PR TITLE
Update extract32() description

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -342,8 +342,8 @@ Data Manipulation
 
         @external
         @view
-        def foo(Bytes[32]) -> address:
-            return extract32(b, 12, output_type=address)
+        def foo(b: Bytes[32]) -> address:
+            return extract32(b, 0, output_type=address)
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did

Learning how extract32() works

### How I did it

Thanks to @skellet0r 

### Description for the changelog

before
```python
@external
@view
def foo(Bytes[32]) -> address:
    return extract32(b, 12, output_type=address)
```
after:
```python
@external
@view
def foo(b: Bytes[32]) -> address:
    return extract32(b, 0, output_type=address)
```

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://mymodernmet.com/wp/wp-content/uploads/2018/01/bailey-dog-meme-1.jpg)
