### PR TITLE
length in the slice function must be constant.

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -368,7 +368,7 @@ Data Manipulation
 
     * ``b``: value being sliced
     * ``start``: start position of the slice
-    * ``length``: length of the slice
+    * ``length``: length of the slice, must be constant. Immutable variable doesn't supported.
 
     If the value being sliced is a ``Bytes`` or ``bytes32``, the return type is ``Bytes``.  If it is a ``String``, the return type is ``String``.
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -368,7 +368,7 @@ Data Manipulation
 
     * ``b``: value being sliced
     * ``start``: start position of the slice
-    * ``length``: length of the slice, must be constant. Immutable variable doesn't supported.
+    * ``length``: length of the slice, must be constant. Immutables and variables are not supported.
 
     If the value being sliced is a ``Bytes`` or ``bytes32``, the return type is ``Bytes``.  If it is a ``String``, the return type is ``String``.
 


### PR DESCRIPTION


### What I did

I tested immutable variable in slice func.

### How I did it

```
### not ok with immutable variable###
### vyper.exceptions.TypeMismatch: Given reference has type Bytes[96], expected Bytes[32] ###

OWNER: immutable(address)
START: constant(uint256) = 1
LOOP: constant(uint256) = 3
SLICE_BYTE: immutable(uint256)

@external
def __init__(_slice: uint256):
    OWNER = msg.sender
    SLICE_BYTE = _slice

@external
@view
def test_slice():
    idx: uint256 = 0
    start_slice: uint256 = 0
    swap_string: Bytes[96] = concat(
        convert(msg.sender, bytes32),
        convert(1234567891, bytes32),
        convert(OWNER, bytes32))
    for i in range(START, LOOP):
        slice_string: Bytes[32] = slice(swap_string, start_slice, SLICE_BYTE)
        idx += 1
        start_slice = idx * SLICE_BYTE
```

### How to verify it

```
### ok ###
START: constant(uint256) = 1
LOOP: constant(uint256) = 3
SLICE_BYTE: constant(uint256) = 32

@external
@view
def test_slice():
    idx: uint256 = 0
    start_slice: uint256 = 0
    swap_string: Bytes[96] = concat(
        convert(msg.sender, bytes32),
        convert(1234567891, bytes32),
        convert(msg.sender, bytes32))
    for i in range(START, LOOP):
        slice_string: Bytes[32] = slice(swap_string, start_slice, SLICE_BYTE)
        idx += 1
        start_slice = idx * SLICE_BYTE
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.smalljoys.me/2018/12/5-110.jpg)
