### PR TITLE
fix a bug in usage of scm-setuptools

### DIFF
--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -1,2 +1,14 @@
 from vyper.compiler import compile_code, compile_codes  # noqa: F401
-from vyper.version import version as __version__
+
+
+try:
+    from importlib.metadata import PackageNotFoundError  # type: ignore
+    from importlib.metadata import version as _version  # type: ignore
+except ModuleNotFoundError:
+    from importlib_metadata import PackageNotFoundError  # type: ignore
+    from importlib_metadata import version as _version  # type: ignore
+
+try:
+    __version__ = _version(__name__)
+except PackageNotFoundError:
+    from vyper.version import version as __version__


### PR DESCRIPTION
The existing way doesn't work if `python setup.py install` hasn't been run yet.
This way works both with pyinstaller and regular setup.py.

### How to verify it
`make docs` works without running `make` first. `make freeze` still produces a binary with a correct version.

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/144144946-0c634b0b-3216-4972-a19f-cba289445e30.png)