### PR TITLE
fix lack of clamping for dynarray make_setter

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -144,6 +144,7 @@ def _dynarray_make_setter(dst, src, pos=None):
         # loop when subtype.is_dynamic AND location == storage
         # OR array_size <= /bound where loop is cheaper than memcpy/
         should_loop |= src.typ.subtype.abi_type.is_dynamic()
+        should_loop |= _needs_clamp(src.typ.subtype, src.encoding)
 
         if should_loop:
             uint = BaseType("uint256")


### PR DESCRIPTION
when the subtype needs clamping, we can't use straight bytes copy, we
have to run make_setter in a loop (which performs clamping)

### How I did it
add a condition for looping in make_setter_dynarray

### How to verify it
https://github.com/vyperlang/vyper/pull/2640/files#diff-d791908f2752921e3a897668bf4c1ed864af3ee089228e1e0f21577bf1f33285R414 should work

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.outdoorlife.com/uploads/2021/04/30/IMG_1859-scaled.jpg?auto=webp)
