### PR TITLE
docs: remove unreferenced var in uint256

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -266,7 +266,7 @@ Operator                     Description
 ``x % y``                    Modulo
 ===========================  ======================
 
-``x``, ``y`` and ``z`` must be of the type ``uint256``.
+``x`` and ``y`` must be of the type ``uint256``.
 
 Decimals
 --------


### PR DESCRIPTION
### What I did

Removed variable ``z`` in the 'Arithmetic Operators' section for uint256.

This variable was originally used for ``uint256_mulmod`` and ``uint256_addmod`` functions, which has been moved to 'Built in Functions', and which documentation was removed from this section in #2081.

### How I did it

NA

### How to verify it

NA

### Description for the changelog

Improve documentation for uint256 type.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images2.minutemediacdn.com/image/upload/c_crop,h_1695,w_2520,x_0,y_142/v1554922648/shape/mentalfloss/548648-istock-462548187.jpg?itok=VjWzHWh3)
