### PR TITLE
throw exception for return type in constructor

### DIFF
--- a/tests/parser/exceptions/test_function_declaration_exception.py
+++ b/tests/parser/exceptions/test_function_declaration_exception.py
@@ -38,6 +38,16 @@ def test_func() -> int128:
 def __init__(a: int128 = 12):
     pass
     """,
+    """
+@external
+def __init__() -> uint256:
+    return 1
+    """,
+    """
+@external
+def __init__() -> bool:
+    pass
+    """,
 ]
 
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -336,6 +336,10 @@ class ContractFunction(BaseTypeDefinition):
         # return types
         if node.returns is None:
             return_type = None
+        elif node.name == "__init__":
+            raise FunctionDeclarationException(
+                "Constructor may not have a return type", node.returns
+            )
         elif isinstance(node.returns, (vy_ast.Name, vy_ast.Call, vy_ast.Subscript)):
             return_type = get_type_from_annotation(node.returns, location=DataLocation.MEMORY)
         elif isinstance(node.returns, vy_ast.Tuple):


### PR DESCRIPTION
### What I did

Fix for #2718.

### How I did it

Raise a `FunctionDeclarationException` if there is a return type for constructor.

### How to verify it

See test cases.

### Commit message

```
fix: throw exception for return type in constructor

Raise a `FunctionDeclarationException` if there is a return 
type for constructor.

resolves: #2718
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/564x/32/ea/df/32eadfcfab5c808a5b6df3585ce5dbc0.jpg)
