### PR TITLE
add ir_runtime output

### DIFF
--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -26,7 +26,7 @@ TRANSLATE_MAP = {
     "evm.deployedBytecode.sourceMap": "source_map",
     "interface": "interface",
     "ir": "ir_dict",
-    "ir_json": "ir_dict",
+    "ir_runtime": "ir_runtime_dict",
     # "metadata": "metadata",  # don't include  in "*" output for now
     "layout": "layout",
     "userdoc": "userdoc",

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -25,7 +25,9 @@ OUTPUT_FORMATS = {
     "external_interface": output.build_external_interface_output,
     "interface": output.build_interface_output,
     "ir": output.build_ir_output,
+    "ir_runtime": output.build_ir_runtime_output,
     "ir_dict": output.build_ir_dict_output,
+    "ir_runtime_dict": output.build_ir_runtime_dict_output,
     "method_identifiers": output.build_method_identifiers_output,
     "metadata": output.build_metadata_output,
     # requires assembly

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -79,16 +79,25 @@ def build_ir_output(compiler_data: CompilerData) -> LLLnode:
     return compiler_data.lll_nodes
 
 
+def build_ir_runtime_output(compiler_data: CompilerData) -> LLLnode:
+    if compiler_data.show_gas_estimates:
+        LLLnode.repr_show_gas = True
+    return compiler_data.lll_runtime
+
+
+def _lll_to_dict(lll_node):
+    args = lll_node.args
+    if len(args) > 0:
+        return {lll_node.value: [_lll_to_dict(x) for x in args]}
+    return lll_node.value
+
+
 def build_ir_dict_output(compiler_data: CompilerData) -> dict:
-    lll = compiler_data.lll_nodes
+    return _lll_to_dict(compiler_data.lll_nodes)
 
-    def _to_dict(lll_node):
-        args = lll_node.args
-        if len(args) > 0:
-            return {lll_node.value: [_to_dict(x) for x in args]}
-        return lll_node.value
 
-    return _to_dict(lll)
+def build_ir_runtime_dict_output(compiler_data: CompilerData) -> dict:
+    return _lll_to_dict(compiler_data.lll_runtime)
 
 
 def build_metadata_output(compiler_data: CompilerData) -> dict:


### PR DESCRIPTION
### What I did
add output format `ir_runtime` which returns only the runtime IR (strips off the constructor code)

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
