### PR TITLE
fix: error handling for string and byte arrays

### DIFF
--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -226,6 +226,74 @@ def foo(x: int128[2][2]):
     """,
         TypeMismatch,
     ),
+    (
+        """
+@external
+def foo():
+    for str in ["hello", "world"]:
+        pass
+    """,
+        StructureException,
+    ),
+    (
+        """
+@external
+def foo():
+    a: String[6] = "hello"
+    b: String[6] = "world"
+    for str in [a, b]:
+        pass
+    """,
+        StructureException,
+    ),
+    (
+        """
+a: String[6]
+b: String[6]
+
+@external
+def foo():
+    self.a = "hello"
+    self.b = "world"
+    for str in [self.a, self.b]:
+        pass
+    """,
+        StructureException,
+    ),
+    (
+        """
+@external
+def foo():
+    for str in [b"hello", b"world"]:
+        pass
+    """,
+        StructureException,
+    ),
+    (
+        """
+@external
+def foo():
+    a: Bytes[6] = b"hello"
+    b: Bytes[6] = b"world"
+    for str in [a, b]:
+        pass
+    """,
+        StructureException,
+    ),
+    (
+        """
+a: Bytes[6]
+b: Bytes[6]
+
+@external
+def foo():
+    self.a = b"hello"
+    self.b = b"world"
+    for str in [self.a, self.b]:
+        pass
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import ArgumentException, InvalidType, SyntaxException
+from vyper.exceptions import ArgumentException, InvalidType, StructureException, SyntaxException
 
 fail_list = [
     (
@@ -20,7 +20,7 @@ def foo():
 def foo():
     raw_log([b"cow"], b"dog")
     """,
-        InvalidType,
+        (InvalidType, StructureException),
     ),
     (
         """

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -21,6 +21,7 @@ from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.abstract import IntegerAbstractType
 from vyper.semantics.types.bases import BaseTypeDefinition
 from vyper.semantics.types.indexable.sequence import ArrayDefinition, TupleDefinition
+from vyper.semantics.types.value.array_value import BytesArrayDefinition, StringDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
 
 
@@ -220,7 +221,13 @@ class _ExprTypeChecker:
             raise InvalidLiteral("Cannot have an empty array", node)
 
         types_list = get_common_types(*node.elements)
+
         if types_list:
+            # Throw exception if only possible type is String or Bytes
+            if len(types_list) == 1:
+                if isinstance(types_list[0], (StringDefinition, BytesArrayDefinition)):
+                    raise StructureException(f"{types_list[0]._id} arrays are not supported", node)
+
             return [ArrayDefinition(i, len(node.elements)) for i in types_list]
 
         raise InvalidLiteral("Array contains multiple, incompatible types", node)


### PR DESCRIPTION
### What I did

Fix for #2502. 

The issue highlighted the lack of a helpful error message for arrays of `String`. While working on the fix, I observed the same issue for `Bytes`, and extended the fix to cover it.

### How I did it

If there is only one possible type for a `List` node, check if it is a `String` or `Bytes`. If yes, raise a `StructureException` with the error message that `String arrays are not supported` / `Bytes arrays are not supported`.

### How to verify it

See tests.

### Description for the changelog

Improve exception handling for string and byte arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQcIxiWM7sj2dy9hCdUpiZoqNeHZFxPYXSGgQ&usqp=CAU)
