### PR TITLE
fix: move .test_durations file to auxiliary repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
       # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
       # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
       - name: Fetch test-durations
-        run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/02997e82f03b14f8a88a270db070adb0912bccfb/test_durations" -o .test_durations
+        run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/2879eae3fefb4eb664914df93e545f9d15fe74fb/test_durations" -o .test_durations
 
 
   # fuzzing + slow/exhaustive tests (things that are too slow to run in

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,11 +109,11 @@ jobs:
   fetch-test-durations:
     runs-on: ubuntu-latest
     steps:
-      # fetch test durations
-      # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
-      # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
-      - name: Fetch test-durations
-        run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/2879eae3fefb4eb664914df93e545f9d15fe74fb/test_durations" -o .test_durations
+    # fetch test durations
+    # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
+    # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
+    - name: Fetch test-durations
+      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/2879eae3fefb4eb664914df93e545f9d15fe74fb/test_durations" -o .test_durations
 
 
   # fuzzing + slow/exhaustive tests (things that are too slow to run in
@@ -136,6 +136,9 @@ jobs:
 
     - name: Install Tox
       run: pip install tox
+
+    - name: show test-durations
+      run: ls -a
 
     - name: Run Tox
       run: TOXENV=fuzzing tox -r -- --splits 45 --group ${{ matrix.group }} --reruns 10 --reruns-delay 1 -r aR tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
     # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
     # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
     - name: Fetch test-durations
-      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/2879eae3fefb4eb664914df93e545f9d15fe74fb/test_durations" -o .test_durations
+      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/54ee7f6a09bd94192d01f8de5293483414295e45/test_durations" -o .test_durations
 
     - name: Run Tox
       run: TOXENV=fuzzing tox -r -- --splits 45 --group ${{ matrix.group }} --reruns 10 --reruns-delay 1 -r aR tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,10 +106,21 @@ jobs:
         if: ${{ needs.tests.result != 'success' }}
         run: exit 1
 
+  fetch-test-durations:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch test durations
+      # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
+      # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
+      - name: Fetch test-durations
+        run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/02997e82f03b14f8a88a270db070adb0912bccfb/test_durations" -o .test_durations
+
+
   # fuzzing + slow/exhaustive tests (things that are too slow to run in
   # the regular test suite)
   fuzzing:
     runs-on: ubuntu-latest
+    needs: fetch-test-durations
 
     strategy:
       matrix:
@@ -126,28 +137,7 @@ jobs:
     - name: Install Tox
       run: pip install tox
 
-    - name: Restore duration cache
-      uses: actions/cache@v2
-      id: test_durations_cache
-      with:
-        path: .test_durations
-        # change the version to reset the cache, do this if
-        # the fuzzer tests get unbalanced
-        key: ${{ runner.os }}-test-durations-cache-v2
-
-    - name: Check test durations existence
-      id: check_test_durations
-      uses: andstor/file-existence-action@v1
-      with:
-        files: .test_durations
-
-    - name: Run build test_duration
-      if: steps.check_test_durations.outputs.files_exists == 'false' # has to run on all, otherwise the first one that finishes creates an empty cache and lock the cache for others
-      id: build_cache_duration
-      run: TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/
-
     - name: Run Tox
-      if: steps.check_test_durations.outputs.files_exists == 'true'
       run: TOXENV=fuzzing tox -r -- --splits 45 --group ${{ matrix.group }} --reruns 10 --reruns-delay 1 -r aR tests/
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,6 @@ jobs:
   # the regular test suite)
   fuzzing:
     runs-on: ubuntu-latest
-    needs: fetch-test-durations
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,15 +106,6 @@ jobs:
         if: ${{ needs.tests.result != 'success' }}
         run: exit 1
 
-  fetch-test-durations:
-    runs-on: ubuntu-latest
-    steps:
-    # fetch test durations
-    # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
-    # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
-    - name: Fetch test-durations
-      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/2879eae3fefb4eb664914df93e545f9d15fe74fb/test_durations" -o .test_durations
-
 
   # fuzzing + slow/exhaustive tests (things that are too slow to run in
   # the regular test suite)
@@ -137,8 +128,11 @@ jobs:
     - name: Install Tox
       run: pip install tox
 
-    - name: show test-durations
-      run: ls -a
+    # fetch test durations
+    # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
+    # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
+    - name: Fetch test-durations
+      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/2879eae3fefb4eb664914df93e545f9d15fe74fb/test_durations" -o .test_durations
 
     - name: Run Tox
       run: TOXENV=fuzzing tox -r -- --splits 45 --group ${{ matrix.group }} --reruns 10 --reruns-delay 1 -r aR tests/


### PR DESCRIPTION
note: pending durations file to be pushed to https://github.com/vyperlang/vyper-test-durations

### What I did

### How I did it

### How to verify it

### Commit message

```
our tests are imbalanced now, and the job to rebuild the durations file
takes too long to run (times out on GH actions 6 hour limit). going
forward we will maintain the `.test_durations` file in the auxiliary
`vyper-test-durations` repo, and manually rebuild it as needed.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
