### PR TITLE
add empty list literals for dynarray

### DIFF
--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -24,12 +24,6 @@ def foo(x: int128):
         pass
     """,
     """
-bar: int128[3]
-@external
-def foo():
-    self.bar = []
-    """,
-    """
 @external
 def foo():
     x: String[100] = "these bytes are nо gооd because the o's are from the Russian alphabet"

--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -38,6 +38,11 @@ invalid_list = [
 def foo():
     raw_log(b"cow", b"dog")
     """,
+    """
+@external
+def foo():
+    xs: uint256[1] = []
+    """,
     # Must be a literal string.
     """
 @external

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -94,7 +94,7 @@ bar: int128[3]
 def foo():
     self.bar = []
     """,
-        InvalidLiteral,
+        InvalidType,
     ),
     (
         """

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -80,6 +80,19 @@ def hoo2() -> DynArray[int128, 2]:
     return empty(DynArray[int128, 2])
 
 @external
+def hoo3() -> DynArray[int128, 2]:
+    return []
+
+@external
+def hoo4() -> DynArray[int128, 2]:
+    self.z = []
+    return self.z
+
+@external
+def hoo5() -> DynArray[DynArray[int128, 2], 2]:
+    return []
+
+@external
 def joo() -> DynArray[int128, 2]:
     self.z = [3, 5]
     x: DynArray[int128, 2] = self.z
@@ -125,8 +138,8 @@ def roo(inp: DynArray[decimal, 2]) -> DynArray[DynArray[decimal, 2], 2]:
     assert c.foo() == [3, 5]
     assert c.goo() == [3, 5]
     assert c.hoo() == [3, 5]
-    assert c.hoo1() == []
-    assert c.hoo2() == []
+    assert c.hoo1() == c.hoo2() == c.hoo3() == c.hoo4() == []
+    assert c.hoo5() == []
     assert c.joo() == [3, 5]
     assert c.koo() == [[1, 2], [3, 4]]
     assert c.loo() == [[1, 2], [3, 4]]

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -21,7 +21,6 @@ from vyper.codegen.types import (
     BaseType,
     ByteArrayLike,
     ByteArrayType,
-    DArrayType,
     InterfaceType,
     MappingType,
     SArrayType,
@@ -40,7 +39,6 @@ from vyper.exceptions import (
     TypeCheckFailure,
     TypeMismatch,
 )
-from vyper.semantics.types import DynamicArrayDefinition
 from vyper.utils import DECIMAL_DIVISOR, SizeLimits, bytes_to_int, checksum_encode, string_to_bytes
 
 # var name: (lllnode, type)

--- a/vyper/codegen/types/convert.py
+++ b/vyper/codegen/types/convert.py
@@ -13,9 +13,9 @@ def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
     if isinstance(typ, new.Bytes32Definition):
         return old.BaseType("bytes32")
     if isinstance(typ, new.BytesArrayDefinition):
-        return old.ByteArrayType(typ.count)
+        return old.ByteArrayType(typ.length)
     if isinstance(typ, new.StringDefinition):
-        return old.StringType(typ.count)
+        return old.StringType(typ.length)
     if isinstance(typ, new.DecimalDefinition):
         return old.BaseType("decimal")
     if isinstance(typ, new.SignedIntegerAbstractType):

--- a/vyper/codegen/types/convert.py
+++ b/vyper/codegen/types/convert.py
@@ -13,7 +13,7 @@ def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
     if isinstance(typ, new.Bytes32Definition):
         return old.BaseType("bytes32")
     if isinstance(typ, new.BytesArrayDefinition):
-        return old.BytesType(typ.count)
+        return old.ByteArrayType(typ.count)
     if isinstance(typ, new.StringDefinition):
         return old.StringType(typ.count)
     if isinstance(typ, new.DecimalDefinition):

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -169,8 +169,6 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         self.visit(node.value, type_)
 
     def visit_List(self, node, type_):
-        if not node.elements:
-            return
         if type_ is None:
             type_ = get_possible_types_from_node(node)
             if len(type_) > 1:

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -448,6 +448,7 @@ def validate_expected_type(node, expected_type):
             types_str = sorted(str(i) for i in given_types)
             given_str = f"{', '.join(types_str[:1])} or {types_str[-1]}"
 
+        # CMC 2022-02-14 maybe TypeMismatch would make more sense here
         raise InvalidType(
             f"Expected {expected_str} but literal can only be cast as {given_str}", node
         )

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -228,8 +228,14 @@ class _ExprTypeChecker:
 
     def types_from_List(self, node):
         # literal array
+
         if not node.elements:
-            raise InvalidLiteral("Cannot have an empty array", node)
+            # empty list literal `[]`
+            # subtype can be anything
+            types_list = types.get_types()
+            # 1 is minimum possible length for dynarray, assignable to anything
+            ret = [DynamicArrayDefinition(t, 1) for t in types_list]
+            return ret
 
         types_list = get_common_types(*node.elements)
 


### PR DESCRIPTION
### What I did
this now compiles
```python
@external
def foo():
    xs: DynArray[uint256, 5] = []
```

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
