### PR TITLE
fix convert to bytes32

### DIFF
--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -113,6 +113,18 @@ def ret10_slice() -> Bytes[10]:
     assert c.ret10_slice() == b"A"
 
 
+def test_slice_convert(get_contract):
+    # test slice of converting between bytes32 and Bytes
+    code = """
+@external
+def f() -> bytes32:
+    a: Bytes[100] = convert("ab", Bytes[100])
+    return convert(slice(a, 0, 1), bytes32)
+    """
+    c = get_contract(code)
+    assert c.f() == b"a" + b"\x00" * 31
+
+
 code_bytes32 = [
     """
 foo: bytes32

--- a/vyper/builtin_functions/convert.py
+++ b/vyper/builtin_functions/convert.py
@@ -52,7 +52,7 @@ def byte_array_to_num(arg, out_type):
     # convert by shr the number of zero bytes (converted to bits)
     # e.g. "abcd000000000000" -> bitcast(000000000000abcd, output_type)
     num_zero_bits = ["mul", 8, ["sub", 32, "len_"]]
-    bitcasted = LLLnode.from_list(shr(num_zero_bits, "val", typ=out_type))
+    bitcasted = LLLnode.from_list(shr(num_zero_bits, "val"), typ=out_type)
 
     result = clamp_basetype(bitcasted)
 

--- a/vyper/builtin_functions/convert.py
+++ b/vyper/builtin_functions/convert.py
@@ -12,9 +12,17 @@ from vyper.codegen.core import (
     getpos,
     int_clamp,
     load_op,
+    shl,
     shr,
+    wordsize,
 )
-from vyper.codegen.types import BaseType, ByteArrayType, StringType, get_type
+from vyper.codegen.types import (
+    DYNAMIC_ARRAY_OVERHEAD,
+    BaseType,
+    ByteArrayType,
+    StringType,
+    get_type,
+)
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import InvalidLiteral, StructureException, TypeMismatch
 from vyper.utils import DECIMAL_DIVISOR, MemoryPositions, SizeLimits
@@ -43,10 +51,12 @@ def byte_array_to_num(arg, out_type):
     # bytestring is right-padded with zeroes, int is left-padded.
     # convert by shr the number of zero bytes (converted to bits)
     # e.g. "abcd000000000000" -> bitcast(000000000000abcd, output_type)
-    bitcasted = LLLnode.from_list(shr("val", ["mul", 8, ["sub", 32, "len_"]]), typ=out_type)
+    num_zero_bits = ["mul", 8, ["sub", 32, "len_"]]
+    bitcasted = LLLnode.from_list(shr(num_zero_bits, "val", typ=out_type))
 
     result = clamp_basetype(bitcasted)
 
+    # TODO use cache_when_complex for these `with` values
     ret = ["with", "val", data, ["with", "len_", len_, result]]
     if arg.is_complex_lll:
         ret = ["with", "bs_start", arg, ret]
@@ -419,16 +429,24 @@ def to_bytes32(expr, args, kwargs, context):
                 f"Unable to convert bytes[{_len}] to bytes32, max length is too " "large."
             )
 
-        if in_arg.location == "storage":
-            return LLLnode.from_list(["sload", ["add", in_arg, 1]], typ=BaseType("bytes32"))
-        else:
+        with in_arg.cache_when_complex("bytes") as (b1, in_arg):
             op = load_op(in_arg.location)
-            return LLLnode.from_list([op, ["add", in_arg, 32]], typ=BaseType("bytes32"))
+            ofst = wordsize(in_arg.location) * DYNAMIC_ARRAY_OVERHEAD
+            bytes_val = [op, ["add", in_arg, ofst]]
+
+            # zero out any dirty bytes (which can happen in the last
+            # word of a bytearray)
+            len_ = get_bytearray_length(in_arg)
+            num_zero_bits = LLLnode.from_list(["mul", ["sub", 32, len_], 8])
+            with num_zero_bits.cache_when_complex("bits") as (b2, num_zero_bits):
+                ret = shl(num_zero_bits, shr(num_zero_bits, bytes_val))
+                ret = b1.resolve(b2.resolve(ret))
 
     else:
-        return LLLnode(
-            value=in_arg.value, args=in_arg.args, typ=BaseType("bytes32"), pos=getpos(expr)
-        )
+        # literal
+        ret = in_arg
+
+    return LLLnode.from_list(ret, typ="bytes32", pos=getpos(expr))
 
 
 @signature(("bytes32", "uint256"), "*")

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1469,6 +1469,7 @@ class Shift(_SimpleBuiltinFunction):
             shift_abs = ["sub", 0, "_s"]
 
         if version_check(begin="constantinople"):
+            # TODO use convenience functions shl and shr in codegen/core.py
             if args[1].typ.is_literal:
                 # optimization when SHL/SHR instructions are available shift distance is a literal
                 value = args[1].value


### PR DESCRIPTION
### What I did
fix case for converting Bytes to bytes32 - https://github.com/vyperlang/vyper/issues/2652

### How I did it
use bit ops to ensure the lower bytes are zeroed

### How to verify it
see test

### Commit message

This commit fixes a bug in converting between Bytes types and bytes32.
Because of how bytes copying (and bytes zeroing -- `bytes = b""`) works,
a bytearray may have dirty bytes in its last word past the end of the
runtime length of the bytestring. For instance, the bytestring "a" maybe
be represented as
```
length | data
0x01   | 0x6162
```
 
This commit fixes that by ensuring that any dirty bytes get zeroed out
in the result by using bitwise operations.
 
This commit also changes the order of arguments in the convenience
functions shl()/shr()/sar() to match the argument order of the EVM.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.natgeofe.com/k/63b1a8a7-0081-493e-8b53-81d01261ab5d/red-panda-full-body_16x9.jpg)
