### PR TITLE
re-enable msg.* env variables in internal functions

### DIFF
--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -417,14 +417,27 @@ def __default__():
     assert w3.eth.get_balance(c.address) == w3.toWei(0.95, "ether")
 
 
-def test_private_msg_sender(get_contract, assert_compile_failed):
+def test_private_msg_sender(get_contract, w3):
     code = """
 @internal
 def _whoami() -> address:
     return msg.sender
+
+@external
+def i_am_me() -> bool:
+    return msg.sender == self._whoami()
+
+@external
+def whoami() -> address:
+    return self._whoami()
     """
 
-    assert_compile_failed(lambda: get_contract(code))
+    c = get_contract(code)
+    addr = w3.eth.accounts[0]
+    assert c.whoami() == addr
+    # TODO figure out why this does not work
+    #assert c.whoami(transact={"from": addr}) == addr, "oh no"
+    assert c.i_am_me()
 
 
 def test_nested_static_params_only(get_contract, assert_tx_failed):

--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -436,7 +436,7 @@ def whoami() -> address:
     addr = w3.eth.accounts[0]
     assert c.whoami() == addr
     # TODO figure out why this does not work
-    #assert c.whoami(transact={"from": addr}) == addr, "oh no"
+    # assert c.whoami(transact={"from": addr}) == addr, "oh no"
     assert c.i_am_me()
 
 

--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -270,6 +270,10 @@ def foo(a: decimal = 3.14, b: decimal[2] = [1.337, 2.69]): pass
 def foo(a: address = msg.sender, b: address[3] = [msg.sender, tx.origin, block.coinbase]): pass
     """,
     """
+@internal
+def foo(a: address = msg.sender, b: address[3] = [msg.sender, tx.origin, block.coinbase]): pass
+    """,
+    """
 @external
 @payable
 def foo(a: uint256 = msg.value): pass
@@ -372,14 +376,6 @@ def foo(a: uint256[2] = [2, self.x]): pass
 def foo(a: uint256 = msg.value): pass
 """,
         NonPayableViolation,
-    ),
-    (
-        """
-# msg.sender in a private function
-@internal
-def foo(a: address = msg.sender): pass
-    """,
-        StateAccessViolation,
     ),
 ]
 

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -2,7 +2,7 @@ import pytest
 from eth_tester.exceptions import TransactionFailed
 
 from vyper import compiler
-from vyper.exceptions import StateAccessViolation, SyntaxException, TypeMismatch
+from vyper.exceptions import SyntaxException, TypeMismatch
 
 
 def test_variable_assignment(get_contract, keccak):
@@ -46,6 +46,19 @@ def foo(bar: uint256) -> Bytes[36]:
     expected_result = method_id + "00" * 31 + encoded_42
 
     assert contract.foo(42).hex() == expected_result
+
+
+@pytest.mark.parametrize("bar", [0, 1, 42, 2**256 - 1])
+def test_calldata_private(get_contract, bar):
+    code = """
+@external
+def foo(bar: uint256) -> uint256:
+    data: Bytes[32] = slice(msg.data, 4, 32)
+    return convert(data, uint256)
+    """
+    c = get_contract(code)
+
+    assert c.foo(bar) == bar
 
 
 def test_memory_pointer_advances_appropriately(get_contract, keccak):
@@ -116,14 +129,6 @@ def foo() -> uint256:
     return bar
     """,
         SyntaxException,
-    ),
-    (
-        """
-@internal
-def foo() -> Bytes[4]:
-    return slice(msg.data, 0, 4)
-    """,
-        StateAccessViolation,
     ),
     (
         """

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -48,7 +48,7 @@ def foo(bar: uint256) -> Bytes[36]:
     assert contract.foo(42).hex() == expected_result
 
 
-@pytest.mark.parametrize("bar", [0, 1, 42, 2**256 - 1])
+@pytest.mark.parametrize("bar", [0, 1, 42, 2 ** 256 - 1])
 def test_calldata_private(get_contract, bar):
     code = """
 @external

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -430,9 +430,9 @@ class Expr:
             isinstance(self.expr.value, vy_ast.Name) and self.expr.value.id in ENVIRONMENT_VARIABLES
         ):
             key = f"{self.expr.value.id}.{self.expr.attr}"
-            if key == "msg.sender" and not self.context.is_internal:
+            if key == "msg.sender":
                 return LLLnode.from_list(["caller"], typ="address", pos=getpos(self.expr))
-            elif key == "msg.data" and not self.context.is_internal:
+            elif key == "msg.data":
                 # This adhoc node will be replaced with a valid node in `Slice/Len.build_LLL`
                 return LLLnode.from_list(["~calldata"], typ=ByteArrayType(0))
             elif key == "msg.value" and self.context.is_payable:

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -25,7 +25,7 @@ from vyper.semantics.environment import CONSTANT_ENVIRONMENT_VARS, MUTABLE_ENVIR
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.abstract import IntegerAbstractType
 from vyper.semantics.types.bases import DataLocation
-from vyper.semantics.types.function import ContractFunction, FunctionVisibility, StateMutability
+from vyper.semantics.types.function import ContractFunction, StateMutability
 from vyper.semantics.types.indexable.sequence import (
     ArrayDefinition,
     DynamicArrayDefinition,

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -166,14 +166,6 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         self.expr_visitor = _LocalExpressionVisitor()
         namespace.update(self.func.arguments)
 
-        if self.func.visibility is FunctionVisibility.INTERNAL:
-            node_list = fn_node.get_descendants(
-                vy_ast.Attribute, {"value.id": "msg", "attr": {"data", "sender"}}
-            )
-            if node_list:
-                raise StateAccessViolation(
-                    f"msg.{node_list[0].attr} is not allowed in internal functions", node_list[0]
-                )
         if self.func.mutability == StateMutability.PURE:
             node_list = fn_node.get_descendants(
                 vy_ast.Attribute,


### PR DESCRIPTION
### What I did
Fix #2631 

### How I did it
Remove the restrictions, fix tests

### How to verify it
Check tests

### Description for the changelog
re-enable msg.* env variables in internal functions
### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
