### PR TITLE
fix: test failures due to basefee calc

### DIFF
--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -85,7 +85,9 @@ CONCISE_NORMALIZERS = (_none_addr,)
 
 @pytest.fixture(scope="module")
 def tester():
-    custom_genesis = PyEVMBackend._generate_genesis_params(overrides={"gas_limit": 4500000})
+    # set absurdly high gas limit so that london basefee never adjusts
+    # (note: 2**63 - 1 is max that evm allows)
+    custom_genesis = PyEVMBackend._generate_genesis_params(overrides={"gas_limit": 10 ** 10})
     custom_genesis["base_fee_per_gas"] = 0
     backend = PyEVMBackend(genesis_parameters=custom_genesis)
     return EthereumTester(backend=backend)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -312,28 +312,15 @@ def getpos(node):
     )
 
 
-# TODO since this is always(?) used as add_ofst(ptr, n*ptr.location.word_scale)
-# maybe the API should be `add_words_to_ofst(ptr, n)` and handle the
-# word_scale multiplication inside
+# add an offset to a pointer, keeping location and encoding info
 def add_ofst(ptr, ofst):
-    ofst = IRnode.from_list(ofst)
-    if isinstance(ptr.value, int) and isinstance(ofst.value, int):
-        # NOTE: duplicate with optimizer rule (but removing this makes a
-        # test on --no-optimize mode use too much gas)
-        ret = ptr.value + ofst.value
-    else:
-        ret = ["add", ptr, ofst]
+    ret = ["add", ptr, ofst]
     return IRnode.from_list(ret, location=ptr.location, encoding=ptr.encoding)
 
 
 # shorthand util
 def _mul(x, y):
-    x, y = IRnode.from_list(x), IRnode.from_list(y)
-    # NOTE: similar deal: duplicate with optimizer rule
-    if isinstance(x.value, int) and isinstance(y.value, int):
-        ret = x.value * y.value
-    else:
-        ret = ["mul", x, y]
+    ret = ["mul", x, y]
     return IRnode.from_list(ret)
 
 


### PR DESCRIPTION
### What I did
fix #2744, and get rid of a spurious optimization in vyper.codegen.core (which was left in to deal with a related issue)

### How I did it
bump the block gas limit so the base fee does not adjust

### How to verify it
tests pass

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/3867501/161397792-b038427a-b78f-4f58-88d0-04bfdc198b85.png)
