### PR TITLE
fix: `_lll_identifier` caching

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -98,6 +98,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
     def _to_dict(sig):
         ret = vars(sig)
         ret["return_type"] = str(ret["return_type"])
+        ret["_lll_identifier"] = sig._lll_identifier
         for attr in ("gas", "func_ast_code"):
             del ret[attr]
         for attr in ("args", "base_args", "default_args"):


### PR DESCRIPTION
since `_lll_identifier` is a cached property, it doesn't show up as a
property until it is called for the first time. this forces it into the
metadata output

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
