### PR TITLE
optimize ceil32

### DIFF
--- a/vyper/lll/compile_lll.py
+++ b/vyper/lll/compile_lll.py
@@ -510,7 +510,9 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
                     "with",
                     "_val",
                     code.args[0],
-                    ["sub", ["add", "_val", 31], ["mod", ["sub", "_val", 1], 32]],
+                    # in mod32 arithmetic, the solution to x + y == 32 is
+                    # y = bitwise_not(x) & 32
+                    ["add", "_val", ["and", ["not", ["sub", "_val", 1]], 31]],
                 ]
             ),
             withargs,


### PR DESCRIPTION
This shaves 1 instruction (push1 32) and 5 gas off the implementation of
ceil32. This LLL op is a hot path because zero-pad uses it.

To verify the formula for y, check the edge cases:
0: and(not(sub(0, 1)), 31) == 0
1: and(not(sub(1, 1)), 31) == 31
2: and(not(sub(1, 1)), 31) == 30
30: and(not(sub(31, 1)), 31) == 2
31: and(not(sub(31, 1)), 31) == 1

### Description for the changelog
Optimize ceil32 implementation

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
