### PR TITLE
fix: type check for constant arrays

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -423,7 +423,7 @@ def ix(i: uint256) -> {type}:
     """
     c = get_contract(code)
     for i, p in enumerate(value):
-        assert c.ix(i) == value[i]
+        assert c.ix(i) == p
     # assert oob
     assert_tx_failed(lambda: c.ix(len(value) + 1))
 

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -182,7 +182,20 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         node._metadata["type"] = get_exact_type_from_node(node)
 
     def visit_Subscript(self, node, type_):
-        base_type = get_exact_type_from_node(node.value)
+        if isinstance(node.value, vy_ast.List):
+            base_type = get_possible_types_from_node(node.value)
+
+            if len(base_type) == 1:
+                base_type = base_type.pop()
+
+            elif type_ and len(base_type) > 1:
+                for p in base_type:
+                    if isinstance(p.value_type, type(type_)):
+                        base_type = p
+                        break
+
+        else:
+            base_type = get_exact_type_from_node(node.value)
         if isinstance(base_type, BaseTypeDefinition):
             # in the vast majority of cases `base_type` is a type definition,
             # however there are some edge cases with args to builtin functions

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -183,15 +183,15 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
 
     def visit_Subscript(self, node, type_):
         if isinstance(node.value, vy_ast.List):
-            base_type = get_possible_types_from_node(node.value)
+            possible_base_types = get_possible_types_from_node(node.value)
 
-            if len(base_type) == 1:
-                base_type = base_type.pop()
+            if len(possible_base_types) == 1:
+                base_type = possible_base_types.pop()
 
-            elif type_ and len(base_type) > 1:
-                for p in base_type:
-                    if isinstance(p.value_type, type(type_)):
-                        base_type = p
+            elif type_ and len(possible_base_types) > 1:
+                for possible_type in possible_base_types:
+                    if isinstance(possible_type.value_type, type(type_)):
+                        base_type = possible_type
                         break
 
         else:

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -240,6 +240,10 @@ class _ExprTypeChecker:
 
     def types_from_Subscript(self, node):
         # index access, e.g. `foo[1]`
+        if isinstance(node.value, vy_ast.List):
+            types_list = self.get_possible_types_from_node(node.value)
+            return [base_type.get_index_type(node.slice.value) for base_type in types_list]
+
         base_type = self.get_exact_type_from_node(node.value)
         return [base_type.get_index_type(node.slice.value)]
 


### PR DESCRIPTION
### What I did

Fix type checker issue in #2534 and #2130.

The type checking for `Subscript` VyperNode type currently assumes that an exact type can be derived for its `value`. Ordinarily, this does not raise an issue for array variables as the `value` of the `Subscript` node in this instance would be a `Name` node type, from which an exact type can be determined. 

However, where the array is a constant, the `value` of the `Subscript` node is now a `List` node. When deriving the type for a `List` node, a list of possible types are returned instead of a specific type (e.g. an array of [0, 1, 2] will return a list of `uint8`, `int128`, `int256` and `uint256`). As a result, a `StructureException` of 'Ambiguous type' will be thrown when there is more than one possible type for an array.

### How I did it

Relax the assumption that an exact type can be derived for a Subscript node where its `value` is a `List` node:
- In `vyper/semantics/validation/annotation.py`, the `visit_Subscript` function is amended to get all possible types where `value` is a `List` node. If only one type is returned, it will be assigned as the base type. If more than one value is returned, we iterate through the list of possible types and return the type that matches the `type_` argument supplied to this function.
- In `vyper/semantics/validation/utils.py`, the `types_from_Subscript` function is amended to return all possible types where `value` is a `List` node.

### How to verify it

See test cases.

### Description for the changelog

Fix type checker issue for constant/literal arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/33/c7/d0/33c7d062ede69129b83bc2567d9879f6.jpg)
