### PR TITLE
fix AnnAssign for interface types

### DIFF
--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -101,6 +101,15 @@ def test():
     assert self.token.totalSupply() > 0
     """,
     """
+interface Foo:
+    def foo(): view
+
+@external
+def test() -> (bool, Foo):
+    x: Foo = Foo(msg.sender)
+    return True, x
+    """
+    """
 from vyper.interfaces import ERC20
 
 a: public(ERC20)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -51,6 +51,7 @@ class Stmt:
     def parse_AnnAssign(self):
         typ = parse_type(
             self.stmt.annotation,
+            sigs=self.context.sigs,
             custom_structs=self.context.structs,
         )
         varname = self.stmt.target.id

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -415,7 +415,7 @@ def parse_type(item, sigs=None, custom_structs=None):
             FAIL()
 
     elif isinstance(item, vy_ast.Tuple):
-        members = [parse_type(x, custom_structs=custom_structs) for x in item.elements]
+        members = [parse_type(x, sigs=sigs, custom_structs=custom_structs) for x in item.elements]
         return TupleType(members)
 
     else:

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -310,10 +310,9 @@ def make_struct_type(name, sigs, members, custom_structs):
     return StructType(o, name)
 
 
-# Parses an expression representing a type. Annotation refers to whether
-# the type is to be located in memory or storage
+# Parses an expression representing a type.
 # TODO: rename me to "lll_type_from_annotation"
-def parse_type(item, sigs=None, custom_structs=None):
+def parse_type(item, sigs, custom_structs):
     def _sanity_check(x):
         assert x, "typechecker missed this"
 


### PR DESCRIPTION
### What I did
fix parsing of interface types in AnnAssign and tuples. respective examples:
```python
x: Foo = Foo(msg.sender)  # Foo is an interface
```
```python
@external
def foo() -> (bool, Foo):  # Foo is an interface
    pass
```

### How I did it
fix missing arguments to `parse_type`
also change "optional" arguments to parse_type into required arguments so this doesn't happen in the future.

### How to verify it
see tests

### Description for the changelog
fix interface types in certain annotations

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/150642388-b69afc96-dca9-4be2-a9bf-a2279b6c7c1b.png)
