### PR TITLE
remove *.vy linguist-language=Python since GitHub linguist now suppor…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.vy linguist-language=Python


### PR DESCRIPTION
…ts .vy syntax natively

### What I did

Removed `.gitattributes` file.

### How I did it

`git rm .gitattributes`

### How to verify it

### Description for the changelog

https://github.com/github/linguist/pull/5778

https://github.com/ribbon-finance/governance/blob/main/contracts/rbn-staking/VotingEscrow.vy
https://gist.github.com/davidhq/779f863c11cc8fbfb654172ad1049942
https://gist.github.com/davidhq/552fa3600f901bca23f1a4f84c17aa1b

### Cute Animal Picture

![cute_animal](https://user-images.githubusercontent.com/3899/155153458-2d73b4bc-64e4-479a-9d92-d0cf0c10be9d.jpeg)

