### PR TITLE
allow lists of any type as loop variable

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -69,6 +69,19 @@ def data() -> int128:
     return -1""",
         7,
     ),
+    # test nested array
+    (
+        """
+@external
+def data() -> int128:
+    ret: int128 = 0
+    xss: int128[3][3] = [[1,2,3],[4,5,6],[7,8,9]]
+    for xs in xss:
+        for x in xs:
+            ret += x
+    return ret""",
+        sum(range(1, 10)),
+    ),
     # test more complicated literal
     (
         """

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -66,6 +66,22 @@ def data() -> int128:
     return -1""",
         7,
     ),
+    # test more complicated literal
+    (
+        """
+struct S:
+    x: int128
+    y: int128
+
+@external
+def data() -> int128:
+    ret: int128 = 0
+    for ss in [[S({x:1, y:2})]]:
+        for s in ss:
+            ret += s.x + s.y
+    return ret""",
+        1+2,
+    ),
     # basic for-in-list addresses
     (
         """

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -554,21 +554,6 @@ def foo():
     """,
         IteratorException,
     ),
-    # nested lists
-    """
-@external
-def foo():
-    x: uint256[5][2] = [[0, 1, 2, 3, 4], [2, 4, 6, 8, 10]]
-    for i in x:
-        pass
-    """,
-    """
-@external
-def foo():
-    x: uint256[5][2] = [[0, 1, 2, 3, 4], [2, 4, 6, 8, 10]]
-    for i in x[1]:
-        pass
-    """,
     (
         """
 @external

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -47,13 +47,16 @@ struct S:
 
 @external
 def data() -> int128:
-    sss: DynArray[DynArray[S, 10], 10] = [[S({x:1, y:2})], [S({x:3, y:4}), S({x:5, y:6}), S({x:7, y:8}), S({x:9, y:10})]]
+    sss: DynArray[DynArray[S, 10], 10] = [
+        [S({x:1, y:2})],
+        [S({x:3, y:4}), S({x:5, y:6}), S({x:7, y:8}), S({x:9, y:10})]
+        ]
     ret: int128 = 0
     for ss in sss:
         for s in ss:
             ret += s.x + s.y
     return ret""",
-        sum(range(1,11)),
+        sum(range(1, 11)),
     ),
     # basic for-in-list literal
     (
@@ -80,7 +83,7 @@ def data() -> int128:
         for s in ss:
             ret += s.x + s.y
     return ret""",
-        1+2,
+        1 + 2,
     ),
     # basic for-in-list addresses
     (

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -38,6 +38,23 @@ def data() -> int128:
     return -1""",
         3,
     ),
+    # test more complicated type
+    (
+        """
+struct S:
+    x: int128
+    y: int128
+
+@external
+def data() -> int128:
+    sss: DynArray[DynArray[S, 10], 10] = [[S({x:1, y:2})], [S({x:3, y:4}), S({x:5, y:6}), S({x:7, y:8}), S({x:9, y:10})]]
+    ret: int128 = 0
+    for ss in sss:
+        for s in ss:
+            ret += s.x + s.y
+    return ret""",
+        sum(range(1,11)),
+    ),
     # basic for-in-list literal
     (
         """

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidLiteral, InvalidType, StructureException, TypeMismatch
+from vyper.exceptions import InvalidLiteral, InvalidType, TypeMismatch
 
 fail_list = [
     (

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -49,36 +49,6 @@ def foo(x: int128[2][2]) -> int128:
     """,
         TypeMismatch,
     ),
-    (
-        """
-# for loops only allowed on base types
-bar: int128[3][3]
-
-@external
-def foo() -> int128[3]:
-    self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    for x in self.bar:
-        if x == [4, 5, 6]:
-            return x
-    return [-1, -2, -3]
-    """,
-        StructureException,
-    ),
-    (
-        """
-# for loops only allowed on base types
-struct Baz:
-    a: uint256
-bar: Baz[3]
-
-@external
-def foo():
-    for x in self.bar:
-        pass
-
-    """,
-        StructureException,
-    ),
 ]
 
 

--- a/vyper/codegen/lll_node.py
+++ b/vyper/codegen/lll_node.py
@@ -122,7 +122,7 @@ class LLLnode:
                     zero_valency_whitelist = {"pass", "pop"}
                     _check(
                         arg.valency == 1 or arg.value in zero_valency_whitelist,
-                        f"invalid argument to opcode or pseudo-opcode: {arg}",
+                        f"invalid argument to `{self.value}`: {arg}",
                     )
                     self.gas += arg.gas
                 # Dynamic gas cost: 8 gas for each byte of logging data

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -17,6 +17,7 @@ from vyper.codegen.core import (
 from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
 from vyper.codegen.types import BaseType, ByteArrayType, DArrayType, SArrayType, parse_type
+from vyper.codegen.types.convert import new_type_to_old_type
 from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure
 
 
@@ -299,13 +300,10 @@ class Stmt:
         with self.context.range_scope():
             iter_list = Expr(self.stmt.iter, self.context).lll_node
 
-        # TODO relax this restriction
-        if not isinstance(iter_list.typ.subtype, BaseType):
-            return
-
         # override with type inferred at typechecking time
-        subtype = BaseType(self.stmt.target._metadata["type"]._id)
-        iter_list.typ.subtype = subtype
+        typ = new_type_to_old_type(self.stmt.iter._metadata["type"])
+        iter_list.typ = typ
+        subtype = typ.subtype
 
         # user-supplied name for loop variable
         varname = self.stmt.target.id

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -301,6 +301,7 @@ class Stmt:
             iter_list = Expr(self.stmt.iter, self.context).lll_node
 
         # override with type inferred at typechecking time
+        # TODO investigate why stmt.target.type != stmt.iter.type.subtype
         target_type = new_type_to_old_type(self.stmt.target._metadata["type"])
         iter_list.typ.subtype = target_type
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -16,7 +16,7 @@ from vyper.codegen.core import (
 )
 from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
-from vyper.codegen.types import BaseType, ByteArrayType, DArrayType, SArrayType, parse_type
+from vyper.codegen.types import BaseType, ByteArrayType, DArrayType, parse_type
 from vyper.codegen.types.convert import new_type_to_old_type
 from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure
 
@@ -324,9 +324,8 @@ class Stmt:
 
         # list literal, force it to memory first
         if isinstance(self.stmt.iter, vy_ast.List):
-            count = iter_list.typ.count
             tmp_list = LLLnode.from_list(
-                obj=self.context.new_internal_variable(iter_list.typ),
+                self.context.new_internal_variable(iter_list.typ),
                 typ=iter_list.typ,
                 location="memory",
             )

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -301,15 +301,14 @@ class Stmt:
             iter_list = Expr(self.stmt.iter, self.context).lll_node
 
         # override with type inferred at typechecking time
-        typ = new_type_to_old_type(self.stmt.iter._metadata["type"])
-        iter_list.typ = typ
-        subtype = typ.subtype
+        target_type = new_type_to_old_type(self.stmt.target._metadata["type"])
+        iter_list.typ.subtype = target_type
 
         # user-supplied name for loop variable
         varname = self.stmt.target.id
         loop_var = LLLnode.from_list(
-            self.context.new_variable(varname, subtype),
-            typ=subtype,
+            self.context.new_variable(varname, target_type),
+            typ=target_type,
             location="memory",
         )
 
@@ -327,8 +326,8 @@ class Stmt:
         if isinstance(self.stmt.iter, vy_ast.List):
             count = iter_list.typ.count
             tmp_list = LLLnode.from_list(
-                obj=self.context.new_internal_variable(SArrayType(subtype, count)),
-                typ=SArrayType(subtype, count),
+                obj=self.context.new_internal_variable(iter_list.typ),
+                typ=iter_list.typ,
                 location="memory",
             )
             ret.append(make_setter(tmp_list, iter_list, self.context, pos=getpos(self.stmt)))
@@ -368,6 +367,7 @@ class Stmt:
                     col_offset=self.stmt.col_offset,
                     end_lineno=self.stmt.end_lineno,
                     end_col_offset=self.stmt.end_col_offset,
+                    node_source_code=self.stmt.get("node_source_code"),
                 ),
                 self.context,
             )
@@ -386,6 +386,7 @@ class Stmt:
                     col_offset=self.stmt.col_offset,
                     end_lineno=self.stmt.end_lineno,
                     end_col_offset=self.stmt.end_col_offset,
+                    node_source_code=self.stmt.get("node_source_code"),
                 ),
                 self.context,
             )

--- a/vyper/codegen/types/convert.py
+++ b/vyper/codegen/types/convert.py
@@ -19,9 +19,11 @@ def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
     if isinstance(typ, new.DecimalDefinition):
         return old.BaseType("decimal")
     if isinstance(typ, new.SignedIntegerAbstractType):
-        return old.BaseType("int" + str(typ._bits))
+        bits = typ._bits  # type: ignore
+        return old.BaseType("int" + str(bits))
     if isinstance(typ, new.UnsignedIntegerAbstractType):
-        return old.BaseType("uint" + str(typ._bits))
+        bits = typ._bits  # type: ignore
+        return old.BaseType("uint" + str(bits))
     if isinstance(typ, new.ArrayDefinition):
         return old.SArrayType(new_type_to_old_type(typ.value_type), typ.length)
     if isinstance(typ, new.DynamicArrayDefinition):

--- a/vyper/codegen/types/convert.py
+++ b/vyper/codegen/types/convert.py
@@ -1,8 +1,9 @@
 # transition module to convert from new types to old types
 
-from vyper.exceptions import InvalidType
-import vyper.semantics.types as new
 import vyper.codegen.types as old
+import vyper.semantics.types as new
+from vyper.exceptions import InvalidType
+
 
 def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
     if isinstance(typ, new.BoolDefinition):
@@ -28,5 +29,7 @@ def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
     if isinstance(typ, new.TupleDefinition):
         return old.TupleType(typ.value_type)
     if isinstance(typ, new.StructDefinition):
-        return old.StructType({n: new_type_to_old_type(t) for (n, t) in typ.members.items()}, typ._id)
+        return old.StructType(
+            {n: new_type_to_old_type(t) for (n, t) in typ.members.items()}, typ._id
+        )
     raise InvalidType(f"unknown type {typ}")

--- a/vyper/codegen/types/convert.py
+++ b/vyper/codegen/types/convert.py
@@ -1,0 +1,32 @@
+# transition module to convert from new types to old types
+
+from vyper.exceptions import InvalidType
+import vyper.semantics.types as new
+import vyper.codegen.types as old
+
+def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
+    if isinstance(typ, new.BoolDefinition):
+        return old.BaseType("bool")
+    if isinstance(typ, new.AddressDefinition):
+        return old.BaseType("address")
+    if isinstance(typ, new.Bytes32Definition):
+        return old.BaseType("bytes32")
+    if isinstance(typ, new.BytesArrayDefinition):
+        return old.BytesType(typ.count)
+    if isinstance(typ, new.StringDefinition):
+        return old.StringType(typ.count)
+    if isinstance(typ, new.DecimalDefinition):
+        return old.BaseType("decimal")
+    if isinstance(typ, new.SignedIntegerAbstractType):
+        return old.BaseType("int" + str(typ._bits))
+    if isinstance(typ, new.UnsignedIntegerAbstractType):
+        return old.BaseType("uint" + str(typ._bits))
+    if isinstance(typ, new.ArrayDefinition):
+        return old.SArrayType(new_type_to_old_type(typ.value_type), typ.length)
+    if isinstance(typ, new.DynamicArrayDefinition):
+        return old.DArrayType(new_type_to_old_type(typ.value_type), typ.length)
+    if isinstance(typ, new.TupleDefinition):
+        return old.TupleType(typ.value_type)
+    if isinstance(typ, new.StructDefinition):
+        return old.StructType({n: new_type_to_old_type(t) for (n, t) in typ.members.items()}, typ._id)
+    raise InvalidType(f"unknown type {typ}")

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -32,7 +32,6 @@ from vyper.semantics.types.indexable.sequence import (
     TupleDefinition,
 )
 from vyper.semantics.types.user.event import Event
-from vyper.semantics.types.user.struct import StructDefinition
 from vyper.semantics.types.utils import get_type_from_annotation
 from vyper.semantics.types.value.address import AddressDefinition
 from vyper.semantics.types.value.array_value import StringDefinition

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -369,12 +369,6 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         if not type_list:
             raise InvalidType("Not an iterable type", node.iter)
 
-        if next((i for i in type_list if isinstance(i, ArrayDefinition)), False):
-            raise StructureException("Cannot iterate over a nested list", node.iter)
-
-        if next((i for i in type_list if isinstance(i, StructDefinition)), False):
-            raise StructureException("Cannot iterate over a list of structs", node.iter)
-
         if isinstance(node.iter, (vy_ast.Name, vy_ast.Attribute)):
             # check for references to the iterated value within the body of the loop
             assign = _check_iterator_assign(node.iter, node)


### PR DESCRIPTION
### What I did
allow lists of any type as loop variable

### How I did it
added a function `new_type_to_old_type` so that we can use the results of the type checker directly. eventually this can replace the old `parse_type` function.

### How to verify it
```python
struct X:
    y: uint256
@external
def foo(xs: DynArray[X, 5]) -> uint256:
    sum: uint256 = 0
    for x in xs:
        sum += x.y
    return sum
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.natgeofe.com/n/e6cb0ee4-77c5-4181-bf6a-b79a28237e6c/gray-whale_3x4.jpg)
