### PR TITLE
test: add test case to overload the safeTransferFrom function

### DIFF
--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -186,6 +186,26 @@ def test_safeTransferFrom_by_owner(c, w3, assert_tx_failed, get_logs):
     assert c.balanceOf(operator) == 2
 
 
+def test_safeTransferFrom_overload_function(c, w3, assert_tx_failed, get_logs):
+    someone, operator = w3.eth.accounts[1:3]
+
+    # transfer by owner
+    tx_hash = c.safeTransferFrom(
+        someone, operator, SOMEONE_TOKEN_IDS[0], b"101", transact={"from": someone}
+    )
+
+    logs = get_logs(tx_hash, c, "Transfer")
+
+    assert len(logs) > 0
+    args = logs[0].args
+    assert args.sender == someone
+    assert args.receiver == operator
+    assert args.tokenId == SOMEONE_TOKEN_IDS[0]
+    assert c.ownerOf(SOMEONE_TOKEN_IDS[0]) == operator
+    assert c.balanceOf(someone) == 2
+    assert c.balanceOf(operator) == 2
+
+
 def test_safeTransferFrom_by_approved(c, w3, get_logs):
     someone, operator = w3.eth.accounts[1:3]
 


### PR DESCRIPTION
### What I did
Adding test case to overload the safeTransferFrom function to make sure that it complies with [eip-721](https://github.com/ethereum/EIPs/blame/master/EIPS/eip-721.md#L93)
### How I did it
Adding extra parameter in the safeTransferFrom test function
```
c.safeTransferFrom(
        someone, operator, SOMEONE_TOKEN_IDS[0], b"101", transact={"from": someone}
    )
```
### How to verify it
run `tox` to test
Before adding test
<img width="1127" alt="Screen Shot 2022-01-26 at 13 22 22" src="https://user-images.githubusercontent.com/6429197/151113724-9c0263b4-51ba-487d-af2c-d8ac84b0afbf.png">
After added
<img width="1127" alt="Screen Shot 2022-01-26 at 13 22 14" src="https://user-images.githubusercontent.com/6429197/151113798-0e154933-e72e-4b26-9e78-94fd0f396a01.png">
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.spoon-tamago.com/wp-content/uploads/2021/07/capybara-onsen.jpeg)
