### PR TITLE
fix: improve error messages for hashmaps

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -80,6 +80,24 @@ def foo():
 def foo():
     true: int128 = 3
     """,
+    """
+n: HashMap[uint256, bool][3]
+    """,
+    """
+a: constant(uint256) = 3
+n: public(HashMap[uint256, Y][a])
+    """,
+    """
+a: immutable(uint256)
+n: public(HashMap[uint256, bool][a])
+
+@external
+def __init__():
+    a = 3
+    """,
+    """
+n: HashMap[uint256, bool][3][3]
+    """,
 ]
 
 

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -98,6 +98,21 @@ def __init__():
     """
 n: HashMap[uint256, bool][3][3]
     """,
+    """
+m1: HashMap[uint8, uint8]
+m2: HashMap[uint8, uint8]
+
+@external
+def __init__():
+    self.m1 = self.m2
+    """,
+    """
+m1: HashMap[uint8, uint8]
+
+@external
+def __init__():
+    self.m1 = 234
+    """,
 ]
 
 

--- a/vyper/semantics/types/indexable/mapping.py
+++ b/vyper/semantics/types/indexable/mapping.py
@@ -40,10 +40,6 @@ class MappingPrimitive(BasePrimitive):
         is_public: bool = False,
         is_immutable: bool = False,
     ) -> MappingDefinition:
-        if isinstance(node, vy_ast.Subscript) and isinstance(
-            node.slice.value, (vy_ast.Int, vy_ast.Name)
-        ):
-            raise StructureException("HashMap arrays are not supported", node)
         if (
             not isinstance(node, vy_ast.Subscript)
             or not isinstance(node.slice, vy_ast.Index)
@@ -51,7 +47,11 @@ class MappingPrimitive(BasePrimitive):
             or len(node.slice.value.elements) != 2
         ):
             raise StructureException(
-                "HashMap must be defined with a key type and a value type", node
+                (
+                    "HashMap must be defined with a key type and a value type, "
+                    "e.g. my_hashmap: HashMap[k, v]"
+                ),
+                node,
             )
         if location != DataLocation.STORAGE or is_immutable:
             raise StructureException("HashMap can only be declared as a storage variable", node)

--- a/vyper/semantics/types/indexable/mapping.py
+++ b/vyper/semantics/types/indexable/mapping.py
@@ -40,6 +40,10 @@ class MappingPrimitive(BasePrimitive):
         is_public: bool = False,
         is_immutable: bool = False,
     ) -> MappingDefinition:
+        if isinstance(node, vy_ast.Subscript) and isinstance(
+            node.slice.value, (vy_ast.Int, vy_ast.Name)
+        ):
+            raise StructureException("HashMap arrays are not supported", node)
         if (
             not isinstance(node, vy_ast.Subscript)
             or not isinstance(node.slice, vy_ast.Index)

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -29,6 +29,7 @@ from vyper.semantics.types.function import (
     MemberFunctionDefinition,
     StateMutability,
 )
+from vyper.semantics.types.indexable.mapping import MappingDefinition
 from vyper.semantics.types.indexable.sequence import (
     ArrayDefinition,
     DynamicArrayDefinition,
@@ -231,6 +232,10 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             raise StructureException("Right-hand side of assignment cannot be a tuple", node.value)
 
         target = get_exact_type_from_node(node.target)
+        if isinstance(target, MappingDefinition):
+            raise StructureException(
+                "Left-hand side of assignment cannot be a HashMap without a key", node
+            )
 
         validate_expected_type(node.value, target)
         target.validate_modification(node, self.func.mutability)


### PR DESCRIPTION
### What I did

Fix for #2779 and #2802 

### How I did it

For 2779: Check for `Int` and `Name` AST node for a `Subscript` node's slice's value (should be `Tuple` for HashMap) when creating from annotation. This could potentially catch `Name` AST nodes that are not of positive integer types, but I think the array error precedes this.

For 2802: Block HashMaps without a key on the LHS of `Assign` AST node. 

### How to verify it

See tests.

### Commit message

```
Improve error messages for HashMap syntax errors.

Fix #2779, Fix #2802
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/photos/giant-panda-baby-over-the-tree-picture-id475398353?b=1&k=20&m=475398353&s=170667a&w=0&h=Tm121zshjOharG0l_FMhy28VPGVj7Zie8Z2EzsPPgqQ=)
