### PR TITLE
fix: allow varargs for print

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -794,3 +794,12 @@ Utilities
         "0000000000000000000000000000000000000000000000000000000000000040"
         "0000000000000000000000000000000000000000000000000000000000000003"
         "3233340000000000000000000000000000000000000000000000000000000000"
+
+
+.. py:function:: print(*args) -> None
+
+    "prints" the arguments by issuing a static call to the "console" address, ``0x000000000000000000636F6E736F6C652E6C6F67``. This is supported by some smart contract development frameworks.
+
+.. note::
+
+    Issuing of the static call is *NOT* mode-dependent (that is, it is not removed from production code), although the compiler will issue a warning whenever ``print`` is used.

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1872,7 +1872,6 @@ class Empty:
 
 class Print(_SimpleBuiltinFunction):
     _id = "print"
-    _inputs = [("arg", "*")]
 
     _warned = False
 
@@ -1881,11 +1880,9 @@ class Print(_SimpleBuiltinFunction):
             vyper_warn("`print` should only be used for debugging!\n" + node._annotated_source)
             self._warned = True
 
-        validate_call_args(node, 1)
         return None
 
-    @validate_inputs
-    def build_IR(self, expr, args, kwargs, context):
+    def build_IR(self, expr, context):
         args = [Expr(arg, context).ir_node for arg in expr.args]
         args_tuple_t = TupleType([x.typ for x in args])
         args_as_tuple = IRnode.from_list(["multi"] + [x for x in args], typ=args_tuple_t)


### PR DESCRIPTION
the codegen was generic in the number of arguments, just need to remove
the check during `fetch_call_return`

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
