### PR TITLE
fix version string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+            # grab the commit passed in via `tag`, if any
+            ref: ${{ github.event.inputs.tag }}
+            # need to fetch unshallow so that setuptools_scm can infer the version
+            fetch-depth: 0
 
       - name: Python
         uses: actions/setup-python@v2
@@ -57,9 +62,6 @@ jobs:
 
       - name: Generate Binary
         run: >-
-          export input_tag=${{ github.event.inputs.tag }} &&
-          git fetch --tags -f &&
-          git checkout ${input_tag:-`git rev-list --tags --max-count=1`} &&
           pip install . &&
           pip install pyinstaller &&
           ./make.cmd freeze

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Generate Binary
         run: >-
           export input_tag=${{ github.event.inputs.tag }} &&
-          git fetch --tags -f &&
+          git fetch --unshallow &&
           git checkout ${input_tag:-`git rev-list --tags --max-count=1`} &&
+          pip install . &&
           pip install pyinstaller &&
-          python setup.py install &&
           make freeze
 
       - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+            # grab the commit passed in via `tag`, if any
+            ref: ${{ github.event.inputs.tag }}
+            # need to fetch unshallow so that setuptools_scm can infer the version
+            fetch-depth: 0
 
       - name: Python
         uses: actions/setup-python@v2
@@ -30,9 +35,6 @@ jobs:
 
       - name: Generate Binary
         run: >-
-          export input_tag=${{ github.event.inputs.tag }} &&
-          git fetch --unshallow &&
-          git checkout ${input_tag:-`git rev-list --tags --max-count=1`} &&
           pip install . &&
           pip install pyinstaller &&
           make freeze

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
           export input_tag=${{ github.event.inputs.tag }} &&
           git fetch --tags -f &&
           git checkout ${input_tag:-`git rev-list --tags --max-count=1`} &&
-          pip install . &&
           pip install pyinstaller &&
+          python setup.py install &&
           make freeze
 
       - name: Upload Artifact

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SHELL := /bin/bash
-OS := $(shell uname -s | tr A-Z a-z)
-VERSION := $(shell PYTHONPATH=. python vyper/cli/vyper_compile.py --version)
 
 ifeq (, $(shell which pip3))
 	pip := $(shell which pip3)
@@ -43,7 +41,9 @@ release: clean
 
 freeze: clean init
 	echo Generating binary...
-	pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name vyper.$(VERSION).$(OS) --add-data vyper:vyper
+	export OS="$$(uname -s | tr A-Z a-z)" && \
+	export VERSION="$$(PYTHONPATH=. python vyper/cli/vyper_compile.py --version)" && \
+	pyinstaller --clean --onefile vyper/cli/vyper_compile.py --name "vyper.$${VERSION}.$${OS}" --add-data vyper:vyper
 
 clean: clean-build clean-docs clean-pyc clean-test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,3 @@
-[build-system]
-requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
-
-[tool.setuptools_scm]
-write_to = "vyper/version.py"
-
 # NOTE: you have to use single-quoted strings in TOML for regular expressions.
 # It's the equivalent of r-strings in Python.  Multiline strings are treated as
 # verbose regular expressions by Black.  Use [ ] to denote a significant space

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,11 @@ def _global_version(version):
 
 setup(
     name="vyper",
-    use_scm_version={"local_scheme": _local_version, "version_scheme": _global_version},
+    use_scm_version={
+        "local_scheme": _local_version,
+        "version_scheme": _global_version,
+        "write_to": "vyper/version.py",
+    },
     description="Vyper: the Pythonic Programming Language for the EVM",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -78,7 +82,7 @@ setup(
         "cached-property==1.5.2 ; python_version<'3.8'",
         "importlib-metadata ; python_version<'3.8'",
     ],
-    setup_requires=["pytest-runner", "setuptools_scm"],
+    setup_requires=["pytest-runner", "setuptools_scm", "wheel"],
     tests_require=extras_require["test"],
     extras_require=extras_require,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,9 @@ setup(
         "semantic-version==2.8.5",
         "cached-property==1.5.2 ; python_version<'3.8'",
         "importlib-metadata ; python_version<'3.8'",
+        "wheel",
     ],
-    setup_requires=["pytest-runner", "setuptools_scm", "wheel"],
+    setup_requires=["pytest-runner", "setuptools_scm"],
     tests_require=extras_require["test"],
     extras_require=extras_require,
     entry_points={

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -14,6 +14,10 @@ except PackageNotFoundError:
 
     from vyper.version import version as version_str
 
+    # strip `.devN` suffix since it is not semver compatible
+    # NOTE: see `_global_version()` in setup.py
     version_str = re.sub(r"\.dev\d+", "", version_str)
+    # fix commit hash
+    # see `_local_version()` in setup.py
     version_str = re.sub(r"\+g([a-f0-9]+).*", r"+commit.\1", version_str)
     __version__ = version_str

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -10,4 +10,8 @@ except ModuleNotFoundError:
 try:
     __version__ = _version(__name__)
 except PackageNotFoundError:
-    from vyper.version import version as __version__
+    from vyper.version import version as version_str
+    import re
+    version_str = re.sub(r"\.dev\d+", "", version_str)
+    version_str = re.sub(r"\+g([a-f0-9]+).*", r"+commit.\1", version_str)
+    __version__ = version_str

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -10,14 +10,4 @@ except ModuleNotFoundError:
 try:
     __version__ = _version(__name__)
 except PackageNotFoundError:
-    import re
-
-    from vyper.version import version as version_str
-
-    # strip `.devN` suffix since it is not semver compatible
-    # NOTE: see `_global_version()` in setup.py
-    version_str = re.sub(r"\.dev\d+", "", version_str)
-    # fix commit hash
-    # see `_local_version()` in setup.py
-    version_str = re.sub(r"\+g([a-f0-9]+).*", r"+commit.\1", version_str)
-    __version__ = version_str
+    from vyper.version import version as __version__

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -10,8 +10,10 @@ except ModuleNotFoundError:
 try:
     __version__ = _version(__name__)
 except PackageNotFoundError:
-    from vyper.version import version as version_str
     import re
+
+    from vyper.version import version as version_str
+
     version_str = re.sub(r"\.dev\d+", "", version_str)
     version_str = re.sub(r"\+g([a-f0-9]+).*", r"+commit.\1", version_str)
     __version__ = version_str


### PR DESCRIPTION
### What I did
- fix version string in `make freeze` generated binaries
- also fix the binary name in the "build.yml" workflow
- see https://gitlab.com/python-devs/importlib_metadata/-/issues/71

- remove pyproject.toml usage of setuptools_scm as it generates a  
  conflicting version string depending on build context
  (`setup.py install`, `pip install`, `make freeze`)

### How I did it
fix the case where the setuptools_scm default version string takes over

### How to verify it
```bash
$ make freeze
...
12198 INFO: Building PKG (CArchive) vyper.0.3.2+commit.c47ce229.linux.pkg completed successfully.
....
$ dist/vyper.0.3.2+commit.c47ce229.linux --version
0.3.2+commit.cf5fad74
```
also testing the artifact workflow here: https://github.com/vyperlang/vyper/actions/runs/1854199900

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://gifts.worldwildlife.org/gift-center/Images/large-species-photo/large-Koala-photo.jpg)
