### PR TITLE
fix: update method_id output_type

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -746,21 +746,21 @@ Utilities
         >>> ExampleContract.foo("hello")
         5
 
-.. py:function:: method_id(method, output_type: type = bytes4) -> Union[bytes4, Bytes[4]]
+.. py:function:: method_id(method, output_type: type = Bytes[4]) -> Union[Bytes[4], bytes4]
 
     Takes a function declaration and returns its method_id (used in data field to call it).
 
     * ``method``: Method declaration as given as a literal string
-    * ``output_type``: The type of output (``bytes4`` or ``Bytes[4]``). Defaults to ``bytes4``.
+    * ``output_type``: The type of output (``Bytes[4]`` or ``bytes4``). Defaults to ``Bytes[4]``.
 
-    Returns a ``bytes4`` value.
+    Returns a value of the type specified by ``output_type``.
 
     .. code-block:: python
 
         @external
         @view
-        def foo() -> bytes4:
-            return method_id('transfer(address,uint256)')
+        def foo() -> Bytes[4]:
+            return method_id('transfer(address,uint256)', output_type=Bytes[4])
 
     .. code-block:: python
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -746,21 +746,20 @@ Utilities
         >>> ExampleContract.foo("hello")
         5
 
-.. py:function:: method_id(method, output_type: type = Bytes[4]) -> Union[bytes32, Bytes[4]]
+.. py:function:: method_id(method) -> bytes4
 
     Takes a function declaration and returns its method_id (used in data field to call it).
 
     * ``method``: Method declaration as given as a literal string
-    * ``output_type``: The type of output (``Bytes[4]`` or ``bytes32``). Defaults to ``Bytes[4]``.
 
-    Returns a value of the type specified by ``output_type``.
+    Returns a ``bytes4`` value.
 
     .. code-block:: python
 
         @external
         @view
-        def foo() -> Bytes[4]:
-            return method_id('transfer(address,uint256)', output_type=Bytes[4])
+        def foo() -> bytes4:
+            return method_id('transfer(address,uint256)')
 
     .. code-block:: python
 

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -15,7 +15,7 @@ interface ERC721Receiver:
             _from: address,
             _tokenId: uint256,
             _data: Bytes[1024]
-        ) -> bytes32: view
+        ) -> bytes4: view
 
 
 # @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are
@@ -265,7 +265,6 @@ def safeTransferFrom(
          Throws if `_tokenId` is not a valid NFT.
          If `_to` is a smart contract, it calls `onERC721Received` on `_to` and throws if
          the return value is not `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
-         NOTE: bytes4 is represented by bytes32 with padding
     @param _from The current owner of the NFT.
     @param _to The new owner.
     @param _tokenId The NFT to transfer.
@@ -273,9 +272,9 @@ def safeTransferFrom(
     """
     self._transferFrom(_from, _to, _tokenId, msg.sender)
     if _to.is_contract: # check if `_to` is a contract address
-        returnValue: bytes32 = ERC721Receiver(_to).onERC721Received(msg.sender, _from, _tokenId, _data)
+        returnValue: bytes4 = ERC721Receiver(_to).onERC721Received(msg.sender, _from, _tokenId, _data)
         # Throws if transfer destination is a contract which does not implement 'onERC721Received'
-        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
+        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes4)
 
 
 @external

--- a/tests/examples/tokens/test_erc721.py
+++ b/tests/examples/tokens/test_erc721.py
@@ -257,8 +257,8 @@ def onERC721Received(
         _from: address,
         _tokenId: uint256,
         _data: Bytes[1024]
-    ) -> bytes32:
-    return method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
+    ) -> bytes4:
+    return method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes4)
     """
     )
     tx_hash = c.safeTransferFrom(

--- a/tests/parser/functions/test_method_id.py
+++ b/tests/parser/functions/test_method_id.py
@@ -41,7 +41,7 @@ def sig() -> Bytes[4]:
 def test_method_id_bytes4_default(get_contract):
     code = """
 @external
-def sig() -> bytes4:
+def sig() -> Bytes[4]:
     return method_id('transfer(address,uint256)')
     """
     c = get_contract(code)

--- a/tests/parser/functions/test_method_id.py
+++ b/tests/parser/functions/test_method_id.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_method_id_test(get_contract_with_gas_estimation):
     method_id_test = """
 @external
@@ -13,36 +16,10 @@ def returnten() -> int128:
     assert c.returnten() == 10
 
 
-def test_method_id_bytes32(get_contract):
+def test_method_id(get_contract):
     code = """
 @external
-def sig() -> bytes32:
-    return method_id('transfer(address,uint256)', output_type=bytes32)
-    """
-    c = get_contract(code)
-    sig = c.sig()
-
-    assert len(sig) == 32
-    assert sig[-4:] == b"\xa9\x05\x9c\xbb"
-
-
-def test_method_id_bytes4(get_contract):
-    code = """
-@external
-def sig() -> Bytes[4]:
-    return method_id('transfer(address,uint256)', output_type=Bytes[4])
-    """
-    c = get_contract(code)
-    sig = c.sig()
-
-    # assert len(sig) == 4
-    assert sig == b"\xa9\x05\x9c\xbb"
-
-
-def test_method_id_bytes4_default(get_contract):
-    code = """
-@external
-def sig() -> Bytes[4]:
+def sig() -> bytes4:
     return method_id('transfer(address,uint256)')
     """
     c = get_contract(code)
@@ -55,16 +32,17 @@ def sig() -> Bytes[4]:
 def test_method_id_invalid_space(get_contract, assert_compile_failed):
     code = """
 @external
-def sig() -> bytes32:
-    return method_id('transfer(address, uint256)', output_type=bytes32)
+def sig() -> bytes4:
+    return method_id('transfer(address, uint256)')
     """
     assert_compile_failed(lambda: get_contract(code))
 
 
-def test_method_id_invalid_type(get_contract, assert_compile_failed):
-    code = """
+@pytest.mark.parametrize("return_type", ["int128", "bytes32", "Bytes[4]"])
+def test_method_id_invalid_type(get_contract, assert_compile_failed, return_type):
+    code = f"""
 @external
-def sig() -> int128:
-    return method_id('transfer(address,uint256)', output_type=int128)
+def sig() -> {return_type}:
+    return method_id('transfer(address,uint256)')
     """
     assert_compile_failed(lambda: get_contract(code))

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -221,7 +221,7 @@ def foo() -> int128:
 def foo(_addr: address) -> int128:
     _response: Bytes[32] = raw_call(
         _addr,
-        method_id("foo()"),
+        method_id("foo()", output_type=Bytes[4]),
         max_outsize=32,
         is_static_call=True,
     )
@@ -251,7 +251,7 @@ def foo() -> int128:
 def foo(_addr: address) -> int128:
     _response: Bytes[32] = raw_call(
         _addr,
-        method_id("foo()"),
+        method_id("foo()", output_type=Bytes[4]),
         max_outsize=32,
         is_static_call=True,
     )
@@ -327,7 +327,7 @@ uncompilable_code = [
 @external
 @view
 def foo(_addr: address):
-    raw_call(_addr, method_id("foo()"))
+    raw_call(_addr, method_id("foo()", output_type=Bytes[4]))
     """,
         StateAccessViolation,
     ),
@@ -335,7 +335,9 @@ def foo(_addr: address):
         """
 @external
 def foo(_addr: address):
-    raw_call(_addr, method_id("foo()"), is_delegate_call=True, is_static_call=True)
+    raw_call(
+        _addr, method_id("foo()", output_type=Bytes[4]), is_delegate_call=True, is_static_call=True
+    )
     """,
         ArgumentException,
     ),

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -221,7 +221,7 @@ def foo() -> int128:
 def foo(_addr: address) -> int128:
     _response: Bytes[32] = raw_call(
         _addr,
-        method_id("foo()", output_type=Bytes[4]),
+        method_id("foo()"),
         max_outsize=32,
         is_static_call=True,
     )
@@ -251,7 +251,7 @@ def foo() -> int128:
 def foo(_addr: address) -> int128:
     _response: Bytes[32] = raw_call(
         _addr,
-        method_id("foo()", output_type=Bytes[4]),
+        method_id("foo()"),
         max_outsize=32,
         is_static_call=True,
     )
@@ -327,7 +327,7 @@ uncompilable_code = [
 @external
 @view
 def foo(_addr: address):
-    raw_call(_addr, method_id("foo()", output_type=Bytes[4]))
+    raw_call(_addr, method_id("foo()"))
     """,
         StateAccessViolation,
     ),
@@ -335,9 +335,7 @@ def foo(_addr: address):
         """
 @external
 def foo(_addr: address):
-    raw_call(
-        _addr, method_id("foo()", output_type=Bytes[4]), is_delegate_call=True, is_static_call=True
-    )
+    raw_call(_addr, method_id("foo()"), is_delegate_call=True, is_static_call=True)
     """,
         ArgumentException,
     ),

--- a/tests/parser/syntax/test_abi_encode.py
+++ b/tests/parser/syntax/test_abi_encode.py
@@ -25,7 +25,7 @@ def foo(x: Bytes[1]) -> Bytes[32]:
 @external
 def foo(x: uint256) -> Bytes[36]:
     _ensure_tuple: bool = False
-    _method_id: Bytes[4] = method_id("foo()")
+    _method_id: Bytes[4] = method_id("foo()", output_type=Bytes[4])
     return _abi_encode(x, ensure_tuple=_ensure_tuple, method_id=_method_id)
     """,
         TypeMismatch,  # ensure_tuple and method_id both must be literals

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -700,7 +700,7 @@ class MethodID:
 
         if node.keywords:
             return_type = get_type_from_annotation(node.keywords[0].value, DataLocation.UNSET)
-            if not isinstance(return_type, Bytes4Definition):
+            if isinstance(return_type, Bytes4Definition):
                 is_bytes4 = True
             elif isinstance(return_type, BytesArrayDefinition) and return_type.length == 4:
                 is_bytes4 = False

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -690,7 +690,7 @@ class MethodID:
     _id = "method_id"
 
     def evaluate(self, node):
-        validate_call_args(node, 1)
+        validate_call_args(node, 1, ["output_type"])
 
         args = node.args
         if not isinstance(args[0], vy_ast.Str):

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -705,10 +705,10 @@ class MethodID:
             elif isinstance(return_type, BytesArrayDefinition) and return_type.length == 4:
                 is_bytes4 = False
             else:
-                raise ArgumentException("output_type must be bytes4 or Bytes[4]", node.keywords[0])
+                raise ArgumentException("output_type must be Bytes[4] or bytes4", node.keywords[0])
         else:
-            # If `output_type` is not given, default to `bytes4`
-            is_bytes4 = True
+            # If `output_type` is not given, default to `Bytes[4]`
+            is_bytes4 = False
 
         value = abi_method_id(args[0].value)
 


### PR DESCRIPTION
### What I did

Fix #2811.

### How I did it

Replace `bytes32` with `bytes4`, and set it as default.

### How to verify it

See updated tests.

### Commit message

```
Update method_id output_type

Replace bytes32 with bytes4, and set bytes4 as default return type.
```

### Description for the changelog

Update method_id output_type

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/98v8izfhnef51.jpg?auto=webp&s=34db5522ca1a8bdb9ceae7107b317b8895c70b6b)
