### PR TITLE
generalize get_element_ptr to all integer types

### DIFF
--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -206,31 +206,33 @@ def test_multi4() -> uint256[2][2][2][2]:
     ]
 
 
-def test_uint256_accessor(get_contract_with_gas_estimation, assert_tx_failed):
-    code = """
+@pytest.mark.parametrize("type_", ["uint8", "uint256"])
+def test_unsigned_accessors(get_contract_with_gas_estimation, assert_tx_failed, type_):
+    code = f"""
 @external
-def bounds_check_uint256(ix: uint256) -> uint256:
+def bounds_check(ix: {type_}) -> uint256:
     xs: uint256[3] = [1,2,3]
     return xs[ix]
     """
     c = get_contract_with_gas_estimation(code)
-    assert c.bounds_check_uint256(0) == 1
-    assert c.bounds_check_uint256(2) == 3
-    assert_tx_failed(lambda: c.bounds_check_uint256(3))
+    assert c.bounds_check(0) == 1
+    assert c.bounds_check(2) == 3
+    assert_tx_failed(lambda: c.bounds_check(3))
 
 
-def test_int128_accessor(get_contract_with_gas_estimation, assert_tx_failed):
-    code = """
+@pytest.mark.parametrize("type_", ["int128", "int256"])
+def test_signed_accessors(get_contract_with_gas_estimation, assert_tx_failed, type_):
+    code = f"""
 @external
-def bounds_check_int128(ix: int128) -> uint256:
+def bounds_check(ix: {type_}) -> uint256:
     xs: uint256[3] = [1,2,3]
     return xs[ix]
     """
     c = get_contract_with_gas_estimation(code)
-    assert c.bounds_check_int128(0) == 1
-    assert c.bounds_check_int128(2) == 3
-    assert_tx_failed(lambda: c.bounds_check_int128(3))
-    assert_tx_failed(lambda: c.bounds_check_int128(-1))
+    assert c.bounds_check(0) == 1
+    assert c.bounds_check(2) == 3
+    assert_tx_failed(lambda: c.bounds_check(3))
+    assert_tx_failed(lambda: c.bounds_check(-1))
 
 
 def test_list_check_heterogeneous_types(get_contract_with_gas_estimation, assert_compile_failed):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -14,7 +14,7 @@ from vyper.codegen.types import (
     TupleLike,
     TupleType,
     ceil32,
-    is_base_type,
+    is_integer_type,
     is_signed_num,
 )
 from vyper.evm.opcodes import version_check
@@ -399,8 +399,7 @@ def _get_element_ptr_array(parent, key, pos, array_bounds_check):
 
     assert isinstance(parent.typ, ArrayLike)
 
-    # TODO allow other integer types
-    if not is_base_type(key.typ, ("int128", "int256", "uint256")):
+    if not is_integer_type(key.typ):
         return
 
     subtype = parent.typ.subtype

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -72,8 +72,8 @@ class IntegerTypeInfo:
 _int_parser = re.compile("^(u?)int([0-9]+)$")
 
 
-def is_integer_type(typename: str) -> bool:
-    return _int_parser.fullmatch(typename) is not None
+def is_integer_type(t: "NodeType") -> bool:
+    return isinstance(t, BaseType) and _int_parser.fullmatch(t.typ) is not None
 
 
 def parse_integer_typeinfo(typename: str) -> IntegerTypeInfo:
@@ -88,7 +88,7 @@ def parse_integer_typeinfo(typename: str) -> IntegerTypeInfo:
 
 
 def _basetype_to_abi_type(t: "BaseType") -> ABIType:
-    if is_integer_type(t.typ):
+    if is_integer_type(t):
         typinfo = parse_integer_typeinfo(t.typ)
         return ABI_GIntM(typinfo.bits, typinfo.is_signed)
     if t.typ == "address":


### PR DESCRIPTION
it was failing for the new uint8 type

fixes #2585 

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
