### PR TITLE
fix: type check for constants

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 from functools import wraps
+from itertools import product
 
 import pytest
 from eth_tester import EthereumTester, PyEVMBackend
@@ -208,3 +209,14 @@ def create2_address_of(keccak):
         return keccak(prefix + addr + salt + keccak(initcode))[12:]
 
     return _f
+
+
+def get_distinct_integer_types_combinations():
+    # TODO Replace with master list of integer types
+    types_list = ["uint8", "int128", "int256", "uint256"]
+    return [(t, rt) for (t, rt) in product(types_list, types_list) if t != rt]
+
+
+@pytest.fixture(params=get_distinct_integer_types_combinations())
+def distinct_int_types(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import logging
 from functools import wraps
-from itertools import product
 
 import pytest
 from eth_tester import EthereumTester, PyEVMBackend
@@ -209,14 +208,3 @@ def create2_address_of(keccak):
         return keccak(prefix + addr + salt + keccak(initcode))[12:]
 
     return _f
-
-
-def get_distinct_integer_types_combinations():
-    # TODO Replace with master list of integer types
-    types_list = ["uint8", "int128", "int256", "uint256"]
-    return [(t, rt) for (t, rt) in product(types_list, types_list) if t != rt]
-
-
-@pytest.fixture(params=get_distinct_integer_types_combinations())
-def distinct_int_types(request):
-    return request.param

--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -1,4 +1,7 @@
+import itertools
 from decimal import Decimal
+
+import pytest
 
 from vyper.compiler import compile_code
 from vyper.exceptions import InvalidType
@@ -128,11 +131,14 @@ def test_add(a: uint256) -> uint256:
     assert c.test_add(7) == 40
 
 
-def test_custom_constants_fail(get_contract, assert_compile_failed, distinct_int_types):
-    type = distinct_int_types[0]
-    return_type = distinct_int_types[1]
+# Would be nice to put this somewhere accessible, like in vyper.types or something
+integer_types = ["uint8", "int128", "int256", "uint256"]
+
+
+@pytest.mark.parametrize("storage_type,return_type", itertools.permutations(integer_types, 2))
+def test_custom_constants_fail(get_contract, assert_compile_failed, storage_type, return_type):
     code = f"""
-MY_CONSTANT: constant({type}) = 1
+MY_CONSTANT: constant({storage_type}) = 1
 
 @external
 def foo() -> {return_type}:

--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -1,7 +1,5 @@
 from decimal import Decimal
 
-import pytest
-
 from vyper.compiler import compile_code
 from vyper.exceptions import InvalidType
 
@@ -130,24 +128,9 @@ def test_add(a: uint256) -> uint256:
     assert c.test_add(7) == 40
 
 
-@pytest.mark.parametrize(
-    "type,return_type",
-    [
-        ("uint256", "uint8"),
-        ("uint256", "int128"),
-        ("uint256", "int256"),
-        ("uint8", "uint256"),
-        ("uint8", "int128"),
-        ("uint8", "int256"),
-        ("int128", "uint8"),
-        ("int128", "int256"),
-        ("int128", "uint256"),
-        ("int256", "uint8"),
-        ("int256", "int128"),
-        ("int256", "uint256"),
-    ],
-)
-def test_custom_constants_fail(get_contract, assert_compile_failed, type, return_type):
+def test_custom_constants_fail(get_contract, assert_compile_failed, distinct_int_types):
+    type = distinct_int_types[0]
+    return_type = distinct_int_types[1]
     code = f"""
 MY_CONSTANT: constant({type}) = 1
 

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -428,24 +428,9 @@ def ix(i: uint256) -> {type}:
     assert_tx_failed(lambda: c.ix(len(value) + 1))
 
 
-@pytest.mark.parametrize(
-    "type,return_type",
-    [
-        ("uint256", "uint8"),
-        ("uint256", "int128"),
-        ("uint256", "int256"),
-        ("uint8", "uint256"),
-        ("uint8", "int128"),
-        ("uint8", "int256"),
-        ("int128", "uint8"),
-        ("int128", "int256"),
-        ("int128", "uint256"),
-        ("int256", "uint8"),
-        ("int256", "int128"),
-        ("int256", "uint256"),
-    ],
-)
-def test_constant_list_fail(get_contract, assert_compile_failed, type, return_type):
+def test_constant_list_fail(get_contract, assert_compile_failed, distinct_int_types):
+    type = distinct_int_types[0]
+    return_type = distinct_int_types[1]
     code = f"""
 MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
 
@@ -456,24 +441,9 @@ def foo() -> {return_type}[3]:
     assert_compile_failed(lambda: get_contract(code), InvalidType)
 
 
-@pytest.mark.parametrize(
-    "type,return_type",
-    [
-        ("uint256", "uint8"),
-        ("uint256", "int128"),
-        ("uint256", "int256"),
-        ("uint8", "uint256"),
-        ("uint8", "int128"),
-        ("uint8", "int256"),
-        ("int128", "uint8"),
-        ("int128", "int256"),
-        ("int128", "uint256"),
-        ("int256", "uint8"),
-        ("int256", "int128"),
-        ("int256", "uint256"),
-    ],
-)
-def test_constant_list_fail_2(get_contract, assert_compile_failed, type, return_type):
+def test_constant_list_fail_2(get_contract, assert_compile_failed, distinct_int_types):
+    type = distinct_int_types[0]
+    return_type = distinct_int_types[1]
     code = f"""
 MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
 
@@ -484,24 +454,9 @@ def foo() -> {return_type}:
     assert_compile_failed(lambda: get_contract(code), InvalidType)
 
 
-@pytest.mark.parametrize(
-    "type,return_type",
-    [
-        ("uint256", "uint8"),
-        ("uint256", "int128"),
-        ("uint256", "int256"),
-        ("uint8", "uint256"),
-        ("uint8", "int128"),
-        ("uint8", "int256"),
-        ("int128", "uint8"),
-        ("int128", "int256"),
-        ("int128", "uint256"),
-        ("int256", "uint8"),
-        ("int256", "int128"),
-        ("int256", "uint256"),
-    ],
-)
-def test_constant_list_fail_3(get_contract, assert_compile_failed, type, return_type):
+def test_constant_list_fail_3(get_contract, assert_compile_failed, distinct_int_types):
+    type = distinct_int_types[0]
+    return_type = distinct_int_types[1]
     code = f"""
 MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
 

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pytest
 
 from vyper.exceptions import ArrayIndexException, InvalidType, OverflowException, TypeMismatch
@@ -428,11 +430,14 @@ def ix(i: uint256) -> {type}:
     assert_tx_failed(lambda: c.ix(len(value) + 1))
 
 
-def test_constant_list_fail(get_contract, assert_compile_failed, distinct_int_types):
-    type = distinct_int_types[0]
-    return_type = distinct_int_types[1]
+# Would be nice to put this somewhere accessible, like in vyper.types or something
+integer_types = ["uint8", "int128", "int256", "uint256"]
+
+
+@pytest.mark.parametrize("storage_type,return_type", itertools.permutations(integer_types, 2))
+def test_constant_list_fail(get_contract, assert_compile_failed, storage_type, return_type):
     code = f"""
-MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
+MY_CONSTANT: constant({storage_type}[3]) = [1, 2, 3]
 
 @external
 def foo() -> {return_type}[3]:
@@ -441,11 +446,10 @@ def foo() -> {return_type}[3]:
     assert_compile_failed(lambda: get_contract(code), InvalidType)
 
 
-def test_constant_list_fail_2(get_contract, assert_compile_failed, distinct_int_types):
-    type = distinct_int_types[0]
-    return_type = distinct_int_types[1]
+@pytest.mark.parametrize("storage_type,return_type", itertools.permutations(integer_types, 2))
+def test_constant_list_fail_2(get_contract, assert_compile_failed, storage_type, return_type):
     code = f"""
-MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
+MY_CONSTANT: constant({storage_type}[3]) = [1, 2, 3]
 
 @external
 def foo() -> {return_type}:
@@ -454,11 +458,10 @@ def foo() -> {return_type}:
     assert_compile_failed(lambda: get_contract(code), InvalidType)
 
 
-def test_constant_list_fail_3(get_contract, assert_compile_failed, distinct_int_types):
-    type = distinct_int_types[0]
-    return_type = distinct_int_types[1]
+@pytest.mark.parametrize("storage_type,return_type", itertools.permutations(integer_types, 2))
+def test_constant_list_fail_3(get_contract, assert_compile_failed, storage_type, return_type):
     code = f"""
-MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
+MY_CONSTANT: constant({storage_type}[3]) = [1, 2, 3]
 
 @external
 def foo(i: uint256) -> {return_type}:

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vyper.exceptions import ArrayIndexException, OverflowException
+from vyper.exceptions import ArrayIndexException, InvalidType, OverflowException, TypeMismatch
 
 
 def test_list_tester_code(get_contract_with_gas_estimation):
@@ -426,6 +426,90 @@ def ix(i: uint256) -> {type}:
         assert c.ix(i) == p
     # assert oob
     assert_tx_failed(lambda: c.ix(len(value) + 1))
+
+
+@pytest.mark.parametrize(
+    "type,return_type",
+    [
+        ("uint256", "uint8"),
+        ("uint256", "int128"),
+        ("uint256", "int256"),
+        ("uint8", "uint256"),
+        ("uint8", "int128"),
+        ("uint8", "int256"),
+        ("int128", "uint8"),
+        ("int128", "int256"),
+        ("int128", "uint256"),
+        ("int256", "uint8"),
+        ("int256", "int128"),
+        ("int256", "uint256"),
+    ],
+)
+def test_constant_list_fail(get_contract, assert_compile_failed, type, return_type):
+    code = f"""
+MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
+
+@external
+def foo() -> {return_type}[3]:
+    return MY_CONSTANT
+    """
+    assert_compile_failed(lambda: get_contract(code), InvalidType)
+
+
+@pytest.mark.parametrize(
+    "type,return_type",
+    [
+        ("uint256", "uint8"),
+        ("uint256", "int128"),
+        ("uint256", "int256"),
+        ("uint8", "uint256"),
+        ("uint8", "int128"),
+        ("uint8", "int256"),
+        ("int128", "uint8"),
+        ("int128", "int256"),
+        ("int128", "uint256"),
+        ("int256", "uint8"),
+        ("int256", "int128"),
+        ("int256", "uint256"),
+    ],
+)
+def test_constant_list_fail_2(get_contract, assert_compile_failed, type, return_type):
+    code = f"""
+MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
+
+@external
+def foo() -> {return_type}:
+    return MY_CONSTANT[0]
+    """
+    assert_compile_failed(lambda: get_contract(code), InvalidType)
+
+
+@pytest.mark.parametrize(
+    "type,return_type",
+    [
+        ("uint256", "uint8"),
+        ("uint256", "int128"),
+        ("uint256", "int256"),
+        ("uint8", "uint256"),
+        ("uint8", "int128"),
+        ("uint8", "int256"),
+        ("int128", "uint8"),
+        ("int128", "int256"),
+        ("int128", "uint256"),
+        ("int256", "uint8"),
+        ("int256", "int128"),
+        ("int256", "uint256"),
+    ],
+)
+def test_constant_list_fail_3(get_contract, assert_compile_failed, type, return_type):
+    code = f"""
+MY_CONSTANT: constant({type}[3]) = [1, 2, 3]
+
+@external
+def foo(i: uint256) -> {return_type}:
+    return MY_CONSTANT[i]
+    """
+    assert_compile_failed(lambda: get_contract(code), TypeMismatch)
 
 
 def test_constant_list_address(get_contract, assert_tx_failed):

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 
 from vyper.ast import nodes as vy_ast
 from vyper.builtin_functions import DISPATCH_TABLE
-from vyper.exceptions import UnfoldableNode
+from vyper.exceptions import UnfoldableNode, VyperException
 from vyper.semantics.types.bases import BaseTypeDefinition, DataLocation
 from vyper.semantics.types.utils import get_type_from_annotation
 
@@ -179,7 +179,7 @@ def replace_user_defined_constants(vyper_module: vy_ast.Module) -> int:
         type_: Union[BaseTypeDefinition, None] = None
         try:
             type_ = get_type_from_annotation(node_annotation_arg, DataLocation.STORAGE)
-        except:  # noqa: E722
+        except VyperException:
             # Defer type exception handling to type checking stage for consistency
             pass
 

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -33,7 +33,6 @@ from vyper.semantics.types.utils import get_type_from_annotation
 from vyper.semantics.types.value.address import AddressDefinition
 from vyper.semantics.types.value.array_value import StringDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
-from vyper.semantics.types.value.numeric import Uint256Definition
 from vyper.semantics.validation.annotation import StatementAnnotationVisitor
 from vyper.semantics.validation.base import VyperNodeVisitorBase
 from vyper.semantics.validation.utils import (
@@ -320,7 +319,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                     raise StateAccessViolation("Value must be a literal", node)
                 if args[0].value <= 0:
                     raise StructureException("For loop must have at least 1 iteration", args[0])
-                validate_expected_type(args[0], Uint256Definition())
+                validate_expected_type(args[0], IntegerAbstractType())
                 type_list = get_possible_types_from_node(args[0])
             else:
                 validate_expected_type(args[0], IntegerAbstractType())

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -113,6 +113,20 @@ class _ExprTypeChecker:
                     )
                 else:
                     raise InvalidReference("Expected a literal or variable", node)
+
+        # Restrict possible types if typedef is propagated in metadata
+        if "type" in node._metadata:
+            propagated_type = node._metadata["type"]
+            # Propagated typedef should be of type str
+            if type(propagated_type) is str:
+                for _, t in enumerate(types_list):
+                    if isinstance(t, (ArrayDefinition, TupleDefinition, DynamicArrayDefinition)):
+                        if propagated_type == t.value_type._id:
+                            types_list = [t]
+                    elif hasattr(t, "_id"):
+                        if propagated_type == t._id:
+                            types_list = [t]
+
         if all(isinstance(i, IntegerAbstractType) for i in types_list):
             # for numeric types, sort according by number of bits descending
             # we do this to ensure literals are cast with the largest possible type

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -19,7 +19,7 @@ from vyper.exceptions import (
 from vyper.semantics import types
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.abstract import IntegerAbstractType
-from vyper.semantics.types.bases import BaseTypeDefinition, DataLocation
+from vyper.semantics.types.bases import BaseTypeDefinition
 from vyper.semantics.types.indexable.sequence import (
     ArrayDefinition,
     DynamicArrayDefinition,
@@ -105,22 +105,8 @@ class _ExprTypeChecker:
             A list of type objects
         """
         # Early termination if typedef is propagated in metadata
-        if "constant_annotation" in node._metadata:
-            # TODO investigate this circular dependency
-            from vyper.semantics.types.utils import get_type_from_annotation
-
-            propagated_type = get_type_from_annotation(
-                node._metadata["constant_annotation"], DataLocation.UNSET
-            )
-
-            if not isinstance(node, vy_ast.List) and isinstance(
-                propagated_type, (ArrayDefinition, DynamicArrayDefinition)
-            ):
-
-                # For array elements, extract the base type from the array definition
-                propagated_type = propagated_type.value_type
-
-            return [propagated_type]
+        if "type" in node._metadata:
+            return [node._metadata["type"]]
 
         fn = self._find_fn(node)
         types_list = fn(node)

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -117,15 +117,10 @@ class _ExprTypeChecker:
         # Restrict possible types if typedef is propagated in metadata
         if "type" in node._metadata:
             propagated_type = node._metadata["type"]
-            # Propagated typedef should be of type str
-            if type(propagated_type) is str:
-                for _, t in enumerate(types_list):
-                    if isinstance(t, (ArrayDefinition, TupleDefinition, DynamicArrayDefinition)):
-                        if propagated_type == t.value_type._id:
-                            types_list = [t]
-                    elif hasattr(t, "_id"):
-                        if propagated_type == t._id:
-                            types_list = [t]
+            for _, t in enumerate(types_list):
+                if type(propagated_type) is type(t):
+                    types_list = [t]
+                    break
 
         if all(isinstance(i, IntegerAbstractType) for i in types_list):
             # for numeric types, sort according by number of bits descending


### PR DESCRIPTION
### What I did

Fix #2592.

Based on the issue, the following code compiles when it should not:
```
MY_CONSTANT: constant(uint256[3]) = [1,2,3]

@external
def foo() -> uint8[3]:
    return MY_CONSTANT
```

While looking into this, I discovered two other similar code snippets that also compile when they should not:
```
MY_CONSTANT: constant(uint256[3]) = [1,2,3]

@external
def foo() -> uint8:
    return MY_CONSTANT[0]
```
```
MY_LIST: constant(uint256[6]) = [1,2,3]

@external
def ix(i: uint256) -> uint8:
    return MY_LIST[i]
```

The bug does not appear to be limited to constant arrays, however. The following code snippet also compiles when it should not:
```
MY_CONSTANT: constant(uint256) = 1

@external
def foo() -> uint8:
    return MY_CONSTANT
```

### How I did it

Propagate the type definition of a constant when it is folded (i.e. replaced by a new AST node) by appending this information as a string to the new node's `_metadata` attribute using the `type` key. This value is then used to narrow down the possible type of a node from a list of possible types. 

### How to verify it

See tests.

### Description for the changelog

Fix type checking for constants

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://gd.image-gmkt.com/li/084/244/1231244084.g_520-w-st_g.jpg)
