### PR TITLE
fix interface list in `for`

### DIFF
--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -22,6 +22,15 @@ def foo():
     for i in range(x, x + 10):
         pass
     """,
+    """
+interface Foo:
+    def kick(): nonpayable
+foos: Foo[3]
+@external
+def kick_foos():
+    for foo in self.foos:
+        foo.kick()
+    """,
 ]
 
 

--- a/vyper/codegen/types/convert.py
+++ b/vyper/codegen/types/convert.py
@@ -10,6 +10,8 @@ def new_type_to_old_type(typ: new.BasePrimitive) -> old.NodeType:
         return old.BaseType("bool")
     if isinstance(typ, new.AddressDefinition):
         return old.BaseType("address")
+    if isinstance(typ, new.InterfaceDefinition):
+        return old.InterfaceType(typ._id)
     if isinstance(typ, new.Bytes32Definition):
         return old.BaseType("bytes32")
     if isinstance(typ, new.BytesArrayDefinition):

--- a/vyper/semantics/types/__init__.py
+++ b/vyper/semantics/types/__init__.py
@@ -8,6 +8,7 @@ from .indexable.sequence import (
     TupleDefinition,
 )
 from .user.event import Event
+from .user.interface import InterfaceDefinition
 from .user.struct import StructDefinition
 from .value.address import AddressDefinition
 from .value.array_value import BytesArrayDefinition, StringDefinition
@@ -19,7 +20,6 @@ from .value.numeric import (
     Int128Definition,
     Uint256Definition,
 )
-from .user.interface import InterfaceDefinition
 
 # any more?
 

--- a/vyper/semantics/types/__init__.py
+++ b/vyper/semantics/types/__init__.py
@@ -19,6 +19,7 @@ from .value.numeric import (
     Int128Definition,
     Uint256Definition,
 )
+from .user.interface import InterfaceDefinition
 
 # any more?
 


### PR DESCRIPTION
### What I did
following code was failing:
```python
xs: MyInterface[N]
for x in self.xs:
    ...
```

### How I did it
there was a missing case in a helper function

### How to verify it
see tests

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
