### PR TITLE
fix: _abi_encode for constant arrays

### DIFF
--- a/tests/parser/syntax/test_abi_encode.py
+++ b/tests/parser/syntax/test_abi_encode.py
@@ -82,6 +82,13 @@ def foo(x: Bytes[1]) -> Bytes[68]:
 def foo(x: Bytes[1]) -> Bytes[68]:
     return _abi_encode(x, ensure_tuple=False, method_id=0x12345678)
     """,
+    """
+BAR: constant(DynArray[uint256, 5]) = [1, 2, 3, 4, 5]
+
+@external
+def foo() -> Bytes[224]:
+    return _abi_encode(BAR)
+    """,
 ]
 
 

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -175,7 +175,7 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_List(self, node, type_):
         if type_ is None:
             type_ = get_possible_types_from_node(node)
-            if len(type_) > 1:
+            if len(type_) >= 1:
                 type_ = type_.pop()
         node._metadata["type"] = type_
         for element in node.elements:


### PR DESCRIPTION
### What I did

Fix for #2661.

When visiting a list node, we pop from the list of possible types derived only if its length is greater than 1. Since constant arrays will have only one possible type after constant folding, this fix relaxes the assertion to greater than or equal to 1. 

### How I did it

Add `=`.

### How to verify it

See test case.

### Description for the changelog

Fix _abi_encode for constant arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpaperaccess.com/full/1746308.jpg)
