### PR TITLE
feat: optimize byte array copier

### DIFF
--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -18,7 +18,7 @@ event Approval:
     spender: indexed(address)
     value: uint256
 
-name: public(String[64])
+name: public(String[32])
 symbol: public(String[32])
 decimals: public(uint8)
 
@@ -35,7 +35,7 @@ minter: address
 
 
 @external
-def __init__(_name: String[64], _symbol: String[32], _decimals: uint8, _supply: uint256):
+def __init__(_name: String[32], _symbol: String[32], _decimals: uint8, _supply: uint256):
     init_supply: uint256 = _supply * 10 ** convert(_decimals, uint256)
     self.name = _name
     self.symbol = _symbol

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -85,17 +85,17 @@ def make_byte_array_copier(dst, src, pos=None):
 
     with src.cache_when_complex("src") as (b1, src):
         with get_bytearray_length(src).cache_when_complex("len") as (b2, len_):
-            n_bytes = get_bytearray_length(src)
+
             max_bytes = src.typ.maxlen
 
             ret = ["seq"]
             # store length
-            ret.append(STORE(dst, n_bytes))
+            ret.append(STORE(dst, len_))
 
             dst = bytes_data_ptr(dst)
             src = bytes_data_ptr(src)
 
-            ret.append(copy_bytes(dst, src, n_bytes, max_bytes))
+            ret.append(copy_bytes(dst, src, len_, max_bytes))
             return b1.resolve(b2.resolve(ret))
 
 
@@ -191,7 +191,7 @@ def _dynarray_make_setter(dst, src, pos=None):
             else:
                 element_size = src.typ.subtype.memory_bytes_required
                 # number of elements * size of element in bytes
-                n_bytes = _mul(get_dyn_array_count(src), element_size)
+                n_bytes = _mul(len_, element_size)
                 max_bytes = src.typ.count * element_size
 
                 src_ = dynarray_data_ptr(src)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -81,13 +81,22 @@ def make_byte_array_copier(dst, src, pos=None):
 
     if src.value == "~empty":
         # set length word to 0.
-        return LLLnode.from_list([store_op(dst.location), dst, 0], pos=pos)
+        return STORE(dst, 0)
 
-    with src.cache_when_complex("src") as (builder, src):
-        n_bytes = ["add", get_bytearray_length(src), 32]
-        max_bytes = src.typ.memory_bytes_required
+    with src.cache_when_complex("src") as (b1, src):
+        with get_bytearray_length(src).cache_when_complex("len") as (b2, len_):
+            n_bytes = get_bytearray_length(src)
+            max_bytes = src.typ.maxlen
 
-        return builder.resolve(copy_bytes(dst, src, n_bytes, max_bytes, pos=pos))
+            ret = ["seq"]
+            # store length
+            ret.append(STORE(dst, n_bytes))
+
+            dst = bytes_data_ptr(dst)
+            src = bytes_data_ptr(src)
+
+            ret.append(copy_bytes(dst, src, n_bytes, max_bytes))
+            return b1.resolve(b2.resolve(ret))
 
 
 # TODO maybe move me to types.py
@@ -99,11 +108,17 @@ def wordsize(location):
     raise CompilerPanic(f"invalid location {location}")  # pragma: notest
 
 
-# TODO refactor: add similar fn for dyn_arrays
 def bytes_data_ptr(ptr):
     if ptr.location is None:
         raise CompilerPanic("tried to modify non-pointer type")
     assert isinstance(ptr.typ, ByteArrayLike)
+    return add_ofst(ptr, wordsize(ptr.location))
+
+
+def dynarray_data_ptr(ptr):
+    if ptr.location is None:
+        raise CompilerPanic("tried to modify non-pointer type")
+    assert isinstance(ptr.typ, DArrayType)
     return add_ofst(ptr, wordsize(ptr.location))
 
 
@@ -155,32 +170,35 @@ def _dynarray_make_setter(dst, src, pos=None):
         should_loop |= src.typ.subtype.abi_type.is_dynamic()
         should_loop |= _needs_clamp(src.typ.subtype, src.encoding)
 
-        if should_loop:
-            uint = BaseType("uint256")
+        with get_dyn_array_count(src).cache_when_complex("darray_count") as (b2, len_):
+            ret = ["seq"]
+            ret.append(STORE(dst, len_))
 
-            # note: name clobbering for the ix is OK because
-            # we never reach outside our level of nesting
-            i = LLLnode.from_list(_freshname("copy_darray_ix"), typ=uint)
+            if should_loop:
+                # note: name clobbering for the ix is OK because
+                # we never reach outside our level of nesting
+                i = LLLnode.from_list(_freshname("copy_darray_ix"), typ="uint256")
 
-            loop_body = make_setter(
-                get_element_ptr(dst, i, array_bounds_check=False, pos=pos),
-                get_element_ptr(src, i, array_bounds_check=False, pos=pos),
-                pos=pos,
-            )
-            loop_body.annotation = f"{dst}[i] = {src}[i]"
+                loop_body = make_setter(
+                    get_element_ptr(dst, i, array_bounds_check=False, pos=pos),
+                    get_element_ptr(src, i, array_bounds_check=False, pos=pos),
+                    pos=pos,
+                )
+                loop_body.annotation = f"{dst}[i] = {src}[i]"
 
-            with get_dyn_array_count(src).cache_when_complex("darray_count") as (b2, len_):
-                store_len = [store_op(dst.location), dst, len_]
-                loop = ["repeat", i, 0, len_, src.typ.count, loop_body]
+                ret.append(["repeat", i, 0, len_, src.typ.count, loop_body])
 
-                return b1.resolve(b2.resolve(["seq", store_len, loop]))
+            else:
+                element_size = src.typ.subtype.memory_bytes_required
+                # number of elements * size of element in bytes
+                n_bytes = _mul(get_dyn_array_count(src), element_size)
+                max_bytes = src.typ.count * element_size
 
-        element_size = src.typ.subtype.memory_bytes_required
-        # 32 bytes + number of elements * size of element in bytes
-        n_bytes = ["add", _mul(get_dyn_array_count(src), element_size), 32]
-        max_bytes = src.typ.memory_bytes_required
+                src_ = dynarray_data_ptr(src)
+                dst_ = dynarray_data_ptr(dst)
+                ret.append(copy_bytes(dst_, src_, n_bytes, max_bytes))
 
-        return b1.resolve(copy_bytes(dst, src, n_bytes, max_bytes, pos=pos))
+            return b1.resolve(b2.resolve(ret))
 
 
 # Copy bytes

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -175,8 +175,6 @@ def _dynarray_make_setter(dst, src, pos=None):
             ret.append(STORE(dst, len_))
 
             if should_loop:
-                # note: name clobbering for the ix is OK because
-                # we never reach outside our level of nesting
                 i = LLLnode.from_list(_freshname("copy_darray_ix"), typ="uint256")
 
                 loop_body = make_setter(

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -170,9 +170,9 @@ def _dynarray_make_setter(dst, src, pos=None):
         should_loop |= src.typ.subtype.abi_type.is_dynamic()
         should_loop |= _needs_clamp(src.typ.subtype, src.encoding)
 
-        with get_dyn_array_count(src).cache_when_complex("darray_count") as (b2, len_):
+        with get_dyn_array_count(src).cache_when_complex("darray_count") as (b2, count):
             ret = ["seq"]
-            ret.append(STORE(dst, len_))
+            ret.append(STORE(dst, count))
 
             if should_loop:
                 i = LLLnode.from_list(_freshname("copy_darray_ix"), typ="uint256")
@@ -184,12 +184,12 @@ def _dynarray_make_setter(dst, src, pos=None):
                 )
                 loop_body.annotation = f"{dst}[i] = {src}[i]"
 
-                ret.append(["repeat", i, 0, len_, src.typ.count, loop_body])
+                ret.append(["repeat", i, 0, count, src.typ.count, loop_body])
 
             else:
                 element_size = src.typ.subtype.memory_bytes_required
                 # number of elements * size of element in bytes
-                n_bytes = _mul(len_, element_size)
+                n_bytes = _mul(count, element_size)
                 max_bytes = src.typ.count * element_size
 
                 src_ = dynarray_data_ptr(src)


### PR DESCRIPTION
### Commit message

    
    this commit optimizes the make_byte_array_copier and
    make_dynarray_copier routines. specifically, it reduces the number of
    words to copy in the main loop by 1. for batch copies
    (memory/calldata/code -> memory), this reduces gas by 3, and for
    non-batch copies (e.g. storage -> memory), this reduces gas by one loop
    iteration and one read. importantly, when the number of bytes is small
    (e.g. copy Bytes[32]), this triggers an optimization in copy_bytes so
    the whole copy operation is a single load/store (plus the load/store
    for the length)


### How I did it

### How to verify it
check tests still pass, check output of ERC20.vy and see there are no loops - bytecode is now 1342 bytes :)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/160047327-4b7ead86-9d6d-472d-bc4d-10d3a4fb790a.png)