### PR TITLE
feat: add unsafe arithmetic ops

### DIFF
--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -1,10 +1,11 @@
-import pytest
 import itertools
-import random
 import operator
+import random
 
-from vyper.utils import BASE_TYPES, DECIMAL_DIVISOR, int_bounds, evm_div
-from vyper.codegen.types.types import BaseType, parse_integer_typeinfo
+import pytest
+
+from vyper.codegen.types.types import parse_integer_typeinfo
+from vyper.utils import BASE_TYPES, evm_div, int_bounds
 
 # TODO something less janky
 integer_types = sorted([t for t in BASE_TYPES if "int" in t])
@@ -48,7 +49,7 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
     else:
         # 0x80 has some weird properties, like
         # it's a fixed point of multiplication by 0xFF
-        fixed_pt = 2**(int_info.bits - 1)
+        fixed_pt = 2 ** (int_info.bits - 1)
         xs += [0, 1, hi - 1, hi, fixed_pt]
         ys += [0, 1, hi - 1, hi, fixed_pt]
         for (x, y) in itertools.product(xs, ys):

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -1,0 +1,37 @@
+import pytest
+from vyper.utils import BASE_TYPES
+
+# TODO something less janky
+numeric_types = [t for t in BASE_TYPES if "int" in t or t == "decimal"]
+
+
+def _as_unsigned(x, bits):
+    if x < 0:
+        return x + 2**bits
+    return x
+
+def _as_signed(x, bits):
+    if x > (2**(bits-1)) - 1:
+        return x - 2**bits
+    return x
+
+# _int_bounds(8, True) -> (-128, 127)
+# _int_bounds(8, False) -> (0, 255)
+def _int_bounds(bits, signed):
+    if signed:
+        return -(2**(bits - 1)), (2**(bits - 1)) - 1
+    return 0, (2**bits) - 1
+
+@pytest.mark.parametrize("typ", numeric_types)
+@pytest.mark.parametrize("op", [)
+def test_unsafe_ops(get_contract, typ, op):
+    code = f"""
+@external
+def bar(x: {typ}, y: {typ}) -> uint256:
+    return unsafe_{op}(x, y)
+    """
+
+    c = get_contract(code)
+    # TODO this should go on the type metadata
+    signed = t.startswith("i") or t == "decimal"
+    if 

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -1,10 +1,9 @@
 import pytest
-import math
 import itertools
 import random
 import operator
 
-from vyper.utils import BASE_TYPES, DECIMAL_DIVISOR, int_bounds, evm_mod, evm_div
+from vyper.utils import BASE_TYPES, DECIMAL_DIVISOR, int_bounds, evm_div
 from vyper.codegen.types.types import BaseType, parse_integer_typeinfo
 
 # TODO something less janky
@@ -12,8 +11,8 @@ integer_types = sorted([t for t in BASE_TYPES if "int" in t])
 
 
 def _as_signed(x, bits):
-    if x > (2**(bits-1)) - 1:
-        return x - 2**bits
+    if x > (2 ** (bits - 1)) - 1:
+        return x - 2 ** bits
     return x
 
 
@@ -26,7 +25,7 @@ def test_unsafe_op_int(get_contract, typ, op):
 def foo(x: {typ}, y: {typ}) -> {typ}:
     return unsafe_{op}(x, y)
     """
-    fns = { "add": operator.add, "sub": operator.sub, "mul": operator.mul, "div": evm_div }
+    fns = {"add": operator.add, "sub": operator.sub, "mul": operator.mul, "div": evm_div}
     fn = fns[op]
 
     int_info = parse_integer_typeinfo(typ)
@@ -36,7 +35,7 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
     xs = [random.randrange(lo, hi) for _ in range(100)]
     ys = [random.randrange(lo, hi) for _ in range(100)]
 
-    mod_bound = 2**int_info.bits
+    mod_bound = 2 ** int_info.bits
 
     # poor man's fuzzing - hypothesis doesn't make it easy
     # with the parametrized strategy
@@ -44,9 +43,7 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
         xs += [lo, -1, 0, 1, hi]
         ys += [lo, -1, 0, 1, hi]
         for (x, y) in itertools.product(xs, ys):
-            res = fn(x, y)  # calculate evm smod
-
-            expected = _as_signed(evm_mod(res, mod_bound), int_info.bits)
+            expected = _as_signed(fn(x, y) % mod_bound, int_info.bits)
             assert c.foo(x, y) == expected
     else:
         xs += [0, 1, hi - 1, hi]

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -1,61 +1,54 @@
 import pytest
+import math
+import itertools
+import random
 import operator
-from hypothesis import assume, given, settings
-from hypothesis import strategies as st
 
-from vyper.utils import BASE_TYPES, DECIMAL_DIVISOR, int_bounds
+from vyper.utils import BASE_TYPES, DECIMAL_DIVISOR, int_bounds, evm_mod, evm_div
 from vyper.codegen.types.types import BaseType, parse_integer_typeinfo
 
 # TODO something less janky
 integer_types = sorted([t for t in BASE_TYPES if "int" in t])
 
 
-# interpret a signed EVM word as an unsigned word
-def _as_unsigned(x, bits):
-    if x < 0:
-        return x + 2**bits
-    return x
-
-
-# interpret an unsigned EVM word as a signed word
 def _as_signed(x, bits):
     if x > (2**(bits-1)) - 1:
         return x - 2**bits
     return x
 
 
-# TODO this is probably more broadly useful
-def _int_strategy(typname):
-    int_info = parse_integer_typeinfo(typname)
-    lo, hi = int_bounds(int_info.is_signed, int_info.bits)
-    return st.integers(min_value=lo, max_value=hi)
-
-def _evm_div(x, y):
-    if y == 0:
-        return 0
-    # note round-to-zero behavior compared to floordiv
-    return int(x / y)
-
 @pytest.mark.parametrize("typ", integer_types)
 @pytest.mark.parametrize("op", ["add", "sub", "mul", "div"])
-@given(st.data())
-def test_unsafe_op_int(get_contract, typ, op, data):
+@pytest.mark.fuzzing
+def test_unsafe_op_int(get_contract, typ, op):
     code = f"""
 @external
 def foo(x: {typ}, y: {typ}) -> {typ}:
     return unsafe_{op}(x, y)
     """
-    fns = { "add": operator.add, "sub": operator.sub, "mul": operator.mul, "div": _evm_div }
+    fns = { "add": operator.add, "sub": operator.sub, "mul": operator.mul, "div": evm_div }
     fn = fns[op]
 
     int_info = parse_integer_typeinfo(typ)
-
-    x = data.draw(_int_strategy(typ))
-    y = data.draw(_int_strategy(typ))
-
     c = get_contract(code)
+
+    lo, hi = int_bounds(int_info.is_signed, int_info.bits)
+    xs = [random.randrange(lo, hi) for _ in range(100)]
+    ys = [random.randrange(lo, hi) for _ in range(100)]
+
     mod_bound = 2**int_info.bits
+
+    # poor man's fuzzing - hypothesis doesn't make it easy
+    # with the parametrized strategy
     if int_info.is_signed:
-        assert c.foo(x, y) == _as_signed(fn(x, y) % mod_bound, int_info.bits)
+        xs += [lo, -1, 0, 1, hi]
+        ys += [lo, -1, 0, 1, hi]
+        for (x, y) in itertools.product(xs, ys):
+            # TODO figure out signed modular arithmetic
+            expected = _as_signed(fn(x, y) % mod_bound, int_info.bits)
+            assert c.foo(x, y) == expected
     else:
-        assert c.foo(x, y) == _as_unsigned(fn(x, y) % mod_bound, int_info.bits)
+        xs += [0, 1, hi - 1, hi]
+        ys += [0, 1, hi - 1, hi]
+        for (x, y) in itertools.product(xs, ys):
+            assert c.foo(x, y) == fn(x, y) % mod_bound

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -40,13 +40,16 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
     # poor man's fuzzing - hypothesis doesn't make it easy
     # with the parametrized strategy
     if int_info.is_signed:
-        xs += [lo, -1, 0, 1, hi]
-        ys += [lo, -1, 0, 1, hi]
+        xs += [lo, lo + 1, -1, 0, 1, hi - 1, hi]
+        ys += [lo, lo + 1, -1, 0, 1, hi - 1, hi]
         for (x, y) in itertools.product(xs, ys):
             expected = _as_signed(fn(x, y) % mod_bound, int_info.bits)
             assert c.foo(x, y) == expected
     else:
-        xs += [0, 1, hi - 1, hi]
-        ys += [0, 1, hi - 1, hi]
+        # 0x80 has some weird properties, like
+        # it's a fixed point of multiplication by 0xFF
+        fixed_pt = 2**(int_info.bits - 1)
+        xs += [0, 1, hi - 1, hi, fixed_pt]
+        ys += [0, 1, hi - 1, hi, fixed_pt]
         for (x, y) in itertools.product(xs, ys):
             assert c.foo(x, y) == fn(x, y) % mod_bound

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -1,37 +1,61 @@
 import pytest
-from vyper.utils import BASE_TYPES
+import operator
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from vyper.utils import BASE_TYPES, DECIMAL_DIVISOR, int_bounds
+from vyper.codegen.types.types import BaseType, parse_integer_typeinfo
 
 # TODO something less janky
-numeric_types = [t for t in BASE_TYPES if "int" in t or t == "decimal"]
+integer_types = sorted([t for t in BASE_TYPES if "int" in t])
 
 
+# interpret a signed EVM word as an unsigned word
 def _as_unsigned(x, bits):
     if x < 0:
         return x + 2**bits
     return x
 
+
+# interpret an unsigned EVM word as a signed word
 def _as_signed(x, bits):
     if x > (2**(bits-1)) - 1:
         return x - 2**bits
     return x
 
-# _int_bounds(8, True) -> (-128, 127)
-# _int_bounds(8, False) -> (0, 255)
-def _int_bounds(bits, signed):
-    if signed:
-        return -(2**(bits - 1)), (2**(bits - 1)) - 1
-    return 0, (2**bits) - 1
 
-@pytest.mark.parametrize("typ", numeric_types)
-@pytest.mark.parametrize("op", [)
-def test_unsafe_ops(get_contract, typ, op):
+# TODO this is probably more broadly useful
+def _int_strategy(typname):
+    int_info = parse_integer_typeinfo(typname)
+    lo, hi = int_bounds(int_info.is_signed, int_info.bits)
+    return st.integers(min_value=lo, max_value=hi)
+
+def _evm_div(x, y):
+    if y == 0:
+        return 0
+    # note round-to-zero behavior compared to floordiv
+    return int(x / y)
+
+@pytest.mark.parametrize("typ", integer_types)
+@pytest.mark.parametrize("op", ["add", "sub", "mul", "div"])
+@given(st.data())
+def test_unsafe_op_int(get_contract, typ, op, data):
     code = f"""
 @external
-def bar(x: {typ}, y: {typ}) -> uint256:
+def foo(x: {typ}, y: {typ}) -> {typ}:
     return unsafe_{op}(x, y)
     """
+    fns = { "add": operator.add, "sub": operator.sub, "mul": operator.mul, "div": _evm_div }
+    fn = fns[op]
+
+    int_info = parse_integer_typeinfo(typ)
+
+    x = data.draw(_int_strategy(typ))
+    y = data.draw(_int_strategy(typ))
 
     c = get_contract(code)
-    # TODO this should go on the type metadata
-    signed = t.startswith("i") or t == "decimal"
-    if 
+    mod_bound = 2**int_info.bits
+    if int_info.is_signed:
+        assert c.foo(x, y) == _as_signed(fn(x, y) % mod_bound, int_info.bits)
+    else:
+        assert c.foo(x, y) == _as_unsigned(fn(x, y) % mod_bound, int_info.bits)

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -33,7 +33,7 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
     c = get_contract(code)
 
     lo, hi = int_bounds(int_info.is_signed, int_info.bits)
-    NUM_CASES = 50  # any more than this and fuzzer takes too long
+    NUM_CASES = 33  # any more than this and fuzzer takes too long
     xs = [random.randrange(lo, hi) for _ in range(NUM_CASES)]
     ys = [random.randrange(lo, hi) for _ in range(NUM_CASES)]
 

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -44,8 +44,9 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
         xs += [lo, -1, 0, 1, hi]
         ys += [lo, -1, 0, 1, hi]
         for (x, y) in itertools.product(xs, ys):
-            # TODO figure out signed modular arithmetic
-            expected = _as_signed(fn(x, y) % mod_bound, int_info.bits)
+            res = fn(x, y)  # calculate evm smod
+
+            expected = _as_signed(evm_mod(res, mod_bound), int_info.bits)
             assert c.foo(x, y) == expected
     else:
         xs += [0, 1, hi - 1, hi]

--- a/tests/parser/functions/test_unsafe_math.py
+++ b/tests/parser/functions/test_unsafe_math.py
@@ -33,8 +33,9 @@ def foo(x: {typ}, y: {typ}) -> {typ}:
     c = get_contract(code)
 
     lo, hi = int_bounds(int_info.is_signed, int_info.bits)
-    xs = [random.randrange(lo, hi) for _ in range(100)]
-    ys = [random.randrange(lo, hi) for _ in range(100)]
+    NUM_CASES = 50  # any more than this and fuzzer takes too long
+    xs = [random.randrange(lo, hi) for _ in range(NUM_CASES)]
+    ys = [random.randrange(lo, hi) for _ in range(NUM_CASES)]
 
     mod_bound = 2 ** int_info.bits
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1753,7 +1753,7 @@ class _UnsafeMath:
 
         ret = [op, a, b]
 
-        if op in ("mul", "add", "sub") and int_info.bits < 256:
+        if int_info.bits < 256:
             # wrap for ops which could under/overflow
             if int_info.is_signed:
                 # e.g. int128 -> (signextend 15 (add x y))

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -37,6 +37,7 @@ from vyper.codegen.types import (
     TupleType,
     is_base_type,
     is_signed_num,
+    parse_integer_typeinfo,
 )
 from vyper.codegen.types.convert import new_type_to_old_type
 from vyper.evm.opcodes import version_check
@@ -1774,12 +1775,12 @@ class _UnsafeMath:
         if op in ("add", "sub"):
             ret = decimal_mod([op, a, b])
         elif op == "mul":
-            ret = decimal_mod(["mul", a, b], DECIMAL_DIVISOR])
+            ret = decimal_mod(["sdiv", ["mul", a, b], DECIMAL_DIVISOR])
         elif op == "div":
             ret = ["sdiv", ["mul", a, DECIMAL_DIVISOR], b]
         else:
             raise CompilerPanic(f"invalid function: unsafe_{self.op}")  # pragma: notest
-        return LLLnode.from_list(ret, typ=otyp])
+        return LLLnode.from_list(ret, typ=otyp)
 
 
 class UnsafeAdd(_UnsafeMath):

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -550,10 +550,10 @@ class Expr:
                 )
 
         ltyp, rtyp = left.typ.typ, right.typ.typ
-        if ltyp != rtyp:
-            # Sanity check - ensure that we aren't dealing with different types
-            # This should be unreachable due to the type check pass
-            return
+
+        # Sanity check - ensure that we aren't dealing with different types
+        # This should be unreachable due to the type check pass
+        assert ltyp == rtyp, "unreachable"
 
         arith = None
         if isinstance(self.expr.op, (vy_ast.Add, vy_ast.Sub)):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -105,6 +105,17 @@ MAX_DECIMAL_PLACES = 10
 DECIMAL_DIVISOR = 10 ** MAX_DECIMAL_PLACES
 
 
+def int_bounds(signed, bits):
+    """
+    calculate the bounds on an integer type
+    ex. int_bounds(8, True) -> (-128, 127)
+        int_bounds(8, False) -> (0, 255)
+    """
+    if signed:
+        return -(2**(bits - 1)), (2**(bits - 1)) - 1
+    return 0, (2**bits) - 1
+
+
 # memory used for system purposes, not for variables
 class MemoryPositions:
     MAXDECIMAL = 32

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -129,8 +129,11 @@ def evm_div(x, y):
 def evm_mod(x, y):
     if y == 0:
         return 0
-    # this doesn't actually work when num digits exceeds fp precision
+
+    # this doesn't actually work when num digits exceeds fp precision:
     # return int(math.fmod(x, y))
+    sign = -1 if x < 0 else 1
+    return sign * (abs(x) % abs(y))  # adapted from py-evm
 
 
 # memory used for system purposes, not for variables

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -1,5 +1,4 @@
 import binascii
-import math
 import sys
 import traceback
 from typing import Dict, List, Union
@@ -113,8 +112,8 @@ def int_bounds(signed, bits):
         int_bounds(8, False) -> (0, 255)
     """
     if signed:
-        return -(2**(bits - 1)), (2**(bits - 1)) - 1
-    return 0, (2**bits) - 1
+        return -(2 ** (bits - 1)), (2 ** (bits - 1)) - 1
+    return 0, (2 ** bits) - 1
 
 
 # EVM div semantics as a python function

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -121,7 +121,7 @@ def evm_div(x, y):
     if y == 0:
         return 0
     # doesn't actually work:
-    #return int(x / y)
+    # return int(x / y)
     sign = -1 if (x * y) < 0 else 1
     return sign * (abs(x) // abs(y))  # adapted from py-evm
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -120,8 +120,10 @@ def int_bounds(signed, bits):
 def evm_div(x, y):
     if y == 0:
         return 0
-    # note round-to-zero behavior compared to floordiv
-    return int(x / y)
+    # doesn't actually work:
+    #return int(x / y)
+    sign = -1 if (x * y) < 0 else 1
+    return sign * (abs(x) // abs(y))  # adapted from py-evm
 
 
 # EVM mod semantics as a python function

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -1,4 +1,5 @@
 import binascii
+import math
 import sys
 import traceback
 from typing import Dict, List, Union
@@ -114,6 +115,22 @@ def int_bounds(signed, bits):
     if signed:
         return -(2**(bits - 1)), (2**(bits - 1)) - 1
     return 0, (2**bits) - 1
+
+
+# EVM div semantics as a python function
+def evm_div(x, y):
+    if y == 0:
+        return 0
+    # note round-to-zero behavior compared to floordiv
+    return int(x / y)
+
+
+# EVM mod semantics as a python function
+def evm_mod(x, y):
+    if y == 0:
+        return 0
+    # this doesn't actually work when num digits exceeds fp precision
+    # return int(math.fmod(x, y))
 
 
 # memory used for system purposes, not for variables


### PR DESCRIPTION
### What I did
introduce unsafe math ops for https://github.com/vyperlang/vyper/issues/2429

### How I did it
add unsafe add/sub/mul/div builtins. for int types that are smaller than 256 bits, they perform wrapping arithmetic

### How to verify it
check the tests

### Commit message

(tbd)

### Description for the changelog
Add `unsafe_` arithmetic ops which don't use checked arithmetic

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
