### PR TITLE
feat: publish immutables layout

### DIFF
--- a/tests/cli/outputs/test_storage_layout.py
+++ b/tests/cli/outputs/test_storage_layout.py
@@ -43,25 +43,23 @@ def public_foo3():
         output_formats=["layout"],
     )
 
-    assert out["layout"] == {
-        "nonreentrant.foo": {"type": "nonreentrant lock", "location": "storage", "slot": 0},
-        "nonreentrant.bar": {"type": "nonreentrant lock", "location": "storage", "slot": 1},
+    assert out["layout"]["storage_layout"] == {
+        "nonreentrant.foo": {"type": "nonreentrant lock", "slot": 0},
+        "nonreentrant.bar": {"type": "nonreentrant lock", "slot": 1},
         "foo": {
             "type": "HashMap[address, uint256]",
-            "location": "storage",
             "slot": 2,
         },
         "arr": {
             "type": "DynArray[uint256, 3]",
-            "location": "storage",
             "slot": 3,
         },
-        "baz": {"type": "Bytes[65]", "location": "storage", "slot": 7},
-        "bar": {"type": "uint256", "location": "storage", "slot": 11},
+        "baz": {"type": "Bytes[65]", "slot": 7},
+        "bar": {"type": "uint256", "slot": 11},
     }
 
 
-def test_immutables_layout():
+def test_storage_and_immutables_layout():
     code = """
 name: String[32]
 SYMBOL: immutable(String[32])
@@ -74,9 +72,11 @@ def __init__():
     """
 
     expected_layout = {
-        "DECIMALS": {"length": 32, "location": "code", "offset": 64, "type": "uint8"},
-        "SYMBOL": {"length": 64, "location": "code", "offset": 0, "type": "String[32]"},
-        "name": {"location": "storage", "slot": 0, "type": "String[32]"},
+        "code_layout": {
+            "DECIMALS": {"length": 32, "offset": 64, "type": "uint8"},
+            "SYMBOL": {"length": 64, "offset": 0, "type": "String[32]"},
+        },
+        "storage_layout": {"name": {"slot": 0, "type": "String[32]"}},
     }
 
     out = compile_code(code, output_formats=["layout"])

--- a/tests/cli/outputs/test_storage_layout.py
+++ b/tests/cli/outputs/test_storage_layout.py
@@ -52,3 +52,25 @@ def public_foo3():
         "baz": {"type": "Bytes[65]", "location": "storage", "slot": 3},
         "bar": {"type": "uint256", "location": "storage", "slot": 7},
     }
+
+
+def test_immutables_layout():
+    code = """
+name: String[32]
+SYMBOL: immutable(String[32])
+DECIMALS: immutable(uint8)
+
+@external
+def __init__():
+    SYMBOL = "VYPR"
+    DECIMALS = 18
+    """
+
+    expected_layout = {
+        "DECIMALS": {"length": 32, "location": "code", "offset": 64, "type": "uint8"},
+        "SYMBOL": {"length": 64, "location": "code", "offset": 0, "type": "String[32]"},
+        "name": {"location": "storage", "slot": 0, "type": "String[32]"},
+    }
+
+    out = compile_code(code, output_formats=["layout"])
+    assert out["layout"] == expected_layout

--- a/tests/cli/outputs/test_storage_layout_overrides.py
+++ b/tests/cli/outputs/test_storage_layout_overrides.py
@@ -10,15 +10,17 @@ a: uint256
 b: uint256"""
 
     storage_layout_overrides = {
-        "a": {"type": "uint256", "location": "storage", "slot": 1},
-        "b": {"type": "uint256", "location": "storage", "slot": 0},
+        "a": {"type": "uint256", "slot": 1},
+        "b": {"type": "uint256", "slot": 0},
     }
+
+    expected_output = {"storage_layout": storage_layout_overrides, "code_layout": {}}
 
     out = compile_code(
         code, output_formats=["layout"], storage_layout_override=storage_layout_overrides
     )
 
-    assert out["layout"] == storage_layout_overrides
+    assert out["layout"] == expected_output
 
 
 def test_storage_layout_for_more_complex():
@@ -57,22 +59,23 @@ def public_foo3():
     """
 
     storage_layout_override = {
-        "nonreentrant.foo": {"type": "nonreentrant lock", "location": "storage", "slot": 8},
-        "nonreentrant.bar": {"type": "nonreentrant lock", "location": "storage", "slot": 7},
+        "nonreentrant.foo": {"type": "nonreentrant lock", "slot": 8},
+        "nonreentrant.bar": {"type": "nonreentrant lock", "slot": 7},
         "foo": {
             "type": "HashMap[address, uint256]",
-            "location": "storage",
             "slot": 1,
         },
-        "baz": {"type": "Bytes[65]", "location": "storage", "slot": 2},
-        "bar": {"type": "uint256", "location": "storage", "slot": 6},
+        "baz": {"type": "Bytes[65]", "slot": 2},
+        "bar": {"type": "uint256", "slot": 6},
     }
+
+    expected_output = {"storage_layout": storage_layout_override, "code_layout": {}}
 
     out = compile_code(
         code, output_formats=["layout"], storage_layout_override=storage_layout_override
     )
 
-    assert out["layout"] == storage_layout_override
+    assert out["layout"] == expected_output
 
 
 def test_simple_collision():
@@ -81,8 +84,8 @@ name: public(String[64])
 symbol: public(String[32])"""
 
     storage_layout_override = {
-        "name": {"location": "storage", "slot": 0, "type": "String[64]"},
-        "symbol": {"location": "storage", "slot": 1, "type": "String[32]"},
+        "name": {"slot": 0, "type": "String[64]"},
+        "symbol": {"slot": 1, "type": "String[32]"},
     }
 
     with pytest.raises(
@@ -101,7 +104,7 @@ name: public(String[64])
 symbol: public(String[32])"""
 
     storage_layout_override = {
-        "name": {"location": "storage", "slot": 0, "type": "String[64]"},
+        "name": {"slot": 0, "type": "String[64]"},
     }
 
     with pytest.raises(

--- a/tests/cli/outputs/test_storage_layout_overrides.py
+++ b/tests/cli/outputs/test_storage_layout_overrides.py
@@ -75,6 +75,28 @@ def public_foo3():
     assert out["layout"] == storage_layout_override
 
 
+def test_immutables_layout():
+    code = """
+name: String[32]
+SYMBOL: immutable(String[32])
+DECIMALS: immutable(uint8)
+
+@external
+def __init__():
+    SYMBOL = "VYPR"
+    DECIMALS = 18
+    """
+
+    expected_layout = {
+        "name": {"type": "String[32]", "location": "storage", "slot": 0},
+        "SYMBOL": {"type": "String[32]", "offset": 0, "length": 64},
+        "DECIMALS": {"type": "uint8", "offset": 64, "length": 32},
+    }
+
+    out = compile_code(code, output_formats=["layout"])
+    assert out["layout"] == expected_layout
+
+
 def test_simple_collision():
     code = """
 name: public(String[64])

--- a/tests/cli/outputs/test_storage_layout_overrides.py
+++ b/tests/cli/outputs/test_storage_layout_overrides.py
@@ -75,28 +75,6 @@ def public_foo3():
     assert out["layout"] == storage_layout_override
 
 
-def test_immutables_layout():
-    code = """
-name: String[32]
-SYMBOL: immutable(String[32])
-DECIMALS: immutable(uint8)
-
-@external
-def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
-    """
-
-    expected_layout = {
-        "name": {"type": "String[32]", "location": "storage", "slot": 0},
-        "SYMBOL": {"type": "String[32]", "offset": 0, "length": 64},
-        "DECIMALS": {"type": "uint8", "offset": 64, "length": 32},
-    }
-
-    out = compile_code(code, output_formats=["layout"])
-    assert out["layout"] == expected_layout
-
-
 def test_simple_collision():
     code = """
 name: public(String[64])

--- a/vyper/semantics/validation/data_positions.py
+++ b/vyper/semantics/validation/data_positions.py
@@ -214,7 +214,7 @@ def set_memory_offsets(fn_node: vy_ast.FunctionDef) -> None:
     pass
 
 
-def set_code_offsets(vyper_module: vy_ast.Module) -> None:
+def set_code_offsets(vyper_module: vy_ast.Module) -> Dict:
 
     ret = {}
     offset = 0
@@ -228,7 +228,12 @@ def set_code_offsets(vyper_module: vy_ast.Module) -> None:
 
         # this could have better typing but leave it untyped until
         # we understand the use case better
-        ret[node.target.id] = {"type": str(type_), "location": "code", "offset": offset, "length": len_ }
+        ret[node.target.id] = {
+            "type": str(type_),
+            "location": "code",
+            "offset": offset,
+            "length": len_,
+        }
 
         offset += len_
 

--- a/vyper/semantics/validation/data_positions.py
+++ b/vyper/semantics/validation/data_positions.py
@@ -27,7 +27,7 @@ def set_data_positions(
         else set_storage_slots(vyper_module)
     )
 
-    return dict(**code_offsets, **storage_slots)
+    return {"storage_layout": storage_slots, "code_layout": code_offsets}
 
 
 class StorageAllocator:
@@ -104,7 +104,6 @@ def set_storage_slots_with_overrides(
 
             ret[variable_name] = {
                 "type": "nonreentrant lock",
-                "location": "storage",
                 "slot": reentrant_slot,
             }
         else:
@@ -133,7 +132,7 @@ def set_storage_slots_with_overrides(
             reserved_slots.reserve_slot_range(var_slot, storage_length, node.target.id)
             type_.set_position(StorageSlot(var_slot))
 
-            ret[node.target.id] = {"type": str(type_), "location": "storage", "slot": var_slot}
+            ret[node.target.id] = {"type": str(type_), "slot": var_slot}
         else:
             raise StorageLayoutException(
                 f"Could not find storage_slot for {node.target.id}. "
@@ -176,7 +175,6 @@ def set_storage_slots(vyper_module: vy_ast.Module) -> StorageLayout:
         # we nail down the format better
         ret[variable_name] = {
             "type": "nonreentrant lock",
-            "location": "storage",
             "slot": storage_slot,
         }
 
@@ -195,7 +193,7 @@ def set_storage_slots(vyper_module: vy_ast.Module) -> StorageLayout:
 
         # this could have better typing but leave it untyped until
         # we understand the use case better
-        ret[node.target.id] = {"type": str(type_), "location": "storage", "slot": storage_slot}
+        ret[node.target.id] = {"type": str(type_), "slot": storage_slot}
 
         # CMC 2021-07-23 note that HashMaps get assigned a slot here.
         # I'm not sure if it's safe to avoid allocating that slot
@@ -230,7 +228,6 @@ def set_code_offsets(vyper_module: vy_ast.Module) -> Dict:
         # we understand the use case better
         ret[node.target.id] = {
             "type": str(type_),
-            "location": "code",
             "offset": offset,
             "length": len_,
         }

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -230,7 +230,9 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
             try:
                 # block immutable if storage variable already exists
                 if name in self.namespace["self"].members:
-                    raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
+                    raise NamespaceCollision(
+                        f"Value '{name}' has already been declared", node
+                    ) from None
                 self.namespace[name] = type_definition
             except VyperException as exc:
                 raise exc.with_annotation(node) from None

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -228,6 +228,9 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
 
         if is_immutable:
             try:
+                # block immutable if storage variable already exists
+                if name in self.namespace["self"].members:
+                    raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
                 self.namespace[name] = type_definition
             except VyperException as exc:
                 raise exc.with_annotation(node) from None


### PR DESCRIPTION
### What I did
publish immutables layout. since the output is a single dict of variable names (see below for ex.), I was a bit concerned about collisions between immutables and storage variables, so I went ahead and blocked those.

```json
{"foo": {"type": "uint256", "location": "code", "offset": 0, "length": 32}, "x": {"type": "uint256", "location": "storage", "slot": 0}}
```

### How I did it
add code offsets dict to the `-f layout` output

### How to verify it
try
```vyper
vyper -f layout /dev/stdin <<EOF
x: uint256
y: immutable(uint256)
@external
def __init__():
    y = 1
EOF
```

### Commit message

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.download.ams.birds.cornell.edu/api/v1/asset/303616431/1800)
