### PR TITLE
ux: reverse order in which exceptions are reported

### DIFF
--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -18,7 +18,7 @@ class ExceptionList(list):
             raise self[0]
         elif len(self) > 1:
             err_msg = ["Compilation failed with the following errors:"]
-            err_msg += [f"{type(i).__name__}: {i}" for i in self]
+            err_msg += [f"{type(i).__name__}: {i}" for i in reversed(self)]
             raise VyperException("\n\n".join(err_msg))
 
 


### PR DESCRIPTION
this commit reverses the order in which multiple exceptions are
reported. this is a usability issue because sometimes when exceptions
cascade, the first error is the most meaningful (other errors depend on
the first error being fixed).

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/166695376-c1be52fa-588e-4cc5-a4ad-9b85e8c0b4ef.png)
