### PR TITLE
fix: refactor events and fix bad assertion

### DIFF
--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -49,6 +49,14 @@ def foo():
 def mint(_to: address, _value: uint256):
     assert msg.sender == self,msg.sender
     """,
+    # literal longer than event member
+    """
+event Foo:
+    message: String[1]
+@external
+def foo():
+    log Foo("abcd")
+    """,
     # Raise reason must be string
     """
 @external

--- a/tests/parser/features/test_logging_bytes_extended.py
+++ b/tests/parser/features/test_logging_bytes_extended.py
@@ -38,7 +38,7 @@ def foo():
 
     assert log[0].args.arg1 == b"hello" * 9
     assert log[0].args.arg2 == b"hello" * 8
-    assert log[0].args.arg3 == b"hello" * 7
+    assert log[0].args.arg3 == b"hello" * 1
 
 
 def test_bytes_logging_extended_passthrough(get_contract_with_gas_estimation, get_logs):

--- a/tests/parser/features/test_logging_bytes_extended.py
+++ b/tests/parser/features/test_logging_bytes_extended.py
@@ -29,8 +29,8 @@ event MyLog:
 def foo():
     a: Bytes[64] = b'hellohellohellohellohellohellohellohellohello'
     b: Bytes[64] = b'hellohellohellohellohellohellohellohello'
-    c: Bytes[64] = b'hellohellohellohellohellohellohello'
-    log MyLog(a, b, c)
+    # test literal much smaller than buffer
+    log MyLog(a, b, b'hello')
     """
 
     c = get_contract_with_gas_estimation(code)

--- a/vyper/codegen/events.py
+++ b/vyper/codegen/events.py
@@ -1,14 +1,9 @@
-from typing import Tuple
-
-from vyper.abi_types import ABI_Tuple
 from vyper.codegen.abi_encoder import abi_encode
-from vyper.codegen.context import Context
 from vyper.codegen.core import getpos, lll_tuple_from_args, unwrap_location
 from vyper.codegen.keccak256_helper import keccak256_helper
 from vyper.codegen.lll_node import LLLnode
 from vyper.codegen.types.types import BaseType, ByteArrayLike, get_type_for_exact_size
 from vyper.exceptions import TypeMismatch
-from vyper.semantics.types import Event
 
 
 # docs.soliditylang.org/en/v0.8.6/abi-spec.html#indexed-event-encoding
@@ -37,28 +32,8 @@ def _gas_bound(num_topics, data_maxlen):
     return LOG_BASE_GAS + GAS_PER_TOPIC * num_topics + GAS_PER_LOG_BYTE * data_maxlen
 
 
-def allocate_buffer_for_log(event: Event, context: Context) -> Tuple[int, int]:
-    """Allocate a buffer to ABI-encode the non-indexed (data) arguments into
-
-    This must be done BEFORE compiling the event arguments to LLL,
-    registering the buffer with the `context` variable (otherwise any
-    function calls inside the event literal will clobber the buffer).
-    """
-    arg_types = list(event.arguments.values())  # the types of the arguments
-    # remove non-data args, as those don't go into the buffer
-    arg_types = [arg_t for arg_t, is_index in zip(arg_types, event.indexed) if not is_index]
-
-    # all args get encoded as one big tuple
-    abi_t = ABI_Tuple([t.abi_type for t in arg_types])
-
-    # make a buffer for the encoded data output
-    buf_maxlen = abi_t.size_bound()
-    t = get_type_for_exact_size(buf_maxlen)
-    return context.new_internal_variable(t), buf_maxlen
-
-
 # docs.soliditylang.org/en/v0.8.6/abi-spec.html#events
-def lll_node_for_log(expr, buf, _maxlen, event, topic_nodes, data_nodes, context):
+def lll_node_for_log(expr, event, topic_nodes, data_nodes, context):
     """Taking LLL nodes as arguments, create the LLL node for a Log statement.
 
     Arguments:
@@ -76,19 +51,19 @@ def lll_node_for_log(expr, buf, _maxlen, event, topic_nodes, data_nodes, context
 
     data = lll_tuple_from_args(data_nodes)
 
-    # sanity check, abi size_bound is the same calculated both ways
-    assert data.typ.abi_type.size_bound() == _maxlen, "bad buffer size"
+    bufsz = data.typ.abi_type.size_bound()
+    buf = context.new_internal_variable(get_type_for_exact_size(bufsz))
 
     # encode_data is an LLLnode which, cleverly, both encodes the data
     # and returns the length of the encoded data as a stack item.
-    encode_data = abi_encode(buf, data, context, pos=_pos, returns_len=True, bufsz=_maxlen)
+    encode_data = abi_encode(buf, data, context, pos=_pos, returns_len=True, bufsz=bufsz)
 
     assert len(topics) <= 4, "too many topics"  # sanity check
     log_opcode = "log" + str(len(topics))
 
     return LLLnode.from_list(
         [log_opcode, buf, encode_data] + topics,
-        add_gas_estimate=_gas_bound(len(topics), _maxlen),
+        add_gas_estimate=_gas_bound(len(topics), bufsz),
         typ=None,
         pos=_pos,
         annotation=f"LOG event {event.signature}",

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -116,10 +116,6 @@ class Stmt:
     def parse_Log(self):
         event = self.stmt._metadata["type"]
 
-        # do this BEFORE evaluating args to LLL to protect the buffer
-        # from internal call clobbering
-        buf, _len = events.allocate_buffer_for_log(event, self.context)
-
         args = [Expr(arg, self.context).lll_node for arg in self.stmt.value.args]
 
         topic_lll = []
@@ -130,9 +126,7 @@ class Stmt:
             else:
                 data_lll.append(arg)
 
-        return events.lll_node_for_log(
-            self.stmt, buf, _len, event, topic_lll, data_lll, self.context
-        )
+        return events.lll_node_for_log(self.stmt, event, topic_lll, data_lll, self.context)
 
     def parse_Call(self):
         is_self_function = (


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/2663

### How I did it (/ Commit message)
previously event logging allocated the buffer prior to generating the
code for abi_encode + issuing log instruction; this is no longer
necessary in the new calling convention, so simplify the code so that
the codegen and buffer allocation happen in the same place.

### How to verify it
see tests

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i2-prod.mirror.co.uk/incoming/article25609246.ece/ALTERNATES/n615/0_PUSS-IN-BOOTS.jpg)
