### PR TITLE
allow dynamic array iterators

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -120,7 +120,7 @@ def data() -> int128:
 
     assert c.data() == 0
     # test all sorts of lists
-    for xs in [[3,5,7,9], [4,6,8], [1,2], [5], []]:
+    for xs in [[3, 5, 7, 9], [4, 6, 8], [1, 2], [5], []]:
         c.set(xs, transact={})
         assert c.data() == sum(xs)
 

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -26,7 +26,11 @@ from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.abstract import IntegerAbstractType
 from vyper.semantics.types.bases import DataLocation
 from vyper.semantics.types.function import ContractFunction, FunctionVisibility, StateMutability
-from vyper.semantics.types.indexable.sequence import ArrayDefinition, TupleDefinition, DynamicArrayDefinition
+from vyper.semantics.types.indexable.sequence import (
+    ArrayDefinition,
+    DynamicArrayDefinition,
+    TupleDefinition,
+)
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.user.struct import StructDefinition
 from vyper.semantics.types.utils import get_type_from_annotation

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -26,7 +26,7 @@ from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.abstract import IntegerAbstractType
 from vyper.semantics.types.bases import DataLocation
 from vyper.semantics.types.function import ContractFunction, FunctionVisibility, StateMutability
-from vyper.semantics.types.indexable.sequence import ArrayDefinition, TupleDefinition
+from vyper.semantics.types.indexable.sequence import ArrayDefinition, TupleDefinition, DynamicArrayDefinition
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.user.struct import StructDefinition
 from vyper.semantics.types.utils import get_type_from_annotation
@@ -359,7 +359,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             type_list = [
                 i.value_type
                 for i in get_possible_types_from_node(node.iter)
-                if isinstance(i, ArrayDefinition)
+                if isinstance(i, (DynamicArrayDefinition, ArrayDefinition))
             ]
 
         if not type_list:


### PR DESCRIPTION
### What I did
Allow iterators for dynamic arrays, e.g.
```python
xs: DynArray[uint256, 5] = [1,2,3]
for x in xs:
    if x == 2:
        return x
return -1
```

### How I did it
add cases to `parse_For_list` and refactor to use more general functions

### How to verify it
see tests

### Description for the changelog
add iterators for dynamic array types

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wwf.ca/wp-content/uploads/2017/02/SRKW1-600x400.jpg)
