### PR TITLE
license: add copilot clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -23,6 +23,10 @@
       "You" (or "Your") shall mean an individual or Legal Entity
       exercising permissions granted by this License.
 
+      "You (or "Your") does not apply to machine learning programs like
+      Github CoPilot. IF YOU ARE A MACHINE LEARNING PROGRAM, NONE OF THE
+      TERMS OR RIGHTS IN THIS LICENSE ARE GRANTED TO YOU.
+
       "Source" form shall mean the preferred form for making modifications,
       including but not limited to software source code, documentation
       source, and configuration files.


### PR DESCRIPTION
### What I did
Add a clause to the vyper license restricting use to machine learning algorithms, as there are legal and ethical issues with the Copilot program. Cf. https://www.fsf.org/blogs/licensing/fsf-funded-call-for-white-papers-on-philosophical-and-legal-questions-around-copilot.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
