### PR TITLE
Throw exception for string and bytes arrays

### DIFF
--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -2,7 +2,13 @@ import itertools
 
 import pytest
 
-from vyper.exceptions import ArrayIndexException, InvalidType, OverflowException, TypeMismatch
+from vyper.exceptions import (
+    ArrayIndexException,
+    InvalidType,
+    OverflowException,
+    StructureException,
+    TypeMismatch,
+)
 
 
 def test_list_tester_code(get_contract_with_gas_estimation):
@@ -1434,3 +1440,29 @@ def foo(i: uint256) -> {return_type}:
     return MY_CONSTANT[i]
     """
     assert_compile_failed(lambda: get_contract(code), TypeMismatch)
+
+
+INVALID_ARRAY_VALUES = [
+    """
+a: DynArray[Bytes[5], 2]
+    """,
+    """
+a: DynArray[String[5], 2]
+    """,
+    """
+a: DynArray[DynArray[Bytes[5], 2], 2]
+    """,
+    """
+a: DynArray[DynArray[String[5], 2], 2]
+    """,
+]
+
+
+@pytest.mark.parametrize("invalid_contracts", INVALID_ARRAY_VALUES)
+def test_invalid_dyn_array_values(
+    get_contract_with_gas_estimation, assert_compile_failed, invalid_contracts
+):
+
+    assert_compile_failed(
+        lambda: get_contract_with_gas_estimation(invalid_contracts), StructureException
+    )

--- a/vyper/semantics/types/indexable/sequence.py
+++ b/vyper/semantics/types/indexable/sequence.py
@@ -12,6 +12,7 @@ from vyper.semantics.types.bases import (
     IndexableTypeDefinition,
     MemberTypeDefinition,
 )
+from vyper.semantics.types.value.array_value import BytesArrayDefinition, StringDefinition
 from vyper.semantics.types.value.numeric import Uint256Definition  # type: ignore
 
 
@@ -210,7 +211,12 @@ class DynamicArrayPrimitive(BasePrimitive):
                 "DynArray must be defined with base type and max length, e.g. DynArray[bool, 5]",
                 node,
             )
+
         value_type = get_type_from_annotation(node.slice.value.elements[0], DataLocation.UNSET)
+
+        if isinstance(value_type, (BytesArrayDefinition, StringDefinition)):
+            raise StructureException(f"{value_type._id} arrays are not supported", node)
+
         max_length = node.slice.value.elements[1].value
         return DynamicArrayDefinition(
             value_type,


### PR DESCRIPTION
### What I did

Throw an exception for string and bytes arrays.

### How I did it

Check for strings and bytes arrays as the value type of a dynamic array.

### How to verify it

See tests.

### Commit message

fix: throw exception for dynarrays of strings and bytes arrays

### Description for the changelog

Throw exception for string and bytes arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-preview.redd.it/q2y1U3_h1xjR-yfgBOti8aHMf6DGuXy5RXG9vXs-rbI.jpg?auto=webp&s=0e4645fb1502a4bd7ae8446dfdeb86749bf325c6)
