### PR TITLE
tune code size / gas for bytes copy routines

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -757,7 +757,7 @@ def _ir_loop_make_setter(dst, src, n, n_bound):
     loop_body.annotation = f"{dst}[i] = {src}[i]"
 
     ret = ["repeat", i, 0, n, n_bound, loop_body]
-    return IRnode.from_list(ret, annotation="__loop_make_setter")
+    return IRnode.from_list(ret)
 
 
 # works for static arrays, and also tuples. works for literals.
@@ -769,7 +769,7 @@ def _unroll_loop_make_setter(dst, src, keys):
         src_i = get_element_ptr(src, k, array_bounds_check=False)
         ret.append(make_setter(dst_i, src_i))
 
-    return IRnode.from_list(ret, annotation="__seq_make_setter")
+    return IRnode.from_list(ret)
 
 
 def _dynarray_make_setter(dst, src):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -21,6 +21,13 @@ from vyper.evm.opcodes import version_check
 from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure, TypeMismatch
 from vyper.utils import GAS_CALLDATACOPY_WORD, GAS_CODECOPY_WORD, GAS_IDENTITY, GAS_IDENTITYWORD
 
+# below how many bytes should we unroll vs loop or staticcall?
+UNROLL_WORD_BYTES_TUNING = 8 * 32
+
+
+# above how many words should we roll an array copy operation?
+ROLL_ARRAY_TUNING = 5
+
 
 # propagate revert message when calls to external contracts fail
 def check_external_call(call_ir):
@@ -89,10 +96,6 @@ def dynarray_data_ptr(ptr):
         raise CompilerPanic("tried to modify non-pointer type")
     assert isinstance(ptr.typ, DArrayType)
     return add_ofst(ptr, ptr.location.word_scale)
-
-
-# below how many bytes should we unroll vs loop or staticcall?
-UNROLL_WORD_BYTES_TUNING = 8 * 32
 
 
 # Copy bytes
@@ -741,9 +744,6 @@ def make_setter(left: IRnode, right: IRnode) -> IRnode:
             return _finalize(_complex_make_setter(left, right))
 
         raise CompilerPanic("unreachable type")  # pragma: notest
-
-
-ROLL_ARRAY_TUNING = 5
 
 
 def _ir_loop_make_setter(dst, src, n, n_bound):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -788,8 +788,9 @@ def _dynarray_make_setter(dst, src):
         if _is_list_literal(src):
             # is literal list, generate instructions
             # to set every element of the lhs
-            assert isinstance(count.value, int), src
-            ret.append(_unroll_loop_make_setter(dst, src, range(count.value)))
+            assert isinstance(count.value, int)
+            keys = [IRnode.from_list(i, typ="uint256") for i in range(count.value)]
+            ret.append(_unroll_loop_make_setter(dst, src, keys))
             return IRnode.from_list(ret)
 
         # for ABI-encoded dynamic data, we must loop to unpack, since

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -320,7 +320,11 @@ class IRnode:
                 # a named IR variable which represents the
                 # output of `ir_node`
                 self.ir_var = IRnode.from_list(
-                    name, typ=ir_node.typ, location=ir_node.location, encoding=ir_node.encoding, annotation=ir_node.annotation
+                    name,
+                    typ=ir_node.typ,
+                    location=ir_node.location,
+                    encoding=ir_node.encoding,
+                    annotation=ir_node.annotation,
                 )
 
             def __enter__(self):

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -320,7 +320,7 @@ class IRnode:
                 # a named IR variable which represents the
                 # output of `ir_node`
                 self.ir_var = IRnode.from_list(
-                    name, typ=ir_node.typ, location=ir_node.location, encoding=ir_node.encoding
+                    name, typ=ir_node.typ, location=ir_node.location, encoding=ir_node.encoding, annotation=ir_node.annotation
                 )
 
             def __enter__(self):

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -16,7 +16,6 @@ from vyper.codegen.core import (
     get_element_ptr,
     getpos,
     is_return_from_function,
-    make_byte_array_copier,
     make_setter,
     pop_dyn_array,
     zero_pad,
@@ -183,7 +182,7 @@ class Stmt:
         # TODO maybe use ensure_in_memory
         if msg_ir.location != MEMORY:
             buf = self.context.new_internal_variable(msg_ir.typ)
-            instantiate_msg = make_byte_array_copier(buf, msg_ir)
+            instantiate_msg = make_setter(buf, msg_ir)
         else:
             buf = _get_last(msg_ir)
             if not isinstance(buf, int):


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/2656, also unroll copy_bytes when the number of words is small (<8).

should refactor a little because a couple code paths look suspiciously similar. also consider exposing the constants `UNROLL_WORD_COPY_TUNING` and `ROLL_ARRAY_TUNING` as optimizer options.

### How I did it

### How to verify it
check IR following contract -- foo has loops, bar has unrolled, baz has loops
```vyper
w: uint256[15]
@external
def foo(x: uint256[15]) -> uint256[15]:
    y: uint256[15] = x
    z: uint256[15] = y
    self.w = z
    return z

w2: uint256[5]
@external
def bar(x: uint256[5]) -> uint256[5]:
    y: uint256[5] = x
    z: uint256[5] = y
    self.w2 = z
    return z

@external
def baz(x: int128[7]) -> int128[7]:
    return x
```

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/161354186-e0d407d1-ebee-42c4-98d4-966b6b9c8216.png)
