### PR TITLE
fix order of literal hex validation rules

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -772,10 +772,10 @@ class Hex(Constant):
     _translated_fields = {"n": "value"}
 
     def validate(self):
-        if len(self.value) % 2:
-            raise InvalidLiteral("Hex notation requires an even number of digits", self)
         if "_" in self.value:
             raise InvalidLiteral("Underscores not allowed in hex literals", self)
+        if len(self.value) % 2:
+            raise InvalidLiteral("Hex notation requires an even number of digits", self)
 
 
 class Str(Constant):


### PR DESCRIPTION
It's more user friendly to complain about the underscores first

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/163472608-ba1adb27-e820-44ec-80b2-8b5f79e99646.png)
