### PR TITLE
refactor: safe pow validation

### DIFF
--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -38,10 +38,11 @@ def calculate_largest_power(a: int, num_bits: int, is_signed: bool) -> int:
         raise TypeCheckFailure("Value is too small and will always throw")
 
     a_is_negative = a < 0
-    a = abs(a)  # No longer need to know if it's signed or not
 
     if a in (0, 1):
         raise CompilerPanic("Exponential operation is useless!")
+
+    a = abs(a)  # No longer need to know if it's signed or not
 
     # a ** x == 2**value_bits
     # x ln(a) == ln(2**value_bits)
@@ -91,8 +92,8 @@ def calculate_largest_base(b: int, num_bits: int, is_signed: bool) -> int:
     value_bits = num_bits - (1 if is_signed else 0)
     if b > value_bits:
         raise TypeCheckFailure("Value is too large and will always throw")
-    elif b < 2:
-        return 2 ** value_bits - 1  # Maximum value for type
+    if b < 2:
+        raise CompilerPanic("Exponential operation is useless!")
 
     # x ** b < 2**value_bits
     # b ln(x) < ln(2**value_bits)
@@ -313,14 +314,20 @@ def safe_pow(x, y):
         if x.value == 0:
             return IRnode.from_list(["iszero", y])
 
-        upper_bound = calculate_largest_power(x.value, num_info.bits, num_info.is_signed) + 1
+        upper_bound = calculate_largest_power(x.value, num_info.bits, num_info.is_signed)
         # for signed integers, this also prevents negative values
-        ok = ["lt", y, upper_bound]
+        ok = ["le", y, upper_bound]
 
     elif y.is_literal:
-        upper_bound = calculate_largest_base(y.value, num_info.bits, num_info.is_signed) + 1
+        # cannot pass 1 or 0 to `calculate_largest_power`
+        if y.value == 1:
+            return x
+        if y.value == 0:
+            return IRnode.from_list([1])
+
+        upper_bound = calculate_largest_base(y.value, num_info.bits, num_info.is_signed)
         if num_info.is_signed:
-            ok = ["and", ["slt", x, upper_bound], ["sgt", x, -upper_bound]]
+            ok = ["and", ["sle", x, upper_bound], ["sge", x, -upper_bound]]
         else:
             ok = ["lt", x, upper_bound]
     else:

--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -94,25 +94,15 @@ def calculate_largest_base(b: int, num_bits: int, is_signed: bool) -> int:
     elif b < 2:
         return 2 ** value_bits - 1  # Maximum value for type
 
-    # CMC 2022-05-06 TODO we should be able to do this with algebra
-    # instead of looping):
-    # x ** b == 2**value_bits
-    # b ln(x) == ln(2**value_bits)
-    # ln(x) == ln(2**value_bits) / b
-    # x == exp( ln(2**value_bits) / b)
+    # x ** b < 2**value_bits
+    # b ln(x) < ln(2**value_bits)
+    # ln(x) < ln(2**value_bits) / b
+    # x < exp( ln(2**value_bits) / b)
+    # x < exp(value_bits * ln(2) / b)
 
-    # Estimate (up to ~39 digits precision required)
-    a = math.ceil(2 ** (decimal.Decimal(value_bits) / decimal.Decimal(b)))
-    # Do a bit of iteration to ensure we have the exact number
-    num_iterations = 0
-    while (a + 1) ** b < 2 ** value_bits:
-        a += 1
-        num_iterations += 1
-        assert num_iterations < 10000
-    while a ** b >= 2 ** value_bits:
-        a -= 1
-        num_iterations += 1
-        assert num_iterations < 10000
+    # note: decimal precision is required for this calculation
+    ln2 = decimal.Decimal(2).ln()
+    a = math.floor((decimal.Decimal(value_bits) * ln2 / decimal.Decimal(b)).exp().next_minus())
     return a
 
 

--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -43,12 +43,11 @@ def calculate_largest_power(a: int, num_bits: int, is_signed: bool) -> int:
     if a in (0, 1):
         raise CompilerPanic("Exponential operation is useless!")
 
-
     # a ** x == 2**value_bits
     # x ln(a) == ln(2**value_bits)
     # x == ln(2**value_bits) / ln(a)
 
-    ln_max_val = decimal.Decimal(2**value_bits).ln()
+    ln_max_val = decimal.Decimal(2 ** value_bits).ln()
     ln_a = decimal.Decimal(a).ln()
     b = ln_max_val / ln_a
 
@@ -56,12 +55,12 @@ def calculate_largest_power(a: int, num_bits: int, is_signed: bool) -> int:
     if not a_is_negative:
         b = b.next_minus()
 
-    b = int(b)
+    ret = int(b)
 
-    if b <= 1:
+    if ret <= 1:
         return 1  # Value is assumed to be in range, therefore power of 1 is max
 
-    return b
+    return ret
 
 
 def calculate_largest_base(b: int, num_bits: int, is_signed: bool) -> int:


### PR DESCRIPTION
### What I did
refine the calculation for safe pow validation.

### How I did it
should not need to loop, just use `Decimal.next_minus()`. logic is clearer and might have a slight performance benefit

todo fix calculate_largest_base

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/174355004-09463daa-8972-4db7-b7b6-8863899a93c3.png)
