### PR TITLE
chore: update web3py function names for test suite

### DIFF
--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -98,7 +98,7 @@ def zero_gas_price_strategy(web3, transaction_params=None):
 @pytest.fixture
 def w3(tester):
     w3 = Web3(EthereumTesterProvider(tester))
-    w3.eth.setGasPriceStrategy(zero_gas_price_strategy)
+    w3.eth.set_gas_price_strategy(zero_gas_price_strategy)
     return w3
 
 
@@ -123,7 +123,7 @@ def _get_contract(w3, source_code, no_optimize, *args, **kwargs):
     }
     tx_info.update(kwargs)
     tx_hash = deploy_transaction.transact(tx_info)
-    address = w3.eth.getTransactionReceipt(tx_hash)["contractAddress"]
+    address = w3.eth.get_transaction_receipt(tx_hash)["contractAddress"]
     return w3.eth.contract(
         address,
         abi=abi,
@@ -143,7 +143,7 @@ def get_contract(w3, no_optimize):
 @pytest.fixture
 def get_logs(w3):
     def get_logs(tx_hash, c, event_name):
-        tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+        tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
         return c._classic_contract.events[event_name]().processReceipt(tx_receipt)
 
     return get_logs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def get_contract_from_lll(w3, no_optimize):
         c = w3.eth.contract(abi=abi, bytecode=bytecode)
         deploy_transaction = c.constructor()
         tx_hash = deploy_transaction.transact()
-        address = w3.eth.getTransactionReceipt(tx_hash)["contractAddress"]
+        address = w3.eth.get_transaction_receipt(tx_hash)["contractAddress"]
         contract = w3.eth.contract(
             address,
             abi=abi,
@@ -105,7 +105,7 @@ def get_contract_module(no_optimize):
     backend = PyEVMBackend(genesis_parameters=custom_genesis)
     tester = EthereumTester(backend=backend)
     w3 = Web3(EthereumTesterProvider(tester))
-    w3.eth.setGasPriceStrategy(zero_gas_price_strategy)
+    w3.eth.set_gas_price_strategy(zero_gas_price_strategy)
 
     def get_contract_module(source_code, *args, **kwargs):
         return _get_contract(w3, source_code, no_optimize, *args, **kwargs)

--- a/tests/examples/auctions/test_blind_auction.py
+++ b/tests/examples/auctions/test_blind_auction.py
@@ -310,9 +310,9 @@ def test_blind_auction(w3, auction_contract):
     _values[2] = 300
     _fakes[2] = True
     _secrets[2] = (1234567).to_bytes(32, byteorder="big")
-    balance_before_reveal = w3.eth.getBalance(k2)
+    balance_before_reveal = w3.eth.get_balance(k2)
     auction_contract.reveal(3, _values, _fakes, _secrets, transact={"value": 0, "from": k2})
-    balance_after_reveal = w3.eth.getBalance(k2)
+    balance_after_reveal = w3.eth.get_balance(k2)
 
     #: Check that highest bidder and highest bid have updated
     assert auction_contract.highestBid() == 200
@@ -331,9 +331,9 @@ def test_blind_auction(w3, auction_contract):
     _values[1] = 275
     _fakes[1] = True
     _secrets[1] = (9876543).to_bytes(32, byteorder="big")
-    balance_before_reveal = w3.eth.getBalance(k3)
+    balance_before_reveal = w3.eth.get_balance(k3)
     auction_contract.reveal(2, _values, _fakes, _secrets, transact={"value": 0, "from": k3})
-    balance_after_reveal = w3.eth.getBalance(k3)
+    balance_after_reveal = w3.eth.get_balance(k3)
 
     #: Check that highest bidder and highest bid have NOT updated
     assert auction_contract.highestBidder() == k2
@@ -350,9 +350,9 @@ def test_blind_auction(w3, auction_contract):
     w3.testing.mine(REVEAL_TIME)
 
     # End the auction
-    balance_before_end = w3.eth.getBalance(k0)
+    balance_before_end = w3.eth.get_balance(k0)
     auction_contract.auctionEnd(transact={"value": 0, "from": k0})
-    balance_after_end = w3.eth.getBalance(k0)
+    balance_after_end = w3.eth.get_balance(k0)
 
     # Check that auction indeed ended
     assert auction_contract.ended() is True
@@ -361,7 +361,7 @@ def test_blind_auction(w3, auction_contract):
     assert balance_after_end == (balance_before_end + 200)
 
     # Check that k1 is able to withdraw their outbid bid
-    balance_before_withdraw = w3.eth.getBalance(k1)
+    balance_before_withdraw = w3.eth.get_balance(k1)
     auction_contract.withdraw(transact={"value": 0, "from": k1})
-    balance_after_withdraw = w3.eth.getBalance(k1)
+    balance_after_withdraw = w3.eth.get_balance(k1)
     assert balance_after_withdraw == (balance_before_withdraw + 100)

--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -5,7 +5,7 @@ EXPIRY = 16
 
 @pytest.fixture
 def auction_start(w3):
-    return w3.eth.getBlock("latest").timestamp + 1
+    return w3.eth.get_block("latest").timestamp + 1
 
 
 @pytest.fixture
@@ -63,9 +63,9 @@ def test_bid(w3, tester, auction_contract, assert_tx_failed):
     # Account has a greater pending return balance after being outbid
     assert pending_return_after_outbid > pending_return_before_outbid
 
-    balance_before_withdrawal = w3.eth.getBalance(k1)
+    balance_before_withdrawal = w3.eth.get_balance(k1)
     auction_contract.withdraw(transact={"from": k1})
-    balance_after_withdrawal = w3.eth.getBalance(k1)
+    balance_after_withdrawal = w3.eth.get_balance(k1)
     # Balance increases after withdrawal
     assert balance_after_withdrawal > balance_before_withdrawal
     # Pending return balance is reset to 0
@@ -80,9 +80,9 @@ def test_end_auction(w3, tester, auction_contract, assert_tx_failed):
     # Move block timestamp foreward to reach auction end time
     # tester.time_travel(tester.get_block_by_number('latest')['timestamp'] + EXPIRY)
     w3.testing.mine(EXPIRY)
-    balance_before_end = w3.eth.getBalance(k1)
+    balance_before_end = w3.eth.get_balance(k1)
     auction_contract.endAuction(transact={"from": k2})
-    balance_after_end = w3.eth.getBalance(k1)
+    balance_after_end = w3.eth.get_balance(k1)
     # Beneficiary receives the highest bid
     assert balance_after_end == balance_before_end + 1 * 10 ** 10
     # Bidder cannot bid after auction end time has been reached

--- a/tests/examples/crowdfund/test_crowdfund_example.py
+++ b/tests/examples/crowdfund/test_crowdfund_example.py
@@ -14,16 +14,16 @@ def test_crowdfund_example(c, w3):
     c.participate(transact={"value": 5})
 
     assert c.timelimit() == 60
-    assert c.deadline() - w3.eth.getBlock("latest").timestamp == 59
-    assert not w3.eth.getBlock("latest").timestamp >= c.deadline()  # expired
-    assert not w3.eth.getBalance(c.address) >= c.goal()  # not reached
+    assert c.deadline() - w3.eth.get_block("latest").timestamp == 59
+    assert not w3.eth.get_block("latest").timestamp >= c.deadline()  # expired
+    assert not w3.eth.get_balance(c.address) >= c.goal()  # not reached
     c.participate(transact={"value": 49})
     # assert c.reached()
-    pre_bal = w3.eth.getBalance(a1)
+    pre_bal = w3.eth.get_balance(a1)
     w3.testing.mine(100)
-    assert not w3.eth.getBlock("latest").number >= c.deadline()  # expired
+    assert not w3.eth.get_block("latest").number >= c.deadline()  # expired
     c.finalize(transact={})
-    post_bal = w3.eth.getBalance(a1)
+    post_bal = w3.eth.get_balance(a1)
     assert post_bal - pre_bal == 54
 
 
@@ -38,7 +38,7 @@ def test_crowdfund_example2(c, w3):
     w3.testing.mine(100)
     # assert c.expired()
     # assert not c.reached()
-    pre_bals = [w3.eth.getBalance(x) for x in [a3, a4, a5, a6]]
+    pre_bals = [w3.eth.get_balance(x) for x in [a3, a4, a5, a6]]
     c.refund(transact={})
-    post_bals = [w3.eth.getBalance(x) for x in [a3, a4, a5, a6]]
+    post_bals = [w3.eth.get_balance(x) for x in [a3, a4, a5, a6]]
     assert [y - x for x, y in zip(pre_bals, post_bals)] == [1, 2, 3, 4]

--- a/tests/examples/market_maker/test_on_chain_market_maker.py
+++ b/tests/examples/market_maker/test_on_chain_market_maker.py
@@ -77,7 +77,7 @@ def test_eth_to_tokens(w3, market_maker, erc20):
 
 def test_tokens_to_eth(w3, market_maker, erc20):
     a1 = w3.eth.accounts[1]
-    a1_balance_before = w3.eth.getBalance(a1)
+    a1_balance_before = w3.eth.get_balance(a1)
 
     erc20.transfer(a1, w3.toWei(2, "ether"), transact={})
     erc20.approve(market_maker.address, w3.toWei(2, "ether"), transact={"from": a1})
@@ -86,17 +86,17 @@ def test_tokens_to_eth(w3, market_maker, erc20):
         w3.toWei(1, "ether"),
         transact={"value": w3.toWei(2, "ether"), "from": a1},
     )
-    assert w3.eth.getBalance(market_maker.address) == w3.toWei(2, "ether")
+    assert w3.eth.get_balance(market_maker.address) == w3.toWei(2, "ether")
     # sent 2 eth, with initiate.
-    assert w3.eth.getBalance(a1) == a1_balance_before - w3.toWei(2, "ether")
+    assert w3.eth.get_balance(a1) == a1_balance_before - w3.toWei(2, "ether")
     assert market_maker.totalTokenQty() == w3.toWei(1, "ether")
 
     erc20.approve(market_maker.address, w3.toWei(1, "ether"), transact={"from": a1})
     market_maker.tokensToEth(w3.toWei(1, "ether"), transact={"from": a1})
     # 1 eth less in market.
-    assert w3.eth.getBalance(market_maker.address) == w3.toWei(1, "ether")
+    assert w3.eth.get_balance(market_maker.address) == w3.toWei(1, "ether")
     # got 1 eth back, for trade.
-    assert w3.eth.getBalance(a1) == a1_balance_before - w3.toWei(1, "ether")
+    assert w3.eth.get_balance(a1) == a1_balance_before - w3.toWei(1, "ether")
     # Tokens increased by 1
     assert market_maker.totalTokenQty() == w3.toWei(2, "ether")
     assert market_maker.totalEthQty() == w3.toWei(1, "ether")
@@ -104,7 +104,7 @@ def test_tokens_to_eth(w3, market_maker, erc20):
 
 def test_owner_withdraw(w3, market_maker, erc20, assert_tx_failed):
     a0, a1 = w3.eth.accounts[:2]
-    a0_balance_before = w3.eth.getBalance(a0)
+    a0_balance_before = w3.eth.get_balance(a0)
     # Approve 2 eth transfers.
     erc20.approve(market_maker.address, w3.toWei(2, "ether"), transact={})
     # Initiate market with 2 eth value.
@@ -114,12 +114,12 @@ def test_owner_withdraw(w3, market_maker, erc20, assert_tx_failed):
         transact={"value": w3.toWei(2, "ether")},
     )
     # 2 eth was sent to market_maker contract.
-    assert w3.eth.getBalance(a0) == a0_balance_before - w3.toWei(2, "ether")
+    assert w3.eth.get_balance(a0) == a0_balance_before - w3.toWei(2, "ether")
     # a0's balance is locked up in market_maker contract.
     assert erc20.balanceOf(a0) == TOKEN_TOTAL_SUPPLY - w3.toWei(1, "ether")
 
     # Only owner can call ownerWithdraw
     assert_tx_failed(lambda: market_maker.ownerWithdraw(transact={"from": a1}))
     market_maker.ownerWithdraw(transact={})
-    assert w3.eth.getBalance(a0) == a0_balance_before  # Eth balance restored.
+    assert w3.eth.get_balance(a0) == a0_balance_before  # Eth balance restored.
     assert erc20.balanceOf(a0) == TOKEN_TOTAL_SUPPLY  # Tokens returned to a0.

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -26,7 +26,7 @@ def get_balance(w3):
     def get_balance():
         a0, a1 = w3.eth.accounts[:2]
         # balance of a1 = seller, a2 = buyer
-        return w3.eth.getBalance(a0), w3.eth.getBalance(a1)
+        return w3.eth.get_balance(a0), w3.eth.get_balance(a1)
 
     return get_balance
 
@@ -140,8 +140,8 @@ def __default__():
     buyer_contract = get_contract(buyer_contract_code, *[c.address])
     buyer_contract_address = buyer_contract.address
     init_bal_a0, init_bal_buyer_contract = (
-        w3.eth.getBalance(a0),
-        w3.eth.getBalance(buyer_contract_address),
+        w3.eth.get_balance(a0),
+        w3.eth.get_balance(buyer_contract_address),
     )
     # Start purchase
     buyer_contract.start_purchase(transact={"value": 4, "from": w3.eth.accounts[1], "gas": 100000})
@@ -152,7 +152,7 @@ def __default__():
     buyer_contract.start_received(transact={"from": w3.eth.accounts[1], "gas": 100000})
 
     # Final check if everything worked. 1 value has been transferred
-    assert w3.eth.getBalance(a0), w3.eth.getBalance(buyer_contract_address) == (
+    assert w3.eth.get_balance(a0), w3.eth.get_balance(buyer_contract_address) == (
         init_bal_a0 + 1,
         init_bal_buyer_contract - 1,
     )

--- a/tests/examples/wallet/test_wallet.py
+++ b/tests/examples/wallet/test_wallet.py
@@ -11,7 +11,7 @@ def c(w3, get_contract):
         code = f.read()
     # Sends wei to the contract for future transactions gas costs
     c = get_contract(code, *[[a1, a2, a3, a4, a5], 3])
-    w3.eth.sendTransaction({"to": c.address, "value": 10 ** 17})
+    w3.eth.send_transaction({"to": c.address, "value": 10 ** 17})
     return c
 
 
@@ -110,7 +110,7 @@ def test_javascript_signatures(w3, get_contract):
         owners = [w3.toChecksumAddress(x) for x in accounts + [a3, zero_address, zero_address]]
         x2 = get_contract(f.read(), *[owners, 2])
 
-    w3.eth.sendTransaction({"to": x2.address, "value": 10 ** 17})
+    w3.eth.send_transaction({"to": x2.address, "value": 10 ** 17})
 
     # There's no need to pass in signatures because the owners are 0 addresses
     # causing them to default to valid signatures

--- a/tests/parser/features/decorators/test_nonreentrant.py
+++ b/tests/parser/features/decorators/test_nonreentrant.py
@@ -154,20 +154,20 @@ def __default__():
     # Test unprotected function without callback.
     reentrant_contract.unprotected_function("some value", False, transact={"value": 1000})
     assert reentrant_contract.special_value() == "some value"
-    assert w3.eth.getBalance(reentrant_contract.address) == 0
-    assert w3.eth.getBalance(calling_contract.address) == 1000
+    assert w3.eth.get_balance(reentrant_contract.address) == 0
+    assert w3.eth.get_balance(calling_contract.address) == 1000
 
     # Test unprotected function with callback to default.
     reentrant_contract.unprotected_function("another value", True, transact={"value": 1000})
     assert reentrant_contract.special_value() == "another value"
-    assert w3.eth.getBalance(reentrant_contract.address) == 1000
-    assert w3.eth.getBalance(calling_contract.address) == 1000
+    assert w3.eth.get_balance(reentrant_contract.address) == 1000
+    assert w3.eth.get_balance(calling_contract.address) == 1000
 
     # Test protected function without callback.
     reentrant_contract.protected_function("surprise!", False, transact={"value": 1000})
     assert reentrant_contract.special_value() == "surprise!"
-    assert w3.eth.getBalance(reentrant_contract.address) == 1000
-    assert w3.eth.getBalance(calling_contract.address) == 2000
+    assert w3.eth.get_balance(reentrant_contract.address) == 1000
+    assert w3.eth.get_balance(calling_contract.address) == 2000
 
     # Test protected function with callback to default.
     assert_tx_failed(

--- a/tests/parser/features/decorators/test_payable.py
+++ b/tests/parser/features/decorators/test_payable.py
@@ -352,7 +352,7 @@ def __default__():
     """
 
     c = get_contract(code)
-    w3.eth.sendTransaction({"to": c.address, "value": 100, "data": "0x12345678"}),
+    w3.eth.send_transaction({"to": c.address, "value": 100, "data": "0x12345678"}),
 
 
 def test_nonpayable_default_func_invalid_calldata(get_contract, w3, assert_tx_failed):
@@ -368,7 +368,7 @@ def __default__():
     """
 
     c = get_contract(code)
-    w3.eth.sendTransaction({"to": c.address, "value": 0, "data": "0x12345678"})
+    w3.eth.send_transaction({"to": c.address, "value": 0, "data": "0x12345678"})
     assert_tx_failed(
-        lambda: w3.eth.sendTransaction({"to": c.address, "value": 100, "data": "0x12345678"})
+        lambda: w3.eth.send_transaction({"to": c.address, "value": 100, "data": "0x12345678"})
     )

--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -408,13 +408,13 @@ def __default__():
 
     c = get_contract_with_gas_estimation(code)
 
-    w3.eth.sendTransaction({"to": c.address, "value": w3.toWei(1, "ether")})
-    assert w3.eth.getBalance(c.address) == w3.toWei(1, "ether")
+    w3.eth.send_transaction({"to": c.address, "value": w3.toWei(1, "ether")})
+    assert w3.eth.get_balance(c.address) == w3.toWei(1, "ether")
     a3 = w3.eth.accounts[2]
-    assert w3.eth.getBalance(a3) == w3.toWei(1000000, "ether")
+    assert w3.eth.get_balance(a3) == w3.toWei(1000000, "ether")
     c.test(True, a3, w3.toWei(0.05, "ether"), transact={})
-    assert w3.eth.getBalance(a3) == w3.toWei(1000000.05, "ether")
-    assert w3.eth.getBalance(c.address) == w3.toWei(0.95, "ether")
+    assert w3.eth.get_balance(a3) == w3.toWei(1000000.05, "ether")
+    assert w3.eth.get_balance(c.address) == w3.toWei(0.95, "ether")
 
 
 def test_private_msg_sender(get_contract, assert_compile_failed):

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -1368,8 +1368,8 @@ def get_lucky(amount_to_send: uint256) -> int128:
     c2.get_lucky(0, transact={"value": 500})
     # Contract 1 received money.
     assert c1.get_balance() == 500
-    assert w3.eth.getBalance(c1.address) == 500
-    assert w3.eth.getBalance(c2.address) == 0
+    assert w3.eth.get_balance(c1.address) == 500
+    assert w3.eth.get_balance(c2.address) == 0
 
     # Send subset of amount
     assert c2.get_lucky(250, call={"value": 500}) == 1
@@ -1377,8 +1377,8 @@ def get_lucky(amount_to_send: uint256) -> int128:
 
     # Contract 1 received more money.
     assert c1.get_balance() == 750
-    assert w3.eth.getBalance(c1.address) == 750
-    assert w3.eth.getBalance(c2.address) == 250
+    assert w3.eth.get_balance(c1.address) == 750
+    assert w3.eth.get_balance(c2.address) == 250
 
 
 def test_external_call_with_gas(assert_tx_failed, get_contract_with_gas_estimation):

--- a/tests/parser/features/external_contracts/test_self_call_struct.py
+++ b/tests/parser/features/external_contracts/test_self_call_struct.py
@@ -26,11 +26,11 @@ def wrap_get_my_struct_BROKEN(_e1: decimal) -> MyStruct:
     c = get_contract(code)
     assert c.wrap_get_my_struct_WORKING(Decimal("0.1")) == (
         Decimal("0.1"),
-        w3.eth.getBlock(w3.eth.blockNumber)["timestamp"],
+        w3.eth.get_block(w3.eth.block_number)["timestamp"],
     )
     assert c.wrap_get_my_struct_BROKEN(Decimal("0.1")) == (
         Decimal("0.1"),
-        w3.eth.getBlock(w3.eth.blockNumber)["timestamp"],
+        w3.eth.get_block(w3.eth.block_number)["timestamp"],
     )
 
 

--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -21,7 +21,7 @@ def foo():
     tx_hash = c.foo(transact={"from": a0, "gas": gas_sent, "gasPrice": 10})
     # More info on receipt status:
     # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md#specification.
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
     assert tx_receipt["status"] == 0
     # Checks for gas refund from revert
     assert tx_receipt["gasUsed"] < gas_sent

--- a/tests/parser/features/test_assert_unreachable.py
+++ b/tests/parser/features/test_assert_unreachable.py
@@ -13,7 +13,7 @@ def foo():
     a0 = w3.eth.accounts[0]
     gas_sent = 10 ** 6
     tx_hash = c.foo(transact={"from": a0, "gas": gas_sent, "gasPrice": 10})
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
 
     assert tx_receipt["status"] == 0
     assert tx_receipt["gasUsed"] == gas_sent  # Drains all gains sent

--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -10,7 +10,7 @@ def _make_tx(w3, address, signature, values):
     # helper function to broadcast transactions that fail clamping check
     sig = keccak(signature.encode()).hex()[:8]
     data = "".join(int(i).to_bytes(32, "big", signed=i < 0).hex() for i in values)
-    w3.eth.sendTransaction({"to": address, "data": f"0x{sig}{data}"})
+    w3.eth.send_transaction({"to": address, "data": f"0x{sig}{data}"})
 
 
 def test_bytes_clamper(assert_tx_failed, get_contract_with_gas_estimation):

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -274,7 +274,7 @@ def foo():
     }
 
     # Event is decoded correctly
-    timestamp = w3.eth.getBlock(w3.eth.blockNumber).timestamp
+    timestamp = w3.eth.get_block(w3.eth.block_number).timestamp
     logs = get_logs(tx_hash, c, "MyLog")
 
     assert logs[0].args.arg1 == [1, 2]
@@ -422,7 +422,7 @@ def foo():
     }
 
     # Event is decoded correctly
-    timestamp = w3.eth.getBlock(w3.eth.blockNumber).timestamp
+    timestamp = w3.eth.get_block(w3.eth.block_number).timestamp
     logs = get_logs(tx_hash, c, "MyLog")
     args = logs[0].args
     assert args.arg1 == 123

--- a/tests/parser/features/test_logging_from_call.py
+++ b/tests/parser/features/test_logging_from_call.py
@@ -77,7 +77,7 @@ def test_func(_value: uint256,input: Bytes[133]):
 
     # assert c.test_func(2**255, b'x' * 129, call={}) == b'x' * 129
     tx_hash = c.test_func(1234444, b"x" * 129, transact={})
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
     print(tx_receipt)
     logs = get_logs(tx_hash, c, "TestLog")
 
@@ -154,7 +154,7 @@ def test_func(_value: uint256,input: Bytes[2048]):
     c = get_contract(code)
 
     tx_hash = c.test_func(333, b"x" * 132, transact={})
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
     print(tx_receipt)
     logs = get_logs(tx_hash, c, "TestLog")
 

--- a/tests/parser/functions/test_create_with_code_of.py
+++ b/tests/parser/functions/test_create_with_code_of.py
@@ -97,7 +97,7 @@ def test2(a: uint256) -> Bytes[100]:
     GAS_SENT = 30000
     tx_hash = c.test2(0, transact={"gas": GAS_SENT})
 
-    receipt = w3.eth.getTransactionReceipt(tx_hash)
+    receipt = w3.eth.get_transaction_receipt(tx_hash)
 
     assert receipt["status"] == 0
     assert receipt["gasUsed"] < GAS_SENT

--- a/tests/parser/functions/test_default_function.py
+++ b/tests/parser/functions/test_default_function.py
@@ -9,11 +9,11 @@ def __init__():
     c = get_contract_with_gas_estimation(code)
 
     assert c.x() == 123
-    assert w3.eth.getBalance(c.address) == 0
+    assert w3.eth.get_balance(c.address) == 0
     assert_tx_failed(
-        lambda: w3.eth.sendTransaction({"to": c.address, "value": w3.toWei(0.1, "ether")})
+        lambda: w3.eth.send_transaction({"to": c.address, "value": w3.toWei(0.1, "ether")})
     )
-    assert w3.eth.getBalance(c.address) == 0
+    assert w3.eth.get_balance(c.address) == 0
 
 
 def test_basic_default(w3, get_logs, get_contract_with_gas_estimation):
@@ -28,9 +28,9 @@ def __default__():
     """
     c = get_contract_with_gas_estimation(code)
 
-    logs = get_logs(w3.eth.sendTransaction({"to": c.address, "value": 10 ** 17}), c, "Sent")
+    logs = get_logs(w3.eth.send_transaction({"to": c.address, "value": 10 ** 17}), c, "Sent")
     assert w3.eth.accounts[0] == logs[0].args.sender
-    assert w3.eth.getBalance(c.address) == w3.toWei(0.1, "ether")
+    assert w3.eth.get_balance(c.address) == w3.toWei(0.1, "ether")
 
 
 def test_basic_default_default_param_function(w3, get_logs, get_contract_with_gas_estimation):
@@ -51,9 +51,9 @@ def __default__():
     """
     c = get_contract_with_gas_estimation(code)
 
-    logs = get_logs(w3.eth.sendTransaction({"to": c.address, "value": 10 ** 17}), c, "Sent")
+    logs = get_logs(w3.eth.send_transaction({"to": c.address, "value": 10 ** 17}), c, "Sent")
     assert w3.eth.accounts[0] == logs[0].args.sender
-    assert w3.eth.getBalance(c.address) == w3.toWei(0.1, "ether")
+    assert w3.eth.get_balance(c.address) == w3.toWei(0.1, "ether")
 
 
 def test_basic_default_not_payable(w3, assert_tx_failed, get_contract_with_gas_estimation):
@@ -67,7 +67,7 @@ def __default__():
     """
     c = get_contract_with_gas_estimation(code)
 
-    assert_tx_failed(lambda: w3.eth.sendTransaction({"to": c.address, "value": 10 ** 17}))
+    assert_tx_failed(lambda: w3.eth.send_transaction({"to": c.address, "value": 10 ** 17}))
 
 
 def test_multi_arg_default(assert_compile_failed, get_contract_with_gas_estimation):
@@ -121,12 +121,12 @@ def __default__():
 
     assert c.blockHashAskewLimitary(0) == 7
 
-    logs = get_logs(w3.eth.sendTransaction({"to": c.address, "value": 0}), c, "Sent")
+    logs = get_logs(w3.eth.send_transaction({"to": c.address, "value": 0}), c, "Sent")
     assert 1 == logs[0].args.sig
 
     logs = get_logs(
         # call blockHashAskewLimitary
-        w3.eth.sendTransaction({"to": c.address, "value": 0, "data": "0x00000000"}),
+        w3.eth.send_transaction({"to": c.address, "value": 0, "data": "0x00000000"}),
         c,
         "Sent",
     )

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -81,7 +81,7 @@ def create_and_return_forwarder(inp: address) -> address:
     c3 = c2.create_and_return_forwarder(c.address, call={})
     c2.create_and_return_forwarder(c.address, transact={})
 
-    c3_contract_code = w3.toBytes(w3.eth.getCode(c3))
+    c3_contract_code = w3.toBytes(w3.eth.get_code(c3))
 
     assert c3_contract_code[:10] == HexBytes(preamble)
     assert c3_contract_code[-15:] == HexBytes(callcode)
@@ -168,7 +168,7 @@ def set(i: int128, owner: address):
 
     # Call outer contract, that make a delegate call to inner_contract.
     tx_hash = outer_contract.set(1, a1, transact={})
-    assert w3.eth.getTransactionReceipt(tx_hash)["status"] == 1
+    assert w3.eth.get_transaction_receipt(tx_hash)["status"] == 1
     assert outer_contract.owners(1) == a1
 
 

--- a/tests/parser/functions/test_send.py
+++ b/tests/parser/functions/test_send.py
@@ -47,12 +47,12 @@ def __default__():
 
     # no value transfer hapenned, variable was not changed
     assert receiver.last_sender() is None
-    assert w3.eth.getBalance(sender.address) == 1
-    assert w3.eth.getBalance(receiver.address) == 0
+    assert w3.eth.get_balance(sender.address) == 1
+    assert w3.eth.get_balance(receiver.address) == 0
 
     sender.test_call(receiver.address, transact={"gas": 100000})
 
     # value transfer hapenned, variable was changed
     assert receiver.last_sender() == sender.address
-    assert w3.eth.getBalance(sender.address) == 0
-    assert w3.eth.getBalance(receiver.address) == 1
+    assert w3.eth.get_balance(sender.address) == 0
+    assert w3.eth.get_balance(receiver.address) == 1

--- a/tests/parser/integration/test_crowdfund.py
+++ b/tests/parser/integration/test_crowdfund.py
@@ -70,11 +70,11 @@ def refund():
     assert not c.reached()
     c.participate(transact={"value": 49})
     assert c.reached()
-    pre_bal = w3.eth.getBalance(a1)
+    pre_bal = w3.eth.get_balance(a1)
     w3.testing.mine(100)
     assert c.expired()
     c.finalize(transact={})
-    post_bal = w3.eth.getBalance(a1)
+    post_bal = w3.eth.get_balance(a1)
     assert post_bal - pre_bal == 54
 
     c = get_contract_with_gas_estimation_for_constants(crowdfund, *[a1, 50, 60])
@@ -85,9 +85,9 @@ def refund():
     w3.testing.mine(100)
     assert c.expired()
     assert not c.reached()
-    pre_bals = [w3.eth.getBalance(x) for x in [a3, a4, a5, a6]]
+    pre_bals = [w3.eth.get_balance(x) for x in [a3, a4, a5, a6]]
     c.refund(transact={})
-    post_bals = [w3.eth.getBalance(x) for x in [a3, a4, a5, a6]]
+    post_bals = [w3.eth.get_balance(x) for x in [a3, a4, a5, a6]]
     assert [y - x for x, y in zip(pre_bals, post_bals)] == [1, 2, 3, 4]
 
 
@@ -162,11 +162,11 @@ def refund():
     assert not c.reached()
     c.participate(transact={"value": 49})
     assert c.reached()
-    pre_bal = w3.eth.getBalance(a1)
+    pre_bal = w3.eth.get_balance(a1)
     w3.testing.mine(100)
     assert c.expired()
     c.finalize(transact={})
-    post_bal = w3.eth.getBalance(a1)
+    post_bal = w3.eth.get_balance(a1)
     assert post_bal - pre_bal == 54
 
     c = get_contract_with_gas_estimation_for_constants(crowdfund2, *[a1, 50, 60])
@@ -177,7 +177,7 @@ def refund():
     w3.testing.mine(100)
     assert c.expired()
     assert not c.reached()
-    pre_bals = [w3.eth.getBalance(x) for x in [a3, a4, a5, a6]]
+    pre_bals = [w3.eth.get_balance(x) for x in [a3, a4, a5, a6]]
     c.refund(transact={})
-    post_bals = [w3.eth.getBalance(x) for x in [a3, a4, a5, a6]]
+    post_bals = [w3.eth.get_balance(x) for x in [a3, a4, a5, a6]]
     assert [y - x for x, y in zip(pre_bals, post_bals)] == [1, 2, 3, 4]

--- a/tests/parser/syntax/test_self_balance.py
+++ b/tests/parser/syntax/test_self_balance.py
@@ -25,6 +25,6 @@ def __default__():
         assert "SELFBALANCE" not in opcodes
 
     c = get_contract_with_gas_estimation(code, evm_version=evm_version)
-    w3.eth.sendTransaction({"to": c.address, "value": 1337})
+    w3.eth.send_transaction({"to": c.address, "value": 1337})
 
     assert c.get_balance() == 1337


### PR DESCRIPTION
### What I did

Update the test suite to the latest web3py function names.

The syntax for the following web3.py functions (currently v5.21.0 in `setup.py`) has changed as follows:
- `getBalance` has been deprecated in favour of `get_balance` (in v5.14.0)
- `getBlock` has been deprecated in favour of `get_block` (in v5.15.0)
- `blockNumber` has been deprecated in favour of `block_number` (in v5.16.0)
- `getCode` has been deprecated in favour of `get_code` (in v5.16.0)
- `sendTransaction` has been deprecated in favour of `send_transaction` (in v5.17.0)
- `getTransactionReceipt` has been deprecated in favour of `get_transaction_receipt` (in v5.18.0)
- `setGasPriceStrategy` has been deprecated in favour of `set_gas_price_strategy` (in v5.18.0)

### How I did it

Use `sed`, as suggested by @fubuloubu. 

Example:
```grep -rl 'getTransactionReceipt' tests/ | xargs sed -i 's/getTransactionReceipt/get_transaction_receipt/g'```

### How to verify it

Run test suite and see the warnings count drop from >11k to ~23.

### Description for the changelog

Update web3py function names in test suite

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://render.fineartamerica.com/images/rendered/search/canvas-print/10/6.5/mirror/break/images-medium-5/2-female-sea-otter-holding-newborn-pup-milo-burcham-canvas-print.jpg)
