### PR TITLE
docs: storage layout override

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -37,6 +37,29 @@ The ``-p`` flag allows you to set a root path that is used when searching for in
 
     $ vyper -p yourProject yourProject/yourFileName.vy
 
+
+.. _compiler-storage-layout:
+
+Storage Layout
+~~~~~~~~~~~~~~
+
+To display the default storage layout for a contract:
+
+::
+
+    $ vyper -f layout yourFileName.vy
+
+This outputs a JSON object detailing the default storage location for all state variables as determined by the compiler.
+
+To override the default storage layout for a contract: 
+
+::
+
+    $ vyper --storage-layout-file storageLayout.json yourFileName.vy
+
+The input to the `--storage-layout-file` flag must match the format of the storage layout output from the ``vyper -f layout`` command.
+
+
 .. _vyper-json:
 
 vyper-json

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -49,7 +49,7 @@ To display the default storage layout for a contract:
 
     $ vyper -f layout yourFileName.vy
 
-This outputs a JSON object detailing the default storage location for all state variables as determined by the compiler.
+This outputs a JSON object detailing the locations for all state variables as determined by the compiler.
 
 To override the default storage layout for a contract: 
 
@@ -57,7 +57,7 @@ To override the default storage layout for a contract:
 
     $ vyper --storage-layout-file storageLayout.json yourFileName.vy
 
-The input to the `--storage-layout-file` flag must match the format of the ``.storage_layout`` field from the ``vyper -f layout`` command.
+The input to the ``--storage-layout-file`` flag must match the format of the ``.storage_layout`` field from the ``vyper -f layout`` command.
 
 
 .. _vyper-json:

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -57,7 +57,7 @@ To override the default storage layout for a contract:
 
     $ vyper --storage-layout-file storageLayout.json yourFileName.vy
 
-The input to the `--storage-layout-file` flag must match the format of the storage layout output from the ``vyper -f layout`` command.
+The input to the `--storage-layout-file` flag must match the format of the ``.storage_layout`` field from the ``vyper -f layout`` command.
 
 
 .. _vyper-json:

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -76,7 +76,7 @@ You cannot directly declare tuple types. However, in certain cases you can use l
 Storage Layout
 ==============
 
-Storage variables are located within a smart contract at specific storage slots. The compiler allocates the first variable to be stored within `slot 0` and subsequent variables are stored in order.
+Storage variables are located within a smart contract at specific storage slots. The compiler allocates the first variable to be stored within ``slot 0`` and subsequent variables are stored in order.
 
 There are cases where it is necessary to override this pattern and to allocate storage variables in custom slots. This behaviour is often required for upgradeable contracts, to ensure that both contracts (the old contract, and the new contract) store the same variable within the same slot.
 
@@ -97,16 +97,16 @@ For example, consider upgrading the following contract:
     minter: public(address)
     balanceOf: public(HashMap[address, uint256])
 
-This would cause an issue when upgrading, as the `balanceOf` mapping would be located at `slot1` in the old contract, and `slot2` in the new contract.
+This would cause an issue when upgrading, as the ``balanceOf`` mapping would be located at ``slot1`` in the old contract, and ``slot2`` in the new contract.
 
-This issue can be avoided by allocating `balanceOf` to `slot1` using the storage layout overrides. The contract can be compiled with ``vyper new_contract.vy --storage-layout-file new_contract_storage.json`` where `new_contract_storage.json` contains the following:
+This issue can be avoided by allocating ``balanceOf`` to ``slot1`` using the storage layout overrides. The contract can be compiled with ``vyper new_contract.vy --storage-layout-file new_contract_storage.json`` where `new_contract_storage.json` contains the following:
 
 .. code-block:: javascript
     
     {
-        "owner": {"type": "address", "location": "storage", "slot": 0}, 
-        "minter": {"type": "address", "location": "storage", "slot": 2}, 
-        "balanceOf": {"type": "HashMap[address, uint256]", "location": "storage", "slot": 1}
+        "owner": {"type": "address", "slot": 0}, 
+        "minter": {"type": "address", "slot": 2}, 
+        "balanceOf": {"type": "HashMap[address, uint256]", "slot": 1}
     }
 
 For further information on generating the storage layout, see :ref:`Storage Layout <compiler-storage-layout>`.

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -76,7 +76,7 @@ You cannot directly declare tuple types. However, in certain cases you can use l
 Storage Layout
 ==============
 
-Storage variables are located within a smart contract at specific storage slots. The compiler allocates the first variable to be stored within ``slot 0`` and subsequent variables are stored in order.
+Storage variables are located within a smart contract at specific storage slots. By default, the compiler allocates the first variable to be stored within ``slot 0``; subsequent variables are stored in order after that.
 
 There are cases where it is necessary to override this pattern and to allocate storage variables in custom slots. This behaviour is often required for upgradeable contracts, to ensure that both contracts (the old contract, and the new contract) store the same variable within the same slot.
 
@@ -99,7 +99,7 @@ For example, consider upgrading the following contract:
 
 This would cause an issue when upgrading, as the ``balanceOf`` mapping would be located at ``slot1`` in the old contract, and ``slot2`` in the new contract.
 
-This issue can be avoided by allocating ``balanceOf`` to ``slot1`` using the storage layout overrides. The contract can be compiled with ``vyper new_contract.vy --storage-layout-file new_contract_storage.json`` where `new_contract_storage.json` contains the following:
+This issue can be avoided by allocating ``balanceOf`` to ``slot1`` using the storage layout overrides. The contract can be compiled with ``vyper new_contract.vy --storage-layout-file new_contract_storage.json`` where ``new_contract_storage.json`` contains the following:
 
 .. code-block:: javascript
     

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -73,8 +73,8 @@ You cannot directly declare tuple types. However, in certain cases you can use l
         a, b = self.foo()
 
 
-Storage Layout Overrides
-========================
+Storage Layout
+==============
 
 Storage variables are located within a smart contract at specific storage slots. The compiler allocates the first variable to be stored within `slot 0` and subsequent variables are stored in order.
 
@@ -108,6 +108,8 @@ This issue can be avoided by allocating `balanceOf` to `slot1` using the storage
         "minter": {"type": "address", "location": "storage", "slot": 2}, 
         "balanceOf": {"type": "HashMap[address, uint256]", "location": "storage", "slot": 1}
     }
+
+For further information on generating the storage layout, see :ref:`Storage Layout <compiler-storage-layout>`.
 
 Scoping Rules
 =============

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -58,7 +58,7 @@ You cannot directly declare tuple types. However, in certain cases you can use l
 .. code-block:: python
 
     @internal
-    def foo() -> (int128: int128):
+    def foo() -> (int128, int128):
         return 2, 3
 
     @external

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -76,7 +76,7 @@ You cannot directly declare tuple types. However, in certain cases you can use l
 Storage Layout
 ==============
 
-Storage variables are located within a smart contract at specific storage slots. By default, the compiler allocates the first variable to be stored within ``slot 0``; subsequent variables are stored in order after that.
+Storage variables are located within a smart contract at specific storage slots. By default, the compiler allocates the first variable to be stored at ``slot 0``; subsequent variables are stored in order after that.
 
 There are cases where it is necessary to override this pattern and to allocate storage variables in custom slots. This behaviour is often required for upgradeable contracts, to ensure that both contracts (the old contract, and the new contract) store the same variable within the same slot.
 


### PR DESCRIPTION
### What I did

Add documentation for storage layout overrides. #2593 

I wasn't 100% sure whether the best place to add this documentation would be. I thought maybe adding it with the section on variable declaration, but am open to other ideas.

### How I did it

Updated `docs/scoping-and-declarations.rst`

### How to verify it

Ran locally with no issues.

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

Add documentation for storage layout overrides

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://149366112.v2.pressablecdn.com/wp-content/uploads/2014/01/7-Super-Smart-Animals-Species.jpg)
