### PR TITLE
refactor: add source_pos info in Expr/Stmt ctors

### DIFF
--- a/vyper/builtin_functions/convert.py
+++ b/vyper/builtin_functions/convert.py
@@ -31,8 +31,8 @@ from vyper.exceptions import CompilerPanic, InvalidLiteral, StructureException, 
 from vyper.utils import DECIMAL_DIVISOR, SizeLimits, int_bounds
 
 
-def _FAIL(ityp, otyp, pos=None):
-    raise TypeMismatch(f"Can't convert {ityp} to {otyp}", pos)
+def _FAIL(ityp, otyp, source_expr=None):
+    raise TypeMismatch(f"Can't convert {ityp} to {otyp}", source_expr)
 
 
 # helper function for `_input_types`

--- a/vyper/builtin_functions/convert.py
+++ b/vyper/builtin_functions/convert.py
@@ -10,7 +10,6 @@ from vyper.codegen.core import (
     bytes_data_ptr,
     clamp_basetype,
     get_bytearray_length,
-    getpos,
     int_clamp,
     sar,
     shl,
@@ -409,4 +408,4 @@ def convert(expr, context):
 
         ret = b.resolve(ret)
 
-    return IRnode.from_list(ret, pos=getpos(expr))
+    return IRnode.from_list(ret)

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -173,6 +173,7 @@ class Context:
     def new_variable(
         self, name: str, typ: NodeType, pos: VyperNode = None, is_mutable: bool = True
     ) -> int:
+        # TODO remove dead arg: pos
         """
         Allocate memory for a user-defined variable.
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -68,7 +68,7 @@ def _codecopy_gas_bound(num_bytes):
 
 
 # Copy byte array word-for-word (including layout)
-def make_byte_array_copier(dst, src, pos=None):
+def make_byte_array_copier(dst, src):
     assert isinstance(src.typ, ByteArrayLike)
     assert isinstance(dst.typ, ByteArrayLike)
 
@@ -114,7 +114,7 @@ def dynarray_data_ptr(ptr):
     return add_ofst(ptr, ptr.location.word_scale)
 
 
-def _dynarray_make_setter(dst, src, pos=None):
+def _dynarray_make_setter(dst, src):
     assert isinstance(src.typ, DArrayType)
     assert isinstance(dst.typ, DArrayType)
 
@@ -136,9 +136,9 @@ def _dynarray_make_setter(dst, src, pos=None):
         n_items = len(src.args)
         for i in range(n_items):
             k = IRnode.from_list(i, typ="uint256")
-            dst_i = get_element_ptr(dst, k, pos=pos, array_bounds_check=False)
-            src_i = get_element_ptr(src, k, pos=pos, array_bounds_check=False)
-            ret.append(make_setter(dst_i, src_i, pos))
+            dst_i = get_element_ptr(dst, k, array_bounds_check=False)
+            src_i = get_element_ptr(src, k, array_bounds_check=False)
+            ret.append(make_setter(dst_i, src_i))
 
         return ret
 
@@ -170,9 +170,8 @@ def _dynarray_make_setter(dst, src, pos=None):
                 i = IRnode.from_list(_freshname("copy_darray_ix"), typ="uint256")
 
                 loop_body = make_setter(
-                    get_element_ptr(dst, i, array_bounds_check=False, pos=pos),
-                    get_element_ptr(src, i, array_bounds_check=False, pos=pos),
-                    pos=pos,
+                    get_element_ptr(dst, i, array_bounds_check=False),
+                    get_element_ptr(src, i, array_bounds_check=False),
                 )
                 loop_body.annotation = f"{dst}[i] = {src}[i]"
 
@@ -199,7 +198,7 @@ def _dynarray_make_setter(dst, src, pos=None):
 # (iv) a constant for the max length (in bytes)
 # NOTE: may pad to ceil32 of `length`! If you ask to copy 1 byte, it may
 # copy an entire (32-byte) word, depending on the copy routine chosen.
-def copy_bytes(dst, src, length, length_bound, pos=None):
+def copy_bytes(dst, src, length, length_bound):
     annotation = f"copy_bytes from {src} to {dst}"
 
     src = IRnode.from_list(src)
@@ -256,7 +255,7 @@ def copy_bytes(dst, src, length, length_bound, pos=None):
         main_loop = ["repeat", i, 0, n, n_bound, copy_one_word]
 
         return b1.resolve(
-            b2.resolve(b3.resolve(IRnode.from_list(main_loop, annotation=annotation, pos=pos)))
+            b2.resolve(b3.resolve(IRnode.from_list(main_loop, annotation=annotation)))
         )
 
 
@@ -282,7 +281,7 @@ def get_dyn_array_count(arg):
     return IRnode.from_list(LOAD(arg), typ=typ)
 
 
-def append_dyn_array(darray_node, elem_node, pos=None):
+def append_dyn_array(darray_node, elem_node):
     assert isinstance(darray_node.typ, DArrayType)
 
     assert darray_node.typ.count > 0, "jerk boy u r out"
@@ -296,16 +295,12 @@ def append_dyn_array(darray_node, elem_node, pos=None):
             # NOTE: typechecks elem_node
             # NOTE skip array bounds check bc we already asserted len two lines up
             ret.append(
-                make_setter(
-                    get_element_ptr(darray_node, len_, array_bounds_check=False, pos=pos),
-                    elem_node,
-                    pos=pos,
-                )
+                make_setter(get_element_ptr(darray_node, len_, array_bounds_check=False), elem_node)
             )
-            return IRnode.from_list(b1.resolve(b2.resolve(ret)), pos=pos)
+            return IRnode.from_list(b1.resolve(b2.resolve(ret)))
 
 
-def pop_dyn_array(darray_node, return_popped_item, pos=None):
+def pop_dyn_array(darray_node, return_popped_item):
     assert isinstance(darray_node.typ, DArrayType)
     ret = ["seq"]
     with darray_node.cache_when_complex("darray") as (b1, darray_node):
@@ -317,9 +312,7 @@ def pop_dyn_array(darray_node, return_popped_item, pos=None):
 
             # NOTE skip array bounds check bc we already asserted len two lines up
             if return_popped_item:
-                popped_item = get_element_ptr(
-                    darray_node, new_len, array_bounds_check=False, pos=pos
-                )
+                popped_item = get_element_ptr(darray_node, new_len, array_bounds_check=False)
                 ret.append(popped_item)
                 typ = popped_item.typ
                 location = popped_item.location
@@ -327,7 +320,7 @@ def pop_dyn_array(darray_node, return_popped_item, pos=None):
             else:
                 typ, location, encoding = None, None, None
             return IRnode.from_list(
-                b1.resolve(b2.resolve(ret)), typ=typ, location=location, encoding=encoding, pos=pos
+                b1.resolve(b2.resolve(ret)), typ=typ, location=location, encoding=encoding
             )
 
 
@@ -366,7 +359,7 @@ def _mul(x, y):
 
 
 # Resolve pointer locations for ABI-encoded data
-def _getelemptr_abi_helper(parent, member_t, ofst, pos=None, clamp=True):
+def _getelemptr_abi_helper(parent, member_t, ofst, clamp=True):
     member_abi_t = member_t.abi_type
 
     # ABI encoding has length word and then pretends length is not there
@@ -388,13 +381,12 @@ def _getelemptr_abi_helper(parent, member_t, ofst, pos=None, clamp=True):
         typ=member_t,
         location=parent.location,
         encoding=parent.encoding,
-        pos=pos,
         annotation=f"{parent}{ofst}",
     )
 
 
 # TODO simplify this code, especially the ABI decoding
-def _get_element_ptr_tuplelike(parent, key, pos):
+def _get_element_ptr_tuplelike(parent, key):
     typ = parent.typ
     assert isinstance(typ, TupleLike)
 
@@ -431,7 +423,7 @@ def _get_element_ptr_tuplelike(parent, key, pos):
             member_abi_t = typ.members[attrs[i]].abi_type
             ofst += member_abi_t.embedded_static_size()
 
-        return _getelemptr_abi_helper(parent, member_t, ofst, pos)
+        return _getelemptr_abi_helper(parent, member_t, ofst)
 
     if parent.location.word_addressable:
         for i in range(index):
@@ -448,7 +440,6 @@ def _get_element_ptr_tuplelike(parent, key, pos):
         location=parent.location,
         encoding=parent.encoding,
         annotation=annotation,
-        pos=pos,
     )
 
 
@@ -457,7 +448,7 @@ def has_length_word(typ):
 
 
 # TODO simplify this code, especially the ABI decoding
-def _get_element_ptr_array(parent, key, pos, array_bounds_check):
+def _get_element_ptr_array(parent, key, array_bounds_check):
 
     assert isinstance(parent.typ, ArrayLike)
 
@@ -500,7 +491,7 @@ def _get_element_ptr_array(parent, key, pos, array_bounds_check):
 
         ofst = _mul(ix, member_abi_t.embedded_static_size())
 
-        return _getelemptr_abi_helper(parent, subtype, ofst, pos)
+        return _getelemptr_abi_helper(parent, subtype, ofst)
 
     if parent.location.word_addressable:
         element_size = subtype.storage_size_in_words
@@ -516,12 +507,10 @@ def _get_element_ptr_array(parent, key, pos, array_bounds_check):
     else:
         data_ptr = parent
 
-    return IRnode.from_list(
-        add_ofst(data_ptr, ofst), typ=subtype, location=parent.location, pos=pos
-    )
+    return IRnode.from_list(add_ofst(data_ptr, ofst), typ=subtype, location=parent.location)
 
 
-def _get_element_ptr_mapping(parent, key, pos):
+def _get_element_ptr_mapping(parent, key):
     assert isinstance(parent.typ, MappingType)
     subtype = parent.typ.valuetype
     key = unwrap_location(key)
@@ -536,18 +525,18 @@ def _get_element_ptr_mapping(parent, key, pos):
 # Take a value representing a memory or storage location, and descend down to
 # an element or member variable
 # This is analogous (but not necessarily equivalent to) getelementptr in LLVM.
-def get_element_ptr(parent, key, pos, array_bounds_check=True):
+def get_element_ptr(parent, key, array_bounds_check=True):
     with parent.cache_when_complex("val") as (b, parent):
         typ = parent.typ
 
         if isinstance(typ, TupleLike):
-            ret = _get_element_ptr_tuplelike(parent, key, pos)
+            ret = _get_element_ptr_tuplelike(parent, key)
 
         elif isinstance(typ, MappingType):
-            ret = _get_element_ptr_mapping(parent, key, pos)
+            ret = _get_element_ptr_mapping(parent, key)
 
         elif isinstance(typ, ArrayLike):
-            ret = _get_element_ptr_array(parent, key, pos, array_bounds_check)
+            ret = _get_element_ptr_array(parent, key, array_bounds_check)
 
         else:
             raise CompilerPanic(f"get_element_ptr cannot be called on {typ}")  # pragma: notest
@@ -741,7 +730,7 @@ def _freshname(name):
 
 
 # Create an x=y statement, where the types may be compound
-def make_setter(left, right, pos):
+def make_setter(left, right):
     check_assign(left, right)
 
     # Basic types
@@ -759,10 +748,10 @@ def make_setter(left, right, pos):
         # TODO rethink/streamline the clamp_basetype logic
         if _needs_clamp(right.typ, right.encoding):
             with right.cache_when_complex("bs_ptr") as (b, right):
-                copier = make_byte_array_copier(left, right, pos)
+                copier = make_byte_array_copier(left, right)
                 ret = b.resolve(["seq", clamp_bytestring(right), copier])
         else:
-            ret = make_byte_array_copier(left, right, pos)
+            ret = make_byte_array_copier(left, right)
 
         return IRnode.from_list(ret)
 
@@ -770,24 +759,24 @@ def make_setter(left, right, pos):
         # TODO should we enable this?
         # implicit conversion from sarray to darray
         # if isinstance(right.typ, SArrayType):
-        #    return _complex_make_setter(left, right, pos)
+        #    return _complex_make_setter(left, right)
 
         # TODO rethink/streamline the clamp_basetype logic
         if _needs_clamp(right.typ, right.encoding):
             with right.cache_when_complex("arr_ptr") as (b, right):
-                copier = _dynarray_make_setter(left, right, pos)
+                copier = _dynarray_make_setter(left, right)
                 ret = b.resolve(["seq", clamp_dyn_array(right), copier])
         else:
-            ret = _dynarray_make_setter(left, right, pos)
+            ret = _dynarray_make_setter(left, right)
 
         return IRnode.from_list(ret)
 
     # Arrays
     elif isinstance(left.typ, (SArrayType, TupleLike)):
-        return _complex_make_setter(left, right, pos)
+        return _complex_make_setter(left, right)
 
 
-def _complex_make_setter(left, right, pos):
+def _complex_make_setter(left, right):
     if right.value == "~empty" and left.location == MEMORY:
         # optimized memzero
         return mzero(left, left.typ.memory_bytes_required)
@@ -809,14 +798,14 @@ def _complex_make_setter(left, right, pos):
     with left.cache_when_complex("_L") as (b1, left), right.cache_when_complex("_R") as (b2, right):
 
         for k in keys:
-            l_i = get_element_ptr(left, k, pos=pos, array_bounds_check=False)
-            r_i = get_element_ptr(right, k, pos=pos, array_bounds_check=False)
-            ret.append(make_setter(l_i, r_i, pos))
+            l_i = get_element_ptr(left, k, array_bounds_check=False)
+            r_i = get_element_ptr(right, k, array_bounds_check=False)
+            ret.append(make_setter(l_i, r_i))
 
         return b1.resolve(b2.resolve(IRnode.from_list(ret)))
 
 
-def ensure_in_memory(ir_var, context, pos=None):
+def ensure_in_memory(ir_var, context):
     """Ensure a variable is in memory. This is useful for functions
     which expect to operate on memory variables.
     """
@@ -825,7 +814,7 @@ def ensure_in_memory(ir_var, context, pos=None):
 
     typ = ir_var.typ
     buf = IRnode.from_list(context.new_internal_variable(typ), typ=typ, location=MEMORY)
-    do_copy = make_setter(buf, ir_var, pos=pos)
+    do_copy = make_setter(buf, ir_var)
 
     return IRnode.from_list(["seq", do_copy, buf], typ=typ, location=MEMORY)
 

--- a/vyper/codegen/events.py
+++ b/vyper/codegen/events.py
@@ -1,5 +1,5 @@
 from vyper.codegen.abi_encoder import abi_encode
-from vyper.codegen.core import getpos, ir_tuple_from_args, unwrap_location
+from vyper.codegen.core import ir_tuple_from_args, unwrap_location
 from vyper.codegen.ir_node import IRnode
 from vyper.codegen.keccak256_helper import keccak256_helper
 from vyper.codegen.types.types import BaseType, ByteArrayLike, get_type_for_exact_size
@@ -45,8 +45,6 @@ def ir_node_for_log(expr, event, topic_nodes, data_nodes, context):
       data_nodes: list of IRnodes which calculate the event data
       context: current memory/frame context
     """
-    _pos = getpos(expr)
-
     topics = _encode_log_topics(expr, event.event_id, topic_nodes, context)
 
     data = ir_tuple_from_args(data_nodes)
@@ -56,7 +54,7 @@ def ir_node_for_log(expr, event, topic_nodes, data_nodes, context):
 
     # encode_data is an IRnode which, cleverly, both encodes the data
     # and returns the length of the encoded data as a stack item.
-    encode_data = abi_encode(buf, data, context, pos=_pos, returns_len=True, bufsz=bufsz)
+    encode_data = abi_encode(buf, data, context, returns_len=True, bufsz=bufsz)
 
     assert len(topics) <= 4, "too many topics"  # sanity check
     log_opcode = "log" + str(len(topics))
@@ -64,7 +62,5 @@ def ir_node_for_log(expr, event, topic_nodes, data_nodes, context):
     return IRnode.from_list(
         [log_opcode, buf, encode_data] + topics,
         add_gas_estimate=_gas_bound(len(topics), bufsz),
-        typ=None,
-        pos=_pos,
         annotation=f"LOG event {event.signature}",
     )

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 import vyper.ast as vy_ast
 from vyper.ast.signatures import FunctionSignature
 from vyper.codegen.context import Constancy, Context
-from vyper.codegen.core import check_single_exit
+from vyper.codegen.core import check_single_exit, getpos
 from vyper.codegen.function_definitions.external_function import generate_ir_for_external_function
 from vyper.codegen.function_definitions.internal_function import generate_ir_for_internal_function
 from vyper.codegen.global_context import GlobalContext
@@ -77,6 +77,9 @@ def generate_ir_for_function(
             o = generate_ir_for_internal_function(code, sig, context)
         else:
             o = generate_ir_for_external_function(code, sig, context, check_nonpayable)
+
+        o.source_pos = getpos(code)
+
         return o, context
 
     _, context = _run_pass(memory_allocator=None)

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -4,7 +4,7 @@ import vyper.utils as util
 from vyper.address_space import CALLDATA, DATA, MEMORY
 from vyper.ast.signatures.function_signature import FunctionSignature, VariableRecord
 from vyper.codegen.context import Context
-from vyper.codegen.core import get_element_ptr, make_setter, getpos
+from vyper.codegen.core import get_element_ptr, getpos, make_setter
 from vyper.codegen.expr import Expr
 from vyper.codegen.function_definitions.utils import get_nonreentrant_lock
 from vyper.codegen.ir_node import Encoding, IRnode

--- a/vyper/codegen/function_definitions/internal_function.py
+++ b/vyper/codegen/function_definitions/internal_function.py
@@ -1,7 +1,6 @@
 from vyper import ast as vy_ast
 from vyper.ast.signatures import FunctionSignature
 from vyper.codegen.context import Context
-from vyper.codegen.core import getpos
 from vyper.codegen.function_definitions.utils import get_nonreentrant_lock
 from vyper.codegen.ir_node import IRnode
 from vyper.codegen.stmt import parse_body
@@ -71,8 +70,4 @@ def generate_ir_for_internal_function(
         ["seq"] + nonreentrant_post + [["exit_to", "return_pc"]],
     ]
 
-    return IRnode.from_list(
-        ["seq", body, cleanup_routine],
-        typ=None,
-        pos=getpos(code),
-    )
+    return IRnode.from_list(["seq", body, cleanup_routine])

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -66,7 +66,7 @@ class IRnode:
         args: List["IRnode"] = None,
         typ: NodeType = None,
         location: Optional[AddrSpace] = None,
-        pos: Optional[Tuple[int, int]] = None,
+        source_pos: Optional[Tuple[int, int]] = None,
         annotation: Optional[str] = None,
         mutable: bool = True,
         add_gas_estimate: int = 0,
@@ -82,7 +82,7 @@ class IRnode:
         assert isinstance(typ, NodeType) or typ is None, repr(typ)
         self.typ = typ
         self.location = location
-        self.pos = pos
+        self.source_pos = source_pos
         self.annotation = annotation
         self.mutable = mutable
         self.add_gas_estimate = add_gas_estimate
@@ -371,7 +371,7 @@ class IRnode:
             and self.args == other.args
             and self.typ == other.typ
             and self.location == other.location
-            and self.pos == other.pos
+            and self.source_pos == other.source_pos
             and self.annotation == other.annotation
             and self.mutable == other.mutable
             and self.add_gas_estimate == other.add_gas_estimate
@@ -411,13 +411,13 @@ class IRnode:
         if self.repr_show_gas and self.gas:
             o += OKBLUE + "{" + ENDC + str(self.gas) + OKBLUE + "} " + ENDC  # add gas for info.
         o += "[" + self._colorise_keywords(self.repr_value)
-        prev_lineno = self.pos[0] if self.pos else None
+        prev_lineno = self.source_pos[0] if self.source_pos else None
         arg_lineno = None
         annotated = False
         has_inner_newlines = False
         for arg in self.args:
             o += ",\n  "
-            arg_lineno = arg.pos[0] if arg.pos else None
+            arg_lineno = arg.source_pos[0] if arg.source_pos else None
             if arg_lineno is not None and arg_lineno != prev_lineno and self.value in ("seq", "if"):
                 o += f"# Line {(arg_lineno)}\n  "
                 prev_lineno = arg_lineno
@@ -448,7 +448,7 @@ class IRnode:
         obj: Any,
         typ: NodeType = None,
         location: Optional[AddrSpace] = None,
-        pos: Tuple[int, int] = None,
+        source_pos: Optional[Tuple[int, int]] = None,
         annotation: Optional[str] = None,
         mutable: bool = True,
         add_gas_estimate: int = 0,
@@ -463,8 +463,8 @@ class IRnode:
             # the input gets modified. CC 20191121.
             if typ is not None:
                 obj.typ = typ
-            if obj.pos is None:
-                obj.pos = pos
+            if obj.source_pos is None:
+                obj.source_pos = source_pos
             if obj.location is None:
                 obj.location = location
             if obj.encoding is None:
@@ -477,7 +477,6 @@ class IRnode:
                 [],
                 typ,
                 location=location,
-                pos=pos,
                 annotation=annotation,
                 mutable=mutable,
                 add_gas_estimate=add_gas_estimate,
@@ -487,12 +486,12 @@ class IRnode:
         else:
             return cls(
                 obj[0],
-                [cls.from_list(o, pos=pos) for o in obj[1:]],
+                [cls.from_list(o, source_pos=source_pos) for o in obj[1:]],
                 typ,
                 location=location,
-                pos=pos,
                 annotation=annotation,
                 mutable=mutable,
+                source_pos=source_pos,
                 add_gas_estimate=add_gas_estimate,
                 valency=valency,
                 encoding=encoding,

--- a/vyper/codegen/keccak256_helper.py
+++ b/vyper/codegen/keccak256_helper.py
@@ -1,6 +1,6 @@
 from math import ceil
 
-from vyper.codegen.core import ensure_in_memory, getpos
+from vyper.codegen.core import ensure_in_memory
 from vyper.codegen.ir_node import IRnode
 from vyper.codegen.types import BaseType, ByteArrayLike, is_base_type
 from vyper.exceptions import CompilerPanic
@@ -28,9 +28,7 @@ def keccak256_helper(expr, ir_arg, context):
     # Can hash literals
     # TODO this is dead code.
     if isinstance(sub, bytes):
-        return IRnode.from_list(
-            bytes_to_int(keccak256(sub)), typ=BaseType("bytes32"), pos=getpos(expr)
-        )
+        return IRnode.from_list(bytes_to_int(keccak256(sub)), typ=BaseType("bytes32"))
 
     # Can hash bytes32 objects
     if is_base_type(sub.typ, "bytes32"):
@@ -41,11 +39,10 @@ def keccak256_helper(expr, ir_arg, context):
                 ["sha3", MemoryPositions.FREE_VAR_SPACE, 32],
             ],
             typ=BaseType("bytes32"),
-            pos=getpos(expr),
             add_gas_estimate=_gas_bound(1),
         )
 
-    sub = ensure_in_memory(sub, context, pos=getpos(expr))
+    sub = ensure_in_memory(sub, context)
 
     return IRnode.from_list(
         [
@@ -55,7 +52,6 @@ def keccak256_helper(expr, ir_arg, context):
             ["sha3", ["add", "_buf", 32], ["mload", "_buf"]],
         ],
         typ=BaseType("bytes32"),
-        pos=getpos(expr),
         annotation="keccak256",
         add_gas_estimate=_gas_bound(ceil(sub.typ.maxlen / 32)),
     )

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -62,7 +62,7 @@ class Stmt:
             custom_structs=self.context.structs,
         )
         varname = self.stmt.target.id
-        pos = self.context.new_variable(varname, typ, pos=self.stmt)
+        pos = self.context.new_variable(varname, typ)
         if self.stmt.value is None:
             return
 
@@ -95,7 +95,6 @@ class Stmt:
         target = self._get_target(self.stmt.target)
 
         ir_node = make_setter(target, sub)
-        ir_node.pos = getpos(self.stmt)
         return ir_node
 
     def parse_If(self):

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -41,16 +41,17 @@ class Stmt:
             raise TypeCheckFailure("Statement node did not produce IR")
 
         self.ir_node.annotation = self.stmt.get("node_source_code")
+        self.ir_node.source_pos = getpos(self.stmt)
 
     def parse_Expr(self):
         return Stmt(self.stmt.value, self.context).ir_node
 
     def parse_Pass(self):
-        return IRnode.from_list("pass", typ=None, pos=getpos(self.stmt))
+        return IRnode.from_list("pass")
 
     def parse_Name(self):
         if self.stmt.id == "vdb":
-            return IRnode("debugger", typ=None, pos=getpos(self.stmt))
+            return IRnode("debugger")
         else:
             raise StructureException(f"Unsupported statement type: {type(self.stmt)}", self.stmt)
 
@@ -80,17 +81,11 @@ class Stmt:
             sub = IRnode(
                 util.bytes_to_int(self.stmt.value.s),
                 typ=BaseType("bytes32"),
-                pos=getpos(self.stmt),
             )
 
-        variable_loc = IRnode.from_list(
-            pos,
-            typ=typ,
-            location=MEMORY,
-            pos=getpos(self.stmt),
-        )
+        variable_loc = IRnode.from_list(pos, typ=typ, location=MEMORY)
 
-        ir_node = make_setter(variable_loc, sub, pos=getpos(self.stmt))
+        ir_node = make_setter(variable_loc, sub)
 
         return ir_node
 
@@ -99,7 +94,7 @@ class Stmt:
         sub = Expr(self.stmt.value, self.context).ir_node
         target = self._get_target(self.stmt.target)
 
-        ir_node = make_setter(target, sub, pos=getpos(self.stmt))
+        ir_node = make_setter(target, sub)
         ir_node.pos = getpos(self.stmt)
         return ir_node
 
@@ -113,7 +108,7 @@ class Stmt:
         with self.context.block_scope():
             test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
             body = ["if", test_expr, parse_body(self.stmt.body, self.context)] + add_on
-            ir_node = IRnode.from_list(body, typ=None, pos=getpos(self.stmt))
+            ir_node = IRnode.from_list(body)
         return ir_node
 
     def parse_Log(self):
@@ -153,10 +148,10 @@ class Stmt:
                 arg = args[0]
                 assert isinstance(darray.typ, DArrayType)
                 assert arg.typ == darray.typ.subtype
-                return append_dyn_array(darray, arg, pos=getpos(self.stmt))
+                return append_dyn_array(darray, arg)
             else:
                 assert len(args) == 0
-                return pop_dyn_array(darray, return_popped_item=False, pos=getpos(self.stmt))
+                return pop_dyn_array(darray, return_popped_item=False)
 
         elif is_self_function:
             return self_call.ir_for_self_call(self.stmt, self.context)
@@ -165,7 +160,7 @@ class Stmt:
 
     def _assert_reason(self, test_expr, msg):
         if isinstance(msg, vy_ast.Name) and msg.id == "UNREACHABLE":
-            return IRnode.from_list(["assert_unreachable", test_expr], typ=None, pos=getpos(msg))
+            return IRnode.from_list(["assert_unreachable", test_expr])
 
         # set constant so that revert reason str is well behaved
         try:
@@ -214,27 +209,28 @@ class Stmt:
         else:
             ir_node = revert_seq
 
-        return IRnode.from_list(ir_node, typ=None, pos=getpos(self.stmt))
+        return IRnode.from_list(ir_node)
 
     def parse_Assert(self):
         test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
         if test_expr.typ.is_literal:
             if test_expr.value == 1:
                 # skip literal assertions that always pass
-                return IRnode.from_list(["pass"], typ=None, pos=getpos(self.stmt))
+                # TODO move this to optimizer
+                return IRnode.from_list(["pass"])
             else:
                 test_expr = test_expr.value
 
         if self.stmt.msg:
             return self._assert_reason(test_expr, self.stmt.msg)
         else:
-            return IRnode.from_list(["assert", test_expr], typ=None, pos=getpos(self.stmt))
+            return IRnode.from_list(["assert", test_expr])
 
     def parse_Raise(self):
         if self.stmt.exc:
             return self._assert_reason(None, self.stmt.exc)
         else:
-            return IRnode.from_list(["revert", 0, 0], typ=None, pos=getpos(self.stmt))
+            return IRnode.from_list(["revert", 0, 0])
 
     def _check_valid_range_constant(self, arg_ast_node, raise_exception=True):
         with self.context.range_scope():
@@ -279,15 +275,15 @@ class Stmt:
         # Type 1 for, e.g. for i in range(10): ...
         if num_of_args == 1:
             arg0_val = self._get_range_const_value(arg0)
-            start = IRnode.from_list(0, typ=iter_typ, pos=getpos(self.stmt))
+            start = IRnode.from_list(0, typ=iter_typ)
             rounds = arg0_val
 
         # Type 2 for, e.g. for i in range(100, 110): ...
         elif self._check_valid_range_constant(self.stmt.iter.args[1], raise_exception=False)[0]:
             arg0_val = self._get_range_const_value(arg0)
             arg1_val = self._get_range_const_value(self.stmt.iter.args[1])
-            start = IRnode.from_list(arg0_val, typ=iter_typ, pos=getpos(self.stmt))
-            rounds = IRnode.from_list(arg1_val - arg0_val, typ=iter_typ, pos=getpos(self.stmt))
+            start = IRnode.from_list(arg0_val, typ=iter_typ)
+            rounds = IRnode.from_list(arg1_val - arg0_val, typ=iter_typ)
 
         # Type 3 for, e.g. for i in range(x, x + 10): ...
         else:
@@ -301,7 +297,7 @@ class Stmt:
 
         varname = self.stmt.target.id
         i = IRnode.from_list(self.context.fresh_varname("range_ix"), typ="uint256")
-        iptr = self.context.new_variable(varname, BaseType(iter_typ), pos=getpos(self.stmt))
+        iptr = self.context.new_variable(varname, BaseType(iter_typ))
 
         self.context.forvars[varname] = True
 
@@ -310,10 +306,7 @@ class Stmt:
         loop_body.append(["mstore", iptr, i])
         loop_body.append(parse_body(self.stmt.body, self.context))
 
-        ir_node = IRnode.from_list(
-            ["repeat", i, start, rounds, rounds, loop_body],
-            pos=getpos(self.stmt),
-        )
+        ir_node = IRnode.from_list(["repeat", i, start, rounds, rounds, loop_body])
         del self.context.forvars[varname]
 
         return ir_node
@@ -330,9 +323,7 @@ class Stmt:
         # user-supplied name for loop variable
         varname = self.stmt.target.id
         loop_var = IRnode.from_list(
-            self.context.new_variable(varname, target_type),
-            typ=target_type,
-            location=MEMORY,
+            self.context.new_variable(varname, target_type), typ=target_type, location=MEMORY
         )
 
         i = IRnode.from_list(self.context.fresh_varname("for_list_ix"), typ="uint256")
@@ -348,15 +339,14 @@ class Stmt:
                 typ=iter_list.typ,
                 location=MEMORY,
             )
-            ret.append(make_setter(tmp_list, iter_list, pos=getpos(self.stmt)))
+            ret.append(make_setter(tmp_list, iter_list))
             iter_list = tmp_list
 
         # set up the loop variable
-        loop_var_ast = getpos(self.stmt.target)
-        e = get_element_ptr(iter_list, i, array_bounds_check=False, pos=loop_var_ast)
+        e = get_element_ptr(iter_list, i, array_bounds_check=False)
         body = [
             "seq",
-            make_setter(loop_var, e, pos=loop_var_ast),
+            make_setter(loop_var, e),
             parse_body(self.stmt.body, self.context),
         ]
 
@@ -369,7 +359,7 @@ class Stmt:
         ret.append(["repeat", i, 0, array_len, repeat_bound, body])
 
         del self.context.forvars[varname]
-        return IRnode.from_list(ret, pos=getpos(self.stmt))
+        return IRnode.from_list(ret)
 
     def parse_AugAssign(self):
         target = self._get_target(self.stmt.target)
@@ -380,7 +370,7 @@ class Stmt:
         with target.cache_when_complex("_loc") as (b, target):
             rhs = Expr.parse_value_expr(
                 vy_ast.BinOp(
-                    left=IRnode.from_list(LOAD(target), typ=target.typ, pos=target.pos),
+                    left=IRnode.from_list(LOAD(target), typ=target.typ),
                     right=sub,
                     op=self.stmt.op,
                     lineno=self.stmt.lineno,
@@ -394,10 +384,10 @@ class Stmt:
             return b.resolve(STORE(target, rhs))
 
     def parse_Continue(self):
-        return IRnode.from_list("continue", typ=None, pos=getpos(self.stmt))
+        return IRnode.from_list("continue")
 
     def parse_Break(self):
-        return IRnode.from_list("break", typ=None, pos=getpos(self.stmt))
+        return IRnode.from_list("break")
 
     def parse_Return(self):
         ir_val = None
@@ -461,4 +451,4 @@ def parse_body(code, context, ensure_terminated=False):
 
     # force zerovalent, even last statement
     ir_node.append("pass")  # CMC 2022-01-16 is this necessary?
-    return IRnode.from_list(ir_node, pos=getpos(code[0]) if code else None)
+    return IRnode.from_list(ir_node)

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -172,10 +172,10 @@ class Instruction(str):
     def __new__(cls, sstr, *args, **kwargs):
         return super().__new__(cls, sstr)
 
-    def __init__(self, sstr, pos=None):
+    def __init__(self, sstr, source_pos=None):
         self.pc_debugger = False
-        if pos is not None:
-            self.lineno, self.col_offset, self.end_lineno, self.end_col_offset = pos
+        if source_pos is not None:
+            self.lineno, self.col_offset, self.end_lineno, self.end_col_offset = source_pos
         else:
             self.lineno, self.col_offset, self.end_lineno, self.end_col_offset = [None] * 4
 
@@ -823,10 +823,10 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
 
     # inject debug opcode.
     elif code.value == "debugger":
-        return mkdebug(pc_debugger=False, pos=code.source_pos)
+        return mkdebug(pc_debugger=False, source_pos=code.source_pos)
     # inject debug opcode.
     elif code.value == "pc_debugger":
-        return mkdebug(pc_debugger=True, pos=code.source_pos)
+        return mkdebug(pc_debugger=True, source_pos=code.source_pos)
     else:
         raise Exception("Weird code element: " + repr(code))
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -130,7 +130,7 @@ def _rewrite_return_sequences(ir_node, label_params=None):
             dest = args[0].value[5:]  # `_sym_foo` -> `foo`
             more_args = ["pass" if t.value == "return_pc" else t for t in args[1:]]
             _t.append(["goto", dest] + more_args)
-            ir_node.args = IRnode.from_list(_t, pos=ir_node.pos).args
+            ir_node.args = IRnode.from_list(_t, source_pos=ir_node.source_pos).args
 
     if ir_node.value == "label":
         label_params = set(t.value for t in ir_node.args[1].args)
@@ -186,7 +186,9 @@ def apply_line_numbers(func):
         code = args[0]
         ret = func(*args, **kwargs)
         new_ret = [
-            Instruction(i, code.pos) if isinstance(i, str) and not isinstance(i, Instruction) else i
+            Instruction(i, code.source_pos)
+            if isinstance(i, str) and not isinstance(i, Instruction)
+            else i
             for i in ret
         ]
         return new_ret
@@ -821,10 +823,10 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
 
     # inject debug opcode.
     elif code.value == "debugger":
-        return mkdebug(pc_debugger=False, pos=code.pos)
+        return mkdebug(pc_debugger=False, pos=code.source_pos)
     # inject debug opcode.
     elif code.value == "pc_debugger":
-        return mkdebug(pc_debugger=True, pos=code.pos)
+        return mkdebug(pc_debugger=True, pos=code.source_pos)
     else:
         raise Exception("Weird code element: " + repr(code))
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -58,8 +58,8 @@ def mksymbol(name=""):
     return f"_sym_{name}{_next_symbol}"
 
 
-def mkdebug(pc_debugger, pos):
-    i = Instruction("DEBUG", pos)
+def mkdebug(pc_debugger, source_pos):
+    i = Instruction("DEBUG", source_pos)
     i.pc_debugger = pc_debugger
     return [i]
 

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -63,7 +63,7 @@ def apply_general_optimizations(node: IRnode) -> IRnode:
     value = node.value
     typ = node.typ
     location = node.location
-    pos = node.pos
+    source_pos = node.source_pos
     annotation = node.annotation
     add_gas_estimate = node.add_gas_estimate
     valency = node.valency
@@ -191,7 +191,7 @@ def apply_general_optimizations(node: IRnode) -> IRnode:
         [value, *argz],
         typ=typ,
         location=location,
-        pos=pos,
+        source_pos=source_pos,
         annotation=annotation,
         add_gas_estimate=add_gas_estimate,
         valency=valency,
@@ -244,7 +244,7 @@ def _merge_memzero(argz):
         if len(mstore_nodes) > 1:
             new_ir = IRnode.from_list(
                 ["calldatacopy", initial_offset, "calldatasize", total_length],
-                pos=mstore_nodes[0].pos,
+                source_pos=mstore_nodes[0].source_pos,
             )
             # replace first zero'ing operation with optimized node and remove the rest
             idx = argz.index(mstore_nodes[0])
@@ -290,7 +290,7 @@ def _merge_calldataload(argz):
         if len(mstore_nodes) > 1:
             new_ir = IRnode.from_list(
                 ["calldatacopy", initial_mem_offset, initial_calldata_offset, total_length],
-                pos=mstore_nodes[0].pos,
+                source_pos=mstore_nodes[0].source_pos,
             )
             # replace first copy operation with optimized node and remove the rest
             idx = argz.index(mstore_nodes[0])


### PR DESCRIPTION
this way we don't have to pass `pos` around everywhere in the call
stack. might make source maps easier to read, too

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/160173539-a455ee07-cc72-4219-9e07-3d3559bb5d01.png)
