### PR TITLE
fix: .codesize codegen on complex attribute

### DIFF
--- a/tests/parser/syntax/test_code_size.py
+++ b/tests/parser/syntax/test_code_size.py
@@ -40,7 +40,7 @@ foo: Foo
 @external
 def bar() -> uint256:
     return self.foo.t.codesize
-    """
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_code_size.py
+++ b/tests/parser/syntax/test_code_size.py
@@ -32,6 +32,15 @@ def foo() -> uint256:
 def foo() -> uint256:
     return self.codesize
     """,
+    """
+struct Foo:
+    t: address
+foo: Foo
+
+@external
+def bar() -> uint256:
+    return self.foo.t.codesize
+    """
 ]
 
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -334,7 +334,7 @@ class Expr:
             addr = Expr.parse_value_expr(self.expr.value, self.context)
             if is_base_type(addr.typ, "address"):
                 if self.expr.attr == "codesize":
-                    if self.expr.value.id == "self":
+                    if self.expr.get("value.id") == "self":
                         eval_code = ["codesize"]
                     else:
                         eval_code = ["extcodesize", addr]


### PR DESCRIPTION
### What I did
fix #2876

### How I did it
the check for `self` in `.codesize` codegen was a little too strict on the type of the AST node. change to not assume `expr.value` is a `Name` AST node.

### How to verify it
see tests

### Commit message

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/170338180-163c84d8-572c-4435-9fe6-4d44fe7100d6.png)
