### PR TITLE
test: resolve hypothesis healthcheck

### DIFF
--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -83,7 +83,7 @@ def _none_addr(datatype, data):
 CONCISE_NORMALIZERS = (_none_addr,)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def tester():
     custom_genesis = PyEVMBackend._generate_genesis_params(overrides={"gas_limit": 4500000})
     custom_genesis["base_fee_per_gas"] = 0
@@ -95,7 +95,7 @@ def zero_gas_price_strategy(web3, transaction_params=None):
     return 0  # zero gas price makes testing simpler.
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def w3(tester):
     w3 = Web3(EthereumTesterProvider(tester))
     w3.eth.set_gas_price_strategy(zero_gas_price_strategy)
@@ -132,7 +132,7 @@ def _get_contract(w3, source_code, no_optimize, *args, **kwargs):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def get_contract(w3, no_optimize):
     def get_contract(source_code, *args, **kwargs):
         return _get_contract(w3, source_code, no_optimize, *args, **kwargs)
@@ -149,7 +149,7 @@ def get_logs(w3):
     return get_logs
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def assert_tx_failed(tester):
     def assert_tx_failed(function_to_test, exception=TransactionFailed, exc_text=None):
         snapshot_id = tester.take_snapshot()

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -44,7 +44,7 @@ def test_initial_state(w3, assert_tx_failed, get_contract, get_balance, contract
     # Check if unlocked() works correctly after initialization
     assert c.unlocked() is True
     # Check that sellers (and buyers) balance is correct
-    assert get_balance() == ((a1_pre_bal - w3.toWei(2, "ether")), a1_pre_bal)
+    assert get_balance() == ((a0_pre_bal - w3.toWei(2, "ether")), a1_pre_bal)
 
 
 def test_abort(w3, assert_tx_failed, get_balance, get_contract, contract_code):


### PR DESCRIPTION
### What I did

Resolve warnings in CI from `hypothesis.HealthCheck` for the `@given` decorator.

### How I did it

Assign `module` scope to the `tester`, `w3`, `get_contract` and `assert_tx_failed` fixtures in `tests/base_conftest.py`.

### How to verify it

Run tests, and see number of warnings drop.

### Description for the changelog

Resolve hypothesis health check by assigning module scope to test fixtures

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/33/c7/d0/33c7d062ede69129b83bc2567d9879f6.jpg)
