### PR TITLE
Use levenshtein distance for better error messages

### DIFF
--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -7,6 +7,7 @@ from vyper.exceptions import (
     StructureException,
     UndeclaredDefinition,
 )
+from vyper.utils import levenshtein_norm
 
 
 class Namespace(dict):
@@ -42,7 +43,10 @@ class Namespace(dict):
 
     def __getitem__(self, key):
         if key not in self:
-            raise UndeclaredDefinition(f"'{key}' has not been declared")
+            distances = sorted([(i, levenshtein_norm(key, i)) for i in self], key=lambda k: k[1])
+            raise UndeclaredDefinition(
+                f"'{key}' has not been declared. Did you mean {distances[0][0]}?"
+            )
         return super().__getitem__(key)
 
     def __enter__(self):

--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -7,7 +7,7 @@ from vyper.exceptions import (
     StructureException,
     UndeclaredDefinition,
 )
-from vyper.utils import levenshtein_norm
+from vyper.utils import get_levenshtein_string
 
 
 class Namespace(dict):
@@ -43,10 +43,8 @@ class Namespace(dict):
 
     def __getitem__(self, key):
         if key not in self:
-            distances = sorted([(i, levenshtein_norm(key, i)) for i in self], key=lambda k: k[1])
-            raise UndeclaredDefinition(
-                f"'{key}' has not been declared. Did you mean {distances[0][0]}?"
-            )
+            levenshtein_string = get_levenshtein_string(key, self, 0.2)
+            raise UndeclaredDefinition(f"'{key}' has not been declared.{levenshtein_string}")
         return super().__getitem__(key)
 
     def __enter__(self):

--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -7,7 +7,7 @@ from vyper.exceptions import (
     StructureException,
     UndeclaredDefinition,
 )
-from vyper.utils import get_levenshtein_string
+from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 
 
 class Namespace(dict):
@@ -43,8 +43,8 @@ class Namespace(dict):
 
     def __getitem__(self, key):
         if key not in self:
-            levenshtein_string = get_levenshtein_string(key, self, 0.2)
-            raise UndeclaredDefinition(f"'{key}' has not been declared.{levenshtein_string}")
+            suggestions_str = get_levenshtein_error_suggestions(key, self, 0.2)
+            raise UndeclaredDefinition(f"'{key}' has not been declared. {suggestions_str}")
         return super().__getitem__(key)
 
     def __enter__(self):

--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -18,7 +18,7 @@ from vyper.exceptions import (
     UnknownAttribute,
 )
 from vyper.semantics.types.abstract import AbstractDataType
-from vyper.utils import get_levenshtein_string
+from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 
 
 class DataLocation(Enum):
@@ -586,8 +586,8 @@ class MemberTypeDefinition(BaseTypeDefinition):
             type_.location = self.location
             type_.is_constant = self.is_constant
             return type_
-        levenshtein_string = get_levenshtein_string(key, self.members, 0.2)
-        raise UnknownAttribute(f"{self} has no member '{key}'.{levenshtein_string}", node)
+        suggestions_str = get_levenshtein_error_suggestions(key, self.members, 0.3)
+        raise UnknownAttribute(f"{self} has no member '{key}'. {suggestions_str}", node)
 
     def __repr__(self):
         return f"{self._id}"

--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -18,7 +18,7 @@ from vyper.exceptions import (
     UnknownAttribute,
 )
 from vyper.semantics.types.abstract import AbstractDataType
-from vyper.utils import levenshtein_norm
+from vyper.utils import get_levenshtein_string
 
 
 class DataLocation(Enum):
@@ -586,12 +586,8 @@ class MemberTypeDefinition(BaseTypeDefinition):
             type_.location = self.location
             type_.is_constant = self.is_constant
             return type_
-        distances = sorted(
-            [(i, levenshtein_norm(key, i)) for i in self.members], key=lambda k: k[1]
-        )
-        raise UnknownAttribute(
-            f"{self} has no member '{key}'. Did you mean '{distances[0][0]}'?", node
-        )
+        levenshtein_string = get_levenshtein_string(key, self.members, 0.2)
+        raise UnknownAttribute(f"{self} has no member '{key}'.{levenshtein_string}", node)
 
     def __repr__(self):
         return f"{self._id}"

--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -18,6 +18,7 @@ from vyper.exceptions import (
     UnknownAttribute,
 )
 from vyper.semantics.types.abstract import AbstractDataType
+from vyper.utils import levenshtein_norm
 
 
 class DataLocation(Enum):
@@ -585,7 +586,12 @@ class MemberTypeDefinition(BaseTypeDefinition):
             type_.location = self.location
             type_.is_constant = self.is_constant
             return type_
-        raise UnknownAttribute(f"{self} has no member '{key}'", node)
+        distances = sorted(
+            [(i, levenshtein_norm(key, i)) for i in self.members], key=lambda k: k[1]
+        )
+        raise UnknownAttribute(
+            f"{self} has no member '{key}'. Did you mean '{distances[0][0]}'?", node
+        )
 
     def __repr__(self):
         return f"{self._id}"

--- a/vyper/semantics/types/user/struct.py
+++ b/vyper/semantics/types/user/struct.py
@@ -14,8 +14,8 @@ from vyper.semantics.namespace import validate_identifier
 from vyper.semantics.types.bases import DataLocation, MemberTypeDefinition, ValueTypeDefinition
 from vyper.semantics.types.indexable.mapping import MappingDefinition
 from vyper.semantics.types.utils import get_type_from_annotation
+from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.validation.utils import validate_expected_type
-from vyper.utils import get_levenshtein_string
 
 
 class StructDefinition(MemberTypeDefinition, ValueTypeDefinition):
@@ -98,9 +98,9 @@ class StructPrimitive:
         keys = list(self.members.keys())
         for i, (key, value) in enumerate(zip(node.args[0].keys, node.args[0].values)):
             if key is None or key.get("id") not in members:
-                levenshtein_string = get_levenshtein_string(key.get("id"), members, 1.0)
+                suggestions_str = get_levenshtein_error_suggestions(key.get("id"), members, 1.0)
                 raise UnknownAttribute(
-                    f"Unknown or duplicate struct member.{levenshtein_string}",
+                    f"Unknown or duplicate struct member. {suggestions_str}",
                     key or value,
                 )
             expected_key = keys[i]

--- a/vyper/semantics/types/user/struct.py
+++ b/vyper/semantics/types/user/struct.py
@@ -15,7 +15,7 @@ from vyper.semantics.types.bases import DataLocation, MemberTypeDefinition, Valu
 from vyper.semantics.types.indexable.mapping import MappingDefinition
 from vyper.semantics.types.utils import get_type_from_annotation
 from vyper.semantics.validation.utils import validate_expected_type
-from vyper.utils import levenshtein_norm
+from vyper.utils import get_levenshtein_string
 
 
 class StructDefinition(MemberTypeDefinition, ValueTypeDefinition):
@@ -98,11 +98,9 @@ class StructPrimitive:
         keys = list(self.members.keys())
         for i, (key, value) in enumerate(zip(node.args[0].keys, node.args[0].values)):
             if key is None or key.get("id") not in members:
-                distances = sorted(
-                    [(i, levenshtein_norm(key.get("id"), i)) for i in members], key=lambda k: k[1]
-                )
+                levenshtein_string = get_levenshtein_string(key.get("id"), members, 1.0)
                 raise UnknownAttribute(
-                    f"Unknown or duplicate struct member. Did you mean '{distances[0][0]}'?",
+                    f"Unknown or duplicate struct member.{levenshtein_string}",
                     key or value,
                 )
             expected_key = keys[i]

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -14,7 +14,7 @@ from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.bases import BaseTypeDefinition, DataLocation
 from vyper.semantics.types.indexable.sequence import ArrayDefinition, TupleDefinition
 from vyper.semantics.validation.utils import get_exact_type_from_node, get_index_value
-from vyper.utils import levenshtein_norm
+from vyper.utils import get_levenshtein_string
 
 
 class StringEnum(enum.Enum):
@@ -155,11 +155,9 @@ def get_type_from_annotation(
     try:
         type_obj = namespace[type_name]
     except UndeclaredDefinition:
-        distances = sorted(
-            [(i, levenshtein_norm(type_name, i)) for i in namespace], key=lambda k: k[1]
-        )
+        levenshtein_string = get_levenshtein_string(type_name, namespace, 0.2)
         raise UnknownType(
-            f"No builtin or user-defined type named '{type_name}'. Did you mean {distances[0][0]}?",
+            f"No builtin or user-defined type named '{type_name}'.{levenshtein_string}",
             node,
         ) from None
 

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -13,8 +13,8 @@ from vyper.exceptions import (
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.bases import BaseTypeDefinition, DataLocation
 from vyper.semantics.types.indexable.sequence import ArrayDefinition, TupleDefinition
+from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.validation.utils import get_exact_type_from_node, get_index_value
-from vyper.utils import get_levenshtein_string
 
 
 class StringEnum(enum.Enum):
@@ -155,9 +155,9 @@ def get_type_from_annotation(
     try:
         type_obj = namespace[type_name]
     except UndeclaredDefinition:
-        levenshtein_string = get_levenshtein_string(type_name, namespace, 0.3)
+        suggestions_str = get_levenshtein_error_suggestions(type_name, namespace, 0.3)
         raise UnknownType(
-            f"No builtin or user-defined type named '{type_name}'.{levenshtein_string}",
+            f"No builtin or user-defined type named '{type_name}'. {suggestions_str}",
             node,
         ) from None
 

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -155,7 +155,7 @@ def get_type_from_annotation(
     try:
         type_obj = namespace[type_name]
     except UndeclaredDefinition:
-        levenshtein_string = get_levenshtein_string(type_name, namespace, 0.2)
+        levenshtein_string = get_levenshtein_string(type_name, namespace, 0.3)
         raise UnknownType(
             f"No builtin or user-defined type named '{type_name}'.{levenshtein_string}",
             node,

--- a/vyper/semantics/validation/levenshtein_utils.py
+++ b/vyper/semantics/validation/levenshtein_utils.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict
+
+
+def levenshtein_norm(source: str, target: str) -> float:
+    """Calculates the normalized Levenshtein distance between two string
+    arguments. The result will be a float in the range [0.0, 1.0], with 1.0
+    signifying the biggest possible distance between strings with these lengths
+
+    From jazzband/docopt-ng
+    https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py
+    """
+
+    # Compute Levenshtein distance using helper function. The max is always
+    # just the length of the longer string, so this is used to normalize result
+    # before returning it
+    distance = levenshtein(source, target)
+    return float(distance) / max(len(source), len(target))
+
+
+def levenshtein(source: str, target: str) -> int:
+    """Computes the Levenshtein
+    (https://en.wikipedia.org/wiki/Levenshtein_distance)
+    and restricted Damerau-Levenshtein
+    (https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance)
+    distances between two Unicode strings with given lengths using the
+    Wagner-Fischer algorithm
+    (https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
+    These distances are defined recursively, since the distance between two
+    strings is just the cost of adjusting the last one or two characters plus
+    the distance between the prefixes that exclude these characters (e.g. the
+    distance between "tester" and "tested" is 1 + the distance between "teste"
+    and "teste"). The Wagner-Fischer algorithm retains this idea but eliminates
+    redundant computations by storing the distances between various prefixes in
+    a matrix that is filled in iteratively.
+
+    From jazzband/docopt-ng
+    https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py
+    """
+
+    # Create matrix of correct size (this is s_len + 1 * t_len + 1 so that the
+    # empty prefixes "" can also be included). The leftmost column represents
+    # transforming various source prefixes into an empty string, which can
+    # always be done by deleting all characters in the respective prefix, and
+    # the top row represents transforming the empty string into various target
+    # prefixes, which can always be done by inserting every character in the
+    # respective prefix. The ternary used to build the list should ensure that
+    # this row and column are now filled correctly
+    s_range = range(len(source) + 1)
+    t_range = range(len(target) + 1)
+    matrix = [[(i if j == 0 else j) for j in t_range] for i in s_range]
+
+    # Iterate through rest of matrix, filling it in with Levenshtein
+    # distances for the remaining prefix combinations
+    for i in s_range[1:]:
+        for j in t_range[1:]:
+            # Applies the recursive logic outlined above using the values
+            # stored in the matrix so far. The options for the last pair of
+            # characters are deletion, insertion, and substitution, which
+            # amount to dropping the source character, the target character,
+            # or both and then calculating the distance for the resulting
+            # prefix combo. If the characters at this point are the same, the
+            # situation can be thought of as a free substitution
+            del_dist = matrix[i - 1][j] + 1
+            ins_dist = matrix[i][j - 1] + 1
+            sub_trans_cost = 0 if source[i - 1] == target[j - 1] else 1
+            sub_dist = matrix[i - 1][j - 1] + sub_trans_cost
+
+            # Choose option that produces smallest distance
+            matrix[i][j] = min(del_dist, ins_dist, sub_dist)
+
+    # At this point, the matrix is full, and the biggest prefixes are just the
+    # strings themselves, so this is the desired distance
+    return matrix[len(source)][len(target)]
+
+
+def get_levenshtein_error_suggestions(key: str, namespace: Dict[str, Any], threshold: float) -> str:
+    """
+    Generate an error message snippet for the suggested closest values in the provided namespace
+    with the shortest normalized Levenshtein distance from the given key if that distance
+    is below the threshold. Otherwise, return an empty string.
+
+    As a heuristic, the threshold value is inversely correlated to the size of the namespace.
+    For a small namespace (e.g. struct members), the threshold value can be the maximum of
+    1.0 since the key must be one of the defined struct members. For a large namespace
+    (e.g. types, builtin functions and state variables), the threshold value should be lower
+    to ensure the matches are relevant.
+
+    :param key: A string of the identifier being accessed
+    :param namespace: A dictionary of the possible identifiers
+    :param threshold: A floating value between 0.0 and 1.0
+
+    :return: The error message snippet if the Levenshtein value is below the threshold,
+        or an empty string.
+    """
+
+    if key is None or key == "":
+        return ""
+
+    distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
+    min_levenshtein_val = distances[0][1]
+    if len(distances) > 0 and min_levenshtein_val <= threshold:
+        if distances[1][1] == min_levenshtein_val:
+            return f"Did you mean '{distances[0][0]}' or '{distances[1][0]}'?"
+        else:
+            return f"Did you mean '{distances[0][0]}'?"
+    return ""

--- a/vyper/semantics/validation/levenshtein_utils.py
+++ b/vyper/semantics/validation/levenshtein_utils.py
@@ -98,8 +98,7 @@ def get_levenshtein_error_suggestions(key: str, namespace: Dict[str, Any], thres
 
     distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
     if len(distances) > 0 and distances[0][1] <= threshold:
-        if len(distances) >= 2 and distances[0][1] == distances[1][1]:
+        if len(distances) > 1 and distances[1][1] <= threshold:
             return f"Did you mean '{distances[0][0]}' or '{distances[1][0]}'?"
-        else:
-            return f"Did you mean '{distances[0][0]}'?"
+        return f"Did you mean '{distances[0][0]}'?"
     return ""

--- a/vyper/semantics/validation/levenshtein_utils.py
+++ b/vyper/semantics/validation/levenshtein_utils.py
@@ -99,6 +99,6 @@ def get_levenshtein_error_suggestions(key: str, namespace: Dict[str, Any], thres
     distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
     if len(distances) > 0 and distances[0][1] <= threshold:
         if len(distances) > 1 and distances[1][1] <= threshold:
-            return f"Did you mean '{distances[0][0]}' or '{distances[1][0]}'?"
+            return f"Did you mean '{distances[0][0]}', or maybe '{distances[1][0]}'?"
         return f"Did you mean '{distances[0][0]}'?"
     return ""

--- a/vyper/semantics/validation/levenshtein_utils.py
+++ b/vyper/semantics/validation/levenshtein_utils.py
@@ -97,9 +97,8 @@ def get_levenshtein_error_suggestions(key: str, namespace: Dict[str, Any], thres
         return ""
 
     distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
-    min_levenshtein_val = distances[0][1]
-    if len(distances) > 0 and min_levenshtein_val <= threshold:
-        if distances[1][1] == min_levenshtein_val:
+    if len(distances) > 0 and distances[0][1] <= threshold:
+        if len(distances) >= 2 and distances[0][1] == distances[1][1]:
             return f"Did you mean '{distances[0][0]}' or '{distances[1][0]}'?"
         else:
             return f"Did you mean '{distances[0][0]}'?"

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -27,6 +27,7 @@ from vyper.semantics.types.utils import check_constant, get_type_from_annotation
 from vyper.semantics.validation.base import VyperNodeVisitorBase
 from vyper.semantics.validation.utils import validate_expected_type, validate_unique_method_ids
 from vyper.typing import InterfaceDict
+from vyper.utils import levenshtein_norm
 
 
 def add_module_namespace(vy_module: vy_ast.Module, interface_codes: InterfaceDict) -> None:
@@ -305,7 +306,12 @@ def _add_import(
     if module == "vyper.interfaces":
         interface_codes = _get_builtin_interfaces()
     if name not in interface_codes:
-        raise UndeclaredDefinition(f"Unknown interface: {name}", node)
+        distances = sorted(
+            [(i, levenshtein_norm(name, i)) for i in _get_builtin_interfaces()], key=lambda k: k[1]
+        )
+        raise UndeclaredDefinition(
+            f"Unknown interface: {name}. Did you mean {distances[0][0]}?", node
+        )
 
     if interface_codes[name]["type"] == "vyper":
         interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -27,7 +27,7 @@ from vyper.semantics.types.utils import check_constant, get_type_from_annotation
 from vyper.semantics.validation.base import VyperNodeVisitorBase
 from vyper.semantics.validation.utils import validate_expected_type, validate_unique_method_ids
 from vyper.typing import InterfaceDict
-from vyper.utils import levenshtein_norm
+from vyper.utils import get_levenshtein_string
 
 
 def add_module_namespace(vy_module: vy_ast.Module, interface_codes: InterfaceDict) -> None:
@@ -306,12 +306,8 @@ def _add_import(
     if module == "vyper.interfaces":
         interface_codes = _get_builtin_interfaces()
     if name not in interface_codes:
-        distances = sorted(
-            [(i, levenshtein_norm(name, i)) for i in _get_builtin_interfaces()], key=lambda k: k[1]
-        )
-        raise UndeclaredDefinition(
-            f"Unknown interface: {name}. Did you mean {distances[0][0]}?", node
-        )
+        levenshtein_string = get_levenshtein_string(name, _get_builtin_interfaces(), 1.0)
+        raise UndeclaredDefinition(f"Unknown interface: {name}.{levenshtein_string}", node)
 
     if interface_codes[name]["type"] == "vyper":
         interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -25,9 +25,9 @@ from vyper.semantics.types.function import ContractFunction
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.utils import check_constant, get_type_from_annotation
 from vyper.semantics.validation.base import VyperNodeVisitorBase
+from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.validation.utils import validate_expected_type, validate_unique_method_ids
 from vyper.typing import InterfaceDict
-from vyper.utils import get_levenshtein_string
 
 
 def add_module_namespace(vy_module: vy_ast.Module, interface_codes: InterfaceDict) -> None:
@@ -306,8 +306,8 @@ def _add_import(
     if module == "vyper.interfaces":
         interface_codes = _get_builtin_interfaces()
     if name not in interface_codes:
-        levenshtein_string = get_levenshtein_string(name, _get_builtin_interfaces(), 1.0)
-        raise UndeclaredDefinition(f"Unknown interface: {name}.{levenshtein_string}", node)
+        suggestions_str = get_levenshtein_error_suggestions(name, _get_builtin_interfaces(), 1.0)
+        raise UndeclaredDefinition(f"Unknown interface: {name}. {suggestions_str}", node)
 
     if interface_codes[name]["type"] == "vyper":
         interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -27,7 +27,7 @@ from vyper.semantics.types.indexable.sequence import (
 )
 from vyper.semantics.types.value.array_value import BytesArrayDefinition, StringDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
-from vyper.utils import levenshtein_norm
+from vyper.utils import get_levenshtein_string
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -153,14 +153,9 @@ class _ExprTypeChecker:
                     node,
                 ) from None
 
-            distances = sorted(
-                [(i, levenshtein_norm(name, i)) for i in var.members], key=lambda k: k[1]
-            )
+            levenshtein_string = get_levenshtein_string(name, var.members, 0.4)
             raise UndeclaredDefinition(
-                (
-                    f"Storage variable '{name}' has not been declared. "
-                    f"Did you mean '{distances[0][0]}'?"
-                ),
+                f"Storage variable '{name}' has not been declared.{levenshtein_string}",
                 node,
             ) from None
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -27,7 +27,7 @@ from vyper.semantics.types.indexable.sequence import (
 )
 from vyper.semantics.types.value.array_value import BytesArrayDefinition, StringDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
-from vyper.utils import get_levenshtein_string
+from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -153,9 +153,9 @@ class _ExprTypeChecker:
                     node,
                 ) from None
 
-            levenshtein_string = get_levenshtein_string(name, var.members, 0.4)
+            suggestions_str = get_levenshtein_error_suggestions(name, var.members, 0.4)
             raise UndeclaredDefinition(
-                f"Storage variable '{name}' has not been declared.{levenshtein_string}",
+                f"Storage variable '{name}' has not been declared. {suggestions_str}",
                 node,
             ) from None
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -27,6 +27,7 @@ from vyper.semantics.types.indexable.sequence import (
 )
 from vyper.semantics.types.value.array_value import BytesArrayDefinition, StringDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
+from vyper.utils import levenshtein_norm
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -151,8 +152,16 @@ class _ExprTypeChecker:
                     f"'{name}' is not a storage variable, it should not be prepended with self",
                     node,
                 ) from None
+
+            distances = sorted(
+                [(i, levenshtein_norm(name, i)) for i in var.members], key=lambda k: k[1]
+            )
             raise UndeclaredDefinition(
-                f"Storage variable '{name}' has not been declared", node
+                (
+                    f"Storage variable '{name}' has not been declared. "
+                    f"Did you mean '{distances[0][0]}'?"
+                ),
+                node,
             ) from None
 
     def types_from_BinOp(self, node):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -473,7 +473,7 @@ def get_levenshtein_string(key: str, namespace: Dict[str, Any], threshold: float
         or an empty string.
     """
     distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
-    if distances[0][1] <= threshold:
+    if len(distances) > 0 and distances[0][1] <= threshold:
         return f" Did you mean '{distances[0][0]}?'"
     return ""
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -381,6 +381,78 @@ def annotate_source_code(
     return "\n".join(cleanup_lines)
 
 
+def levenshtein_norm(source: str, target: str) -> float:
+    """Calculates the normalized Levenshtein distance between two string
+    arguments. The result will be a float in the range [0.0, 1.0], with 1.0
+    signifying the biggest possible distance between strings with these lengths
+
+    From jazzband/docopt-ng
+    https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py
+    """
+
+    # Compute Levenshtein distance using helper function. The max is always
+    # just the length of the longer string, so this is used to normalize result
+    # before returning it
+    distance = levenshtein(source, target)
+    return float(distance) / max(len(source), len(target))
+
+
+def levenshtein(source: str, target: str) -> int:
+    """Computes the Levenshtein
+    (https://en.wikipedia.org/wiki/Levenshtein_distance)
+    and restricted Damerau-Levenshtein
+    (https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance)
+    distances between two Unicode strings with given lengths using the
+    Wagner-Fischer algorithm
+    (https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
+    These distances are defined recursively, since the distance between two
+    strings is just the cost of adjusting the last one or two characters plus
+    the distance between the prefixes that exclude these characters (e.g. the
+    distance between "tester" and "tested" is 1 + the distance between "teste"
+    and "teste"). The Wagner-Fischer algorithm retains this idea but eliminates
+    redundant computations by storing the distances between various prefixes in
+    a matrix that is filled in iteratively.
+
+    From jazzband/docopt-ng
+    https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py
+    """
+
+    # Create matrix of correct size (this is s_len + 1 * t_len + 1 so that the
+    # empty prefixes "" can also be included). The leftmost column represents
+    # transforming various source prefixes into an empty string, which can
+    # always be done by deleting all characters in the respective prefix, and
+    # the top row represents transforming the empty string into various target
+    # prefixes, which can always be done by inserting every character in the
+    # respective prefix. The ternary used to build the list should ensure that
+    # this row and column are now filled correctly
+    s_range = range(len(source) + 1)
+    t_range = range(len(target) + 1)
+    matrix = [[(i if j == 0 else j) for j in t_range] for i in s_range]
+
+    # Iterate through rest of matrix, filling it in with Levenshtein
+    # distances for the remaining prefix combinations
+    for i in s_range[1:]:
+        for j in t_range[1:]:
+            # Applies the recursive logic outlined above using the values
+            # stored in the matrix so far. The options for the last pair of
+            # characters are deletion, insertion, and substitution, which
+            # amount to dropping the source character, the target character,
+            # or both and then calculating the distance for the resulting
+            # prefix combo. If the characters at this point are the same, the
+            # situation can be thought of as a free substitution
+            del_dist = matrix[i - 1][j] + 1
+            ins_dist = matrix[i][j - 1] + 1
+            sub_trans_cost = 0 if source[i - 1] == target[j - 1] else 1
+            sub_dist = matrix[i - 1][j - 1] + sub_trans_cost
+
+            # Choose option that produces smallest distance
+            matrix[i][j] = min(del_dist, ins_dist, sub_dist)
+
+    # At this point, the matrix is full, and the biggest prefixes are just the
+    # strings themselves, so this is the desired distance
+    return matrix[len(source)][len(target)]
+
+
 __all__ = [
     "cached_property",
 ]

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -2,7 +2,7 @@ import binascii
 import decimal
 import sys
 import traceback
-from typing import Any, Dict, List, Union
+from typing import List, Union
 
 from vyper.exceptions import DecimalOverrideException, InvalidLiteral
 
@@ -379,107 +379,6 @@ def annotate_source_code(
     cleanup_lines += [""] * (num_lines - len(cleanup_lines))
 
     return "\n".join(cleanup_lines)
-
-
-def levenshtein_norm(source: str, target: str) -> float:
-    """Calculates the normalized Levenshtein distance between two string
-    arguments. The result will be a float in the range [0.0, 1.0], with 1.0
-    signifying the biggest possible distance between strings with these lengths
-
-    From jazzband/docopt-ng
-    https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py
-    """
-
-    # Compute Levenshtein distance using helper function. The max is always
-    # just the length of the longer string, so this is used to normalize result
-    # before returning it
-    distance = levenshtein(source, target)
-    return float(distance) / max(len(source), len(target))
-
-
-def levenshtein(source: str, target: str) -> int:
-    """Computes the Levenshtein
-    (https://en.wikipedia.org/wiki/Levenshtein_distance)
-    and restricted Damerau-Levenshtein
-    (https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance)
-    distances between two Unicode strings with given lengths using the
-    Wagner-Fischer algorithm
-    (https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm).
-    These distances are defined recursively, since the distance between two
-    strings is just the cost of adjusting the last one or two characters plus
-    the distance between the prefixes that exclude these characters (e.g. the
-    distance between "tester" and "tested" is 1 + the distance between "teste"
-    and "teste"). The Wagner-Fischer algorithm retains this idea but eliminates
-    redundant computations by storing the distances between various prefixes in
-    a matrix that is filled in iteratively.
-
-    From jazzband/docopt-ng
-    https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py
-    """
-
-    # Create matrix of correct size (this is s_len + 1 * t_len + 1 so that the
-    # empty prefixes "" can also be included). The leftmost column represents
-    # transforming various source prefixes into an empty string, which can
-    # always be done by deleting all characters in the respective prefix, and
-    # the top row represents transforming the empty string into various target
-    # prefixes, which can always be done by inserting every character in the
-    # respective prefix. The ternary used to build the list should ensure that
-    # this row and column are now filled correctly
-    s_range = range(len(source) + 1)
-    t_range = range(len(target) + 1)
-    matrix = [[(i if j == 0 else j) for j in t_range] for i in s_range]
-
-    # Iterate through rest of matrix, filling it in with Levenshtein
-    # distances for the remaining prefix combinations
-    for i in s_range[1:]:
-        for j in t_range[1:]:
-            # Applies the recursive logic outlined above using the values
-            # stored in the matrix so far. The options for the last pair of
-            # characters are deletion, insertion, and substitution, which
-            # amount to dropping the source character, the target character,
-            # or both and then calculating the distance for the resulting
-            # prefix combo. If the characters at this point are the same, the
-            # situation can be thought of as a free substitution
-            del_dist = matrix[i - 1][j] + 1
-            ins_dist = matrix[i][j - 1] + 1
-            sub_trans_cost = 0 if source[i - 1] == target[j - 1] else 1
-            sub_dist = matrix[i - 1][j - 1] + sub_trans_cost
-
-            # Choose option that produces smallest distance
-            matrix[i][j] = min(del_dist, ins_dist, sub_dist)
-
-    # At this point, the matrix is full, and the biggest prefixes are just the
-    # strings themselves, so this is the desired distance
-    return matrix[len(source)][len(target)]
-
-
-def get_levenshtein_string(key: str, namespace: Dict[str, Any], threshold: float) -> str:
-    """
-    Generate an error message snippet for the first value in the provided namespace
-    with the shortest normalized Levenshtein distance from the given key if that distance
-    is below the threshold. Otherwise, return an empty string.
-
-    As a heuristic, the threshold value is inversely correlated to the size of the namespace.
-    For a small namespace (e.g. struct members), the threshold value can be the maximum of
-    1.0 since the key must be one of the defined struct members. For a large namespace
-    (e.g. types, builtin functions and state variables), the threshold value should be lower
-    to ensure the matches are relevant.
-
-    :param key: A string of the identifier being accessed
-    :param namespace: A dictionary of the possible identifiers
-    :param threshold: A floating value between 0.0 and 1.0
-
-    :return: The error message snippet if the Levenshtein value is below the threshold,
-        or an empty string.
-    """
-
-    if key is None or key == "":
-        return ""
-
-    distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
-    if len(distances) > 0 and distances[0][1] <= threshold:
-        return f" Did you mean '{distances[0][0]}'?"
-    return ""
 
 
 __all__ = [

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -472,9 +472,13 @@ def get_levenshtein_string(key: str, namespace: Dict[str, Any], threshold: float
     :return: The error message snippet if the Levenshtein value is below the threshold,
         or an empty string.
     """
+
+    if key is None or key == "":
+        return ""
+
     distances = sorted([(i, levenshtein_norm(key, i)) for i in namespace], key=lambda k: k[1])
     if len(distances) > 0 and distances[0][1] <= threshold:
-        return f" Did you mean '{distances[0][0]}?'"
+        return f" Did you mean '{distances[0][0]}'?"
     return ""
 
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -453,7 +453,7 @@ def levenshtein(source: str, target: str) -> int:
     return matrix[len(source)][len(target)]
 
 
-def get_levenshtein_string(key: str, namespace: Dict[str, Any], threshold: float):
+def get_levenshtein_string(key: str, namespace: Dict[str, Any], threshold: float) -> str:
     """
     Generate an error message snippet for the first value in the provided namespace
     with the shortest normalized Levenshtein distance from the given key if that distance


### PR DESCRIPTION
### What I did

Fix for #2767 

### How I did it

Refer to Brownie and docopt-ng. Helper function is extracted from the source at [docopt-ng](https://github.com/jazzband/docopt-ng/blob/bbed40a2335686d2e14ac0e6c3188374dc4784da/docopt.py).

### How to verify it

### Commit message

Use Levenshtein distance for better error messages

### Description for the changelog

Use Levenshtein distance for better error messages

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTpgtNnTLUh9UFuk7bA0_6RhMF6InOK6sYGjQ&usqp=CAU)
