### PR TITLE
fix: type inference on MemberFunction args

### DIFF
--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -755,7 +755,7 @@ def bounds_check_int128(ix: int128) -> uint256:
     assert_tx_failed(lambda: c.bounds_check_int128(-1))
 
 
-def test_list_check_heterogeneous_types(get_contract_with_gas_estimation, assert_compile_failed):
+def test_index_exception(get_contract_with_gas_estimation, assert_compile_failed):
     code = """
 @external
 def fail() -> uint256:
@@ -763,6 +763,7 @@ def fail() -> uint256:
     return xs[3]
     """
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), ArrayIndexException)
+
     code = """
 @external
 def fail() -> uint256:
@@ -888,6 +889,20 @@ my_array: DynArray[uint256, 5]
 def foo(xs: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
     for x in xs:
         self.my_array.append(x)
+    return self.my_array
+    """,
+        lambda xs: xs,
+    ),
+    (
+        """
+my_array: DynArray[uint256, 5]
+some_var: uint256
+@external
+def foo(xs: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
+    for x in xs:
+        self.some_var = x
+        # test that typechecker for append args works
+        self.my_array.append(self.some_var)
     return self.my_array
     """,
         lambda xs: xs,

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -137,9 +137,9 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
             for value, arg_type in zip(node.args[0].values, list(call_type.members.values())):
                 self.visit(value, arg_type)
         elif isinstance(call_type, MemberFunctionDefinition):
-            if node_type:
-                for arg in node.args:
-                    self.visit(arg, node_type.value_type)
+            assert len(node.args) == len(call_type.arg_types)
+            for arg, arg_type in zip(node.args, call_type.arg_types):
+                self.visit(arg, arg_type)
         elif node.func.id not in ("empty", "range"):
             # builtin functions
             for arg in node.args:

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -438,7 +438,6 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
     def visit_Expr(self, node):
         if not isinstance(node.value, vy_ast.Call):
-            # CMC 2022-04-01 this seems in the wrong place.
             raise StructureException("Expressions without assignment are disallowed", node)
 
         fn_type = get_exact_type_from_node(node.value.func)
@@ -463,6 +462,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         if isinstance(fn_type, MemberFunctionDefinition) and fn_type.is_modifying:
             fn_type.underlying_type.validate_modification(node, self.func.mutability)
 
+        # NOTE: fetch_call_return validates call args.
         return_value = fn_type.fetch_call_return(node.value)
         if (
             return_value


### PR DESCRIPTION
e.g.
```vyper
dyn_array.append(self.foo[msg.sender])
```

### What I did

### How I did it
fix the relevant case during type annotation. push down the known type from `MemberFunction.arg_types`.

### How to verify it
see tests -- note that the new test in https://github.com/vyperlang/vyper/pull/2769/commits/eb46e1ccfb1242dff475ea74427f90c804a70903 will fail before the fix applied in https://github.com/vyperlang/vyper/pull/2769/commits/39810f8ca3235ad338860a62299714b70bcc20d5.

### Commit message

### Description for the changelog

### Cute Animal Picture

(save the manatees)
![image](https://user-images.githubusercontent.com/3867501/162580106-13ab41a2-36be-48f8-b88d-12db04d9e191.png)

