### PR TITLE
fix: block struct literals with keys out of order

### DIFF
--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -1,3 +1,5 @@
+from vyper.exceptions import InvalidAttribute
+
 def test_multi_setter_test(get_contract_with_gas_estimation):
     multi_setter_test = """
 dog: int128[3]
@@ -145,7 +147,7 @@ def gop() -> int128:
     assert c.gop() == 87198763254321
 
 
-def test_struct_assignment_order(get_contract_with_gas_estimation):
+def test_struct_assignment_order(get_contract, assert_compile_failed):
     code = """
 struct Foo:
     a: uint256
@@ -153,18 +155,11 @@ struct Foo:
 
 @external
 @view
-def test1() -> uint256:
-    foo: Foo = Foo({a: 297, b: 2})
-    return foo.a
-
-@external
-@view
 def test2() -> uint256:
     foo: Foo = Foo({b: 2, a: 297})
     return foo.a
     """
-    c = get_contract_with_gas_estimation(code)
-    assert c.test1() == c.test2() == 297
+    assert_compile_failed(lambda: get_contract(code), InvalidAttribute)
 
 
 def test_type_converter_setter_test(get_contract_with_gas_estimation):

--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -1,5 +1,6 @@
 from vyper.exceptions import InvalidAttribute
 
+
 def test_multi_setter_test(get_contract_with_gas_estimation):
     multi_setter_test = """
 dog: int128[3]

--- a/tests/parser/syntax/test_ann_assign.py
+++ b/tests/parser/syntax/test_ann_assign.py
@@ -3,6 +3,7 @@ from pytest import raises
 
 from vyper import compiler
 from vyper.exceptions import (
+    InvalidAttribute,
     InvalidType,
     UndeclaredDefinition,
     UnknownAttribute,
@@ -70,7 +71,29 @@ struct S:
     b: decimal
 @external
 def foo() -> int128:
-    s: S = S({b: 1.2, c: 1, d: 33, e: 55})
+    s: S = S({a: 1})
+    """,
+        VariableDeclarationException,
+    ),
+    (
+        """
+struct S:
+    a: int128
+    b: decimal
+@external
+def foo() -> int128:
+    s: S = S({b: 1.2, a: 1})
+    """,
+        InvalidAttribute,
+    ),
+    (
+        """
+struct S:
+    a: int128
+    b: decimal
+@external
+def foo() -> int128:
+    s: S = S({a: 1, b: 1.2, c: 1, d: 33, e: 55})
     return s.a
     """,
         UnknownAttribute,
@@ -107,12 +130,8 @@ def foo() -> bool:
 
 @pytest.mark.parametrize("bad_code", fail_list)
 def test_as_wei_fail(bad_code):
-    if isinstance(bad_code, tuple):
-        with raises(bad_code[1]):
-            compiler.compile_code(bad_code[0])
-    else:
-        with raises(VariableDeclarationException):
-            compiler.compile_code(bad_code)
+    with raises(bad_code[1]):
+        compiler.compile_code(bad_code[0])
 
 
 valid_list = [

--- a/tests/parser/syntax/test_no_none.py
+++ b/tests/parser/syntax/test_no_none.py
@@ -190,15 +190,6 @@ struct Mom:
 
 @external
 def foo():
-    mom: Mom = Mom({b: None, a: 0})
-    """,
-        """
-struct Mom:
-    a: uint256
-    b: int128
-
-@external
-def foo():
     mom: Mom = Mom({a: None, b: None})
     """,
     ]

--- a/vyper/codegen/abi_encoder.py
+++ b/vyper/codegen/abi_encoder.py
@@ -17,9 +17,6 @@ def _deconstruct_complex_type(ir_node):
     ir_t = ir_node.typ
     assert isinstance(ir_t, (TupleLike, SArrayType))
 
-    if ir_node.value == "multi":  # is literal
-        return ir_node.args
-
     if isinstance(ir_t, TupleLike):
         ks = ir_t.tuple_keys()
     else:
@@ -155,7 +152,6 @@ def abi_encoding_matches_vyper(typ):
 # the abi_encode routine will push the output len onto the stack,
 # otherwise it will return 0 items to the stack.
 def abi_encode(dst, ir_node, context, bufsz, returns_len=False):
-
     dst = IRnode.from_list(dst, typ=ir_node.typ, location=MEMORY)
     abi_t = dst.typ.abi_type
     size_bound = abi_t.size_bound()


### PR DESCRIPTION
### What I did
the following example generated incorrect code:
```vyper
struct A:
    a: uint256
    b: uint256

@external
def foo() -> A
    return A({b: 2, a: 1})  # returns (1, 2) instead of (2, 1)
```

After this commit, this code should raise `InvalidAttribute`.

### How I did it
In order to handle out of order keys in a sane way, we would be required
to change the order of execution. Assuming that keys being out of order
from the type definition is a code smell, block the behavior during
semantic analysis.

Also remove some dead code

(Note: unexpected order of execution was used for the first place of the underhanded solidity contest this year: https://blog.soliditylang.org/2022/04/09/announcing-the-underhanded-contest-winners-2022/.)

### How to verify it
see test update

### Commit message

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/163652540-5bfd44ca-5ea5-4692-9099-ec329dbb419b.png)

