### PR TITLE
chore: update eth_tester version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "pytest-cov>=2.10,<3.0",
         "pytest-instafail>=0.4,<1.0",
         "pytest-xdist>=1.32,<2.0",
-        "eth-tester[py-evm]>=0.6.0b4,<0.7",
+        "eth-tester[py-evm]>=0.6.0b6,<0.7",
         "py-evm>=0.5.0a3,<0.6",
         "web3==5.27.0",
         "tox>=3.15,<4.0",


### PR DESCRIPTION
### What I did

Fix for #2667.

Update `eth_tester` version to `0.6.0b6`.

### How I did it

Change the version number in `setup.py`.

### How to verify it

Run `python setup.py test`.

### Description for the changelog

Update eth_tester version to 0.6.0b6

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.cabq.gov/artsculture/biopark/news/10-cool-facts-about-penguins/@@images/1a36b305-412d-405e-a38b-0947ce6709ba.jpeg)
