### PR TITLE
chore: bump durations cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,8 +250,9 @@ jobs:
       id: test_durations_cache
       with:
         path: .test_durations
-        # change the version to reset the cache
-        key: ${{ runner.os }}-test-durations-cache-v1
+        # change the version to reset the cache, do this if
+        # the fuzzer tests get unbalanced
+        key: ${{ runner.os }}-test-durations-cache-v2
 
     - name: Check test durations existence
       id: check_test_durations


### PR DESCRIPTION
in recent builds, the test are unevenly distributed to one runner. reset
the durations cache to fix.

e.g. https://github.com/vyperlang/vyper/runs/5686498127

### What I did

### How I did it

### How to verify it

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
