### PR TITLE
fix: allow referencing events from interfaces

### DIFF
--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -8,16 +8,6 @@ from vyper.interfaces import ERC20Detailed
 implements: ERC20
 implements: ERC20Detailed
 
-event Transfer:
-    sender: indexed(address)
-    receiver: indexed(address)
-    value: uint256
-
-event Approval:
-    owner: indexed(address)
-    spender: indexed(address)
-    value: uint256
-
 name: public(String[32])
 symbol: public(String[32])
 decimals: public(uint8)
@@ -43,7 +33,7 @@ def __init__(_name: String[32], _symbol: String[32], _decimals: uint8, _supply: 
     self.balanceOf[msg.sender] = init_supply
     self.totalSupply = init_supply
     self.minter = msg.sender
-    log Transfer(ZERO_ADDRESS, msg.sender, init_supply)
+    log ERC20.Transfer(ZERO_ADDRESS, msg.sender, init_supply)
 
 
 
@@ -58,7 +48,7 @@ def transfer(_to : address, _value : uint256) -> bool:
     #       so the following subtraction would revert on insufficient balance
     self.balanceOf[msg.sender] -= _value
     self.balanceOf[_to] += _value
-    log Transfer(msg.sender, _to, _value)
+    log ERC20.Transfer(msg.sender, _to, _value)
     return True
 
 
@@ -77,7 +67,7 @@ def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
     # NOTE: vyper does not allow underflows
     #      so the following subtraction would revert on insufficient allowance
     self.allowance[_from][msg.sender] -= _value
-    log Transfer(_from, _to, _value)
+    log ERC20.Transfer(_from, _to, _value)
     return True
 
 
@@ -93,7 +83,7 @@ def approve(_spender : address, _value : uint256) -> bool:
     @param _value The amount of tokens to be spent.
     """
     self.allowance[msg.sender][_spender] = _value
-    log Approval(msg.sender, _spender, _value)
+    log ERC20.Approval(msg.sender, _spender, _value)
     return True
 
 
@@ -110,7 +100,7 @@ def mint(_to: address, _value: uint256):
     assert _to != ZERO_ADDRESS
     self.totalSupply += _value
     self.balanceOf[_to] += _value
-    log Transfer(ZERO_ADDRESS, _to, _value)
+    log ERC20.Transfer(ZERO_ADDRESS, _to, _value)
 
 
 @internal
@@ -124,7 +114,7 @@ def _burn(_to: address, _value: uint256):
     assert _to != ZERO_ADDRESS
     self.totalSupply -= _value
     self.balanceOf[_to] -= _value
-    log Transfer(_to, ZERO_ADDRESS, _value)
+    log ERC20.Transfer(_to, ZERO_ADDRESS, _value)
 
 
 @external

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -18,41 +18,6 @@ interface ERC721Receiver:
         ) -> bytes4: view
 
 
-# @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are
-#      created (`from` == 0) and destroyed (`to` == 0). Exception: during contract creation, any
-#      number of NFTs may be created and assigned without emitting Transfer. At the time of any
-#      transfer, the approved address for that NFT (if any) is reset to none.
-# @param _from Sender of NFT (if address is zero address it indicates token creation).
-# @param _to Receiver of NFT (if address is zero address it indicates token destruction).
-# @param _tokenId The NFT that got transfered.
-event Transfer:
-    sender: indexed(address)
-    receiver: indexed(address)
-    tokenId: indexed(uint256)
-
-# @dev This emits when the approved address for an NFT is changed or reaffirmed. The zero
-#      address indicates there is no approved address. When a Transfer event emits, this also
-#      indicates that the approved address for that NFT (if any) is reset to none.
-# @param _owner Owner of NFT.
-# @param _approved Address that we are approving.
-# @param _tokenId NFT which we are approving.
-event Approval:
-    owner: indexed(address)
-    approved: indexed(address)
-    tokenId: indexed(uint256)
-
-# @dev This emits when an operator is enabled or disabled for an owner. The operator can manage
-#      all NFTs of the owner.
-# @param _owner Owner of NFT.
-# @param _operator Address to which we are setting operator rights.
-# @param _approved Status of operator rights(true if operator rights are given and false if
-# revoked).
-event ApprovalForAll:
-    owner: indexed(address)
-    operator: indexed(address)
-    approved: bool
-
-
 # @dev Mapping from NFT ID to the address that owns it.
 idToOwner: HashMap[uint256, address]
 
@@ -227,7 +192,7 @@ def _transferFrom(_from: address, _to: address, _tokenId: uint256, _sender: addr
     # Add NFT
     self._addTokenTo(_to, _tokenId)
     # Log the transfer
-    log Transfer(_from, _to, _tokenId)
+    log ERC721.Transfer(_from, _to, _tokenId)
 
 
 ### TRANSFER FUNCTIONS ###
@@ -298,7 +263,7 @@ def approve(_approved: address, _tokenId: uint256):
     assert (senderIsOwner or senderIsApprovedForAll)
     # Set the approval
     self.idToApprovals[_tokenId] = _approved
-    log Approval(owner, _approved, _tokenId)
+    log ERC721.Approval(owner, _approved, _tokenId)
 
 
 @external
@@ -314,7 +279,7 @@ def setApprovalForAll(_operator: address, _approved: bool):
     # Throws if `_operator` is the `msg.sender`
     assert _operator != msg.sender
     self.ownerToOperators[msg.sender][_operator] = _approved
-    log ApprovalForAll(msg.sender, _operator, _approved)
+    log ERC721.ApprovalForAll(msg.sender, _operator, _approved)
 
 
 ### MINT & BURN FUNCTIONS ###
@@ -336,7 +301,7 @@ def mint(_to: address, _tokenId: uint256) -> bool:
     assert _to != ZERO_ADDRESS
     # Add NFT. Throws if `_tokenId` is owned by someone
     self._addTokenTo(_to, _tokenId)
-    log Transfer(ZERO_ADDRESS, _to, _tokenId)
+    log ERC721.Transfer(ZERO_ADDRESS, _to, _tokenId)
     return True
 
 
@@ -356,4 +321,4 @@ def burn(_tokenId: uint256):
     assert owner != ZERO_ADDRESS
     self._clearApproval(owner, _tokenId)
     self._removeTokenFrom(owner, _tokenId)
-    log Transfer(owner, ZERO_ADDRESS, _tokenId)
+    log ERC721.Transfer(owner, ZERO_ADDRESS, _tokenId)

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -141,7 +141,7 @@ pass_stmt: _PASS
 break_stmt: _BREAK
 continue_stmt: _CONTINUE
 
-log_stmt: _LOG NAME "(" [arguments] ")"
+log_stmt: _LOG [NAME DOT] NAME "(" [arguments] ")"
 return_stmt: _RETURN [_expr ("," _expr)*]
 _UNREACHABLE: "UNREACHABLE"
 raise_stmt: _RAISE -> raise

--- a/vyper/semantics/types/user/interface.py
+++ b/vyper/semantics/types/user/interface.py
@@ -4,14 +4,19 @@ from typing import Dict, List, Tuple, Union
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Address, ABIType
 from vyper.ast.validation import validate_call_args
-from vyper.exceptions import InterfaceViolation, NamespaceCollision, StructureException, UnknownAttribute
+from vyper.exceptions import (
+    InterfaceViolation,
+    NamespaceCollision,
+    StructureException,
+    UnknownAttribute,
+)
 from vyper.semantics.namespace import get_namespace, validate_identifier
 from vyper.semantics.types.bases import DataLocation, MemberTypeDefinition, ValueTypeDefinition
 from vyper.semantics.types.function import ContractFunction
 from vyper.semantics.types.user.event import Event
 from vyper.semantics.types.value.address import AddressDefinition
-from vyper.semantics.validation.utils import validate_expected_type, validate_unique_method_ids
 from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
+from vyper.semantics.validation.utils import validate_expected_type, validate_unique_method_ids
 
 
 class InterfaceDefinition(MemberTypeDefinition, ValueTypeDefinition):

--- a/vyper/semantics/types/user/interface.py
+++ b/vyper/semantics/types/user/interface.py
@@ -59,13 +59,13 @@ class InterfacePrimitive:
         self.events = events
 
     def __repr__(self):
-        return f"{self._id} declaration object"
+        return f"{self._id} interface object"
 
     # follow MemberTypeDefinition API
     def get_member(self, key, node):
         if key in self.events:
             return self.events[key]
-        suggestions_str = get_levenshtein_error_suggestions(key, self.members, 0.3)
+        suggestions_str = get_levenshtein_error_suggestions(key, self.events, 0.3)
         raise UnknownAttribute(f"{self} has no member '{key}'. {suggestions_str}", node)
 
     def from_annotation(

--- a/vyper/semantics/types/user/interface.py
+++ b/vyper/semantics/types/user/interface.py
@@ -100,18 +100,10 @@ class InterfacePrimitive:
             or not hasattr(namespace["self"].members[name], "compare_signature")
             or not namespace["self"].members[name].compare_signature(type_)
         ]
-        # check for missing events
-        unimplemented += [
-            name
-            for name, event in self.events.items()
-            if name not in namespace
-            or not isinstance(namespace[name], Event)
-            or namespace[name].event_id != event.event_id
-        ]
         if unimplemented:
             missing_str = ", ".join(sorted(unimplemented))
             raise InterfaceViolation(
-                f"Contract does not implement all interface functions or events: {missing_str}",
+                f"Contract does not implement all interface functions: {missing_str}",
                 node,
             )
 

--- a/vyper/semantics/validation/annotation.py
+++ b/vyper/semantics/validation/annotation.py
@@ -80,7 +80,7 @@ class StatementAnnotationVisitor(_AnnotationVisitorBase):
         self.expr_visitor.visit(node.test)
 
     def visit_Log(self, node):
-        node._metadata["type"] = self.namespace[node.value.func.id]
+        node._metadata["type"] = get_exact_type_from_node(node.value.func)
         self.expr_visitor.visit(node.value)
 
     def visit_Return(self, node):

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -140,7 +140,7 @@ class _ExprTypeChecker:
 
     def types_from_Attribute(self, node):
         # variable attribute, e.g. `foo.bar`
-        var = self.get_exact_type_from_node(node.value)
+        var = self.get_exact_type_from_node(node.value, only_definitions=False)
         name = node.attr
         try:
             return [var.get_member(name, node)]


### PR DESCRIPTION
allow the following:
```vyper
import bar as Bar

@external
def foo():
    log Bar.SomeEvent(...)
```

### What I did

### How I did it
allow interfaces to resolve to events in `get_type_from_node` for interface members.

### How to verify it
see usage in ERC20.vy and ERC721.vy

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/167615747-01c6f0e8-bf6a-4328-8dff-30e5522f5f12.png)
