### PR TITLE
fix: dynamic array typechecker bugs

### DIFF
--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -3,13 +3,12 @@ import itertools
 import pytest
 
 from vyper.exceptions import (
-    ArrayIndexException,
     ArgumentException,
+    ArrayIndexException,
     ImmutableViolation,
-    StateAccessViolation,
-    InvalidLiteral,
     InvalidType,
     OverflowException,
+    StateAccessViolation,
     StructureException,
     TypeMismatch,
 )
@@ -1032,38 +1031,53 @@ def foo() -> DynArray[{subtyp}, 3]:
 
 
 invalid_appends_pops = [
-    ("""
+    (
+        """
 @external
 def foo() -> DynArray[uint256, 3]:
     x: DynArray[uint256, 3] = []
     x.append()
-    """, ArgumentException),
-    ("""
+    """,
+        ArgumentException,
+    ),
+    (
+        """
 @external
 def foo() -> DynArray[uint256, 3]:
     x: DynArray[uint256, 3] = []
     x.append(1,2)
-    """, ArgumentException),
-    ("""
+    """,
+        ArgumentException,
+    ),
+    (
+        """
 @external
 def foo() -> DynArray[uint256, 3]:
     x: DynArray[uint256, 3] = []
     x.pop(1)
-    """, ArgumentException),
-    ("""
+    """,
+        ArgumentException,
+    ),
+    (
+        """
 @external
 def foo(x: DynArray[uint256, 3]) -> DynArray[uint256, 3]:
     x.append(1)
     return x
-    """, ImmutableViolation),
-    ("""
+    """,
+        ImmutableViolation,
+    ),
+    (
+        """
 foo: DynArray[uint256, 3]
 @external
 @view
 def bar() -> DynArray[uint256, 3]:
     self.foo.append(1)
     return self.foo
-    """, StateAccessViolation),
+    """,
+        StateAccessViolation,
+    ),
 ]
 
 

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -4,6 +4,10 @@ import pytest
 
 from vyper.exceptions import (
     ArrayIndexException,
+    ArgumentException,
+    ImmutableViolation,
+    StateAccessViolation,
+    InvalidLiteral,
     InvalidType,
     OverflowException,
     StructureException,
@@ -995,6 +999,77 @@ def foo(xs: DynArray[uint256, 5]) -> uint256:
         lambda xs: None,
     ),
 ]
+
+
+@pytest.mark.parametrize("subtyp", ["uint8", "int128", "uint256"])
+def test_append_literal(get_contract, subtyp):
+    data = [1, 2, 3]
+    if subtyp == "int128":
+        data = [-1, 2, 3]
+    code = f"""
+@external
+def foo() -> DynArray[{subtyp}, 3]:
+    x: DynArray[{subtyp}, 3] = []
+    x.append({data[0]})
+    x.append({data[1]})
+    x.append({data[2]})
+    return x
+    """
+    c = get_contract(code)
+    assert c.foo() == data
+
+
+@pytest.mark.parametrize("subtyp,lit", [("uint8", 256), ("uint256", -1), ("int128", 2 ** 127)])
+def test_append_invalid_literal(get_contract, assert_compile_failed, subtyp, lit):
+    code = f"""
+@external
+def foo() -> DynArray[{subtyp}, 3]:
+    x: DynArray[{subtyp}, 3] = []
+    x.append({lit})
+    return x
+    """
+    assert_compile_failed(lambda: get_contract(code), InvalidType)
+
+
+invalid_appends_pops = [
+    ("""
+@external
+def foo() -> DynArray[uint256, 3]:
+    x: DynArray[uint256, 3] = []
+    x.append()
+    """, ArgumentException),
+    ("""
+@external
+def foo() -> DynArray[uint256, 3]:
+    x: DynArray[uint256, 3] = []
+    x.append(1,2)
+    """, ArgumentException),
+    ("""
+@external
+def foo() -> DynArray[uint256, 3]:
+    x: DynArray[uint256, 3] = []
+    x.pop(1)
+    """, ArgumentException),
+    ("""
+@external
+def foo(x: DynArray[uint256, 3]) -> DynArray[uint256, 3]:
+    x.append(1)
+    return x
+    """, ImmutableViolation),
+    ("""
+foo: DynArray[uint256, 3]
+@external
+@view
+def bar() -> DynArray[uint256, 3]:
+    self.foo.append(1)
+    return self.foo
+    """, StateAccessViolation),
+]
+
+
+@pytest.mark.parametrize("code,exception_type", invalid_appends_pops)
+def test_invalid_append_pop(get_contract, assert_compile_failed, code, exception_type):
+    assert_compile_failed(lambda: get_contract(code), exception_type)
 
 
 @pytest.mark.parametrize("code,check_result", append_pop_tests)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -10,6 +10,8 @@ from vyper.codegen.core import (
     STORE,
     IRnode,
     append_dyn_array,
+    check_assign,
+    dummy_node_for_type,
     get_dyn_array_count,
     get_element_ptr,
     getpos,
@@ -143,10 +145,12 @@ class Stmt:
             darray = Expr(self.stmt.func.value, self.context).ir_node
             args = [Expr(x, self.context).ir_node for x in self.stmt.args]
             if self.stmt.func.attr == "append":
+                # sanity checks
                 assert len(args) == 1
                 arg = args[0]
                 assert isinstance(darray.typ, DArrayType)
-                assert arg.typ == darray.typ.subtype
+                check_assign(dummy_node_for_type(darray.typ.subtype), dummy_node_for_type(arg.typ))
+
                 return append_dyn_array(darray, arg)
             else:
                 assert len(args) == 0

--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -435,7 +435,6 @@ class BaseTypeDefinition:
         """
         raise StructureException(f"Type '{self}' does not support indexing", node)
 
-
     def get_member(self, key: str, node: vy_ast.Attribute) -> "BaseTypeDefinition":
         """
         Validate an attribute reference and return the given type for the member.

--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -11,6 +11,7 @@ from vyper.exceptions import (
     InvalidLiteral,
     InvalidOperation,
     NamespaceCollision,
+    StateAccessViolation,
     StructureException,
     UnexpectedNodeType,
     UnexpectedValue,
@@ -208,7 +209,7 @@ class BasePrimitive:
         raise StructureException("Type is not callable", node)
 
     @classmethod
-    def get_index_type(self, node: vy_ast.Index) -> None:
+    def get_subscripted_type(self, node: vy_ast.Index) -> None:
         # always raises - do not implement in inherited classes
         raise StructureException("Types cannot be indexed", node)
 
@@ -218,7 +219,9 @@ class BasePrimitive:
         raise StructureException("Types do not have members", node)
 
     @classmethod
-    def validate_modification(cls, node: Union[vy_ast.Assign, vy_ast.AugAssign]) -> None:
+    def validate_modification(
+        cls, node: Union[vy_ast.Assign, vy_ast.AugAssign], mutability: Any
+    ) -> None:
         # always raises - do not implement in inherited classes
         raise InvalidOperation("Cannot assign to a type", node)
 
@@ -405,14 +408,25 @@ class BaseTypeDefinition:
         """
         raise StructureException("Value is not callable", node)
 
-    def get_index_type(self, node: vy_ast.Index) -> "BaseTypeDefinition":
+    def validate_index_type(self, node: vy_ast.Index) -> None:
         """
-        Validate an index reference and return the given type at the index.
+        Validate an index reference, e.g. x[1]. Raises if the index is invalid.
 
         Arguments
         ---------
         node : Index
             Vyper ast node from the `slice` member of a Subscript node.
+        """
+        raise StructureException(f"Type '{self}' does not support indexing", node)
+
+    def get_subscripted_type(self, node: vy_ast.Index) -> "BaseTypeDefinition":
+        """
+        Return the type of a subscript expression, e.g. x[1]
+
+        Arguments
+        ---------
+        node: Index
+            Vyper ast node from the `slice` member of a Subscript node
 
         Returns
         -------
@@ -420,6 +434,7 @@ class BaseTypeDefinition:
             Type object for value at the given index.
         """
         raise StructureException(f"Type '{self}' does not support indexing", node)
+
 
     def get_member(self, key: str, node: vy_ast.Attribute) -> "BaseTypeDefinition":
         """
@@ -440,7 +455,11 @@ class BaseTypeDefinition:
         """
         raise StructureException(f"Type '{self}' does not support members", node)
 
-    def validate_modification(self, node: Union[vy_ast.Assign, vy_ast.AugAssign, vy_ast.Call]) -> None:
+    def validate_modification(
+        self,
+        node: Union[vy_ast.Assign, vy_ast.AugAssign, vy_ast.Call],
+        mutability: Any,  # should be StateMutability, import cycle
+    ) -> None:
         """
         Validate an attempt to modify this value.
 
@@ -450,7 +469,17 @@ class BaseTypeDefinition:
         ---------
         node : Assign | AugAssign | Call
             Vyper ast node of the modifying action.
+        mutability: StateMutability
+            The mutability of the context (e.g., pure function) we are currently in
         """
+        # TODO: break this cycle, probably by moving this to validation module
+        from vyper.semantics.types.function import StateMutability
+
+        if mutability <= StateMutability.VIEW and self.location == DataLocation.STORAGE:
+            raise StateAccessViolation(
+                f"Cannot modify storage in a {mutability.value} function", node
+            )
+
         if self.location == DataLocation.CALLDATA:
             raise ImmutableViolation("Cannot write to calldata", node)
         if self.is_constant:

--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -440,7 +440,7 @@ class BaseTypeDefinition:
         """
         raise StructureException(f"Type '{self}' does not support members", node)
 
-    def validate_modification(self, node: Union[vy_ast.Assign, vy_ast.AugAssign]) -> None:
+    def validate_modification(self, node: Union[vy_ast.Assign, vy_ast.AugAssign, vy_ast.Call]) -> None:
         """
         Validate an attempt to modify this value.
 
@@ -448,7 +448,7 @@ class BaseTypeDefinition:
 
         Arguments
         ---------
-        node : Assign | AugAssign
+        node : Assign | AugAssign | Call
             Vyper ast node of the modifying action.
         """
         if self.location == DataLocation.CALLDATA:

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -16,7 +16,7 @@ from vyper.exceptions import (
 )
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.bases import BaseTypeDefinition, DataLocation, StorageSlot
-from vyper.semantics.types.indexable.sequence import DynamicArrayDefinition, TupleDefinition
+from vyper.semantics.types.indexable.sequence import TupleDefinition
 from vyper.semantics.types.utils import (
     StringEnum,
     check_kwargable,
@@ -520,13 +520,17 @@ class MemberFunctionDefinition(BaseTypeDefinition):
         name: the name of this method. ex. "append"
         arg_types: the argument types this method accepts. ex. [int128]
         return_type: the return type of this method. ex. None
-        is_modifying: whether this method modifies the object it is attached to. ex. True
     """
 
     _is_callable = True
 
     def __init__(
-            self, underlying_type: BaseTypeDefinition, name: str, arg_types: List[BaseTypeDefinition], return_type: BaseTypeDefinition, is_modifying: bool
+        self,
+        underlying_type: BaseTypeDefinition,
+        name: str,
+        arg_types: List[BaseTypeDefinition],
+        return_type: Optional[BaseTypeDefinition],
+        is_modifying: bool,
     ) -> None:
         super().__init__(DataLocation.UNSET)
         self.underlying_type = underlying_type

--- a/vyper/semantics/types/indexable/mapping.py
+++ b/vyper/semantics/types/indexable/mapping.py
@@ -20,8 +20,10 @@ class MappingDefinition(IndexableTypeDefinition):
             and self.value_type == other.value_type
         )
 
-    def get_index_type(self, node):
+    def validate_index_type(self, node):
         validate_expected_type(node, self.key_type)
+
+    def get_subscripted_type(self, node):
         return self.value_type
 
 

--- a/vyper/semantics/types/indexable/sequence.py
+++ b/vyper/semantics/types/indexable/sequence.py
@@ -218,7 +218,9 @@ class DynamicArrayPrimitive(BasePrimitive):
                 node,
             )
 
-        value_type = get_type_from_annotation(node.slice.value.elements[0], location, is_constant, is_public, is_immutable)
+        value_type = get_type_from_annotation(
+            node.slice.value.elements[0], location, is_constant, is_public, is_immutable
+        )
 
         if isinstance(value_type, (BytesArrayDefinition, StringDefinition)):
             raise StructureException(f"{value_type._id} arrays are not supported", node)

--- a/vyper/semantics/types/indexable/sequence.py
+++ b/vyper/semantics/types/indexable/sequence.py
@@ -100,14 +100,16 @@ class ArrayDefinition(_SequenceDefinition):
     def size_in_bytes(self):
         return self.value_type.size_in_bytes * self.length
 
-    def get_index_type(self, node):
+    def validate_index_type(self, node):
         if isinstance(node, vy_ast.Int):
             if node.value < 0:
                 raise ArrayIndexException("Vyper does not support negative indexing", node)
             if node.value >= self.length:
                 raise ArrayIndexException("Index out of range", node)
-        else:
-            validation.utils.validate_expected_type(node, IntegerAbstractType())
+
+        validation.utils.validate_expected_type(node, IntegerAbstractType())
+
+    def get_subscripted_type(self, node):
         return self.value_type
 
     def compare_type(self, other):
@@ -141,7 +143,9 @@ class DynamicArrayDefinition(_SequenceDefinition, MemberTypeDefinition):
         # if added as _type_members
         from vyper.semantics.types.function import MemberFunctionDefinition
 
-        self.add_member("append", MemberFunctionDefinition(self, "append", [self.value_type], None, True))
+        self.add_member(
+            "append", MemberFunctionDefinition(self, "append", [self.value_type], None, True)
+        )
         self.add_member("pop", MemberFunctionDefinition(self, "pop", [], self.value_type, True))
 
     def __repr__(self):
@@ -160,7 +164,7 @@ class DynamicArrayDefinition(_SequenceDefinition, MemberTypeDefinition):
     def size_in_bytes(self):
         return self.value_type.size_in_bytes * self.length
 
-    def get_index_type(self, node):
+    def validate_index_type(self, node):
         if isinstance(node, vy_ast.Int):
             if node.value < 0:
                 raise ArrayIndexException("Vyper does not support negative indexing", node)
@@ -168,6 +172,8 @@ class DynamicArrayDefinition(_SequenceDefinition, MemberTypeDefinition):
                 raise ArrayIndexException("Index out of range", node)
         else:
             validation.utils.validate_expected_type(node, IntegerAbstractType())
+
+    def get_subscripted_type(self, node):
         return self.value_type
 
     def compare_type(self, other):
@@ -212,7 +218,7 @@ class DynamicArrayPrimitive(BasePrimitive):
                 node,
             )
 
-        value_type = get_type_from_annotation(node.slice.value.elements[0], DataLocation.UNSET)
+        value_type = get_type_from_annotation(node.slice.value.elements[0], location, is_constant, is_public, is_immutable)
 
         if isinstance(value_type, (BytesArrayDefinition, StringDefinition)):
             raise StructureException(f"{value_type._id} arrays are not supported", node)
@@ -267,13 +273,15 @@ class TupleDefinition(_SequenceDefinition):
     def size_in_bytes(self):
         return sum(i.size_in_bytes for i in self.value_type)
 
-    def get_index_type(self, node):
+    def validate_index_type(self, node):
         if not isinstance(node, vy_ast.Int):
             raise InvalidType("Tuple indexes must be literals", node)
         if node.value < 0:
             raise ArrayIndexException("Vyper does not support negative indexing", node)
         if node.value >= self.length:
             raise ArrayIndexException("Index out of range", node)
+
+    def get_subscripted_type(self, node):
         return self.value_type[node.value]
 
     def compare_type(self, other):

--- a/vyper/semantics/types/indexable/sequence.py
+++ b/vyper/semantics/types/indexable/sequence.py
@@ -141,8 +141,8 @@ class DynamicArrayDefinition(_SequenceDefinition, MemberTypeDefinition):
         # if added as _type_members
         from vyper.semantics.types.function import MemberFunctionDefinition
 
-        self.add_member("append", MemberFunctionDefinition(self, "append", [self.value_type]))
-        self.add_member("pop", MemberFunctionDefinition(self, "pop", []))
+        self.add_member("append", MemberFunctionDefinition(self, "append", [self.value_type], None, True))
+        self.add_member("pop", MemberFunctionDefinition(self, "pop", [], self.value_type, True))
 
     def __repr__(self):
         return f"DynArray[{self.value_type}, {self.length}]"

--- a/vyper/semantics/types/indexable/sequence.py
+++ b/vyper/semantics/types/indexable/sequence.py
@@ -141,8 +141,8 @@ class DynamicArrayDefinition(_SequenceDefinition, MemberTypeDefinition):
         # if added as _type_members
         from vyper.semantics.types.function import MemberFunctionDefinition
 
-        self.add_member("append", MemberFunctionDefinition(self, "append", 0, 1))
-        self.add_member("pop", MemberFunctionDefinition(self, "pop", 0, 0))
+        self.add_member("append", MemberFunctionDefinition(self, "append", [self.value_type]))
+        self.add_member("pop", MemberFunctionDefinition(self, "pop", []))
 
     def __repr__(self):
         return f"DynArray[{self.value_type}, {self.length}]"

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -202,7 +202,7 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         if isinstance(base_type, BaseTypeDefinition):
             # in the vast majority of cases `base_type` is a type definition,
             # however there are some edge cases with args to builtin functions
-            self.visit(node.slice, base_type.get_index_type(node.slice.value))
+            self.visit(node.slice, base_type.get_subscripted_type(node.slice.value))
         self.visit(node.value, base_type)
 
     def visit_Tuple(self, node, type_):

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -270,10 +270,15 @@ class _ExprTypeChecker:
         # index access, e.g. `foo[1]`
         if isinstance(node.value, vy_ast.List):
             types_list = self.get_possible_types_from_node(node.value)
-            return [base_type.get_index_type(node.slice.value) for base_type in types_list]
+            ret = []
+            for t in types_list:
+                t.validate_index_type(node.slice.value)
+                ret.append(t.get_subscripted_type(node.slice.value))
+            return ret
 
-        base_type = self.get_exact_type_from_node(node.value)
-        return [base_type.get_index_type(node.slice.value)]
+        t = self.get_exact_type_from_node(node.value)
+        t.validate_index_type(node.slice.value)
+        return [t.get_subscripted_type(node.slice.value)]
 
     def types_from_Tuple(self, node):
         types_list = [self.get_exact_type_from_node(i) for i in node.elements]


### PR DESCRIPTION
fix several bugs in dynamic arrays typechecking.

existing code gives false negatives when typechecker allows something
but the types are not equal, for instance:

```vyper
x: DynArray[int128, 5] = []
x.append(1)  # 1 has type uint256

y: DynArray[String[32], 5] = []
x.append("hello")  # "hello" has type String[5]
```

existing code also fails to check state access and constancy violations for dynamic arrays.

### What I did

### How I did it
    fix dynamic array type from annotation

    also, separate validate_index_type and get_subscripted_type, to separate
    the concerns of validating an Index expression and getting the type of a
    Subscript expression.
    
    slight refactor of validate_modification. state access checks are always
    performed right next to validate_modification, so move the state access
    check logic down into validate_modification.

    add modification checks for append/pop

    clean up the API for MemberFunctionDefinition

### How to verify it
see tests

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
