### PR TITLE
fix bytes20 literals

### DIFF
--- a/tests/ast/nodes/test_hex.py
+++ b/tests/ast/nodes/test_hex.py
@@ -30,6 +30,9 @@ def foo():
     """
 foo: constant(bytes20) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,
+    """
+foo: constant(bytes4) = 0x12_34_56
+    """,
 ]
 
 

--- a/tests/ast/nodes/test_hex.py
+++ b/tests/ast/nodes/test_hex.py
@@ -1,30 +1,34 @@
 import pytest
 
 from vyper import ast as vy_ast
+from vyper import semantics
 from vyper.exceptions import InvalidLiteral
 
 code_invalid_checksum = [
     """
-foo: constant(address) = 0x6b175474e89094c44da98b954eedeac495271d0f
+foo: constant(address) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,
     """
-foo: constant(address[1]) = [0x6b175474e89094c44da98b954eedeac495271d0f]
-    """,
-    """
-@external
-def foo():
-    bar: address = 0x6b175474e89094c44da98b954eedeac495271d0f
+foo: constant(address[1]) = [0x6b175474e89094c44da98b954eedeac495271d0F]
     """,
     """
 @external
 def foo():
-    bar: address[1] = [0x6b175474e89094c44da98b954eedeac495271d0f]
+    bar: address = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,
     """
 @external
 def foo():
-    for i in [0x6b175474e89094c44da98b954eedeac495271d0f]:
+    bar: address[1] = [0x6b175474e89094c44da98b954eedeac495271d0F]
+    """,
+    """
+@external
+def foo():
+    for i in [0x6b175474e89094c44da98b954eedeac495271d0F]:
         pass
+    """,
+    """
+foo: constant(bytes20) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,
 ]
 
@@ -35,3 +39,4 @@ def test_invalid_checksum(code):
 
     with pytest.raises(InvalidLiteral):
         vy_ast.validation.validate_literal_nodes(vyper_module)
+        semantics.validate_semantics(vyper_module, {})

--- a/tests/functional/context/types/test_pure_types.py
+++ b/tests/functional/context/types/test_pure_types.py
@@ -32,7 +32,10 @@ PRIMITIVES = {
 VALID_LITERALS = {
     AddressPrimitive: ["0x6B175474E89094C44Da98b954EedeAC495271d0F"],
     BoolPrimitive: ["True", "False"],
-    Bytes32Primitive: ["0x6b175474e89094c44da98b954eedeac495271d0f4da98b954eedeac495271d0f", "0x6B175474E89094C44DA98B954EEDEAC495271D0F4DA98B954EEDEAC495271D0F"],
+    Bytes32Primitive: [
+        "0x6b175474e89094c44da98b954eedeac495271d0f4da98b954eedeac495271d0f",
+        "0x6B175474E89094C44DA98B954EEDEAC495271D0F4DA98B954EEDEAC495271D0F",
+    ],
     BytesArrayPrimitive: ["b''", "b'this is thirty three bytes long!!'", r"b'\xbe\xef'"],
     DecimalPrimitive: ["-1.666", "3.31337", "8008135.0", "1.2345678901"],
     Int128Primitive: ["-1", "0", "12", "42"],

--- a/tests/functional/context/types/test_pure_types.py
+++ b/tests/functional/context/types/test_pure_types.py
@@ -32,7 +32,7 @@ PRIMITIVES = {
 VALID_LITERALS = {
     AddressPrimitive: ["0x6B175474E89094C44Da98b954EedeAC495271d0F"],
     BoolPrimitive: ["True", "False"],
-    Bytes32Primitive: ["0x6B175474E89094C44Da98b954EedeAC495271d0F4Da98b954EedeAC495271d0F"],
+    Bytes32Primitive: ["0x6b175474e89094c44da98b954eedeac495271d0f4da98b954eedeac495271d0f", "0x6B175474E89094C44DA98B954EEDEAC495271D0F4DA98B954EEDEAC495271D0F"],
     BytesArrayPrimitive: ["b''", "b'this is thirty three bytes long!!'", r"b'\xbe\xef'"],
     DecimalPrimitive: ["-1.666", "3.31337", "8008135.0", "1.2345678901"],
     Int128Primitive: ["-1", "0", "12", "42"],

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -650,7 +650,7 @@ def foo() -> {o_typ}:
     if o_typ.startswith("bytes"):
         skip_c1 = True
 
-    #if o_typ in ("address", "bytes20"):
+    # if o_typ in ("address", "bytes20"):
     #    skip_c1 = True
 
     if not skip_c1:

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -486,11 +486,6 @@ def test_convert() -> {o_typ}:
         # type of arg is inferrred to be bytes20
         c1_exception = InvalidType
 
-    if i_typ == "bytes20":
-        # Skip because raw bytes20 is treated as address
-        # revisit when bytes20 works.
-        skip_c1 = True
-
     if c1_exception is not None:
         assert_compile_failed(lambda: get_contract_with_gas_estimation(contract_1), c1_exception)
     elif not skip_c1:
@@ -515,11 +510,8 @@ def test_state_variable_convert() -> {o_typ}:
     return convert(self.bar, {o_typ})
     """
 
-    skip_c3 = i_typ == "bytes20"  # literals do not work
-
-    if not skip_c3:
-        c3 = get_contract_with_gas_estimation(contract_3)
-        assert c3.test_state_variable_convert() == expected_val
+    c3 = get_contract_with_gas_estimation(contract_3)
+    assert c3.test_state_variable_convert() == expected_val
 
     contract_4 = f"""
 @external
@@ -669,11 +661,8 @@ def foo():
     foobar: {o_typ} = convert(bar, {o_typ})
     """
 
-    skip_c2 = i_typ == "bytes20"  # can't handle bytes20 literals
-
-    if not skip_c2:
-        c2 = get_contract_with_gas_estimation(contract_2)
-        assert_tx_failed(lambda: c2.foo())
+    c2 = get_contract_with_gas_estimation(contract_2)
+    assert_tx_failed(lambda: c2.foo())
 
     contract_3 = f"""
 @external

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -488,6 +488,10 @@ def test_convert() -> {o_typ}:
     if i_typ == "bytes20" and is_checksum_encoded(_vyper_literal(val, "bytes20")):
         skip_c1 = True
 
+    # typechecker inference borked, ambiguity with bytes20
+    if i_typ == "address" and o_typ == "bytes20" and val == val.lower():
+        skip_c1 = True
+
     if c1_exception is not None:
         assert_compile_failed(lambda: get_contract_with_gas_estimation(contract_1), c1_exception)
     elif not skip_c1:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -774,6 +774,8 @@ class Hex(Constant):
     def validate(self):
         if len(self.value) % 2:
             raise InvalidLiteral("Hex notation requires an even number of digits", self)
+        if "_" in self.value:
+            raise InvalidLiteral("Underscores not allowed in hex literals", self)
 
 
 class Str(Constant):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -774,12 +774,6 @@ class Hex(Constant):
     def validate(self):
         if len(self.value) % 2:
             raise InvalidLiteral("Hex notation requires an even number of digits", self)
-        if len(self.value) == 42 and checksum_encode(self.value) != self.value:
-            raise InvalidLiteral(
-                "Address checksum mismatch. If you are sure this is the right "
-                f"address, the correct checksummed form is: {checksum_encode(self.value)}",
-                self,
-            )
 
 
 class Str(Constant):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -15,7 +15,7 @@ from vyper.exceptions import (
     UnfoldableNode,
     ZeroDivisionException,
 )
-from vyper.utils import MAX_DECIMAL_PLACES, SizeLimits, annotate_source_code, checksum_encode
+from vyper.utils import MAX_DECIMAL_PLACES, SizeLimits, annotate_source_code
 
 NODE_BASE_ATTRIBUTES = (
     "_children",

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -24,12 +24,12 @@ from vyper.codegen.types import (
     DArrayType,
     InterfaceType,
     MappingType,
-    is_bytes_m_type,
     SArrayType,
     StringType,
     StructType,
     TupleType,
     is_base_type,
+    is_bytes_m_type,
     is_numeric_type,
 )
 from vyper.codegen.types.convert import new_type_to_old_type

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -42,7 +42,13 @@ from vyper.exceptions import (
     TypeMismatch,
     UnimplementedException,
 )
-from vyper.utils import DECIMAL_DIVISOR, SizeLimits, bytes_to_int, is_checksum_encoded, string_to_bytes
+from vyper.utils import (
+    DECIMAL_DIVISOR,
+    SizeLimits,
+    bytes_to_int,
+    is_checksum_encoded,
+    string_to_bytes,
+)
 
 ENVIRONMENT_VARIABLES = {
     "block",

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -42,7 +42,7 @@ from vyper.exceptions import (
     TypeMismatch,
     UnimplementedException,
 )
-from vyper.utils import DECIMAL_DIVISOR, SizeLimits, bytes_to_int, checksum_encode, string_to_bytes
+from vyper.utils import DECIMAL_DIVISOR, SizeLimits, bytes_to_int, is_checksum_encoded, string_to_bytes
 
 ENVIRONMENT_VARIABLES = {
     "block",
@@ -220,7 +220,7 @@ class Expr:
 
         if is_base_type(inferred_type, "address"):
             # sanity check typechecker did its job
-            assert len(hexstr) == 42 and checksum_encode(hexstr) == hexstr
+            assert len(hexstr) == 42 and is_checksum_encoded(hexstr)
             typ = BaseType("address")
             return IRnode.from_list(int(self.expr.value, 16), typ=typ)
 

--- a/vyper/semantics/types/value/address.py
+++ b/vyper/semantics/types/value/address.py
@@ -1,6 +1,6 @@
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Address, ABIType
-from vyper.exceptions import CompilerPanic, InvalidLiteral
+from vyper.exceptions import InvalidLiteral
 from vyper.utils import checksum_encode
 
 from ..bases import BasePrimitive, MemberTypeDefinition, ValueTypeDefinition
@@ -37,7 +37,7 @@ class AddressPrimitive(BasePrimitive):
         addr = node.value
         if len(addr) != 42:
             n_bytes = (len(addr) - 2) // 2
-            raise InvalidLiteral("Invalid address. Expected 20 bytes, got {n_bytes}.", node)
+            raise InvalidLiteral(f"Invalid address. Expected 20 bytes, got {n_bytes}.", node)
 
         if checksum_encode(addr) != addr:
             raise InvalidLiteral(

--- a/vyper/semantics/types/value/address.py
+++ b/vyper/semantics/types/value/address.py
@@ -36,8 +36,14 @@ class AddressPrimitive(BasePrimitive):
         super().from_literal(node)
         addr = node.value
         if len(addr) != 42:
-            raise InvalidLiteral("Invalid literal for type 'address'", node)
+            n_bytes = (len(addr) - 2) // 2
+            raise InvalidLiteral("Invalid address. Expected 20 bytes, got {n_bytes}.", node)
+
         if checksum_encode(addr) != addr:
-            # this should have been caught in `vyper.ast.nodes.Hex.validate`
-            raise CompilerPanic("Address checksum mismatch")
+            raise InvalidLiteral(
+                "Address checksum mismatch. If you are sure this is the right "
+                f"address, the correct checksummed form is: {checksum_encode(addr)}",
+                node,
+            )
+
         return AddressDefinition()

--- a/vyper/semantics/types/value/address.py
+++ b/vyper/semantics/types/value/address.py
@@ -1,7 +1,7 @@
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Address, ABIType
 from vyper.exceptions import InvalidLiteral
-from vyper.utils import checksum_encode
+from vyper.utils import checksum_encode, is_checksum_encoded
 
 from ..bases import BasePrimitive, MemberTypeDefinition, ValueTypeDefinition
 from .array_value import BytesArrayDefinition
@@ -39,7 +39,7 @@ class AddressPrimitive(BasePrimitive):
             n_bytes = (len(addr) - 2) // 2
             raise InvalidLiteral(f"Invalid address. Expected 20 bytes, got {n_bytes}.", node)
 
-        if checksum_encode(addr) != addr:
+        if not is_checksum_encoded(addr):
             raise InvalidLiteral(
                 "Address checksum mismatch. If you are sure this is the right "
                 f"address, the correct checksummed form is: {checksum_encode(addr)}",

--- a/vyper/semantics/types/value/bytes_fixed.py
+++ b/vyper/semantics/types/value/bytes_fixed.py
@@ -25,9 +25,17 @@ class BytesMPrimitive(BasePrimitive):
 
     @classmethod
     def from_literal(cls, node: vy_ast.Constant) -> BaseTypeDefinition:
-        if isinstance(node, vy_ast.Hex) and len(node.value) != 2 + 2 * cls._length:
-            raise InvalidLiteral("Invalid literal for type bytes32", node)
         obj = super().from_literal(node)
+        val = node.value
+        m = cls._length
+
+        if len(val) != 2 + 2 * m:
+            raise InvalidLiteral("Invalid literal for type bytes32", node)
+
+        nibbles = val[2:]  # strip leading 0x
+        if nibbles not in (nibbles.lower(), nibbles.upper()):
+            raise InvalidLiteral(f"Cannot mix uppercase and lowercase for bytes{m} literal", node)
+
         return obj
 
 

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -164,6 +164,10 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
             self.visit(node.right, type_)
 
     def visit_Constant(self, node, type_):
+        if type_ is None:
+            possible_types = get_possible_types_from_node(node)
+            if len(possible_types) == 1:
+                type_ = possible_types.pop()
         node._metadata["type"] = type_
 
     def visit_Dict(self, node, type_):
@@ -175,6 +179,8 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_List(self, node, type_):
         if type_ is None:
             type_ = get_possible_types_from_node(node)
+            # CMC 2022-04-14 this seems sus. try to only annotate
+            # if get_possible_types only returns 1 type
             if len(type_) >= 1:
                 type_ = type_.pop()
         node._metadata["type"] = type_

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -115,6 +115,10 @@ def bytes_to_int(bytez):
     return o
 
 
+def is_checksum_encoded(addr):
+    return addr == checksum_encode(addr)
+
+
 # Encodes an address using ethereum's checksum scheme
 def checksum_encode(addr):  # Expects an input of the form 0x<40 hex chars>
     assert addr[:2] == "0x" and len(addr) == 42, addr


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/2780

also fix https://github.com/vyperlang/vyper/issues/2790 by blocking underscores in hex literals.

### How I did it
propagate more type info down into codegen. note the bandaid in expr.py due to type annotations sometimes missing.

### How to verify it
see tests

### Commit message


### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/163435667-bf76ba6d-b5ff-46a7-81c9-d097436b0644.png)
