### PR TITLE
fix: allow struct constants

### DIFF
--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -236,7 +236,7 @@ def test_replace_userdefined_attribute(source):
     assert vy_ast.compare_nodes(l_ast, r_ast)
 
 
-userdefined_struct = [("b: Foo = FOO", "b: Foo = Foo({{a: 123, b: 456}})")]
+userdefined_struct = [("b: Foo = FOO", "b: Foo = Foo({a: 123, b: 456})")]
 
 
 @pytest.mark.parametrize("source", userdefined_struct)
@@ -246,7 +246,7 @@ struct Foo:
     a: uint256
     b: uint256
 
-FOO: constant(Foo) = Foo({{a: 123, b: 456}})
+FOO: constant(Foo) = Foo({a: 123, b: 456})
     """
     l_source = f"{preamble}\n{source[0]}"
     r_source = f"{preamble}\n{source[1]}"
@@ -269,7 +269,7 @@ struct Foo:
     a: uint256
     b: uint256
 
-FOO: constant(Foo) = Foo({{a: 123, b: 456}})
+FOO: constant(Foo) = Foo({a: 123, b: 456})
     """
     l_source = f"{preamble}\n{source[0]}"
     r_source = f"{preamble}\n{source[1]}"

--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -282,6 +282,62 @@ FOO: constant(Foo) = Foo({a: 123, b: 456})
     assert vy_ast.compare_nodes(l_ast, r_ast)
 
 
+userdefined_nested_struct = [
+    ("b: Foo = FOO", "b: Foo = Foo({f1: Bar({b1: 123, b2: 456}), f2: 789})")
+]
+
+
+@pytest.mark.parametrize("source", userdefined_nested_struct)
+def test_replace_userdefined_nested_struct(source):
+    preamble = """
+struct Bar:
+    b1: uint256
+    b2: uint256
+
+struct Foo:
+    f1: Bar
+    f2: uint256
+
+FOO: constant(Foo) = Foo({f1: Bar({b1: 123, b2: 456}), f2: 789})
+    """
+    l_source = f"{preamble}\n{source[0]}"
+    r_source = f"{preamble}\n{source[1]}"
+
+    l_ast = vy_ast.parse_to_ast(l_source)
+    folding.replace_user_defined_constants(l_ast)
+
+    r_ast = vy_ast.parse_to_ast(r_source)
+
+    assert vy_ast.compare_nodes(l_ast, r_ast)
+
+
+userdefined_nested_struct_member = [("b: uint256 = FOO.f1.b1", "b: uint256 = 123")]
+
+
+@pytest.mark.parametrize("source", userdefined_nested_struct_member)
+def test_replace_userdefined_nested_struct_member(source):
+    preamble = """
+struct Bar:
+    b1: uint256
+    b2: uint256
+
+struct Foo:
+    f1: Bar
+    f2: uint256
+
+FOO: constant(Foo) = Foo({f1: Bar({b1: 123, b2: 456}), f2: 789})
+    """
+    l_source = f"{preamble}\n{source[0]}"
+    r_source = f"{preamble}\n{source[1]}"
+
+    l_ast = vy_ast.parse_to_ast(l_source)
+    folding.replace_user_defined_constants(l_ast)
+
+    r_ast = vy_ast.parse_to_ast(r_source)
+
+    assert vy_ast.compare_nodes(l_ast, r_ast)
+
+
 builtin_folding_functions = [("ceil(4.2)", "5"), ("floor(4.2)", "4")]
 
 builtin_folding_sources = [

--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -259,29 +259,6 @@ FOO: constant(Foo) = Foo({a: 123, b: 456})
     assert vy_ast.compare_nodes(l_ast, r_ast)
 
 
-userdefined_struct_member = [("b: uint256 = FOO.a", "b: uint256 = 123")]
-
-
-@pytest.mark.parametrize("source", userdefined_struct_member)
-def test_replace_userdefined_struct_member(source):
-    preamble = """
-struct Foo:
-    a: uint256
-    b: uint256
-
-FOO: constant(Foo) = Foo({a: 123, b: 456})
-    """
-    l_source = f"{preamble}\n{source[0]}"
-    r_source = f"{preamble}\n{source[1]}"
-
-    l_ast = vy_ast.parse_to_ast(l_source)
-    folding.replace_user_defined_constants(l_ast)
-
-    r_ast = vy_ast.parse_to_ast(r_source)
-
-    assert vy_ast.compare_nodes(l_ast, r_ast)
-
-
 userdefined_nested_struct = [
     ("b: Foo = FOO", "b: Foo = Foo({f1: Bar({b1: 123, b2: 456}), f2: 789})")
 ]
@@ -289,33 +266,6 @@ userdefined_nested_struct = [
 
 @pytest.mark.parametrize("source", userdefined_nested_struct)
 def test_replace_userdefined_nested_struct(source):
-    preamble = """
-struct Bar:
-    b1: uint256
-    b2: uint256
-
-struct Foo:
-    f1: Bar
-    f2: uint256
-
-FOO: constant(Foo) = Foo({f1: Bar({b1: 123, b2: 456}), f2: 789})
-    """
-    l_source = f"{preamble}\n{source[0]}"
-    r_source = f"{preamble}\n{source[1]}"
-
-    l_ast = vy_ast.parse_to_ast(l_source)
-    folding.replace_user_defined_constants(l_ast)
-
-    r_ast = vy_ast.parse_to_ast(r_source)
-
-    assert vy_ast.compare_nodes(l_ast, r_ast)
-
-
-userdefined_nested_struct_member = [("b: uint256 = FOO.f1.b1", "b: uint256 = 123")]
-
-
-@pytest.mark.parametrize("source", userdefined_nested_struct_member)
-def test_replace_userdefined_nested_struct_member(source):
     preamble = """
 struct Bar:
     b1: uint256

--- a/tests/ast/test_folding.py
+++ b/tests/ast/test_folding.py
@@ -236,6 +236,52 @@ def test_replace_userdefined_attribute(source):
     assert vy_ast.compare_nodes(l_ast, r_ast)
 
 
+userdefined_struct = [("b: Foo = FOO", "b: Foo = Foo({{a: 123, b: 456}})")]
+
+
+@pytest.mark.parametrize("source", userdefined_struct)
+def test_replace_userdefined_struct(source):
+    preamble = """
+struct Foo:
+    a: uint256
+    b: uint256
+
+FOO: constant(Foo) = Foo({{a: 123, b: 456}})
+    """
+    l_source = f"{preamble}\n{source[0]}"
+    r_source = f"{preamble}\n{source[1]}"
+
+    l_ast = vy_ast.parse_to_ast(l_source)
+    folding.replace_user_defined_constants(l_ast)
+
+    r_ast = vy_ast.parse_to_ast(r_source)
+
+    assert vy_ast.compare_nodes(l_ast, r_ast)
+
+
+userdefined_struct_member = [("b: uint256 = FOO.a", "b: uint256 = 123")]
+
+
+@pytest.mark.parametrize("source", userdefined_struct_member)
+def test_replace_userdefined_struct_member(source):
+    preamble = """
+struct Foo:
+    a: uint256
+    b: uint256
+
+FOO: constant(Foo) = Foo({{a: 123, b: 456}})
+    """
+    l_source = f"{preamble}\n{source[0]}"
+    r_source = f"{preamble}\n{source[1]}"
+
+    l_ast = vy_ast.parse_to_ast(l_source)
+    folding.replace_user_defined_constants(l_ast)
+
+    r_ast = vy_ast.parse_to_ast(r_source)
+
+    assert vy_ast.compare_nodes(l_ast, r_ast)
+
+
 builtin_folding_functions = [("ceil(4.2)", "5"), ("floor(4.2)", "4")]
 
 builtin_folding_sources = [

--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -281,7 +281,27 @@ def foo(a: uint256 = msg.value): pass
     """
 @external
 def foo(a: uint256 = 2**8): pass
-     """,
+    """,
+    """
+struct Bar:
+    a: address
+    b: uint256
+
+@external
+def foo(bar: Bar = Bar({a: msg.sender, b: 1})): pass
+    """,
+    """
+struct Baz:
+    c: address
+    d: int128
+
+struct Bar:
+    a: address
+    b: Baz
+
+@external
+def foo(bar: Bar = Bar({a: msg.sender, b: Baz({c: block.coinbase, d: -10})})): pass
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -222,6 +222,22 @@ B: constant(uint256) = 2
 
 CONST_BAR: constant(Foo) = Foo({a: A, b: B})
     """,
+    """
+struct Foo:
+    a: uint256
+    b: uint256
+
+struct Bar:
+    c: Foo
+    d: int128
+
+A: constant(uint256) = 1
+B: constant(uint256) = 2
+C: constant(Foo) = Foo({a: A, b: B})
+D: constant(int128) = -1
+
+CONST_BAR: constant(Bar) = Bar({c: C, d: D})
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -90,11 +90,11 @@ C1: constant(uint256) = block.number
     # cannot assign function result to a constant
     (
         """
-@external
+@internal
 def foo() -> uint256:
     return 42
 
-c1: constant(uint256) = self.foo
+c1: constant(uint256) = self.foo()
      """,
         StateAccessViolation,
     ),

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -87,6 +87,16 @@ C1: constant(uint256) = block.number
     """,
         StateAccessViolation,
     ),
+    (
+        """
+struct Foo:
+    a: uint256
+    b: uint256
+
+CONST_BAR: constant(Foo) = Foo({a: 1, b: block.number})
+    """,
+        StateAccessViolation,
+    ),
     # cannot assign function result to a constant
     (
         """
@@ -194,6 +204,23 @@ MY_DECIMAL: constant(decimal) = -1e38
     """,
     """
 CONST_BYTES: constant(Bytes[4]) = b'1234'
+    """,
+    """
+struct Foo:
+    a: uint256
+    b: uint256
+
+CONST_BAR: constant(Foo) = Foo({a: 1, b: 2})
+    """,
+    """
+struct Foo:
+    a: uint256
+    b: uint256
+
+A: constant(uint256) = 1
+B: constant(uint256) = 2
+
+CONST_BAR: constant(Foo) = Foo({a: A, b: B})
     """,
 ]
 

--- a/tests/parser/syntax/test_structs.py
+++ b/tests/parser/syntax/test_structs.py
@@ -532,6 +532,15 @@ struct X:
     baz: int128
 x: X
     """,
+    """
+struct C:
+    a: uint256
+    b: uint256
+
+@external
+def foo():
+    bar: C = C({a: 1, b: block.timestamp})
+    """,
 ]
 
 

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -183,7 +183,9 @@ def replace_user_defined_constants(vyper_module: vy_ast.Module) -> int:
                 else None
             )
         except UnknownType:
-            # Handle structs as user-defined types
+            # handle user-defined types e.g. structs - it's OK to not
+            # propagate the type annotation here because user-defined
+            # types can be unambiguously inferred at typechecking time
             type_ = None
 
         changed_nodes += replace_constant(

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -370,41 +370,36 @@ def replace_constant(
                 continue
 
         if isinstance(parent, vy_ast.Attribute) and is_struct:
-            if parent_attribute_ids and len(parent_attribute_ids) > 0:
-                found = False
-                for i in range(len(parent_attribute_ids)):
-                    # Iterate through the list of parent attributes
-                    parent_attr = parent_attribute_ids[i]
-                    if hasattr(parent, "attr"):
-                        if parent.attr != parent_attr:
-                            # Early termination if parent attribute does not
-                            # match current node path
-                            break
-                        else:
-                            if i == len(parent_attribute_ids) - 1:
-                                if not hasattr(parent.get_ancestor(), "attr"):
-                                    # If all attributes match, and the current
-                                    # parent is not a nested member, continue with the
-                                    # replacement. Otherwise, continue.
-                                    found = True
-                            else:
-                                # Continue iteration until all parent attributes
-                                # are checked
-                                parent = parent.get_ancestor()
-                    else:
-                        # If current parent does not have an `attr` field,
-                        # but there is an attribute to be checked, skip.
-                        break
-
-                # Only replace if all parent attributes match. Otherwise, skip.
-                if found:
-                    node = parent
-                else:
-                    continue
-
-            else:
+            if not parent_attribute_ids:
                 # Skip if accessing attribute of struct but parent attributes
                 # are not provided
+                continue
+
+            found = False
+            for i in range(len(parent_attribute_ids)):
+                if not hasattr(parent, "attr"):
+                    # If current parent does not have an `attr` field,
+                    # but there is an attribute to be checked, skip.
+                    break
+
+                # Iterate through the list of parent attributes
+                if parent.attr != parent_attribute_ids[i]:
+                    # Early termination if parent attribute does not match current node path
+                    break
+
+                if i == len(parent_attribute_ids) - 1 and not hasattr(
+                    parent.get_ancestor(), "attr"
+                ):
+                    # If all attributes match, and the current parent is not a nested member,
+                    # continue with the replacement. Otherwise, skip replacement.
+                    found = True
+                    node = parent
+
+                # Continue iteration until all parent attributes are checked
+                parent = parent.get_ancestor()
+
+            # Only replace if all parent attributes match. Otherwise, skip.
+            if not found:
                 continue
 
         try:

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -325,10 +325,6 @@ def replace_constant(
         Boolean indicating if `UnfoldableNode` exception should be raised or ignored.
     type_ : BaseTypeDefinition, optional
         Type definition to be propagated to type checker.
-    attribute_id: str, optional
-        String representing the `.attr` attribute of an `Attribute` node that is
-        to be used to further filter nodes after getting descendants based on `id_`.
-        Used to propagate a struct member's name.
     parent_attribute_ids: List[str], optional
         List of parent attributes (representing the `.attr` attribute of an `Attribute` node)
         that should be traceable from the node to be replaced.

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -381,6 +381,8 @@ def replace_constant(
                     parent_attr = parent_attribute_ids[i]
                     if hasattr(parent, "attr"):
                         if parent.attr != parent_attr:
+                            # Early termination if parent attribute does not
+                            # match current node path
                             break
                         else:
                             if i == len(parent_attribute_ids) - 1:
@@ -398,7 +400,7 @@ def replace_constant(
                         # but there is an attribute to be checked, skip.
                         break
 
-                # Only replace if all parent attributes match
+                # Only replace if all parent attributes match. Otherwise, skip.
                 if found:
                     node = parent
                 else:

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -1,3 +1,4 @@
+import copy
 from decimal import Decimal
 from typing import Union
 
@@ -283,6 +284,8 @@ def replace_constant(
                 continue
 
         try:
+            # Codegen may mutate AST (particularly structs).
+            replacement_node = copy.deepcopy(replacement_node)
             new_node = _replace(node, replacement_node, type_=type_)
         except UnfoldableNode:
             if raise_on_error:

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -199,8 +199,10 @@ def replace_user_defined_constants(vyper_module: vy_ast.Module) -> int:
                 # its literal value
                 struct_dict = node.value.args[0]
 
+                # Pass empty list of parent attributes for first call to struct members
+                # helper function
                 changed_nodes = _replace_struct_members(
-                    vyper_module, struct_dict, node.target.id, changed_nodes
+                    vyper_module, struct_dict, node.target.id, changed_nodes, []
                 )
 
     return changed_nodes
@@ -211,7 +213,7 @@ def _replace_struct_members(
     dict_node: vy_ast.Dict,
     id_: str,
     changed_nodes: int,
-    parent_attribute_ids: List[str] = [],
+    parent_attribute_ids: List[str],
 ) -> int:
     """
     Helper function to recursively replace nested structs members

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -224,6 +224,7 @@ def _replace(old_node, new_node, type_=None):
         new_node = new_node.from_node(old_node, elements=list_values)
         if type_:
             new_node._metadata["type"] = type_
+        return new_node
     elif isinstance(new_node, vy_ast.Call):
         # Replace `Name` node with `Call` node
         return new_node

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -373,43 +373,41 @@ def replace_constant(
             if assign and node in assign.target.get_descendants(include_self=True):
                 continue
 
-        if isinstance(parent, vy_ast.Attribute):
-            if is_struct:
-                if parent_attribute_ids and len(parent_attribute_ids) > 0:
-                    found = False
-                    for i in range(len(parent_attribute_ids)):
-                        # Iterate through the list of parent attributes
-                        parent_attr = parent_attribute_ids[i]
-                        if hasattr(parent, "attr"):
-                            if parent.attr != parent_attr:
-                                break
-                            else:
-                                if i == len(parent_attribute_ids) - 1:
-                                    if not hasattr(parent.get_ancestor(), "attr"):
-                                        # If all attributes match, and the current
-                                        # parent is not a nested member, continue with the
-                                        # replacement. Otherwise, continue.
-                                        found = True
-                                        break
-                                else:
-                                    # Continue iteration until all parent attributes
-                                    # are checked
-                                    parent = parent.get_ancestor()
-                        else:
-                            # If current parent does not have an `attr` field,
-                            # but there is an attribute to be checked, skip.
+        if isinstance(parent, vy_ast.Attribute) and is_struct:
+            if parent_attribute_ids and len(parent_attribute_ids) > 0:
+                found = False
+                for i in range(len(parent_attribute_ids)):
+                    # Iterate through the list of parent attributes
+                    parent_attr = parent_attribute_ids[i]
+                    if hasattr(parent, "attr"):
+                        if parent.attr != parent_attr:
                             break
-
-                    # Only replace if all parent attributes match
-                    if found:
-                        node = parent
+                        else:
+                            if i == len(parent_attribute_ids) - 1:
+                                if not hasattr(parent.get_ancestor(), "attr"):
+                                    # If all attributes match, and the current
+                                    # parent is not a nested member, continue with the
+                                    # replacement. Otherwise, continue.
+                                    found = True
+                            else:
+                                # Continue iteration until all parent attributes
+                                # are checked
+                                parent = parent.get_ancestor()
                     else:
-                        continue
+                        # If current parent does not have an `attr` field,
+                        # but there is an attribute to be checked, skip.
+                        break
 
+                # Only replace if all parent attributes match
+                if found:
+                    node = parent
                 else:
-                    # Skip if accessing attribute of struct but parent attributes
-                    # are not provided
                     continue
+
+            else:
+                # Skip if accessing attribute of struct but parent attributes
+                # are not provided
+                continue
 
         try:
             new_node = _replace(node, replacement_node, type_=type_)

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -427,20 +427,6 @@ def replace_constant(
             if assign and node in assign.target.get_descendants(include_self=True):
                 continue
 
-        if isinstance(parent, vy_ast.Attribute) and is_struct:
-            if not parent_attribute_ids:
-                # Skip if accessing attribute of struct but parent attributes
-                # are not provided
-                continue
-
-            node = _get_struct_attribute_root_node(
-                parent,
-                parent_attribute_ids,
-            )
-
-            if not node:
-                continue
-
         try:
             new_node = _replace(node, replacement_node, type_=type_)
         except UnfoldableNode:

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -19,7 +19,7 @@ from vyper.semantics.types.bases import BaseTypeDefinition, DataLocation, Storag
 from vyper.semantics.types.indexable.sequence import DynamicArrayDefinition, TupleDefinition
 from vyper.semantics.types.utils import (
     StringEnum,
-    check_constant,
+    check_kwargable,
     generate_abi_type,
     get_type_from_abi,
     get_type_from_annotation,
@@ -323,7 +323,7 @@ class ContractFunction(BaseTypeDefinition):
                 arg.annotation, location=DataLocation.CALLDATA, is_constant=True
             )
             if value is not None:
-                if not check_constant(value):
+                if not check_kwargable(value):
                     raise StateAccessViolation(
                         "Value must be literal or environment variable", value
                     )

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -202,8 +202,14 @@ def check_constant(node: vy_ast.VyperNode) -> bool:
         if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
             for v in args[0].values:
                 # Check struct members
-                if not _check_literal(v):
-                    return False
+                if isinstance(v, vy_ast.Call):
+                    # If nested struct, check recursively
+                    if not check_constant(v):
+                        return False
+                else:
+                    # If not nested struct, check for literals
+                    if not _check_literal(v):
+                        return False
             return True
 
     value_type = get_exact_type_from_node(node)

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -193,14 +193,26 @@ def check_constant(node: vy_ast.VyperNode) -> bool:
     if isinstance(node, vy_ast.Call):
         args = node.args
         if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
-            return all(
-                check_constant(v)
-                if isinstance(v, vy_ast.Call)  # Nested structs
-                else _check_literal(v)  # Literals
-                for v in args[0].values
-            )
+            return all(check_constant(v) for v in args[0].values)
+
+    return False
+
+
+def check_kwargable(node: vy_ast.VyperNode) -> bool:
+    """
+    Check if the given node can be used as a default arg
+    """
+    if _check_literal(node):
+        return True
+    if isinstance(node, (vy_ast.Tuple, vy_ast.List)):
+        return all(check_kwargable(item) for item in node.elements)
+    if isinstance(node, vy_ast.Call):
+        args = node.args
+        if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
+            return all(check_kwargable(v) for v in args[0].values)
 
     value_type = get_exact_type_from_node(node)
+    # is_constant here actually means not_assignable, and is to be renamed
     return getattr(value_type, "is_constant", False)
 
 

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -19,7 +19,6 @@ from vyper.exceptions import (
     VariableDeclarationException,
     VyperException,
 )
-from vyper.semantics.environment import get_constant_vars
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.bases import DataLocation
 from vyper.semantics.types.function import ContractFunction
@@ -213,10 +212,6 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
                 raise VariableDeclarationException("Constant must be declared with a value", node)
             if not check_constant(node.value):
                 raise StateAccessViolation("Value must be a literal", node.value)
-            if isinstance(node.value, vy_ast.Attribute):
-                # Check for environment variables
-                if node.value.get("value.id") in get_constant_vars():
-                    raise StateAccessViolation("Value must be a literal", node.value)
 
             validate_expected_type(node.value, type_definition)
             try:


### PR DESCRIPTION
### What I did

Fix for #1430, extending on #2396.

The following code results in an error in v0.3.1:
```
# @version ^0.3.0

struct Foo:
    a: uint256
    b: uint256

CONST_BAR: constant(Foo) = Foo({a: 7, b: 2})
```
```
vyper.exceptions.StateAccessViolation: Value must be a literal
  contract "contracts/constantStruct1.vy", line 7:27 
       6
  ---> 7 CONST_BAR: constant(Foo) = Foo({a: 7, b: 2})
  ----------------------------------^
       8
```

[UPDATE]

After the above changes, attempting to return a struct constant or any of its member values resulted in an unhandled compiler error (see comments below) due to struct constants not being propagated during constant folding. I have made changes to handle constant propagation for folding of struct constants, and a minor change to handle constant struct members.

### How I did it

Type checking for struct constants
- Modify `check_constant` function in `vyper/semantics/types/utils.py` to handle structs by checking if each member is a literal value. ~~For nested structs, make a recursive call.~~
- Change `visit_AnnAssign` function of `ModuleNodeVisitor` class in `vyper/semantics/validation/module.py` to check `node.value` using `check_constants` (instead of `check_literals`), and to check for any reference to environment variables (which should not be accessible at compile time (?)). 

Folding for struct constants
- For constant top-level structs, replace the `Name` node with the entire `Call` node of the defined constant.
- ~~Where the constant to be replaced is a user-defined struct, loop through its members to also replace such references with the constant value of the respective struct member. This is done through a helper function `_replace_struct_members`, which takes in a path of parent attributes that should be present in a Name node that is to be replaced. For example, `Foo.a.b` where `a` is a struct will be represented as the following when used~~
```
`b`  (`Attribute` node)
 |---> `a` (`Attribute` node)
        |---> `Foo` (`Name` node)
```
~~but during construction we visit in the order `Foo` >> `a` >> `b`. Since the search for nodes to be replaced is premised on `Name` nodes (i.e. `Foo`), we need to store a path of parent attributes for all possible (plain and nested) struct members (including structs) in order to trace the path of parent attributes backwards.~~
- ~~Add an additional parameter `parent_attributes_ids` to `replace_constant()` helper function to supplement the `id_` parameter, so as to enable additional filtering of nodes successively if they are referencing a struct member (plain or nested, including nested structs).~~
- Handle `Call` AST node in `_replace()` helper function as this is the node type for structs.

### How to verify it

See test cases.

### Commit message

```
This commit enables constant structs, and constant struct members. 
It also introduces a new helper function named "check_kwargable",
that checks if a given node can be a kwarg to a function. This is 
meant to clarify the existing "check_constant" helper function, 
which actually checks whether a given node is not assignable.

The fix for constant structs is handled in the AST folding by
replacing references to a constant struct with the corresponding
Call AST node. The constant struct is then recursively checked
by the "check_constant" helper function to ensure all nested
structs and struct members are not assignable or a literal value.

This commit also involves a related change to the semantics 
validation of a function. Previously, both the validation of a 
function's kwargs and a module-level constant uses the same
"check_constant" function. While it previously conveniently 
covered both use cases of "not_assignable" and "is_kwargable",
this approach breaks for constant structs. Therefore, a new 
helper function "check_kwargable" has been added to separate
the use cases.

Resolves: #1430 
See also: #2396 
```

### Description for the changelog

Allow constant structs.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpaperaccess.com/full/1154679.jpg)
