### PR TITLE
fix empty byte array comparison

### DIFF
--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -283,26 +283,58 @@ def foo() -> (Bytes[5], Bytes[5]):
     assert a == b == b""
 
 
-@pytest.mark.parametrize("value,result", [("helloooo", False), ("hello", False), ("", True)])
-def test_empty_string_comparison(get_contract_with_gas_estimation, value, result):
-    contract = """
+@pytest.mark.parametrize(
+    "length,value,result",
+    [
+        (1, "a", False),
+        (1, "", True),
+        (8, "helloooo", False),
+        (8, "hello", False),
+        (8, "", True),
+        (40, "a", False),
+        (40, "hellohellohellohellohellohellohellohello", False),
+        (40, "", True),
+    ],
+)
+@pytest.mark.parametrize("op", ["==", "!="])
+def test_empty_string_comparison(get_contract_with_gas_estimation, length, value, result, op):
+    contract = f"""
 @external
-def foo(xs: String[8]) -> bool:
-    return xs == empty(String[8])
+def foo(xs: String[{length}]) -> bool:
+    return xs {op} empty(String[{length}])
     """
     c = get_contract_with_gas_estimation(contract)
-    assert c.foo(value) == result
+    if op == "==":
+        assert c.foo(value) == result
+    elif op == "!=":
+        assert c.foo(value) != result
 
 
-@pytest.mark.parametrize("value,result", [(b"helloooo", False), (b"hello", False), (b"", True)])
-def test_empty_bytes_comparison(get_contract_with_gas_estimation, value, result):
-    contract = """
+@pytest.mark.parametrize(
+    "length,value,result",
+    [
+        (1, b"a", False),
+        (1, b"", True),
+        (8, b"helloooo", False),
+        (8, b"hello", False),
+        (8, b"", True),
+        (40, b"a", False),
+        (40, b"hellohellohellohellohellohellohellohello", False),
+        (40, b"", True),
+    ],
+)
+@pytest.mark.parametrize("op", ["==", "!="])
+def test_empty_bytes_comparison(get_contract_with_gas_estimation, length, value, result, op):
+    contract = f"""
 @external
-def foo(xs: Bytes[8]) -> bool:
-    return empty(Bytes[8]) == xs
+def foo(xs: Bytes[{length}]) -> bool:
+    return empty(Bytes[{length}]) {op} xs
     """
     c = get_contract_with_gas_estimation(contract)
-    assert c.foo(value) == result
+    if op == "==":
+        assert c.foo(value) == result
+    elif op == "!=":
+        assert c.foo(value) != result
 
 
 def test_empty_struct(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -283,6 +283,28 @@ def foo() -> (Bytes[5], Bytes[5]):
     assert a == b == b""
 
 
+@pytest.mark.parametrize("value,result", [("helloooo", False), ("hello", False), ("", True)])
+def test_empty_string_comparison(get_contract_with_gas_estimation, value, result):
+    contract = """
+@external
+def foo(xs: String[8]) -> bool:
+    return xs == empty(String[8])
+    """
+    c = get_contract_with_gas_estimation(contract)
+    assert c.foo(value) == result
+
+
+@pytest.mark.parametrize("value,result", [(b"helloooo", False), (b"hello", False), (b"", True)])
+def test_empty_bytes_comparison(get_contract_with_gas_estimation, value, result):
+    contract = """
+@external
+def foo(xs: Bytes[8]) -> bool:
+    return empty(Bytes[8]) == xs
+    """
+    c = get_contract_with_gas_estimation(contract)
+    assert c.foo(value) == result
+
+
 def test_empty_struct(get_contract_with_gas_estimation):
     code = """
 struct FOOBAR:

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -164,3 +164,57 @@ def foo2(a: address) -> bool:
 @pytest.mark.parametrize("good_code", valid_list)
 def test_bool_success(good_code):
     assert compiler.compile_code(good_code) is not None
+
+
+@pytest.mark.parametrize(
+    "length,value,result",
+    [
+        (1, "a", False),
+        (1, "", True),
+        (8, "helloooo", False),
+        (8, "hello", False),
+        (8, "", True),
+        (40, "a", False),
+        (40, "hellohellohellohellohellohellohellohello", False),
+        (40, "", True),
+    ],
+)
+@pytest.mark.parametrize("op", ["==", "!="])
+def test_empty_string_comparison(get_contract_with_gas_estimation, length, value, result, op):
+    contract = f"""
+@external
+def foo(xs: String[{length}]) -> bool:
+    return xs {op} ""
+    """
+    c = get_contract_with_gas_estimation(contract)
+    if op == "==":
+        assert c.foo(value) == result
+    elif op == "!=":
+        assert c.foo(value) != result
+
+
+@pytest.mark.parametrize(
+    "length,value,result",
+    [
+        (1, b"a", False),
+        (1, b"", True),
+        (8, b"helloooo", False),
+        (8, b"hello", False),
+        (8, b"", True),
+        (40, b"a", False),
+        (40, b"hellohellohellohellohellohellohellohello", False),
+        (40, b"", True),
+    ],
+)
+@pytest.mark.parametrize("op", ["==", "!="])
+def test_empty_bytes_comparison(get_contract_with_gas_estimation, length, value, result, op):
+    contract = f"""
+@external
+def foo(xs: Bytes[{length}]) -> bool:
+    return b"" {op} xs
+    """
+    c = get_contract_with_gas_estimation(contract)
+    if op == "==":
+        assert c.foo(value) == result
+    elif op == "!=":
+        assert c.foo(value) != result

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -796,8 +796,31 @@ class Expr:
 
         # Compare (limited to 32) byte arrays.
         if isinstance(left.typ, ByteArrayLike) and isinstance(right.typ, ByteArrayLike):
+<<<<<<< HEAD
             left = Expr(self.expr.left, self.context).ir_node
             right = Expr(self.expr.right, self.context).ir_node
+=======
+            left = Expr(self.expr.left, self.context).lll_node
+            right = Expr(self.expr.right, self.context).lll_node
+
+            length_mismatch = left.typ.maxlen != right.typ.maxlen
+            empty_eq_length_array = left.typ.maxlen == right.typ.maxlen and (
+                right.value == "~empty" or left.value == "~empty"
+            )
+            left_over_32 = left.typ.maxlen > 32
+            right_over_32 = right.typ.maxlen > 32
+
+            if length_mismatch or empty_eq_length_array or left_over_32 or right_over_32:
+                left_keccak = keccak256_helper(self.expr, left, self.context)
+                right_keccak = keccak256_helper(self.expr, right, self.context)
+
+                if op == "eq" or op == "ne":
+                    return LLLnode.from_list(
+                        [op, left_keccak, right_keccak],
+                        typ="bool",
+                        pos=getpos(self.expr),
+                    )
+>>>>>>> handle empty byte array comparisons
 
             left_keccak = keccak256_helper(self.expr, left, self.context)
             right_keccak = keccak256_helper(self.expr, right, self.context)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -796,31 +796,8 @@ class Expr:
 
         # Compare (limited to 32) byte arrays.
         if isinstance(left.typ, ByteArrayLike) and isinstance(right.typ, ByteArrayLike):
-<<<<<<< HEAD
             left = Expr(self.expr.left, self.context).ir_node
             right = Expr(self.expr.right, self.context).ir_node
-=======
-            left = Expr(self.expr.left, self.context).lll_node
-            right = Expr(self.expr.right, self.context).lll_node
-
-            length_mismatch = left.typ.maxlen != right.typ.maxlen
-            empty_eq_length_array = left.typ.maxlen == right.typ.maxlen and (
-                right.value == "~empty" or left.value == "~empty"
-            )
-            left_over_32 = left.typ.maxlen > 32
-            right_over_32 = right.typ.maxlen > 32
-
-            if length_mismatch or empty_eq_length_array or left_over_32 or right_over_32:
-                left_keccak = keccak256_helper(self.expr, left, self.context)
-                right_keccak = keccak256_helper(self.expr, right, self.context)
-
-                if op == "eq" or op == "ne":
-                    return LLLnode.from_list(
-                        [op, left_keccak, right_keccak],
-                        typ="bool",
-                        pos=getpos(self.expr),
-                    )
->>>>>>> handle empty byte array comparisons
 
             left_keccak = keccak256_helper(self.expr, left, self.context)
             right_keccak = keccak256_helper(self.expr, right, self.context)


### PR DESCRIPTION
### What I did

Fix for #2704.

### How I did it

Handle comparison of byte arrays (bytes, strings) that are `empty(String[N])` or `empty(Bytes[N])` by adding a flag to check for instances where both byte arrays are of equal max length and at least one value is `~empty`. If yes, check the length of the non-empty side against 0.

[UPDATE]

Comparison of byte arrays that are empty (i.e. "", b"") are updated to use the same codepath, instead of applying keccak to both values.

### How to verify it

See tests.

### Commit message

```
This commit fixes an issue with equality checks involving empty(byte arrays)
(i.e. empty(Bytes[N]), empty(String[N])). 

A new flag is introduced to check if comparison involves an empty(byte array).
If yes, check the length of the non-empty side against 0.

Additionally, another flag is introduced to check if comparison involves a byte array
that is empty (i.e. "", b""). If yes, this will take the same codepath as above. This 
eliminates the need to keccak both values, reducing the size of the contract.

Resolves: #2704
```

### Description for the changelog

Fix empty byte array comparison.t

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/b3/f5/05/b3f505691f10a84867497d7b58e7525a.png)
