### PR TITLE
chore: refactor integer types as constant

### DIFF
--- a/tests/parser/types/numbers/test_constants.py
+++ b/tests/parser/types/numbers/test_constants.py
@@ -5,6 +5,7 @@ import pytest
 
 from vyper.compiler import compile_code
 from vyper.exceptions import InvalidType
+from vyper.semantics.types.value.numeric import INTEGER_TYPES
 from vyper.utils import MemoryPositions
 
 
@@ -132,11 +133,7 @@ def test_add(a: uint256) -> uint256:
     assert c.test_add(7) == 40
 
 
-# Would be nice to put this somewhere accessible, like in vyper.types or something
-integer_types = ["uint8", "int128", "int256", "uint256"]
-
-
-@pytest.mark.parametrize("storage_type,return_type", itertools.permutations(integer_types, 2))
+@pytest.mark.parametrize("storage_type,return_type", itertools.permutations(INTEGER_TYPES, 2))
 def test_custom_constants_fail(get_contract, assert_compile_failed, storage_type, return_type):
     code = f"""
 MY_CONSTANT: constant({storage_type}) = 1

--- a/vyper/semantics/types/value/numeric.py
+++ b/vyper/semantics/types/value/numeric.py
@@ -1,3 +1,5 @@
+import inspect
+import sys
 from typing import Optional, Tuple, Type, Union
 
 from vyper import ast as vy_ast
@@ -5,6 +7,7 @@ from vyper.abi_types import ABI_FixedMxN, ABI_GIntM, ABIType
 from vyper.exceptions import CompilerPanic, InvalidOperation, OverflowException
 from vyper.semantics.types.abstract import (
     FixedAbstractType,
+    IntegerAbstractType,
     SignedIntegerAbstractType,
     UnsignedIntegerAbstractType,
 )
@@ -193,3 +196,10 @@ class DecimalPrimitive(_NumericPrimitive):
     _id = "decimal"
     _type = DecimalDefinition
     _valid_literal = (vy_ast.Decimal,)
+
+
+INTEGER_TYPES = [
+    c()._id
+    for _, c in inspect.getmembers(sys.modules[__name__], inspect.isclass)
+    if issubclass(c, IntegerAbstractType) and hasattr(c, "_id")
+]


### PR DESCRIPTION
### What I did

Add a master list of integer types to reduce code duplication.

TODO: Run through test suite and refactor if this is acceptable.

### How I did it

Get the `_id` of all classes that inherit from `IntegerAbstractType`.

### How to verify it

See sample test case that has been refactored.

### Description for the changelog

Add master list of integer types

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/i9kggxfeyde51.jpg?auto=webp&s=c149c9b82e1a0927200b860363bc06100831a217)
