### PR TITLE
docs: rm note about msg.sender being unavailable

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -55,7 +55,6 @@ Internal functions (marked with the ``@internal`` decorator) are only accessible
     def calculate(amount: uint256) -> uint256:
         return self._times_two(amount)
 
-Internal functions do not have access to ``msg.sender`` or ``msg.value``. If you require these values within an internal function you must pass them as parameters.
 
 Mutability
 ----------


### PR DESCRIPTION
was missed in 43f491fd801 (#2659)

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/165974068-d36cdd0d-e6dd-4d19-8138-de320839271a.png)
