### PR TITLE
chore: update ERC721 to use bytes4

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -67,11 +67,11 @@ ownerToOperators: HashMap[address, HashMap[address, bool]]
 minter: address
 
 # @dev Static list of supported ERC165 interface ids
-SUPPORTED_INTERFACES: constant(bytes32[2]) = [
+SUPPORTED_INTERFACES: constant(bytes4[2]) = [
     # ERC165 interface ID of ERC165
-    0x01ffc9a700000000000000000000000000000000000000000000000000000000,
+    0x01ffc9a7,
     # ERC165 interface ID of ERC721
-    0x80ac58cd00000000000000000000000000000000000000000000000000000000,
+    0x80ac58cd,
 ]
 
 @external
@@ -84,14 +84,11 @@ def __init__():
 
 @pure
 @external
-#def supportsInterface(interface_id: bytes4) -> bool:
-def pizza_mandate_apology(interface_id_int: uint256) -> bool:
+def supportsInterface(interface_id: bytes4) -> bool:
     """
     @dev Interface identification is specified in ERC-165.
     @param interface_id Id of the interface
     """
-    # NOTE: Signature is a hack until Vyper adds `bytes4` type
-    interface_id: bytes32 = convert(interface_id_int, bytes32)
     return interface_id in SUPPORTED_INTERFACES
 
 

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -2,9 +2,11 @@
 # @author Ryuya Nakamura (@nrryuya)
 # Modified from: https://github.com/vyperlang/vyper/blob/de74722bf2d8718cca46902be165f9fe0e3641dd/examples/tokens/ERC721.vy
 
+from vyper.interfaces import ERC165
 from vyper.interfaces import ERC721
 
 implements: ERC721
+implements: ERC165
 
 # Interface for the contract called by safeTransferFrom()
 interface ERC721Receiver:

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -6,9 +6,9 @@ OPERATOR_TOKEN_ID = 10
 NEW_TOKEN_ID = 20
 INVALID_TOKEN_ID = 99
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
-ERC165_CHECK_CALL = "0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000"
-ERC165_INVALID_CALL = "0x01ffc9a7ffffffff00000000000000000000000000000000000000000000000000000000"
-ERC721_CHECK_CALL = "0x01ffc9a780ac58cd00000000000000000000000000000000000000000000000000000000"
+ERC165_SIG = "0x01ffc9a7"
+ERC165_INVALID_SIG = "0xffffffff"
+ERC721_SIG = "0x80ac58cd"
 
 
 @pytest.fixture
@@ -30,16 +30,15 @@ def test_erc165(w3, c):
     #   The source contract makes a STATICCALL to the destination address with input data:
     #       0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000
     #       and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`
-    assert to_int(w3.eth.call({"to": c.address, "data": ERC165_CHECK_CALL, "gas": 30000})) == 1
+    assert c.supportsInterface(ERC165_SIG)
     #   If the call fails or return false, the destination contract does not implement ERC-165.
     #   If the call returns true, a second call is made with input data:
     #       0x01ffc9a7ffffffff00000000000000000000000000000000000000000000000000000000.
-    assert to_int(w3.eth.call({"to": c.address, "data": ERC165_INVALID_CALL})) == 0
+    assert not c.supportsInterface(ERC165_INVALID_SIG)
     #   If the second call fails or returns true, the destination contract does not implement
     #   ERC-165. Otherwise it implements ERC-165.
 
-    # NOTE: Just to check for ERC721 calls
-    assert to_int(w3.eth.call({"to": c.address, "data": ERC721_CHECK_CALL})) == 1
+    assert c.supportsInterface(ERC721_SIG)
 
 
 def test_balanceOf(c, w3, assert_tx_failed):

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -1,5 +1,4 @@
 import pytest
-from eth_utils import to_int
 
 SOMEONE_TOKEN_IDS = [1, 2, 3]
 OPERATOR_TOKEN_ID = 10

--- a/tests/parser/exceptions/test_type_mismatch_exception.py
+++ b/tests/parser/exceptions/test_type_mismatch_exception.py
@@ -8,7 +8,7 @@ fail_list = [
     """
 @external
 def foo():
-    b: Bytes[1] = 0x05
+    b: Bytes[1] = b"\x05"
     x: uint256 = as_wei_value(b, "babbage")
     """,
 ]

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -195,12 +195,8 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                     node.lineno,
                     node.col_offset,
                 )
-            if len(value) in (42, 66):
-                node.ast_type = "Hex"
-                node.n = value
-            else:
-                node.ast_type = "Bytes"
-                node.value = int(value, 16).to_bytes(len(value) // 2 - 1, "big")
+            node.ast_type = "Hex"
+            node.n = value
 
         elif value.lower()[:2] == "0b":
             node.ast_type = "Bytes"

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1962,8 +1962,9 @@ class ABIEncode(_SimpleBuiltinFunction):
             return fourbytes_to_int(method_id.value)
 
         if isinstance(method_id, vy_ast.Hex):
-            _check(method_id.value <= 2 ** 32)
-            return method_id.value
+            hexstr = method_id.value # e.g. 0xdeadbeef
+            _check(len(hexstr) // 2 - 1 <= 4)
+            return int(hexstr, 16)
 
         _check(False)
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1962,7 +1962,7 @@ class ABIEncode(_SimpleBuiltinFunction):
             return fourbytes_to_int(method_id.value)
 
         if isinstance(method_id, vy_ast.Hex):
-            hexstr = method_id.value # e.g. 0xdeadbeef
+            hexstr = method_id.value  # e.g. 0xdeadbeef
             _check(len(hexstr) // 2 - 1 <= 4)
             return int(hexstr, 16)
 

--- a/vyper/builtin_interfaces/ERC165.py
+++ b/vyper/builtin_interfaces/ERC165.py
@@ -1,0 +1,6 @@
+interface_code = """
+@view
+@external
+def supportsInterface(interface_id: bytes4) -> bool:
+    pass
+"""

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -268,10 +268,6 @@ class Expr:
 
     # Byte literals
     def parse_Bytes(self):
-        typ = new_type_to_old_type(self.expr._metadata["type"])
-        if not isinstance(typ, ByteArrayType):
-            return # typecheck failure
-
         bytez = self.expr.s
         bytez_length = len(self.expr.s)
         typ = ByteArrayType(bytez_length, is_literal=True)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -21,7 +21,6 @@ from vyper.codegen.types import (
     BaseType,
     ByteArrayLike,
     ByteArrayType,
-    is_bytes_m_type,
     DArrayType,
     InterfaceType,
     MappingType,
@@ -247,7 +246,7 @@ class Expr:
             )
 
         else:
-            n_bytes = (len(hexstr) - 2) // 2 # e.g. "0x1234" is 2 bytes
+            n_bytes = (len(hexstr) - 2) // 2  # e.g. "0x1234" is 2 bytes
             # TODO: typ = new_type_to_old_type(self.expr._metadata["type"])
             #       assert n_bytes == typ._bytes_info.m
 


### PR DESCRIPTION
### What I did
update ERC721 to use bytes4, and fix some issues with bytes literals
notably, hex literals are always interpreted as bytesN now (not Bytes), and vice versa - bytes literals are always Bytes, not bytesN

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
