### PR TITLE
fix: gas estimate in presence of immutables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,11 +111,11 @@ def get_contract_module(no_optimize):
 
 
 def get_compiler_gas_estimate(code, func):
-    lll_nodes = compiler.phases.CompilerData(code).lll_nodes
+    lll_runtime = compiler.phases.CompilerData(code).lll_runtime
     if func:
-        return compiler.utils.build_gas_estimates(lll_nodes)[func] + 22000
+        return compiler.utils.build_gas_estimates(lll_runtime)[func] + 22000
     else:
-        return sum(compiler.utils.build_gas_estimates(lll_nodes).values()) + 22000
+        return sum(compiler.utils.build_gas_estimates(lll_runtime).values()) + 22000
 
 
 def check_gas_on_chain(w3, tester, code, func=None, res=None):

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -99,7 +99,7 @@ def build_method_identifiers_output(compiler_data: CompilerData) -> dict:
 def build_abi_output(compiler_data: CompilerData) -> list:
     abi = compiler_data.vyper_module_folded._metadata["type"].to_abi_dict()
     # Add gas estimates for each function to ABI
-    gas_estimates = build_gas_estimates(compiler_data.lll_nodes)
+    gas_estimates = build_gas_estimates(compiler_data.lll_runtime)
     for func in abi:
         try:
             func_signature = func["name"]

--- a/vyper/compiler/utils.py
+++ b/vyper/compiler/utils.py
@@ -1,18 +1,10 @@
 from vyper.old_codegen.lll_node import LLLnode
 
 
-def build_gas_estimates(lll_nodes: LLLnode) -> dict:
+def build_gas_estimates(lll_runtime: LLLnode) -> dict:
     gas_estimates: dict = {}
 
-    # Extract the stuff inside the LLL bracket
-    if (
-        lll_nodes.value == "seq"
-        and len(lll_nodes.args) > 0
-        and lll_nodes.args[-1].value == "return"
-    ):
-        lll_nodes = lll_nodes.args[-1].args[1].args[1]
-
-    external_sub = next((i for i in lll_nodes.args if i.value == "with"), None)
+    external_sub = next((i for i in lll_runtime.args if i.value == "with"), None)
     if external_sub:
         for func_lll in external_sub.args[-1].args:
             if func_lll.func_name is not None:

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -187,6 +187,7 @@ PSEUDO_OPCODES: OpcodeMap = {
     "UCLAMPLT": (None, 2, 1, 25),
     "UCLAMPLE": (None, 2, 1, 30),
     "CLAMP_NONZERO": (None, 1, 1, 19),
+    "CODELOAD": (None, 1, 1, 9),
     "ASSERT": (None, 1, 0, 85),
     "ASSERT_UNREACHABLE": (None, 1, 0, 17),
     "PASS": (None, 0, 0, 0),


### PR DESCRIPTION
### What I did
Fix #2552

### How I did it
First of all the LLL `codeload` macro had an incorrect gas estimate, second of all the heuristic for finding the runtime LLL was wrong.

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
