### PR TITLE
fix: bytesM literal validation

### DIFF
--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -320,6 +320,14 @@ def assign():
     """,
         InvalidType,
     ),
+    (
+        """
+@external
+def assign():
+    xs: bytes4 = 0x1234abcdef # bytes5 literal
+    """,
+        InvalidType,
+    ),
 ]
 
 

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -1,4 +1,6 @@
-from vyper.exceptions import TypeMismatch
+import pytest
+
+from vyper.exceptions import InvalidType, TypeMismatch
 
 
 def test_test_bytes(get_contract_with_gas_estimation, assert_tx_failed):
@@ -225,15 +227,35 @@ def test_bytes32_literals(get_contract):
     code = """
 @external
 def test() -> bool:
-    l: bytes32 = b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\xac\\x58\\xcd'  # noqa: E501
-    j: bytes32 = 0x0000000000000000000000000000000000000000000000000000000080ac58cd
-    return l == j
+    l: bytes32 = 0x0000000000000000000000000000000000000000000000000000000080ac58cd
+    return l == 0x0000000000000000000000000000000000000000000000000000000080ac58cd
 
     """
 
     c = get_contract(code)
 
     assert c.test() is True
+
+
+@pytest.mark.parametrize("m,val", [(2, b"ab"), (3, b"ab"), (3, b"abc")])
+def test_bytes_literals(get_contract, m, val):
+    vyper_literal = "0x" + val.ljust(m, b"\x00").hex()
+    code = f"""
+@external
+def test() -> bool:
+    l: bytes{m} = {vyper_literal}
+    return l == {vyper_literal}
+
+@external
+def test2(l: bytes{m} = {vyper_literal}) -> bool:
+    return l == {vyper_literal}
+    """
+
+    c = get_contract(code)
+
+    assert c.test() is True
+    assert c.test2() is True
+    assert c.test2(val) is True
 
 
 def test_zero_padding_with_private(get_contract):
@@ -272,11 +294,37 @@ def get_count() -> Bytes[24]:
     assert c.get_count() == b"\x01\x01\x01\x01\x01\x01\x01\x01"
 
 
-def test_bytes_to_bytes32_assigment(get_contract, assert_compile_failed):
-    code = """
+cases_invalid_assignments = [
+    (
+        """
 @external
 def assign():
-    xs: Bytes[32] = b'abcdef'
+    xs: Bytes[32] = b"abcdef"
     y: bytes32 = xs
+    """,
+        TypeMismatch,
+    ),
+    (
+        """
+@external
+def assign():
+    xs: bytes6 = b"abcdef"
+    """,
+        InvalidType,
+    ),
+    (
+        """
+@external
+def assign():
+    xs: bytes4 = 0xabcdef  # bytes3 literal
+    """,
+        InvalidType,
+    ),
+]
+
+
+@pytest.mark.parametrize("code,exc", cases_invalid_assignments)
+def test_invalid_assignments(get_contract, assert_compile_failed, code, exc):
+    code = """
     """
-    assert_compile_failed(lambda: get_contract(code), TypeMismatch)
+    assert_compile_failed(lambda: get_contract(code), exc)

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -325,6 +325,4 @@ def assign():
 
 @pytest.mark.parametrize("code,exc", cases_invalid_assignments)
 def test_invalid_assignments(get_contract, assert_compile_failed, code, exc):
-    code = """
-    """
     assert_compile_failed(lambda: get_contract(code), exc)

--- a/vyper/semantics/types/value/bytes_fixed.py
+++ b/vyper/semantics/types/value/bytes_fixed.py
@@ -21,12 +21,10 @@ class BytesMPrimitive(BasePrimitive):
     _length: int
 
     _as_array = True
-    _valid_literal = (vy_ast.Bytes, vy_ast.Hex)
+    _valid_literal = (vy_ast.Hex,)
 
     @classmethod
     def from_literal(cls, node: vy_ast.Constant) -> BaseTypeDefinition:
-        if isinstance(node, vy_ast.Bytes) and len(node.value) != cls._length:
-            raise InvalidLiteral("Invalid literal for type bytes32", node)
         if isinstance(node, vy_ast.Hex) and len(node.value) != 2 + 2 * cls._length:
             raise InvalidLiteral("Invalid literal for type bytes32", node)
         obj = super().from_literal(node)


### PR DESCRIPTION
fix https://github.com/vyperlang/vyper/issues/2778

bytesM cannot be assigned from Bytes[M] in the typechecker, but the
following literal assignment bypasses the typechecker rule:

```vyper
name: public(bytes6)

@external
def __init__():
    self.name = b"Celina"
```

### What I did

### How I did it
block interpretation of literal Bytes as bytes

### How to verify it
see tests

### Commit message

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
