### PR TITLE
fix references to immutable variables in constructor

### DIFF
--- a/tests/parser/features/test_immutable.py
+++ b/tests/parser/features/test_immutable.py
@@ -32,6 +32,29 @@ def get_value() -> {typ}:
     assert c.get_value() == value
 
 
+@pytest.mark.parametrize("val", [0, 1, 2 ** 256 - 1])
+def test_usage_in_constructor(get_contract, val):
+    code = """
+A: immutable(uint256)
+a: public(uint256)
+
+
+@external
+def __init__(_a: uint256):
+    A = _a
+    self.a = A
+
+
+@external
+@view
+def a1() -> uint256:
+    return A
+    """
+
+    c = get_contract(code, val)
+    assert c.a1() == c.a() == val
+
+
 def test_multiple_immutable_values(get_contract):
     code = """
 a: immutable(uint256)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -326,7 +326,7 @@ class Expr:
             is_constructor = self.expr.get_ancestor(vy_ast.FunctionDef).get("name") == "__init__"
             if is_constructor:
                 # store memory position for later access in module.py in the variable record
-                memory_loc = self.context.new_variable(f"#immutable_{self.expr.id}", var.typ)
+                memory_loc = self.context.new_variable(self.expr.id, var.typ)
                 self.context.global_ctx._globals[self.expr.id].pos = memory_loc
                 # store the data offset in the variable record as well for accessing
                 data_offset = self.expr._metadata["type"].position.offset


### PR DESCRIPTION
### What I did
fix #2626 

### How I did it
with the name as is, it won't get picked up by the branch in
`parse_Name` which checks `context.vars`, and so a fresh memory location
gets allocated. this commit changes the key inserted into context.vars
so that it will get picked up properly.

### How to verify it
before:
```
    # Line 10
    /* A = _a */ [mstore, 224 <A>, [codeload, /* _a */ [with, val, ~codelen, val]]],
    # Line 11
    /* self.a = A */ [sstore, 0 <self.a>, [mload, 256 <A>]],  # <-- SHOULD BE mload 224
```
after:
```
    # Line 10
    /* A = _a */ [mstore, 224 <A>, [codeload, /* _a */ [with, val, ~codelen, val]]],
    # Line 11
    /* self.a = A */ [sstore, 0 <self.a>, [mload, 224 <A>]],
```
i guess i can write a test too

### Description for the changelog
fix references to immutable variables in constructor

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.marinemammalcenter.org/storage/app/uploads/public/d60/299/459/thumb__1600_0_0_0_crop.jpg)
