### PR TITLE
add commit hash to --version even on tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,15 @@ extras_require["dev"] = (
 with open("README.md", "r") as f:
     long_description = f.read()
 
+
+# force commit hash to be appended to version even when tag is exact
+# (breaks PEP 440, but this is the debug info, not the version tag for pypi)
+def _local_version(version):
+    return f"+{version.node}-dirty" if version.dirty else f'+{version.node}'
+
 setup(
     name="vyper",
-    use_scm_version=True,
+    use_scm_version={"local_scheme": _local_version},
     description="Vyper: the Pythonic Programming Language for the EVM",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### What I did
normally setuptools_scm strips the commit hash when building from an
exact tag (e.g. git tag is v1.1.1); this adds it back on

### How I did it
Override the `"local_scheme"` parameters in setuptools_scm

### How to verify it
Locally create a test tag like v0.3.2, `make install` and check that `vyper --version` has commit hash in it.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
