### PR TITLE
fix type of storage variables containing interface

### DIFF
--- a/examples/factory/Exchange.vy
+++ b/examples/factory/Exchange.vy
@@ -5,12 +5,12 @@ interface Factory:
     def register(): nonpayable
 
 
-token: public(address)
-factory: address
+token: public(ERC20)
+factory: Factory
 
 
 @external
-def __init__(_token: address, _factory: address):
+def __init__(_token: ERC20, _factory: Factory):
     self.token = _token
     self.factory = _factory
 
@@ -18,7 +18,7 @@ def __init__(_token: address, _factory: address):
 @external
 def initialize():
     # Anyone can safely call this function because of EXTCODEHASH
-    Factory(self.factory).register()
+    self.factory.register()
 
 
 # NOTE: This contract restricts trading to only be done by the factory.
@@ -28,13 +28,13 @@ def initialize():
 
 @external
 def receive(_from: address, _amt: uint256):
-    assert msg.sender == self.factory
-    success: bool = ERC20(self.token).transferFrom(_from, self, _amt)
+    assert msg.sender == self.factory.address
+    success: bool = self.token.transferFrom(_from, self, _amt)
     assert success
 
 
 @external
 def transfer(_to: address, _amt: uint256):
-    assert msg.sender == self.factory
-    success: bool = ERC20(self.token).transfer(_to, _amt)
+    assert msg.sender == self.factory.address
+    success: bool = self.token.transfer(_to, _amt)
     assert success

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -1,12 +1,14 @@
+from vyper.interfaces import ERC20
+
 interface Exchange:
-    def token() -> address: view
+    def token() -> address: view  # TODO: return ERC20
     def receive(_from: address, _amt: uint256): nonpayable
     def transfer(_to: address, _amt: uint256): nonpayable
 
 
 exchange_codehash: public(bytes32)
 # Maps token addresses to exchange addresses
-exchanges: public(HashMap[address, address])
+exchanges: public(HashMap[ERC20, Exchange])
 
 
 @external
@@ -30,12 +32,14 @@ def register():
     # NOTE: Use exchange's token address because it should be globally unique
     # NOTE: Should do checks that it hasn't already been set,
     #       which has to be rectified with any upgrade strategy.
-    self.exchanges[Exchange(msg.sender).token()] = msg.sender
+    exchange: Exchange = Exchange(msg.sender)
+    token: ERC20 = ERC20(exchange.token())
+    self.exchanges[token] = exchange
 
 
 @external
-def trade(_token1: address, _token2: address, _amt: uint256):
+def trade(_token1: ERC20, _token2: ERC20, _amt: uint256):
     # Perform a straight exchange of token1 to token 2 (1:1 price)
     # NOTE: Any practical implementation would need to solve the price oracle problem
-    Exchange(self.exchanges[_token1]).receive(msg.sender, _amt)
-    Exchange(self.exchanges[_token2]).transfer(msg.sender, _amt)
+    self.exchanges[_token1].receive(msg.sender, _amt)
+    self.exchanges[_token2].transfer(msg.sender, _amt)

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -1,7 +1,7 @@
 from vyper.interfaces import ERC20
 
 interface Exchange:
-    def token() -> address: view  # TODO: return ERC20
+    def token() -> ERC20: view
     def receive(_from: address, _amt: uint256): nonpayable
     def transfer(_to: address, _amt: uint256): nonpayable
 
@@ -33,8 +33,7 @@ def register():
     # NOTE: Should do checks that it hasn't already been set,
     #       which has to be rectified with any upgrade strategy.
     exchange: Exchange = Exchange(msg.sender)
-    token: ERC20 = ERC20(exchange.token())
-    self.exchanges[token] = exchange
+    self.exchanges[exchange.token()] = exchange
 
 
 @external

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -154,6 +154,17 @@ a: public(ERC20)
 def test():
     b: address = self.a.address
     """,
+    """
+interface MyInterface:
+    def some_func(): nonpayable
+
+my_interface: MyInterface[3]
+idx: uint256
+
+@external
+def __init__():
+    self.my_interface[self.idx] = MyInterface(ZERO_ADDRESS)
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -165,6 +165,12 @@ idx: uint256
 def __init__():
     self.my_interface[self.idx] = MyInterface(ZERO_ADDRESS)
     """,
+    """
+interface MyInterface:
+    def kick(): payable
+
+kickers: HashMap[address, MyInterface]
+    """,
 ]
 
 

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -58,11 +58,6 @@ class VariableRecord:
         return math.ceil(self.typ.memory_bytes_required / 32)
 
 
-class ContractRecord(VariableRecord):
-    def __init__(self, *args):
-        super(ContractRecord, self).__init__(*args)
-
-
 @dataclass
 class FunctionArg:
     name: str

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -1081,9 +1081,9 @@ class Expr:
     def parse_value_expr(cls, expr, context):
         return unwrap_location(cls(expr, context).lll_node)
 
-    # Parse an expression that represents an address in memory/calldata or storage.
+    # Parse an expression that represents a pointer to memory/calldata or storage.
     @classmethod
-    def parse_variable_location(cls, expr, context):
+    def parse_pointer_expr(cls, expr, context):
         o = cls(expr, context).lll_node
         if not o.location:
             raise StructureException("Looking for a variable location, instead got a value", expr)

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -1,5 +1,4 @@
 import vyper.utils as util
-from vyper import ast as vy_ast
 from vyper.codegen.abi_encoder import abi_encode
 from vyper.codegen.core import (
     calculate_type_for_external_return,
@@ -8,11 +7,10 @@ from vyper.codegen.core import (
     dummy_node_for_type,
     get_element_ptr,
     getpos,
-    unwrap_location,
 )
 from vyper.codegen.lll_node import Encoding, LLLnode
-from vyper.codegen.types import TupleType, get_type_for_exact_size, InterfaceType
-from vyper.exceptions import StateAccessViolation, StructureException, TypeCheckFailure
+from vyper.codegen.types import InterfaceType, TupleType, get_type_for_exact_size
+from vyper.exceptions import StateAccessViolation, TypeCheckFailure
 
 
 def _pack_arguments(contract_sig, args, context, pos):

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from vyper import ast as vy_ast
-from vyper.ast.signatures.function_signature import ContractRecord, VariableRecord
+from vyper.ast.signatures.function_signature import VariableRecord
 from vyper.codegen.types import InterfaceType, parse_type
 from vyper.exceptions import CompilerPanic, InvalidType, StructureException
 from vyper.typing import InterfaceImports
@@ -133,32 +133,6 @@ class GlobalContext:
                 raise StructureException("Invalid contract reference", item)
         return _defs
 
-    def get_item_name_and_attributes(self, item, attributes):
-        is_map_invocation = (
-            isinstance(item, vy_ast.Call) and isinstance(item.func, vy_ast.Name)
-        ) and item.func.id == "HashMap"
-
-        if isinstance(item, vy_ast.Name):
-            return item.id, attributes
-        elif isinstance(item, vy_ast.AnnAssign):
-            return self.get_item_name_and_attributes(item.annotation, attributes)
-        elif isinstance(item, vy_ast.Subscript):
-            return self.get_item_name_and_attributes(item.value, attributes)
-        elif is_map_invocation:
-            if len(item.args) != 2:
-                raise StructureException(
-                    "Map type expects two type arguments HashMap[type1, type2]", item.func
-                )
-            return self.get_item_name_and_attributes(item.args, attributes)
-        # elif ist
-        elif isinstance(item, vy_ast.Call) and isinstance(item.func, vy_ast.Name):
-            attributes[item.func.id] = True
-            # Raise for multiple args
-            if len(item.args) != 1:
-                raise StructureException(f"{item.func.id} expects one arg (the type)")
-            return self.get_item_name_and_attributes(item.args[0], attributes)
-        return None, attributes
-
     @staticmethod
     def get_call_func_name(item):
         if isinstance(item.annotation, vy_ast.Call) and isinstance(
@@ -167,7 +141,6 @@ class GlobalContext:
             return item.annotation.func.id
 
     def add_globals_and_events(self, item):
-        item_attributes = {"public": False}
 
         if self._nonrentrant_counter:
             raise CompilerPanic("Re-entrancy lock was set before all storage slots were defined")
@@ -180,29 +153,11 @@ class GlobalContext:
         if self.get_call_func_name(item) == "constant":
             return
 
-        item_name, item_attributes = self.get_item_name_and_attributes(item, item_attributes)
-
         # references to `len(self._globals)` are remnants of deprecated code, retained
         # to preserve existing interfaces while we complete a larger refactor. location
         # and size of storage vars is handled in `vyper.context.validation.data_positions`
-        if item_name in self._contracts or item_name in self._interfaces:
-            if self.get_call_func_name(item) == "address":
-                raise StructureException(
-                    f"Persistent address({item_name}) style contract declarations "
-                    "are not support anymore."
-                    f" Use {item.target.id}: {item_name} instead"
-                )
-            self._globals[item.target.id] = ContractRecord(
-                item.target.id,
-                len(self._globals),
-                InterfaceType(item_name),
-                True,
-            )
-        elif self.get_call_func_name(item) == "public":
-            if isinstance(item.annotation.args[0], vy_ast.Name) and item_name in self._contracts:
-                typ = InterfaceType(item_name)
-            else:
-                typ = self.parse_type(item.annotation.args[0])
+        if self.get_call_func_name(item) == "public":
+            typ = self.parse_type(item.annotation.args[0])
             self._globals[item.target.id] = VariableRecord(
                 item.target.id,
                 len(self._globals),
@@ -220,10 +175,11 @@ class GlobalContext:
             )
 
         elif isinstance(item.annotation, (vy_ast.Name, vy_ast.Call, vy_ast.Subscript)):
+            typ = self.parse_type(item.annotation)
             self._globals[item.target.id] = VariableRecord(
                 item.target.id,
                 len(self._globals),
-                self.parse_type(item.annotation),
+                typ,
                 True,
             )
         else:

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from vyper import ast as vy_ast
 from vyper.ast.signatures.function_signature import VariableRecord
-from vyper.codegen.types import InterfaceType, parse_type
+from vyper.codegen.types import parse_type
 from vyper.exceptions import CompilerPanic, InvalidType, StructureException
 from vyper.typing import InterfaceImports
 from vyper.utils import cached_property

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -188,7 +188,7 @@ class GlobalContext:
     def parse_type(self, ast_node):
         return parse_type(
             ast_node,
-            sigs=self._contracts,
+            sigs=set(self._contracts.keys()) | set(self._interfaces.keys()),
             custom_structs=self._structs,
         )
 

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -185,10 +185,17 @@ class GlobalContext:
         else:
             raise InvalidType("Invalid global type specified", item)
 
+    @property
+    def interface_names(self):
+        """
+        The set of names which are known to possibly be InterfaceType
+        """
+        return set(self._contracts.keys()) | set(self._interfaces.keys())
+
     def parse_type(self, ast_node):
         return parse_type(
             ast_node,
-            sigs=set(self._contracts.keys()) | set(self._interfaces.keys()),
+            sigs=self.interface_names,
             custom_structs=self._structs,
         )
 

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -73,6 +73,7 @@ def parse_external_interfaces(external_interfaces, global_ctx):
             # Recognizes already-defined structs
             sig = FunctionSignature.from_definition(
                 _def,
+                sigs=global_ctx.interface_names,
                 interface_def=True,
                 constant_override=constant,
                 custom_structs=global_ctx._structs,

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -438,7 +438,7 @@ class Stmt:
                     raise TypeCheckFailure(f"Failed constancy check\n{_dbg_expr}")
             return target
 
-        target = Expr.parse_variable_location(target, self.context)
+        target = Expr.parse_pointer_expr(target, self.context)
         if (target.location == "storage" and self.context.is_constant()) or not target.mutable:
             raise TypeCheckFailure(f"Failed constancy check\n{_dbg_expr}")
         return target

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -370,7 +370,6 @@ def parse_type(item, sigs, custom_structs):
             length = item.slice.value.n
             _sanity_check(isinstance(length, int) and length > 0)
 
-
             # ByteArray
             if getattr(item.value, "id", None) == "Bytes":
                 return ByteArrayType(length)

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -314,6 +314,8 @@ def make_struct_type(name, sigs, members, custom_structs):
 # Parses an expression representing a type.
 # TODO: rename me to "lll_type_from_annotation"
 def parse_type(item, sigs, custom_structs):
+    # sigs: set of interface or contract names in scope
+    # custom_structs: struct definitions in scope
     def _sanity_check(x):
         assert x, "typechecker missed this"
 

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -370,6 +370,7 @@ def parse_type(item, sigs, custom_structs):
             length = item.slice.value.n
             _sanity_check(isinstance(length, int) and length > 0)
 
+
             # ByteArray
             if getattr(item.value, "id", None) == "Bytes":
                 return ByteArrayType(length)


### PR DESCRIPTION
### What I did
fix #2696 

### Commit message
```
`global_context.py` had some old helper function called               
`get_item_name_and_attributes` which behaved incorrectly for complex  
types containing interfaces (specifically, an array of interfaces like
`MyInterface[3]`). Luckily, `parse_type` works better now and the code
seems to work after removing `get_item_name_and_attributes`. We also had    
a ContractRecord class which is now unused, so I removed it.          
             
Also now allow interfaces in interface signatures
```

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
