### PR TITLE
Fix input validation of function "as_wei_value"

### DIFF
--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1028,7 +1028,7 @@ class AsWeiValue:
         value, denom_name = args[0], args[1].decode()
 
         denom_divisor = next(v for k, v in self.wei_denoms.items() if denom_name in k)
-        if value.typ.typ == "uint256":
+        if value.typ.typ == "uint256" or value.typ.typ == "uint8":
             sub = [
                 "with",
                 "ans",


### PR DESCRIPTION
### What I did
Fixed input validation of function "as_wei_value", a compilation error was thrown when the type of parameter "value" is uint8.
Issue:  [2711](https://github.com/vyperlang/vyper/issues/2711)

### How I did it
I added an additional check to the line that checked if the type of "value" was uint256.

### How to verify it

### Description for the changelog
Fixed input validation of function "as_wei_value", a compilation error was thrown when the type of parameter "value" is uint8.

### Cute Animal Picture

![Anu preto](https://s2.glbimg.com/qJMSizyjnMwkc8q7opNut-5avnk=/21x82:1280x876/1000x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2019/q/8/opBqZaTnaM3rOF1vFJxw/whatsapp-image-2019-08-15-at-10.47.31.jpeg)
