### PR TITLE
add additional tests for recently added behavior

### DIFF
--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -99,9 +99,9 @@ def foo(s: bytes{n}) -> bytes{n}:
 @pytest.mark.parametrize("n", list(range(1, 32)))  # bytes32 always passes
 def test_bytes_m_clamper_failing(w3, get_contract, assert_tx_failed, n, evm_version):
     values = []
-    values.append(b"\x00" * n + b"\x80") # just one bit set
-    values.append(b"\xff" * n + b"\x80") # n*8 + 1 bits set
-    values.append(b"\x00" * 31 + b"\x01") # bytes32
+    values.append(b"\x00" * n + b"\x80")  # just one bit set
+    values.append(b"\xff" * n + b"\x80")  # n*8 + 1 bits set
+    values.append(b"\x00" * 31 + b"\x01")  # bytes32
     values.append(b"\xff" * 32)  # bytes32
     values.append(bytes(range(32)))  # 0x00010203..1f
     values.append(bytes(range(1, 33)))  # 0x01020304..a0
@@ -138,11 +138,11 @@ def foo(s: int{bits}) -> int{bits}:
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-@pytest.mark.parametrize("n", list(range(31))) # int256 does not clamp
+@pytest.mark.parametrize("n", list(range(31)))  # int256 does not clamp
 def test_sint_clamper_failing(w3, assert_tx_failed, get_contract, n, evm_version):
     bits = 8 * (n + 1)
     lo, hi = int_bounds(True, bits)
-    values = [-2 ** 255, 2 ** 255 - 1, lo - 1, hi + 1]
+    values = [-(2 ** 255), 2 ** 255 - 1, lo - 1, hi + 1]
     code = f"""
 @external
 def foo(s: int{bits}) -> int{bits}:
@@ -184,7 +184,7 @@ def foo(s: bool) -> bool:
 @pytest.mark.parametrize("n", list(range(32)))
 def test_uint_clamper_passing(w3, get_contract, evm_version, n):
     bits = 8 * (n + 1)
-    values = [0, 1, 2**bits - 1]
+    values = [0, 1, 2 ** bits - 1]
     code = f"""
 @external
 def foo(s: uint{bits}) -> uint{bits}:
@@ -200,7 +200,7 @@ def foo(s: uint{bits}) -> uint{bits}:
 @pytest.mark.parametrize("n", list(range(31)))  # uint256 has no failing cases
 def test_uint_clamper_failing(w3, assert_tx_failed, get_contract, evm_version, n):
     bits = 8 * (n + 1)
-    values = [-1, -2**255, 2**bits]
+    values = [-1, -(2 ** 255), 2 ** bits]
     code = f"""
 @external
 def foo(s: uint{bits}) -> uint{bits}:

--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -4,6 +4,7 @@ import pytest
 from eth_utils import keccak
 
 from vyper.evm.opcodes import EVM_VERSIONS
+from vyper.utils import int_bounds
 
 
 def _make_tx(w3, address, signature, values):
@@ -79,29 +80,37 @@ def get_foo() -> Bytes[3]:
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-@pytest.mark.parametrize("value", [0, 1, -1, 2 ** 127 - 1, -(2 ** 127)])
-def test_int128_clamper_passing(w3, get_contract, value, evm_version):
-    code = """
+@pytest.mark.parametrize("n", list(range(32)))
+def test_sint_clamper_passing(w3, get_contract, n, evm_version):
+    bits = 8 * (n + 1)
+    lo, hi = int_bounds(True, bits)
+    values = [-1, 0, 1, lo, hi]
+    code = f"""
 @external
-def foo(s: int128) -> int128:
+def foo(s: int{bits}) -> int{bits}:
     return s
     """
 
     c = get_contract(code, evm_version=evm_version)
-    assert c.foo(value) == value
+    for v in values:
+        assert c.foo(v) == v
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-@pytest.mark.parametrize("value", [2 ** 127, -(2 ** 127) - 1, 2 ** 255 - 1, -(2 ** 255)])
-def test_int128_clamper_failing(w3, assert_tx_failed, get_contract, value, evm_version):
-    code = """
+@pytest.mark.parametrize("n", list(range(31))) # int256 does not clamp
+def test_sint_clamper_failing(w3, assert_tx_failed, get_contract, n, evm_version):
+    bits = 8 * (n + 1)
+    lo, hi = int_bounds(True, bits)
+    values = [-2 ** 255, 2 ** 255 - 1, lo - 1, hi + 1]
+    code = f"""
 @external
-def foo(s: int128) -> int128:
+def foo(s: int{bits}) -> int{bits}:
     return s
     """
 
     c = get_contract(code, evm_version=evm_version)
-    assert_tx_failed(lambda: _make_tx(w3, c.address, "foo(int128)", [value]))
+    for v in values:
+        assert_tx_failed(lambda: _make_tx(w3, c.address, f"foo(int{bits})", [v]))
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -395,8 +395,12 @@ def test_ok() -> Bytes[2]:
     return self.foo.ok()
 
 @external
-def test_fail() -> Bytes[3]:
+def test_fail1() -> Bytes[3]:
     return self.foo.should_fail()
+
+@external
+def test_fail2() -> Bytes[3]:
+    return concat(self.foo.should_fail(), b"")
     """
 
     bad_c = get_contract(external_contract)
@@ -405,7 +409,8 @@ def test_fail() -> Bytes[3]:
     assert bad_c.should_fail() == b"123"
 
     assert c.test_ok() == b"12"
-    assert_tx_failed(lambda: c.test_fail())
+    assert_tx_failed(lambda: c.test_fail1())
+    assert_tx_failed(lambda: c.test_fail2())
 
 
 # test data returned from external interface gets clamped


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message
```
add additional tests for recently fixed and added behavior.

tests include:
- validation of returndata inside concat (cf. 049dbdc647b2ce83)
- signed/unsigned integer clamps
- bytes_m clamps
```

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/163466546-23c588df-885e-460a-be3d-4166cf603d83.png)

