### PR TITLE
fix: improve modification check of storage variables used as iterator

### DIFF
--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -396,7 +396,10 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
         # Check if `iter` is a storage variable. get_descendants` is used to check for
         # nested `self` (e.g. structs)
-        iter_is_storage_var = len(node.iter.get_descendants(vy_ast.Name, {"id": "self"})) > 0
+        iter_is_storage_var = (
+            isinstance(node.iter, vy_ast.Attribute)
+            and len(node.iter.get_descendants(vy_ast.Name, {"id": "self"})) > 0
+        )
 
         if iter_is_storage_var:
             # check if iterated value may be modified by function calls inside the loop

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -394,7 +394,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             if assign:
                 raise ImmutableViolation("Cannot modify array during iteration", assign)
 
-        if node.iter.get("value.id") == "self":
+        # Check if `iter` is a storage variable. get_descendants` is used to check for
+        # nested `self` (e.g. structs)
+        iter_is_storage_var = len(node.iter.get_descendants(vy_ast.Name, {"id": "self"})) > 0
+
+        if iter_is_storage_var:
             # check if iterated value may be modified by function calls inside the loop
             iter_name = node.iter.attr
             for call_node in node.get_descendants(vy_ast.Call, {"func.value.id": "self"}):


### PR DESCRIPTION
### What I did

Fix #2866.

### How I did it

Check if `iter` is a storage variable by checking its child nodes for `Name` with `id` attribute set to `self`.

### How to verify it

See new tests

### Commit message

```
fix: improve modification check for storage variable iterators

Fix #2866
```

### Description for the changelog

Improve modification check of storage variables used as iterators

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/9KA0T_Qr4jc/sddefault.jpg)
