### PR TITLE
refactor: add address space abstraction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras_require = {
     ],
     "lint": [
         "black==21.9b0",
+        "click<8.1.0",  # temporary pin - black21.9b0 fails with 8.1.0
         "flake8==3.9.2",
         "flake8-bugbear==20.1.4",
         "flake8-use-fstring==1.1",

--- a/vyper/address_space.py
+++ b/vyper/address_space.py
@@ -14,11 +14,11 @@ class AddrSpace:
 
     Attributes:
         name: human-readable nickname for the address space
-        load_op: the opcode for loading a word from this address space
-        store_op: the opcode for storing a word to this address space
         word_scale: a constant which helps calculate offsets in a given
             address space. 1 for word-addressable locations (storage),
             32 for byte-addressable locations (memory, calldata, code)
+        load_op: the opcode for loading a word from this address space
+        store_op: the opcode for storing a word to this address space
     """
 
     name: str

--- a/vyper/address_space.py
+++ b/vyper/address_space.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class AddrSpace:
+    """
+    Object representing an "address space" (similar to the LLVM concept).
+    It includes some information about the address space so that codegen
+    can be written in a more generic way.
+    """
+
+    name: str
+    wordsize: int
+    load_op: str
+    store_op: Optional[str]
+
+
+# alternative:
+# class Memory(AddrSpace):
+#   @property
+#   def wordsize(self):
+#     return 32
+# # implement more properties...
+#
+# MEMORY = Memory()
+
+MEMORY = AddrSpace("memory", 32, "mload", "mstore")
+STORAGE = AddrSpace("storage", 1, "sload", "sstore")
+CALLDATA = AddrSpace("calldata", 32, "calldataload", None)
+# immutables address space: "immutables" section of memory
+# which is read-write in deploy code but then gets turned into
+# the "data" section of the runtime code
+IMMUTABLES = AddrSpace("immutables", 32, "iload", "istore")
+# data addrspace: "data" section of runtime code, read-only.
+DATA = AddrSpace("data", 32, "dload", None)

--- a/vyper/address_space.py
+++ b/vyper/address_space.py
@@ -26,6 +26,14 @@ class AddrSpace:
     load_op: str
     store_op: Optional[str]
 
+    @property
+    def word_addressable(self):
+        return self.word_scale == 1
+
+    @property
+    def byte_addressable(self):
+        return self.word_scale == 32
+
 
 # alternative:
 # class Memory(AddrSpace):

--- a/vyper/address_space.py
+++ b/vyper/address_space.py
@@ -1,25 +1,28 @@
 from dataclasses import dataclass
 from typing import Optional
 
+# TODO consider renaming this module to avoid confusion with the EVM
+# concept of addresses (160-bit account IDs).
+
 
 @dataclass(frozen=True)
 class AddrSpace:
     """
-    Object representing an "address space" (similar to the LLVM concept).
-    It includes some information about the address space so that codegen
-    can be written in a more generic way.
+    Object representing info about the "address space", analogous to the
+    LLVM concept. It includes some metadata so that codegen can be
+    written in a more generic way.
 
     Attributes:
         name: human-readable nickname for the address space
-        wordsize: the number of "slots" in this address space an EVM
-            word takes up. currently 1 for storage, and 32 for
-            everything else
         load_op: the opcode for loading a word from this address space
         store_op: the opcode for storing a word to this address space
+        word_scale: a constant which helps calculate offsets in a given
+            address space. 1 for word-addressable locations (storage),
+            32 for byte-addressable locations (memory, calldata, code)
     """
 
     name: str
-    wordsize: int
+    word_scale: int
     load_op: str
     store_op: Optional[str]
 
@@ -27,7 +30,7 @@ class AddrSpace:
 # alternative:
 # class Memory(AddrSpace):
 #   @property
-#   def wordsize(self):
+#   def word_scale(self):
 #     return 32
 # # implement more properties...
 #

--- a/vyper/address_space.py
+++ b/vyper/address_space.py
@@ -19,19 +19,21 @@ class AddrSpace:
             32 for byte-addressable locations (memory, calldata, code)
         load_op: the opcode for loading a word from this address space
         store_op: the opcode for storing a word to this address space
+            (an address space is read-only if store_op is None)
     """
 
     name: str
     word_scale: int
     load_op: str
-    store_op: Optional[str]
+    # TODO maybe make positional instead of defaulting to None
+    store_op: Optional[str] = None
 
     @property
-    def word_addressable(self):
+    def word_addressable(self) -> bool:
         return self.word_scale == 1
 
     @property
-    def byte_addressable(self):
+    def byte_addressable(self) -> bool:
         return self.word_scale == 32
 
 
@@ -46,10 +48,10 @@ class AddrSpace:
 
 MEMORY = AddrSpace("memory", 32, "mload", "mstore")
 STORAGE = AddrSpace("storage", 1, "sload", "sstore")
-CALLDATA = AddrSpace("calldata", 32, "calldataload", None)
+CALLDATA = AddrSpace("calldata", 32, "calldataload")
 # immutables address space: "immutables" section of memory
 # which is read-write in deploy code but then gets turned into
 # the "data" section of the runtime code
 IMMUTABLES = AddrSpace("immutables", 32, "iload", "istore")
 # data addrspace: "data" section of runtime code, read-only.
-DATA = AddrSpace("data", 32, "dload", None)
+DATA = AddrSpace("data", 32, "dload")

--- a/vyper/address_space.py
+++ b/vyper/address_space.py
@@ -8,6 +8,14 @@ class AddrSpace:
     Object representing an "address space" (similar to the LLVM concept).
     It includes some information about the address space so that codegen
     can be written in a more generic way.
+
+    Attributes:
+        name: human-readable nickname for the address space
+        wordsize: the number of "slots" in this address space an EVM
+            word takes up. currently 1 for storage, and 32 for
+            everything else
+        load_op: the opcode for loading a word from this address space
+        store_op: the opcode for storing a word to this address space
     """
 
     name: str

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 
 from vyper import ast as vy_ast
+from vyper.address_space import MEMORY
 from vyper.codegen.ir_node import Encoding
 from vyper.codegen.types import NodeType, parse_type
 from vyper.exceptions import StructureException
@@ -23,7 +24,7 @@ class VariableRecord:
         typ,
         mutable,
         encoding=Encoding.VYPER,
-        location="memory",
+        location=MEMORY,
         blockscopes=None,
         defined_at=None,
         is_internal=False,

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -546,7 +546,7 @@ class Concat:
 
                 length = [arg.location.load_op, "_arg"]
                 argstart = IRnode.from_list(
-                    ["add", "_arg", arg.location.wordsize], location=arg.location
+                    ["add", "_arg", arg.location.word_scale], location=arg.location
                 )
 
                 # Make a copier to copy over data from that argument

--- a/vyper/codegen/abi_encoder.py
+++ b/vyper/codegen/abi_encoder.py
@@ -1,9 +1,10 @@
+from vyper.address_space import MEMORY
 from vyper.codegen.core import (
+    STORE,
     add_ofst,
     get_dyn_array_count,
     get_element_ptr,
     make_setter,
-    store_op,
     zero_pad,
 )
 from vyper.codegen.ir_node import IRnode
@@ -66,7 +67,7 @@ def _encode_dyn_array_helper(dst, ir_node, context, pos):
     # TODO handle this upstream somewhere
     if ir_node.value == "multi":
         buf = context.new_internal_variable(dst.typ)
-        buf = IRnode.from_list(buf, typ=dst.typ, location="memory")
+        buf = IRnode.from_list(buf, typ=dst.typ, location=MEMORY)
         return [
             "seq",
             make_setter(buf, ir_node, pos),
@@ -81,7 +82,7 @@ def _encode_dyn_array_helper(dst, ir_node, context, pos):
     len_ = get_dyn_array_count(ir_node)
     with len_.cache_when_complex("len") as (b, len_):
         # set the length word
-        ret.append([store_op(dst.location), dst, len_])
+        ret.append(STORE(dst, len_))
 
         # prepare the loop
         t = BaseType("uint256")
@@ -144,7 +145,7 @@ def _encode_dyn_array_helper(dst, ir_node, context, pos):
 # otherwise it will return 0 items to the stack.
 def abi_encode(dst, ir_node, context, pos=None, bufsz=None, returns_len=False):
 
-    dst = IRnode.from_list(dst, typ=ir_node.typ, location="memory")
+    dst = IRnode.from_list(dst, typ=ir_node.typ, location=MEMORY)
     abi_t = dst.typ.abi_type
     size_bound = abi_t.size_bound()
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -433,10 +433,10 @@ def _get_element_ptr_tuplelike(parent, key, pos):
 
         return _getelemptr_abi_helper(parent, member_t, ofst, pos)
 
-    if parent.location.word_scale == 1:
+    if parent.location.word_addressable:
         for i in range(index):
             ofst += typ.members[attrs[i]].storage_size_in_words
-    elif parent.location.word_scale == 32:
+    elif parent.location.byte_addressable:
         for i in range(index):
             ofst += typ.members[attrs[i]].memory_bytes_required
     else:
@@ -502,9 +502,9 @@ def _get_element_ptr_array(parent, key, pos, array_bounds_check):
 
         return _getelemptr_abi_helper(parent, subtype, ofst, pos)
 
-    if parent.location.word_scale == 1:
+    if parent.location.word_addressable:
         element_size = subtype.storage_size_in_words
-    elif parent.location.word_scale == 32:
+    elif parent.location.byte_addressable:
         element_size = subtype.memory_bytes_required
     else:
         raise CompilerPanic("unreachable")  # pragma: notest

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1,6 +1,7 @@
 from decimal import Context, setcontext
 
 from vyper import ast as vy_ast
+from vyper.address_space import CALLDATA, DATA, IMMUTABLES, MEMORY, STORAGE
 from vyper.codegen.ir_node import Encoding, IRnode
 from vyper.codegen.types import (
     DYNAMIC_ARRAY_OVERHEAD,
@@ -99,27 +100,18 @@ def make_byte_array_copier(dst, src, pos=None):
             return b1.resolve(b2.resolve(ret))
 
 
-# TODO maybe move me to types.py
-def wordsize(location):
-    if location in ("memory", "calldata", "data", "immutables"):
-        return 32
-    if location == "storage":
-        return 1
-    raise CompilerPanic(f"invalid location {location}")  # pragma: notest
-
-
 def bytes_data_ptr(ptr):
     if ptr.location is None:
         raise CompilerPanic("tried to modify non-pointer type")
     assert isinstance(ptr.typ, ByteArrayLike)
-    return add_ofst(ptr, wordsize(ptr.location))
+    return add_ofst(ptr, ptr.location.wordsize)
 
 
 def dynarray_data_ptr(ptr):
     if ptr.location is None:
         raise CompilerPanic("tried to modify non-pointer type")
     assert isinstance(ptr.typ, DArrayType)
-    return add_ofst(ptr, wordsize(ptr.location))
+    return add_ofst(ptr, ptr.location.wordsize)
 
 
 def _dynarray_make_setter(dst, src, pos=None):
@@ -127,14 +119,14 @@ def _dynarray_make_setter(dst, src, pos=None):
     assert isinstance(dst.typ, DArrayType)
 
     if src.value == "~empty":
-        return IRnode.from_list([store_op(dst.location), dst, 0], pos=pos)
+        return IRnode.from_list(STORE(dst, 0))
 
     if src.value == "multi":
         ret = ["seq"]
         # handle literals
 
         # write the length word
-        store_length = [store_op(dst.location), dst, len(src.args)]
+        store_length = STORE(dst, len(src.args))
         ann = None
         if src.annotation is not None:
             ann = f"len({src.annotation})"
@@ -225,16 +217,16 @@ def copy_bytes(dst, src, length, length_bound, pos=None):
             ret = IRnode.from_list(copy_op, annotation=annotation)
             return b1.resolve(b2.resolve(b3.resolve(ret)))
 
-        if dst.location == "memory" and src.location in ("memory", "calldata", "data"):
+        if dst.location == MEMORY and src.location in (MEMORY, CALLDATA, DATA):
             # special cases: batch copy to memory
             # TODO: iloadbytes
-            if src.location == "memory":
+            if src.location == MEMORY:
                 copy_op = ["staticcall", "gas", 4, src, length, dst, length]
                 gas_bound = _identity_gas_bound(length_bound)
-            elif src.location == "calldata":
+            elif src.location == CALLDATA:
                 copy_op = ["calldatacopy", dst, src, length]
                 gas_bound = _calldatacopy_gas_bound(length_bound)
-            elif src.location == "data":
+            elif src.location == DATA:
                 copy_op = ["dloadbytes", dst, src, length]
                 # note: dloadbytes compiles to CODECOPY
                 gas_bound = _codecopy_gas_bound(length_bound)
@@ -242,7 +234,7 @@ def copy_bytes(dst, src, length, length_bound, pos=None):
             ret = IRnode.from_list(copy_op, annotation=annotation, add_gas_estimate=gas_bound)
             return b1.resolve(b2.resolve(b3.resolve(ret)))
 
-        if dst.location == "immutables" and src.location in ("memory", "data"):
+        if dst.location == IMMUTABLES and src.location in (MEMORY, DATA):
             # TODO istorebytes-from-mem, istorebytes-from-calldata(?)
             # compile to identity, CODECOPY respectively.
             pass
@@ -256,8 +248,8 @@ def copy_bytes(dst, src, length, length_bound, pos=None):
         n = ["div", ["ceil32", length], 32]
         n_bound = ceil32(length_bound) // 32
 
-        dst_i = add_ofst(dst, _mul(i, wordsize(dst.location)))
-        src_i = add_ofst(src, _mul(i, wordsize(src.location)))
+        dst_i = add_ofst(dst, _mul(i, dst.location.wordsize))
+        src_i = add_ofst(src, _mul(i, src.location.wordsize))
 
         copy_one_word = STORE(dst_i, LOAD(src_i))
 
@@ -271,7 +263,7 @@ def copy_bytes(dst, src, length, length_bound, pos=None):
 # get the number of bytes at runtime
 def get_bytearray_length(arg):
     typ = BaseType("uint256")
-    return IRnode.from_list([load_op(arg.location), arg], typ=typ)
+    return IRnode.from_list(LOAD(arg), typ=typ)
 
 
 # get the number of elements at runtime
@@ -287,7 +279,7 @@ def get_dyn_array_count(arg):
         # empty(DynArray[])
         return IRnode.from_list(0, typ=typ)
 
-    return IRnode.from_list([load_op(arg.location), arg], typ=typ)
+    return IRnode.from_list(LOAD(arg), typ=typ)
 
 
 def append_dyn_array(darray_node, elem_node, pos=None):
@@ -300,7 +292,7 @@ def append_dyn_array(darray_node, elem_node, pos=None):
         len_ = get_dyn_array_count(darray_node)
         with len_.cache_when_complex("old_darray_len") as (b2, len_):
             ret.append(["assert", ["le", len_, darray_node.typ.count - 1]])
-            ret.append([store_op(darray_node.location), darray_node, ["add", len_, 1]])
+            ret.append(STORE(darray_node, ["add", len_, 1]))
             # NOTE: typechecks elem_node
             # NOTE skip array bounds check bc we already asserted len two lines up
             ret.append(
@@ -321,7 +313,7 @@ def pop_dyn_array(darray_node, return_popped_item, pos=None):
         new_len = IRnode.from_list(["sub", old_len, 1], typ="uint256")
 
         with new_len.cache_when_complex("new_len") as (b2, new_len):
-            ret.append([store_op(darray_node.location), darray_node, new_len])
+            ret.append(STORE(darray_node, new_len))
 
             # NOTE skip array bounds check bc we already asserted len two lines up
             if return_popped_item:
@@ -348,7 +340,7 @@ def getpos(node):
     )
 
 
-# TODO since this is always(?) used as add_ofst(ptr, n*wordsize(ptr.location))
+# TODO since this is always(?) used as add_ofst(ptr, n*ptr.location.wordsize)
 # maybe the API should be `add_words_to_ofst(ptr, n)` and handle the
 # wordsize multiplication inside
 def add_ofst(ptr, ofst):
@@ -381,7 +373,7 @@ def _getelemptr_abi_helper(parent, member_t, ofst, pos=None, clamp=True):
     # e.g. [[1,2]] is encoded as 0x01 <len> 0x20 <inner array ofst> <encode(inner array)>
     # note that inner array ofst is 0x20, not 0x40.
     if has_length_word(parent.typ):
-        parent = add_ofst(parent, wordsize(parent.location) * DYNAMIC_ARRAY_OVERHEAD)
+        parent = add_ofst(parent, parent.location.wordsize * DYNAMIC_ARRAY_OVERHEAD)
 
     ofst_ir = add_ofst(parent, ofst)
 
@@ -430,7 +422,7 @@ def _get_element_ptr_tuplelike(parent, key, pos):
     ofst = 0  # offset from parent start
 
     if parent.encoding in (Encoding.ABI, Encoding.JSON_ABI):
-        if parent.location == "storage":
+        if parent.location == STORAGE:
             raise CompilerPanic("storage variables should not be abi encoded")  # pragma: notest
 
         member_t = typ.members[attrs[index]]
@@ -441,10 +433,10 @@ def _get_element_ptr_tuplelike(parent, key, pos):
 
         return _getelemptr_abi_helper(parent, member_t, ofst, pos)
 
-    if parent.location == "storage":
+    if parent.location.wordsize == 1:
         for i in range(index):
             ofst += typ.members[attrs[i]].storage_size_in_words
-    elif parent.location in ("calldata", "memory", "data", "immutables"):
+    elif parent.location.wordsize == 32:
         for i in range(index):
             ofst += typ.members[attrs[i]].memory_bytes_required
     else:
@@ -501,7 +493,7 @@ def _get_element_ptr_array(parent, key, pos, array_bounds_check):
         ix = IRnode.from_list([clamp_op, ix, bound], typ=ix.typ)
 
     if parent.encoding in (Encoding.ABI, Encoding.JSON_ABI):
-        if parent.location == "storage":
+        if parent.location == STORAGE:
             raise CompilerPanic("storage variables should not be abi encoded")  # pragma: notest
 
         member_abi_t = subtype.abi_type
@@ -510,15 +502,17 @@ def _get_element_ptr_array(parent, key, pos, array_bounds_check):
 
         return _getelemptr_abi_helper(parent, subtype, ofst, pos)
 
-    if parent.location == "storage":
+    if parent.location.wordsize == 1:
         element_size = subtype.storage_size_in_words
-    elif parent.location in ("calldata", "memory", "data", "immutables"):
+    elif parent.location.wordsize == 32:
         element_size = subtype.memory_bytes_required
+    else:
+        raise CompilerPanic("unreachable")  # pragma: notest
 
     ofst = _mul(ix, element_size)
 
     if has_length_word(parent.typ):
-        data_ptr = add_ofst(parent, wordsize(parent.location) * DYNAMIC_ARRAY_OVERHEAD)
+        data_ptr = add_ofst(parent, parent.location.wordsize * DYNAMIC_ARRAY_OVERHEAD)
     else:
         data_ptr = parent
 
@@ -533,10 +527,10 @@ def _get_element_ptr_mapping(parent, key, pos):
     key = unwrap_location(key)
 
     # TODO when is key None?
-    if key is None or parent.location != "storage":
+    if key is None or parent.location != STORAGE:
         raise TypeCheckFailure("bad dereference on mapping {parent}[{sub}]")
 
-    return IRnode.from_list(["sha3_64", parent, key], typ=subtype, location="storage")
+    return IRnode.from_list(["sha3_64", parent, key], typ=subtype, location=STORAGE)
 
 
 # Take a value representing a memory or storage location, and descend down to
@@ -561,49 +555,30 @@ def get_element_ptr(parent, key, pos, array_bounds_check=True):
         return b.resolve(ret)
 
 
-# TODO phase this out - make private and use LOAD instead
-def load_op(location):
-    if location == "memory":
-        return "mload"
-    if location == "storage":
-        return "sload"
-    if location == "calldata":
-        return "calldataload"
-    if location == "data":
-        # refers to data section of currently executing code
-        return "dload"
-    if location == "immutables":
-        # special address space for manipulating immutables before deploy
-        # only makes sense in a constructor
-        return "iload"
-    raise CompilerPanic(f"unreachable {location}")  # pragma: notest
-
-
-# TODO phase this out - make private and use STORE instead
-def store_op(location):
-    if location == "memory":
-        return "mstore"
-    if location == "storage":
-        return "sstore"
-    if location == "immutables":
-        return "istore"
-    raise CompilerPanic(f"unreachable {location}")  # pragma: notest
-
-
 def LOAD(ptr: IRnode) -> IRnode:
-    return IRnode.from_list([load_op(ptr.location), ptr])
+    if ptr.location is None:
+        raise CompilerPanic("cannot dereference non-pointer type")
+    op = ptr.location.load_op
+    if op is None:
+        raise CompilerPanic(f"unreachable {ptr.location}")  # pragma: notest
+    return IRnode.from_list([op, ptr])
 
 
 def STORE(ptr: IRnode, val: IRnode) -> IRnode:
-    return IRnode.from_list([store_op(ptr.location), ptr, val])
+    if ptr.location is None:
+        raise CompilerPanic("cannot dereference non-pointer type")
+    op = ptr.location.store_op
+    if op is None:
+        raise CompilerPanic(f"unreachable {ptr.location}")  # pragma: notest
+    return IRnode.from_list([op, ptr, val])
 
 
 # Unwrap location
 def unwrap_location(orig):
-    if orig.location in ("memory", "storage", "calldata", "data", "immutables"):
+    if orig.location is not None:
         return IRnode.from_list(LOAD(orig), typ=orig.typ)
     else:
-        # CMC 20210909 TODO double check if this branch can be removed
+        # CMC 2022-03-24 TODO refactor so this branch can be removed
         if orig.value == "~empty":
             return IRnode.from_list(0, typ=orig.typ)
         return orig
@@ -777,8 +752,7 @@ def make_setter(left, right, pos):
         if _needs_clamp(right.typ, enc):
             right = clamp_basetype(right)
 
-        op = store_op(left.location)
-        return IRnode.from_list([op, left, right], pos=pos)
+        return STORE(left, right)
 
     # Byte arrays
     elif isinstance(left.typ, ByteArrayLike):
@@ -814,7 +788,7 @@ def make_setter(left, right, pos):
 
 
 def _complex_make_setter(left, right, pos):
-    if right.value == "~empty" and left.location == "memory":
+    if right.value == "~empty" and left.location == MEMORY:
         # optimized memzero
         return mzero(left, left.typ.memory_bytes_required)
 
@@ -846,14 +820,14 @@ def ensure_in_memory(ir_var, context, pos=None):
     """Ensure a variable is in memory. This is useful for functions
     which expect to operate on memory variables.
     """
-    if ir_var.location == "memory":
+    if ir_var.location == MEMORY:
         return ir_var
 
     typ = ir_var.typ
-    buf = IRnode.from_list(context.new_internal_variable(typ), typ=typ, location="memory")
+    buf = IRnode.from_list(context.new_internal_variable(typ), typ=typ, location=MEMORY)
     do_copy = make_setter(buf, ir_var, pos=pos)
 
-    return IRnode.from_list(["seq", do_copy, buf], typ=typ, location="memory")
+    return IRnode.from_list(["seq", do_copy, buf], typ=typ, location=MEMORY)
 
 
 def eval_seq(ir_node):

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -1,4 +1,5 @@
 import vyper.utils as util
+from vyper.address_space import MEMORY
 from vyper.codegen.abi_encoder import abi_encode
 from vyper.codegen.core import (
     calculate_type_for_external_return,
@@ -101,7 +102,7 @@ def _unpack_returndata(buf, contract_sig, skip_contract_check, context, pos):
     # in most cases, this simply will evaluate to ret.
     # in the special case where the return type has been wrapped
     # in a tuple AND its ABI type is dynamic, it expands to buf+32.
-    buf = IRnode(buf, typ=return_t, encoding=_returndata_encoding(contract_sig), location="memory")
+    buf = IRnode(buf, typ=return_t, encoding=_returndata_encoding(contract_sig), location=MEMORY)
 
     if should_unwrap_abi_tuple:
         buf = get_element_ptr(buf, 0, pos=None, array_bounds_check=False)
@@ -173,7 +174,7 @@ def _external_call_helper(
         # set the encoding to ABI here, downstream code will decode and add clampers.
         sub,
         typ=contract_sig.return_type,
-        location="memory",
+        location=MEMORY,
         encoding=_returndata_encoding(contract_sig),
         pos=pos,
     )

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -1,6 +1,7 @@
 from typing import Any, List
 
 import vyper.utils as util
+from vyper.address_space import CALLDATA, DATA, MEMORY
 from vyper.ast.signatures.function_signature import FunctionSignature, VariableRecord
 from vyper.codegen.context import Context
 from vyper.codegen.core import get_element_ptr, getpos, make_setter
@@ -46,9 +47,9 @@ def _register_function_args(context: Context, sig: FunctionSignature) -> List[IR
 
     # tuple with the abi_encoded args
     if sig.is_init_func:
-        base_args_ofst = IRnode(0, location="data", typ=base_args_t, encoding=Encoding.ABI)
+        base_args_ofst = IRnode(0, location=DATA, typ=base_args_t, encoding=Encoding.ABI)
     else:
-        base_args_ofst = IRnode(4, location="calldata", typ=base_args_t, encoding=Encoding.ABI)
+        base_args_ofst = IRnode(4, location=CALLDATA, typ=base_args_t, encoding=Encoding.ABI)
 
     for i, arg in enumerate(sig.base_args):
 
@@ -57,7 +58,7 @@ def _register_function_args(context: Context, sig: FunctionSignature) -> List[IR
         if _should_decode(arg.typ):
             # allocate a memory slot for it and copy
             p = context.new_variable(arg.name, arg.typ, is_mutable=False)
-            dst = IRnode(p, typ=arg.typ, location="memory")
+            dst = IRnode(p, typ=arg.typ, location=MEMORY)
             ret.append(make_setter(dst, arg_ir, pos=pos))
         else:
             # leave it in place
@@ -99,7 +100,7 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature, pos: Any)
         method_id = _annotated_method_id(abi_sig)
 
         calldata_kwargs_ofst = IRnode(
-            4, location="calldata", typ=calldata_args_t, encoding=Encoding.ABI
+            4, location=CALLDATA, typ=calldata_args_t, encoding=Encoding.ABI
         )
 
         # a sequence of statements to strictify kwargs into memory
@@ -116,13 +117,13 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature, pos: Any)
 
             dst = context.lookup_var(arg_meta.name).pos
 
-            lhs = IRnode(dst, location="memory", typ=arg_meta.typ)
+            lhs = IRnode(dst, location=MEMORY, typ=arg_meta.typ)
             rhs = get_element_ptr(calldata_kwargs_ofst, k, pos=None, array_bounds_check=False)
             ret.append(make_setter(lhs, rhs, pos))
 
         for x in default_kwargs:
             dst = context.lookup_var(x.name).pos
-            lhs = IRnode(dst, location="memory", typ=x.typ)
+            lhs = IRnode(dst, location=MEMORY, typ=x.typ)
             kw_ast_val = sig.default_values[x.name]  # e.g. `3` in x: int = 3
             rhs = Expr(kw_ast_val, context).ir_node
             ret.append(make_setter(lhs, rhs, pos))

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -2,6 +2,7 @@ import re
 from enum import Enum, auto
 from typing import Any, List, Optional, Tuple, Union
 
+from vyper.address_space import AddrSpace
 from vyper.codegen.types import BaseType, NodeType, ceil32
 from vyper.compiler.settings import VYPER_COLOR_OUTPUT
 from vyper.evm.opcodes import get_ir_opcodes
@@ -64,7 +65,7 @@ class IRnode:
         value: Union[str, int],
         args: List["IRnode"] = None,
         typ: NodeType = None,
-        location: str = None,
+        location: Optional[AddrSpace] = None,
         pos: Optional[Tuple[int, int]] = None,
         annotation: Optional[str] = None,
         mutable: bool = True,
@@ -281,6 +282,12 @@ class IRnode:
     def is_literal(self):
         return isinstance(self.value, int) or self.value == "multi"
 
+    @property
+    def is_pointer(self):
+        # not used yet but should help refactor/clarify downstream code
+        # eventually
+        return self.location is not None
+
     # This function is slightly confusing but abstracts a common pattern:
     # when an IR value needs to be computed once and then cached as an
     # IR value (if it is expensive, or more importantly if its computation
@@ -440,7 +447,7 @@ class IRnode:
         cls,
         obj: Any,
         typ: NodeType = None,
-        location: str = None,
+        location: Optional[AddrSpace] = None,
         pos: Tuple[int, int] = None,
         annotation: Optional[str] = None,
         mutable: bool = True,

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 
+from vyper.address_space import MEMORY
 from vyper.codegen.abi_encoder import abi_encode
 from vyper.codegen.context import Context
 from vyper.codegen.core import (
@@ -52,7 +53,7 @@ def make_return_stmt(ir_val: IRnode, stmt: Any, context: Context) -> Optional[IR
         return finalize(["pass"])
 
     if context.is_internal:
-        dst = IRnode.from_list(["return_buffer"], typ=context.return_type, location="memory")
+        dst = IRnode.from_list(["return_buffer"], typ=context.return_type, location=MEMORY)
         fill_return_buffer = make_setter(dst, ir_val, pos=_pos)
         jump_to_exit += ["return_pc"]
 

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -1,3 +1,4 @@
+from vyper.address_space import MEMORY
 from vyper.codegen.core import getpos, make_setter
 from vyper.codegen.ir_node import IRnode, push_label_to_stack
 from vyper.codegen.types import TupleType
@@ -66,7 +67,7 @@ def ir_for_self_call(stmt_expr, context):
 
     # note: dst_tuple_t != args_tuple_t
     dst_tuple_t = TupleType([arg.typ for arg in sig.args])
-    args_dst = IRnode(sig.frame_start, typ=dst_tuple_t, location="memory")
+    args_dst = IRnode(sig.frame_start, typ=dst_tuple_t, location=MEMORY)
 
     # if one of the arguments is a self call, the argument
     # buffer could get borked. to prevent against that,
@@ -78,7 +79,7 @@ def ir_for_self_call(stmt_expr, context):
         tmp_args_buf = IRnode(
             context.new_internal_variable(dst_tuple_t),
             typ=dst_tuple_t,
-            location="memory",
+            location=MEMORY,
         )
         copy_args.append(
             # --> args evaluate here <--
@@ -110,7 +111,7 @@ def ir_for_self_call(stmt_expr, context):
     o = IRnode.from_list(
         call_sequence,
         typ=sig.return_type,
-        location="memory",
+        location=MEMORY,
         pos=pos,
         annotation=stmt_expr.get("node_source_code"),
         add_gas_estimate=sig.gas,

--- a/vyper/codegen/types/types.py
+++ b/vyper/codegen/types/types.py
@@ -65,6 +65,8 @@ class NodeType(abc.ABC):
 
     @property
     def storage_size_in_words(self) -> int:
+        # consider renaming if other word-addressable address spaces are
+        # added to EVM or exist in other arches
         """
         Returns the number of words required to allocate in storage for this type
         """


### PR DESCRIPTION
### What I did
add address space abstraction to help clarify the purpose of the `location` field on `IRnode`.

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://blog.nature.org/science/files/2021/03/29773746712_e022c8920c_k.jpg)
