### PR TITLE
fix typo in function validation error message

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -458,7 +458,7 @@ class ContractFunction(BaseTypeDefinition):
 
     def fetch_call_return(self, node: vy_ast.Call) -> Optional[BaseTypeDefinition]:
         if node.get("func.value.id") == "self" and self.visibility == FunctionVisibility.EXTERNAL:
-            raise CallViolation("Cannnot call external functions via 'self'", node)
+            raise CallViolation("Cannot call external functions via 'self'", node)
 
         # for external calls, include gas and value as optional kwargs
         kwarg_keys = self.kwarg_keys.copy()
@@ -469,7 +469,7 @@ class ContractFunction(BaseTypeDefinition):
         if self.mutability < StateMutability.PAYABLE:
             kwarg_node = next((k for k in node.keywords if k.arg == "value"), None)
             if kwarg_node is not None:
-                raise CallViolation("Cannnot send ether to nonpayable function", kwarg_node)
+                raise CallViolation("Cannot send ether to nonpayable function", kwarg_node)
 
         for arg, expected in zip(node.args, self.arguments.values()):
             validate_expected_type(arg, expected)


### PR DESCRIPTION
### What I did
Fixed the spelling of the word cannot
### How I did it
Removed a letter
### How to verify it
Check the spelling
### Commit message
It's a tiny change.
### Description for the changelog
_Fixed a minor spelling error_
### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://static.inspiremore.com/wp-content/uploads/2015/08/15074405/101.jpg)
