### PR TITLE
fix: ad-hoc rule for json serialization of seq

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -87,7 +87,7 @@ def build_ir_runtime_output(compiler_data: CompilerData) -> LLLnode:
 
 def _lll_to_dict(lll_node):
     args = lll_node.args
-    if len(args) > 0:
+    if len(args) > 0 or lll_node.value == "seq":
         return {lll_node.value: [_lll_to_dict(x) for x in args]}
     return lll_node.value
 


### PR DESCRIPTION
when `seq` has no arguments (i.e., it is a no-op), it shows up in the
JSON representation as `"seq"`, instead of `{"seq": []}`. this commit
changes the representation to be the same in both cases, making it so
that downstream tools do not need to handle this inconsistency.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
