### PR TITLE
fix: concat for bytesM, M<32

### DIFF
--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -1,5 +1,3 @@
-import random
-
 from vyper.exceptions import TypeMismatch
 
 
@@ -145,8 +143,7 @@ def small_bytes4(a: bytes8, b: Bytes[32], c: bytes8) -> Bytes[48]:
     contract = get_contract_with_gas_estimation(code)
 
     def bytes_for_len(n):
-        # note: python 3.9 has `randbytes` for this.
-        return random.randrange(2 ** (8 * n)).to_bytes(n, "big")
+        return bytes([i % 256 for i in range(1, n + 1)])
 
     a, b = bytes_for_len(1), bytes_for_len(2)
     assert contract.small_bytes1(a, b) == a + b

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -143,6 +143,7 @@ def small_bytes4(a: bytes8, b: Bytes[32], c: bytes8) -> Bytes[48]:
     contract = get_contract_with_gas_estimation(code)
 
     i = 0
+
     def bytes_for_len(n):
         nonlocal i
         # bytes constructor with state

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -1,4 +1,5 @@
 from vyper.exceptions import TypeMismatch
+import random
 
 
 def test_concat(get_contract_with_gas_estimation):
@@ -122,6 +123,7 @@ def small_output(a: String[5], b: String[4]) -> String[9]:
 
 
 def test_small_bytes(get_contract_with_gas_estimation):
+    # TODO maybe use parametrization or hypothesis for the examples
     code = """
 @external
 def small_bytes1(a: bytes1, b: Bytes[2]) -> Bytes[3]:
@@ -139,24 +141,35 @@ def small_bytes3(a: bytes4, b: bytes32) -> Bytes[36]:
 def small_bytes4(a: bytes8, b: Bytes[32], c: bytes8) -> Bytes[48]:
     return concat(a, b, c)
     """
-    c = get_contract_with_gas_estimation(code)
+    contract = get_contract_with_gas_estimation(code)
 
     def bytes_for_len(n):
-        return b"\xff" * n
+        # note: python 3.9 has `randbytes` for this.
+        return random.randrange(2**(8*n)).to_bytes(n, "big")
 
-    assert c.small_bytes1(bytes_for_len(1), bytes_for_len(2)) == bytes_for_len(3)
-    assert c.small_bytes1(bytes_for_len(1), bytes_for_len(1)) == bytes_for_len(2)
+    a, b = bytes_for_len(1), bytes_for_len(2)
+    assert contract.small_bytes1(a, b) == a + b
 
-    assert c.small_bytes2(bytes_for_len(1), bytes_for_len(2)) == bytes_for_len(3)
-    assert c.small_bytes2(bytes_for_len(0), bytes_for_len(2)) == bytes_for_len(2)
+    a, b = bytes_for_len(1), bytes_for_len(1)
+    assert contract.small_bytes1(a, b) == a + b
 
-    assert c.small_bytes3(bytes_for_len(4), bytes_for_len(32)) == bytes_for_len(36)
+    a, b = bytes_for_len(1), bytes_for_len(2)
+    assert contract.small_bytes2(a, b) == a + b
 
-    assert c.small_bytes4(bytes_for_len(8), bytes_for_len(32), bytes_for_len(8)) == bytes_for_len(
-        48
-    )
-    assert c.small_bytes4(bytes_for_len(8), bytes_for_len(1), bytes_for_len(8)) == bytes_for_len(17)
-    assert c.small_bytes4(bytes_for_len(8), bytes_for_len(0), bytes_for_len(8)) == bytes_for_len(16)
+    a, b = b"", bytes_for_len(2)
+    assert contract.small_bytes2(a, b) == a + b
+
+    a, b = bytes_for_len(4), bytes_for_len(32)
+    assert contract.small_bytes3(a, b) == a + b
+
+    a, b, c = bytes_for_len(8), bytes_for_len(32), bytes_for_len(8)
+    assert contract.small_bytes4(a, b, c) == a + b + c
+
+    a, b, c = bytes_for_len(8), bytes_for_len(1), bytes_for_len(8)
+    assert contract.small_bytes4(a, b, c) == a + b + c
+
+    a, b, c = bytes_for_len(8), bytes_for_len(0), bytes_for_len(8)
+    assert contract.small_bytes4(a, b, c) == a + b + c
 
 
 def test_large_output(get_contract_with_gas_estimation, assert_compile_failed):

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -1,5 +1,6 @@
-from vyper.exceptions import TypeMismatch
 import random
+
+from vyper.exceptions import TypeMismatch
 
 
 def test_concat(get_contract_with_gas_estimation):
@@ -145,7 +146,7 @@ def small_bytes4(a: bytes8, b: Bytes[32], c: bytes8) -> Bytes[48]:
 
     def bytes_for_len(n):
         # note: python 3.9 has `randbytes` for this.
-        return random.randrange(2**(8*n)).to_bytes(n, "big")
+        return random.randrange(2 ** (8 * n)).to_bytes(n, "big")
 
     a, b = bytes_for_len(1), bytes_for_len(2)
     assert contract.small_bytes1(a, b) == a + b

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -142,8 +142,17 @@ def small_bytes4(a: bytes8, b: Bytes[32], c: bytes8) -> Bytes[48]:
     """
     contract = get_contract_with_gas_estimation(code)
 
+    i = 0
     def bytes_for_len(n):
-        return bytes([i % 256 for i in range(1, n + 1)])
+        nonlocal i
+        # bytes constructor with state
+        # (so we don't keep generating the same string)
+        xs = []
+        for _ in range(n):
+            i += 1
+            i %= 256
+            xs.append(i)
+        return bytes(xs)
 
     a, b = bytes_for_len(1), bytes_for_len(2)
     assert contract.small_bytes1(a, b) == a + b

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -121,6 +121,44 @@ def small_output(a: String[5], b: String[4]) -> String[9]:
     assert c.small_output("", "") == ""
 
 
+def test_small_bytes(get_contract_with_gas_estimation):
+    code = """
+@external
+def small_bytes1(a: bytes1, b: Bytes[2]) -> Bytes[3]:
+    return concat(a, b)
+
+@external
+def small_bytes2(a: Bytes[1], b: bytes2) -> Bytes[3]:
+    return concat(a, b)
+
+@external
+def small_bytes3(a: bytes4, b: bytes32) -> Bytes[36]:
+    return concat(a, b)
+
+@external
+def small_bytes4(a: bytes8, b: Bytes[32], c: bytes8) -> Bytes[48]:
+    return concat(a, b, c)
+    """
+    c = get_contract_with_gas_estimation(code)
+
+    def bytes_for_len(n):
+        return b"\xff" * n
+
+    assert c.small_bytes1(bytes_for_len(1), bytes_for_len(2)) == bytes_for_len(3)
+    assert c.small_bytes1(bytes_for_len(1), bytes_for_len(1)) == bytes_for_len(2)
+
+    assert c.small_bytes2(bytes_for_len(1), bytes_for_len(2)) == bytes_for_len(3)
+    assert c.small_bytes2(bytes_for_len(0), bytes_for_len(2)) == bytes_for_len(2)
+
+    assert c.small_bytes3(bytes_for_len(4), bytes_for_len(32)) == bytes_for_len(36)
+
+    assert c.small_bytes4(bytes_for_len(8), bytes_for_len(32), bytes_for_len(8)) == bytes_for_len(
+        48
+    )
+    assert c.small_bytes4(bytes_for_len(8), bytes_for_len(1), bytes_for_len(8)) == bytes_for_len(17)
+    assert c.small_bytes4(bytes_for_len(8), bytes_for_len(0), bytes_for_len(8)) == bytes_for_len(16)
+
+
 def test_large_output(get_contract_with_gas_estimation, assert_compile_failed):
     code = """
 @external

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -547,6 +547,7 @@ class Concat:
                     argdata = bytes_data_ptr(arg)
 
                     with get_bytearray_length(arg).cache_when_complex("len") as (b2, arglen):
+
                         do_copy = [
                             "seq",
                             copy_bytes(dst_data, argdata, arglen, arg.typ.maxlen),


### PR DESCRIPTION
### What I did
fix concat for `bytesM` where `M < 32` (new bytes types).

### How I did it
fix the codegen, also use routines from vyper.codegen.core.

h/t to @hedgar2017 for reporting

### How to verify it
see tests

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/162336490-3ea56f6a-5ff3-4d58-9911-3ad19a112d23.png)

