### PR TITLE
add "metadata" output format

### DIFF
--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -1,12 +1,15 @@
 import math
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 from vyper import ast as vy_ast
 from vyper.codegen.lll_node import Encoding
 from vyper.codegen.types import NodeType, parse_type
 from vyper.exceptions import StructureException
 from vyper.utils import cached_property, mkalphanum
+
+# dict from function names to signatures
+FunctionSignatures = Dict[str, "FunctionSignature"]
 
 
 # Function variable

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -3,7 +3,7 @@
 from typing import Any, List, Tuple, Union
 
 from vyper import ast as vy_ast
-from vyper.ast.signatures.function_signature import FunctionSignature
+from vyper.ast.signatures.function_signature import FunctionSignature, FunctionSignatures
 from vyper.codegen.core import make_setter
 from vyper.codegen.function_definitions import (
     generate_lll_for_function,
@@ -232,7 +232,7 @@ def parse_regular_functions(
 
 
 # Main python parse tree => LLL method
-def parse_tree_to_lll(global_ctx: GlobalContext) -> Tuple[LLLnode, LLLnode]:
+def parse_tree_to_lll(global_ctx: GlobalContext) -> Tuple[LLLnode, LLLnode, FunctionSignatures]:
     _names_def = [_def.name for _def in global_ctx._defs]
     # Checks for duplicate function names
     if len(set(_names_def)) < len(_names_def):
@@ -286,4 +286,4 @@ def parse_tree_to_lll(global_ctx: GlobalContext) -> Tuple[LLLnode, LLLnode]:
     else:
         runtime = o.copy()
 
-    return LLLnode.from_list(o), LLLnode.from_list(runtime)
+    return LLLnode.from_list(o), LLLnode.from_list(runtime), sigs

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -27,6 +27,7 @@ OUTPUT_FORMATS = {
     "ir": output.build_ir_output,
     "ir_dict": output.build_ir_dict_output,
     "method_identifiers": output.build_method_identifiers_output,
+    "metadata": output.build_metadata_output,
     # requires assembly
     "abi": output.build_abi_output,
     "asm": output.build_asm_output,

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -79,7 +79,7 @@ def build_ir_output(compiler_data: CompilerData) -> LLLnode:
     return compiler_data.lll_nodes
 
 
-def build_ir_dict_output(compiler_data: CompilerData) -> LLLnode:
+def build_ir_dict_output(compiler_data: CompilerData) -> dict:
     lll = compiler_data.lll_nodes
 
     def _to_dict(lll_node):
@@ -89,6 +89,20 @@ def build_ir_dict_output(compiler_data: CompilerData) -> LLLnode:
         return lll_node.value
 
     return _to_dict(lll)
+
+
+def build_metadata_output(compiler_data: CompilerData) -> dict:
+    warnings.warn("metadata output format is unstable!")
+    sigs = compiler_data.function_signatures
+
+    def _to_dict(sig):
+        ret = vars(sig)
+        ret["return_type"] = str(ret["return_type"])
+        for attr in ["gas", "func_ast_code"]:
+            del ret[attr]
+        return ret
+
+    return {"function_signatures": {name: _to_dict(sig) for (name, sig) in sigs.items()}}
 
 
 def build_method_identifiers_output(compiler_data: CompilerData) -> dict:

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -102,7 +102,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
             del ret[attr]
         return ret
 
-    return {"function_signatures": {name: _to_dict(sig) for (name, sig) in sigs.items()}}
+    return {"function_info": {name: _to_dict(sig) for (name, sig) in sigs.items()}}
 
 
 def build_method_identifiers_output(compiler_data: CompilerData) -> dict:


### PR DESCRIPTION
### What I did
This commit adds a "metadata" output format which is intended to be
useful for downstream tooling. Right now it is limited to function
signatures and their metadata, but it could be extended to more metadata
about modules such as type definitions and in-scope interfaces
(basically everything in GlobalContext).

### How I did it

### How to verify it
```python
# tmp/foo.vy
@internal
def foo() -> (uint256, uint256, uint256):
    return 1, 2, 3

@internal
def bar():
    pass

@external
def baz():
    self.foo()
    self.bar()
```
```
$ vyper -f metadata tmp/foo.vy
/home/charles/.venvs/vyper/lib/python3.8/site-packages/vyper-0.3.2+commit.b77ab184-py3.8.egg/vyper/compiler/output.py:93: UserWarning: metadata output format is unstable!
  warnings.warn("metadata output format is unstable!")
{"function_signatures": {"foo": {"name": "foo", "args": [], "return_type": "(uint256, uint256, uint256)", "mutability": "nonpayable", "internal": true, "nonreentrant_key": null, "is_from_json": false, "base_args": [], "default_args": [], "default_values": {}, "frame_start": 224, "frame_size": 0, "_lll_identifier": "internal_foo___"}, "bar": {"name": "bar", "args": [], "return_type": "None", "mutability": "nonpayable", "internal": true, "nonreentrant_key": null, "is_from_json": false, "base_args": [], "default_args": [], "default_values": {}, "frame_start": 224, "frame_size": 0, "_lll_identifier": "internal_bar___"}, "baz": {"name": "baz", "args": [], "return_type": "None", "mutability": "nonpayable", "internal": false, "nonreentrant_key": null, "is_from_json": false, "base_args": [], "default_args": [], "default_values": {}, "frame_start": 224, "frame_size": 96}}}
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
