### PR TITLE
feat: add `select` opcode to LLL

### DIFF
--- a/vyper/lll/README.md
+++ b/vyper/lll/README.md
@@ -300,7 +300,7 @@ Compare or equal
 `(ne x y)` is equivalent to `(iszero (eq x y))`
 
 ### SELECT
-`(select cond x y)` is similar to `(if cond x y)` but it may evaluate both branches. Whether or not both branches are taken is unspecified. It is analogous to LLVM `select` and is intended to compile to branchless code.
+`(select cond x y)` is similar to `(if cond x y)` but it may evaluate both branches. Whether or not both branches are taken is unspecified. If `cond` is not in `(0, 1)` the behavior is undefined. It is analogous to LLVM `select` and is intended to compile to branchless code.
 
 ### CLAMP\*
 

--- a/vyper/lll/README.md
+++ b/vyper/lll/README.md
@@ -299,6 +299,9 @@ Compare or equal
 
 `(ne x y)` is equivalent to `(iszero (eq x y))`
 
+### SELECT
+`(select cond x y)` is similar to `(if cond x y)` but it may evaluate both branches. It is analogous to LLVM `select` and is intended to compile to branchless code.
+
 ### CLAMP\*
 
 Clamp pseudo-opcodes ensure that an input is bounded by some other input(s), and returns its first input.

--- a/vyper/lll/README.md
+++ b/vyper/lll/README.md
@@ -300,7 +300,7 @@ Compare or equal
 `(ne x y)` is equivalent to `(iszero (eq x y))`
 
 ### SELECT
-`(select cond x y)` is similar to `(if cond x y)` but it may evaluate both branches. It is analogous to LLVM `select` and is intended to compile to branchless code.
+`(select cond x y)` is similar to `(if cond x y)` but it may evaluate both branches. Whether or not both branches are taken is unspecified. It is analogous to LLVM `select` and is intended to compile to branchless code.
 
 ### CLAMP\*
 

--- a/vyper/lll/compile_lll.py
+++ b/vyper/lll/compile_lll.py
@@ -572,6 +572,26 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
             ]
         )
         return o
+    elif code.value == "select":
+        # b ^ ((a ^ b) * cond) where cond is 1 or 0
+        # let t = a ^ b
+        cond = code.args[0]
+        a = code.args[1]
+        b = code.args[2]
+
+        o = []
+        o.extend(_compile_to_assembly(b, withargs, existing_labels, break_dest, height))
+        o.extend(_compile_to_assembly(a, withargs, existing_labels, break_dest, height + 1))
+        # stack: b a
+        o.extend(["DUP2", "XOR"])
+        # stack: b t
+        o.extend(_compile_to_assembly(cond, withargs, existing_labels, break_dest, height + 2))
+        # stack: b t cond
+        o.extend(["MUL", "XOR"])
+
+        # stack: b ^ (t * cond)
+        return o
+
     # <= operator
     elif code.value == "le":
         return _compile_to_assembly(

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -173,6 +173,7 @@ VALID_LLL_MACROS = {
     "debugger",
     "ge",
     "if",
+    "select",
     "le",
     "lll",
     "ne",


### PR DESCRIPTION
this is an optimizing opcode for ternary operations. this is useful
because even in the presence of perfect liveness analysis, branches
still need to issue more POPs than are required with a specialized
`select` opcode.

this commit also modifies the `min/max` to use the new opcode, as an
example.

fixes https://github.com/vyperlang/vyper/issues/2382

h/t to @yaronvel - https://twitter.com/yaron_velner/status/1499461195073568769

### What I did

### How I did it

### How to verify it
tests still pass

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/XdM6c4juY1g/maxresdefault.jpg)
