### PR TITLE
optimize ceil32

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -878,8 +878,7 @@ def zero_pad(bytez_placeholder):
     #   followed by the *minimum* number of zero-bytes
     #   such that len(enc(X)) is a multiple of 32.
     # optimized form of ceil32(len) - len:
-    # num_zero_bytes = 32 - len % 32.
-    num_zero_bytes = ["sub", 32, ["and", "len", 31]]
+    num_zero_bytes = ["and", 31, ["sub", 0, "len"]]
     return IRnode.from_list(
         ["with", "len", len_, ["with", "dst", dst, mzero("dst", num_zero_bytes)]],
         annotation="Zero pad",

--- a/vyper/ir/README.md
+++ b/vyper/ir/README.md
@@ -338,4 +338,4 @@ def ceil32(x):
     return x if x % 32 == 0 else x + 32 - (x % 32)
 ```
 
-In IR, `(ceil32 x)` is equivalent to `(with x_ x (sub (add x_ 31) (mod (x_ 1) 32)))`
+In IR, `(ceil32 x)` is equivalent to `(and (add x 31) (not 31))`

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -753,24 +753,19 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
             break_dest,
             height,
         )
+
     # e.g. 95 -> 96, 96 -> 96, 97 -> 128
     elif code.value == "ceil32":
+        # floor32(x) = x - x % 32 == x & 0b11..100000 == x & (~31)
+        # ceil32(x) = floor32(x + 31) == (x + 31) & (~31)
         return _compile_to_assembly(
-            IRnode.from_list(
-                [
-                    "with",
-                    "_val",
-                    code.args[0],
-                    # in mod32 arithmetic, the solution to x + y == 32 is
-                    # y = bitwise_not(x) & 31
-                    ["add", "_val", ["and", ["not", ["sub", "_val", 1]], 31]],
-                ]
-            ),
+            IRnode.from_list(["and", ["add", o, 31], ["not", 31]]),
             withargs,
             existing_labels,
             break_dest,
             height,
         )
+
     # jump to a symbol, and push variable # of arguments onto stack
     elif code.value == "goto":
         o = []

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -758,8 +758,9 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
     elif code.value == "ceil32":
         # floor32(x) = x - x % 32 == x & 0b11..100000 == x & (~31)
         # ceil32(x) = floor32(x + 31) == (x + 31) & (~31)
+        x = code.args[0]
         return _compile_to_assembly(
-            IRnode.from_list(["and", ["add", o, 31], ["not", 31]]),
+            IRnode.from_list(["and", ["add", x, 31], ["not", 31]]),
             withargs,
             existing_labels,
             break_dest,


### PR DESCRIPTION
down from 9 to 6 instructions (all G_low)

also optimize out a couple instances of ceil32

### What I did
steal a couple easy optimizations out of https://github.com/vyperlang/vyper/pull/2647

### How I did it
note that `ceil32(x) == floor32(x + 31)`

### How to verify it
tests still pass

### Commit message

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/162864152-ca1eff91-781d-4506-9b30-6a1b674d6002.png)
