### PR TITLE
fix an occasional bug in grammar fuzzing

### DIFF
--- a/tests/grammar/test_grammar.py
+++ b/tests/grammar/test_grammar.py
@@ -9,6 +9,7 @@ from hypothesis.extra.lark import LarkStrategy
 
 from tests.grammar.conftest import get_lark_grammar
 from vyper.ast import Module, parse_to_ast
+from vyper.ast.pre_parser import pre_parse
 
 
 def test_basic_grammar(lark_grammar):
@@ -101,9 +102,9 @@ def has_no_docstrings(c):
 
 
 @pytest.mark.fuzzing
-@given(code=from_grammar().filter(lambda c: has_no_docstrings(c)))
+@given(code=from_grammar().filter(lambda c: utf8_encodable(c)))
 @hypothesis.settings(deadline=400, max_examples=500, suppress_health_check=(HealthCheck.too_slow,))
 def test_grammar_bruteforce(code):
     if utf8_encodable(code):
-        tree = parse_to_ast(code + "\n")
+        tree = parse_to_ast(pre_parse(code + "\n")[1])
         assert isinstance(tree, Module)


### PR DESCRIPTION
it would throw on the following code string: `#\r""""""`. this commit
changes the grammar test function to use the same code path as
`vyper.compile_codes`.

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
