### PR TITLE
docs: msg.sender is available even in internal fns

### DIFF
--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -30,10 +30,6 @@ Name                 Type             Value
 
 .. note::
 
-    ``msg.data``, ``msg.sender`` and ``msg.value`` can only be accessed from external functions. If you require these values within a private function, they must be passed as parameters.
-
-.. note::
-
     ``msg.data`` requires the usage of :func:`slice <slice>` to explicitly extract a section of calldata. If the extracted section exceeds the bounds of calldata, this will throw. You can check the size of ``msg.data`` using :func:`len <len>`.
 
 .. _constants-self:

--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -84,9 +84,6 @@ contract, we are provided with a built-in variable ``msg`` and we can access
 the public address of any method caller with ``msg.sender``. Similarly, the
 amount of ether a user sends can be accessed by calling ``msg.value``.
 
-.. note:: ``msg.sender`` and ``msg.value`` can only be accessed from external
-  functions. If you require these values within an internal function they must be passed as parameters.
-
 Here, we first check whether the current time is within the bidding period by
 comparing with the auction's start and end times using the ``assert`` function
 which takes any boolean statement. We also check to see if the new bid is greater
@@ -418,10 +415,6 @@ Let’s move onto the constructor.
   :language: python
   :lineno-start: 53
   :lines: 53-62
-
-.. note:: ``msg.sender`` and ``msg.value`` can only be accessed from external
-  functions. If you require these values within an internal function they must be
-  passed as parameters.
 
 In the constructor, we hard-coded the contract to accept an
 array argument of exactly two proposal names of type ``bytes32`` for the contracts


### PR DESCRIPTION
### What I did
fix #2636 

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
