### PR TITLE
fix error construction with ExceptionList

### DIFF
--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -20,8 +20,6 @@ x: [bar(int128), baz(baffle)]
     """
 struct A:
     b: B
-struct B:
-    a: A
     """,
 ]
 

--- a/tests/parser/exceptions/test_vyper_exception_pos.py
+++ b/tests/parser/exceptions/test_vyper_exception_pos.py
@@ -12,3 +12,20 @@ def test_type_exception_pos():
     assert e.value.lineno == 1
     assert e.value.col_offset == 2
     assert str(e.value) == "line 1:2 Fail!"
+
+
+# multiple exceptions in file
+def test_multiple_exceptions(get_contract, assert_compile_failed):
+    code = """
+struct A:
+    b: B  # unknown type
+
+foo: immutable(uint256)
+bar: immutable(uint256)
+@external
+def __init__():
+    self.foo = 1  # SyntaxException
+    self.bar = 2  # SyntaxException
+
+    """
+    assert_compile_failed(lambda: get_contract(code), VyperException)

--- a/tests/parser/features/external_contracts/test_modifiable_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_modifiable_external_contract_calls.py
@@ -243,8 +243,6 @@ def test_invalid_if_have_modifiability_not_declared(
     code = """
 interface Bar:
     def set_lucky(_lucky: int128): pass
-
-modifiable_bar_contract: public(Bar)
 """
     assert_compile_failed(
         lambda: get_contract_with_gas_estimation_for_constants(code), StructureException

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -17,13 +17,9 @@ class ExceptionList(list):
         if len(self) == 1:
             raise self[0]
         elif len(self) > 1:
-            if len(set(type(i) for i in self)) > 1:
-                err_type = StructureException
-            else:
-                err_type = type(self[0])
             err_msg = ["Compilation failed with the following errors:"]
             err_msg += [f"{type(i).__name__}: {i}" for i in self]
-            raise err_type("\n\n".join(err_msg))
+            raise VyperException("\n\n".join(err_msg))
 
 
 class VyperException(Exception):


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it
check the following code
```vyper
foo: immutable(uint256)
bar: immutable(uint256)
@external
def __init__():
    self.foo = 1  # SyntaxException
    self.bar = 2  # SyntaxException
```
on master, the exception constructor fails. with this patch, the compiler correctly throws multiple syntax exceptions

### Commit message
```
The pretty-printed error message was arbitrarily choosing the first
exception in the list to use as the top-level exception. This commit
changes the behavior to use a generic VyperException (which is OK
because the child exceptions retain their names in the final output).
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
