### PR TITLE
Better error message for unsupported kwargs in function calls

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -1495,6 +1495,14 @@ interface Bar:
 def foo(a: address):
     Bar(a).bar(1)
     """,
+    """
+interface Bar:
+    def bar(x: uint256, y: uint256) -> uint256: view
+
+@external
+def foo(a: address, x: uint256, y: uint256):
+    Bar(a).bar(x, y=y)
+    """,
 ]
 
 

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -449,6 +449,15 @@ def bar(a: int128) -> int128:
 def foo() -> int128:
     return self.bar(1, 2)
     """,
+    """
+@internal
+def _foo(x: uint256, y: uint256 = 1):
+    pass
+
+@external
+def foo(x: uint256, y: uint256):
+    self._foo(x, y=y)
+    """,
 ]
 
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -469,16 +469,13 @@ class ContractFunction(BaseTypeDefinition):
                 if not isinstance(kwarg.value, vy_ast.NameConstant):
                     raise InvalidType("skip_contract_check must be literal bool", kwarg.value)
             else:
-                if not isinstance(kwarg.arg, vy_ast.VyperNode):
-                    raise ArgumentException(
-                        (
-                            "Usage of kwarg in Vyper is restricted to gas=, "
-                            "value= and skip_contract_check="
-                        ),
-                        kwarg.value,
-                    )
-                # To preserve for future kwargs (?)
-                validate_expected_type(kwarg.arg, kwarg.value)
+                raise ArgumentException(
+                    (
+                        "Usage of kwarg in Vyper is restricted to gas=, "
+                        "value= and skip_contract_check="
+                    ),
+                    kwarg.value,
+                )
 
         return self.return_type
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
@@ -469,10 +470,20 @@ class ContractFunction(BaseTypeDefinition):
                 if not isinstance(kwarg.value, vy_ast.NameConstant):
                     raise InvalidType("skip_contract_check must be literal bool", kwarg.value)
             else:
+                kwarg_pattern = fr"{kwarg.arg}\s*=\s*{re.escape(kwarg.value.node_source_code)}"
+                modified_line = re.sub(
+                    kwarg_pattern, kwarg.value.node_source_code, node.node_source_code
+                )
+                error_suggestion = (
+                    f"\n(hint: Try removing the kwarg: `{modified_line}`)"
+                    if modified_line != node.node_source_code
+                    else ""
+                )
+
                 raise ArgumentException(
                     (
                         "Usage of kwarg in Vyper is restricted to gas=, "
-                        "value= and skip_contract_check="
+                        f"value= and skip_contract_check=. {error_suggestion}"
                     ),
                     kwarg,
                 )

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -470,6 +470,8 @@ class ContractFunction(BaseTypeDefinition):
                 if not isinstance(kwarg.value, vy_ast.NameConstant):
                     raise InvalidType("skip_contract_check must be literal bool", kwarg.value)
             else:
+                # Generate the modified source code string with the kwarg removed
+                # as a suggestion to the user.
                 kwarg_pattern = fr"{kwarg.arg}\s*=\s*{re.escape(kwarg.value.node_source_code)}"
                 modified_line = re.sub(
                     kwarg_pattern, kwarg.value.node_source_code, node.node_source_code

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -477,6 +477,8 @@ class ContractFunction(BaseTypeDefinition):
                         ),
                         kwarg.value,
                     )
+                # To preserve for future kwargs (?)
+                validate_expected_type(kwarg.arg, kwarg.value)
 
         return self.return_type
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -469,7 +469,14 @@ class ContractFunction(BaseTypeDefinition):
                 if not isinstance(kwarg.value, vy_ast.NameConstant):
                     raise InvalidType("skip_contract_check must be literal bool", kwarg.value)
             else:
-                validate_expected_type(kwarg.arg, kwarg.value)
+                if not isinstance(kwarg.arg, vy_ast.VyperNode):
+                    raise ArgumentException(
+                        (
+                            "Usage of kwarg in Vyper is restricted to gas=, "
+                            "value= and skip_contract_check="
+                        ),
+                        kwarg.value,
+                    )
 
         return self.return_type
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -474,7 +474,7 @@ class ContractFunction(BaseTypeDefinition):
                         "Usage of kwarg in Vyper is restricted to gas=, "
                         "value= and skip_contract_check="
                     ),
-                    kwarg.value,
+                    kwarg,
                 )
 
         return self.return_type


### PR DESCRIPTION
### What I did

Fix for #2525 

### How I did it

Throw an `ArgumentException` error during validation of kwargs other than `gas`, `value` and `skip_contract_check`.

### How to verify it

See tests.

### Commit message

Better error message for unsupported kwargs in function calls.

### Description for the changelog

Better error message for unsupported kwargs in function calls.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSPXq3YT76s7GknLyyHRp_PNEFKl0o_Z-uyAQ&usqp=CAU)
