### PR TITLE
update build artifacts CI to build a binary when master updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - master
 
 defaults:
   run:


### PR DESCRIPTION
This will allow people to test new features before a new release, and when new stuff gets merged into master