### PR TITLE
chore: remove instructions for linguist-language

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ To compile a contract, use:
 vyper your_file_name.vy
 ```
 
-**Alternative for GitHub syntax highlighting: Add a `.gitattributes` file with the line `*.vy linguist-language=Python`**
-
 There is also an [online compiler](https://vyper.online/) available you can use to experiment with
 the language and compile to ``bytecode`` and/or ``LLL``.
 


### PR DESCRIPTION
no longer required as github has vyper syntax highlighting now

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
