### PR TITLE
fix: improve error message for `self.(immutable name)`

### DIFF
--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -179,8 +179,17 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
                         vy_ast.Assign, filters={"target.id": node.target.id}
                     )
                     if not assignments:
+                        # Special error message for common wrong usages via `self.<immutable name>`
+                        wrong_self_attribute = self.ast.get_descendants(
+                            vy_ast.Attribute, {"value.id": "self", "attr": node.target.id}
+                        )
+                        message = (
+                            "Immutable variables must be accessed without 'self'"
+                            if wrong_self_attribute
+                            else "Immutable definition requires an assignment in the constructor"
+                        )
                         raise SyntaxException(
-                            "Immutable definition requires an assignment in the constructor",
+                            message,
                             node.node_source_code,
                             node.lineno,
                             node.col_offset,

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -185,7 +185,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
                         )
                         message = (
                             "Immutable variables must be accessed without 'self'"
-                            if wrong_self_attribute
+                            if len(wrong_self_attribute) > 0
                             else "Immutable definition requires an assignment in the constructor"
                         )
                         raise SyntaxException(


### PR DESCRIPTION
### What I did

Fixes https://github.com/vyperlang/vyper/issues/2554

### How I did it

There already exists an error message when immutable variables don't have initialization in a constructor.
I added one more check to see if there's `self.(immutable name)` within module ast and prepared an specialized error message for such possibly common wrong usage.

### How to verify it

Added a test case `test_compilation_fails_with_exception_message` in `tests/parser/syntax/test_immutables.py`.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()

P.S.

Happy new year! I hope I'm not disturbing maintainers during holidays.
I appreciate the code review, but please feel free to postpone it if you're in a busy time.
Thank you!