### PR TITLE
fix: add extcodesize check when `default_return_value` is activated

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -2351,6 +2351,10 @@ def transferBorked(erc20: ERC20, receiver: address, amount: uint256):
     # would fail without default_return_value
     c.safeTransfer(bad_erc20.address, c.address, 0)
 
+    # default_return_value should fail on EOAs (addresses with no code)
+    random_address = "0x0000000000000000000000000000000000001234"
+    assert_tx_failed(lambda: c.safeTransfer(random_address, c.address, 1))
+
 
 def test_default_override2(get_contract, assert_tx_failed):
     bad_code_1 = """


### PR DESCRIPTION
### What I did
as title.

### How I did it
in the branch where `returndatasize == 0`, add an extcodesize check.

### How to verify it
see tests

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/169713696-47746907-bc51-4c5c-b685-a8a0d53aa557.png)
