### PR TITLE
fix: throw exception for `continue` outside `for` loop

### DIFF
--- a/tests/parser/features/iteration/test_continue.py
+++ b/tests/parser/features/iteration/test_continue.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_continue1(get_contract_with_gas_estimation):
     code = """
 @external
@@ -53,3 +56,32 @@ def foo() -> int128:
 """
     c = get_contract_with_gas_estimation(code)
     assert c.foo() == 3
+
+
+fail_list = [
+    """
+@external
+def foo():
+    a: uint256 = 3
+    continue
+    """,
+    """
+@external
+def foo():
+    if True:
+        continue
+    """,
+    """
+@external
+def foo():
+    for i in [1, 2, 3]:
+        b: uint256 = i
+    if True:
+        continue
+    """,
+]
+
+
+@pytest.mark.parametrize("bad_code", fail_list)
+def test_block_fail(assert_compile_failed, get_contract_with_gas_estimation, bad_code):
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(bad_code))

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -270,7 +270,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
     def visit_Continue(self, node):
         for_node = node.get_ancestor(vy_ast.For)
-        if not for_node:
+        if for_node is None:
             raise StructureException("`continue` must be enclosed in a `for` loop", node)
 
     def visit_Return(self, node):

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -156,7 +156,6 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
     ignored_types = (
         vy_ast.Break,
         vy_ast.Constant,
-        vy_ast.Continue,
         vy_ast.Pass,
     )
     scope_name = "function"
@@ -268,6 +267,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         except InvalidType:
             raise InvalidType("Assertion test value must be a boolean", node.test)
         self.expr_visitor.visit(node.test)
+
+    def visit_Continue(self, node):
+        for_node = node.get_ancestor(vy_ast.For)
+        if not for_node:
+            raise StructureException("`continue` must be enclosed in a `for` loop", node)
 
     def visit_Return(self, node):
         values = node.value


### PR DESCRIPTION
### What I did

Fix #2858.

### How I did it

Visit `Continue` nodes in local validation and check if there is a `For` node in its ancestors.

### How to verify it

See new tests.

### Commit message

```
Fix: throw exception for `continue` outside `for` loop
```

### Description for the changelog

Throw exception for `continue` outside `for` loop

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-preview.redd.it/kPm83LewI0Qc5ya69zCS3MyrHzJ_1GPqRAqzwDKlbpQ.jpg?auto=webp&s=20cd77aa61d6a873eb542c365dc299f68a390849)
