### PR TITLE
feat: close external section with goto fallback

### DIFF
--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -168,12 +168,19 @@ def parse_regular_functions(
             external_seq.append(["assert", ["iszero", "callvalue"]])
             external_seq += nonpayable_funcs
 
+    # ensure the external jumptable section gets closed out
+    # (for basic block hygiene and also for zksync interpreter)
+    # NOTE: this jump gets optimized out in assembly since the
+    # fallback label is the immediate next instruction,
+    close_selector_section = ["goto", "fallback"]
+
     # bytecode is organized by: external functions, fallback fn, internal functions
     # this way we save gas and reduce bytecode by not jumping over internal functions
     runtime = [
         "seq",
         func_init_lll(),
         ["with", "_calldata_method_id", ["mload", 0], external_seq],
+        close_selector_section,
         ["label", "fallback", ["var_list"], fallback_lll],
     ]
     runtime.extend(internal_funcs)


### PR DESCRIPTION
### What I did
ensure basic block hygiene by closing with a terminating instruction (goto)

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://d.newsweek.com/en/full/1837953/dolphin.jpg?w=1600&h=1200&q=88&f=7815dd2a1bf746d6bd01b230b93818ac)
