### PR TITLE
fix the serialization of HashMap type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import find_packages, setup
 import re
+
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [
@@ -48,10 +49,12 @@ def _local_version(version):
 
 def _global_version(version):
     from setuptools_scm.version import guess_next_dev_version
+
     # strip `.devN` suffix since it is not semver compatible
     # minor regex hack to avoid messing too much with setuptools-scm internals
     version_str = guess_next_dev_version(version)
     return re.sub("\.dev\d+", "", version_str)
+
 
 setup(
     name="vyper",

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -86,7 +86,7 @@ CONCISE_NORMALIZERS = (_none_addr,)
 @pytest.fixture
 def tester():
     custom_genesis = PyEVMBackend._generate_genesis_params(overrides={"gas_limit": 4500000})
-    custom_genesis['base_fee_per_gas'] = 0
+    custom_genesis["base_fee_per_gas"] = 0
     backend = PyEVMBackend(genesis_parameters=custom_genesis)
     return EthereumTester(backend=backend)
 

--- a/tests/cli/outputs/test_storage_layout.py
+++ b/tests/cli/outputs/test_storage_layout.py
@@ -45,7 +45,7 @@ def public_foo3():
         "nonreentrant.foo": {"type": "nonreentrant lock", "location": "storage", "slot": 0},
         "nonreentrant.bar": {"type": "nonreentrant lock", "location": "storage", "slot": 1},
         "foo": {
-            "type": "HashMap[address, uint256][address, uint256]",
+            "type": "HashMap[address, uint256]",
             "location": "storage",
             "slot": 2,
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def get_contract_module(no_optimize):
     the same contract is called over multiple runs of the test.
     """
     custom_genesis = PyEVMBackend._generate_genesis_params(overrides={"gas_limit": 4500000})
-    custom_genesis['base_fee_per_gas'] = 0
+    custom_genesis["base_fee_per_gas"] = 0
     backend = PyEVMBackend(genesis_parameters=custom_genesis)
     tester = EthereumTester(backend=backend)
     w3 = Web3(EthereumTesterProvider(tester))

--- a/tests/parser/functions/test_return.py
+++ b/tests/parser/functions/test_return.py
@@ -12,9 +12,11 @@ def hardtest(arg1: Bytes[64], arg2: Bytes[64]) -> Bytes[128]:
     # Make sure underlying structe is correctly right padded
     classic_contract = c._classic_contract
     func = classic_contract.functions.hardtest(b"hello" * 5, b"hello" * 10)
-    tx = func.buildTransaction({
-        "gasPrice": 0,
-    })
+    tx = func.buildTransaction(
+        {
+            "gasPrice": 0,
+        }
+    )
     del tx["chainId"]
     del tx["gasPrice"]
 

--- a/vyper/semantics/types/indexable/mapping.py
+++ b/vyper/semantics/types/indexable/mapping.py
@@ -11,7 +11,7 @@ class MappingDefinition(IndexableTypeDefinition):
     _id = "HashMap"
 
     def __repr__(self):
-        return f"{self._id}[{self.key_type}, {self.value_type}]"
+        return f"HashMap[{self.key_type}, {self.value_type}]"
 
     def compare_type(self, other):
         return (


### PR DESCRIPTION
The way it is currently written, e.g. `HashMap[x, y]` gets serialized as
`HashMap[x, y][x, y]`. This doesn't affect much since most outputs use
ABI typenames but the `-f layout` output uses this serializer.

### How to verify it
Check `vyper -f layout` before and after for this contract:
```python
# map.vy
x: public(HashMap[uint256, uint256])
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
