### PR TITLE
fix: struct declaration error message

### DIFF
--- a/vyper/semantics/types/user/struct.py
+++ b/vyper/semantics/types/user/struct.py
@@ -140,7 +140,9 @@ def build_primitive_from_node(base_node: vy_ast.EventDef) -> StructPrimitive:
     members: OrderedDict = OrderedDict()
     for node in base_node.body:
         if not isinstance(node, vy_ast.AnnAssign):
-            raise StructureException("Structs can only variable definitions", node)
+            raise StructureException(
+                "Struct declarations can only contain variable definitions", node
+            )
         if node.value is not None:
             raise StructureException("Cannot assign a value during struct declaration", node)
         if not isinstance(node.target, vy_ast.Name):


### PR DESCRIPTION
### What I did

Fix typo in struct declaration error message

### How I did it

Fix the typo.

### How to verify it

See updated error message.

### Commit message

Fix typo in struct declaration error message

### Description for the changelog

Fix typo in struct declaration error message

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/photos/koala-resting-and-sleeping-on-his-tree-picture-id530674261?k=20&m=530674261&s=612x612&w=0&h=uxOELphW4N4Mo7tEtEszk8mJRZ3hAqmCyhAbTpDyL7I=)
