### PR TITLE
fix: disallow dynarray methods during iteration

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -492,7 +492,7 @@ def foo():
     """,
         ImmutableViolation,
     ),
-     # invalid modification of dynarray
+    # invalid modification of dynarray
     (
         """
 @external
@@ -503,7 +503,7 @@ def foo():
     """,
         ImmutableViolation,
     ),
-     # invalid modification of dynarray
+    # invalid modification of dynarray
     (
         """
 array: DynArray[uint256, 5]
@@ -522,7 +522,7 @@ def foo():
     """,
         ImmutableViolation,
     ),
-     (
+    (
         """
 @external
 def foo(x: int128):

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -470,7 +470,59 @@ def foo(x: int128):
     """,
         ImmutableViolation,
     ),
+    # invalid modification of dynarray
     (
+        """
+@external
+def foo():
+    xs: DynArray[uint256, 5] = [1,2,3]
+    for x in xs:
+        xs.pop()
+    """,
+        ImmutableViolation,
+    ),
+    # invalid modification of dynarray
+    (
+        """
+@external
+def foo():
+    xs: DynArray[uint256, 5] = [1,2,3]
+    for x in xs:
+        xs.append(x)
+    """,
+        ImmutableViolation,
+    ),
+     # invalid modification of dynarray
+    (
+        """
+@external
+def foo():
+    xs: DynArray[DynArray[uint256, 5], 5] = [[1,2,3]]
+    for x in xs:
+        x.pop()
+    """,
+        ImmutableViolation,
+    ),
+     # invalid modification of dynarray
+    (
+        """
+array: DynArray[uint256, 5]
+@internal
+def a():
+    self.b()
+
+@internal
+def b():
+    self.array.pop()
+
+@external
+def foo():
+    for x in self.array:
+        self.a()
+    """,
+        ImmutableViolation,
+    ),
+     (
         """
 @external
 def foo(x: int128):

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -108,7 +108,11 @@ def _check_iterator_assign(
         attr_node = node.get_ancestor(vy_ast.Attribute)
         # note the use of get_descendants() blocks statements like
         # self.my_array[i].append(x)
-        if attr_node is not None and node in attr_node.value.get_descendants(include_self=True) and attr_node.attr in ("append", "pop", "extend"):
+        if (
+            attr_node is not None
+            and node in attr_node.value.get_descendants(include_self=True)
+            and attr_node.attr in ("append", "pop", "extend")
+        ):
             return node
 
     return None

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -100,7 +100,15 @@ def _check_iterator_assign(
     for node in similar_nodes:
         # raise if the node is the target of an assignment statement
         assign_node = node.get_ancestor((vy_ast.Assign, vy_ast.AugAssign))
+        # note the use of get_descendants() blocks statements like
+        # self.my_array[i] = x
         if assign_node and node in assign_node.target.get_descendants(include_self=True):
+            return node
+
+        attr_node = node.get_ancestor(vy_ast.Attribute)
+        # note the use of get_descendants() blocks statements like
+        # self.my_array[i].append(x)
+        if attr_node is not None and node in attr_node.value.get_descendants(include_self=True) and attr_node.attr in ("append", "pop", "extend"):
             return node
 
     return None


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/2865

### How I did it
expand the logic in `_validate_iterator_assign` to catch dynarray modifying methods

### How to verify it
see tests

### Commit message

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/169808544-b281ee93-e3c8-4825-a7f7-a3a39790c37a.png)
