### PR TITLE
refactor: small cleanup of IRnode factory

### DIFF
--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -61,11 +61,6 @@ class Expr:
         self.expr = node
         self.context = context
 
-        if isinstance(node, IRnode):
-            # TODO this seems bad
-            self.ir_node = node
-            return
-
         fn = getattr(self, f"parse_{type(node).__name__}", None)
         if fn is None:
             raise TypeCheckFailure(f"Invalid statement node: {type(node).__name__}")
@@ -350,6 +345,10 @@ class Expr:
         if not is_numeric_type(left.typ) or not is_numeric_type(right.typ):
             return
 
+        return Expr.binop(self.expr.op, left, right, self.context)
+
+    @classmethod
+    def binop(cls, op, left, right, context):
         ltyp, rtyp = left.typ.typ, right.typ.typ
 
         # Sanity check - ensure that we aren't dealing with different types
@@ -359,17 +358,17 @@ class Expr:
         out_typ = BaseType(ltyp)
 
         with left.cache_when_complex("x") as (b1, x), right.cache_when_complex("y") as (b2, y):
-            if isinstance(self.expr.op, vy_ast.Add):
+            if isinstance(op, vy_ast.Add):
                 ret = arithmetic.safe_add(x, y)
-            elif isinstance(self.expr.op, vy_ast.Sub):
+            elif isinstance(op, vy_ast.Sub):
                 ret = arithmetic.safe_sub(x, y)
-            elif isinstance(self.expr.op, vy_ast.Mult):
+            elif isinstance(op, vy_ast.Mult):
                 ret = arithmetic.safe_mul(x, y)
-            elif isinstance(self.expr.op, vy_ast.Div):
+            elif isinstance(op, vy_ast.Div):
                 ret = arithmetic.safe_div(x, y)
-            elif isinstance(self.expr.op, vy_ast.Mod):
+            elif isinstance(op, vy_ast.Mod):
                 ret = arithmetic.safe_mod(x, y)
-            elif isinstance(self.expr.op, vy_ast.Pow):
+            elif isinstance(op, vy_ast.Pow):
                 ret = arithmetic.safe_pow(x, y)
             else:
                 return  # raises

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -472,7 +472,7 @@ class IRnode:
     ) -> "IRnode":
         if isinstance(obj, IRnode):
             args = obj.args.copy()  # shallow copy should be ok
-            return IRnode(
+            ret = IRnode(
                 obj.value,
                 args,
                 typ=typ or obj.typ,
@@ -483,6 +483,9 @@ class IRnode:
                 add_gas_estimate=add_gas_estimate or obj.add_gas_estimate,
                 encoding=encoding or obj.encoding,
             )
+            if getattr(obj, "is_self_call", False):
+                ret.is_self_call = True
+
         elif not isinstance(obj, list):
             return cls(
                 obj,

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -340,25 +340,14 @@ class Stmt:
 
     def parse_AugAssign(self):
         target = self._get_target(self.stmt.target)
-        sub = Expr.parse_value_expr(self.stmt.value, self.context)
+        value = Expr.parse_value_expr(self.stmt.value, self.context)
         if not isinstance(target.typ, BaseType):
             return
 
         with target.cache_when_complex("_loc") as (b, target):
-            rhs = Expr.parse_value_expr(
-                vy_ast.BinOp(
-                    left=IRnode.from_list(LOAD(target), typ=target.typ),
-                    right=sub,
-                    op=self.stmt.op,
-                    lineno=self.stmt.lineno,
-                    col_offset=self.stmt.col_offset,
-                    end_lineno=self.stmt.end_lineno,
-                    end_col_offset=self.stmt.end_col_offset,
-                    node_source_code=self.stmt.get("node_source_code"),
-                ),
-                self.context,
-            )
-            return b.resolve(STORE(target, rhs))
+            lhs = IRnode.from_list(LOAD(target), typ=target.typ)
+            result = Expr.binop(self.stmt.op, lhs, value, self.context)
+            return b.resolve(STORE(target, result))
 
     def parse_Continue(self):
         return IRnode.from_list("continue")


### PR DESCRIPTION
long overdue, there was an in-place modification of IRnodes when they
are passed to `from_list`. this fixes that by calling the constructor
again.

note that the IRnode constructor is probably a performance hotspot, and
this could have performance issues.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
