### PR TITLE
fix(semantics): fix crash when calling non callable self members

### DIFF
--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -97,18 +97,21 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
 
         # get list of internal function calls made by each function
         function_defs = self.ast.get_children(vy_ast.FunctionDef)
-        call_function_names = set(node.name for node in function_defs)
+        function_names = set(node.name for node in function_defs)
         for node in function_defs:
-            self_members[node.name].internal_calls = set(
+            calls_to_self = set(
                 i.func.attr for i in node.get_descendants(vy_ast.Call, {"func.value.id": "self"})
-            ).intersection(call_function_names)
+            )
+            # anything that is not a function call will get semantically checked later
+            calls_to_self = calls_to_self.intersection(function_names)
+            self_members[node.name].internal_calls = calls_to_self
             if node.name in self_members[node.name].internal_calls:
                 self_node = node.get_descendants(
                     vy_ast.Attribute, {"value.id": "self", "attr": node.name}
                 )[0]
                 raise CallViolation(f"Function '{node.name}' calls into itself", self_node)
 
-        for fn_name in sorted(call_function_names):
+        for fn_name in sorted(function_names):
 
             if fn_name not in self_members:
                 # the referenced function does not exist - this is an issue, but we'll report

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -96,12 +96,12 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
         module_node._metadata["type"] = interface
 
         # get list of internal function calls made by each function
-        call_function_names = set()
-        for node in self.ast.get_children(vy_ast.FunctionDef):
-            call_function_names.add(node.name)
+        function_defs = self.ast.get_children(vy_ast.FunctionDef)
+        call_function_names = set(node.name for node in function_defs)
+        for node in function_defs:
             self_members[node.name].internal_calls = set(
                 i.func.attr for i in node.get_descendants(vy_ast.Call, {"func.value.id": "self"})
-            )
+            ).intersection(call_function_names)
             if node.name in self_members[node.name].internal_calls:
                 self_node = node.get_descendants(
                     vy_ast.Attribute, {"value.id": "self", "attr": node.name}


### PR DESCRIPTION
### What I did

Fixes https://github.com/vyperlang/vyper/issues/2536 by filtering `internal_calls` by functions defined within the module. Considering the use of `internal_calls` attribute is only for this semantic analysis `_find_cyclic_call`, this filtering makes sense to me.

The error due to the invalid calls (like in the issue's snippet) will be catched naturally in the later phase of semantic analysis, so I didn't craft anything for that.

### How I did it

see "What I did"

### How to verify it

I added a test case `test_global_ann_assign_callable_no_crash` based on the snippet from the issue, which would cause a crash in `_find_cyclic_call` without this PR's change.
I didn't run the full test yet locally, so I'd like to see CI if this change brings any regressions.

### Description for the changelog

NA?

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()


P.S.

Recently, I started to read some code around Ethereum's ecosystem and Vyper hit my rader as I have a few experience in python ast.
The code base looks very interesting and I hope I can learn a lot and contribute something here.
Thanks for the code review!



