### PR TITLE
fix: per-method calldatasize checks

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -2459,12 +2459,7 @@ TEST_ADDR = b"".join(chr(i).encode("utf-8") for i in range(20)).hex()
 
 @pytest.mark.parametrize(
     "typ,val",
-    [
-        ("address", TEST_ADDR),
-        ("uint256", 2 ** 256 - 1),
-        ("int128", 2 ** 127 - 1),
-        ("bool", True),
-    ],
+    [("address", TEST_ADDR), ("uint256", 2 ** 256 - 1), ("int128", 2 ** 127 - 1), ("bool", True)],
 )
 def test_calldata_clamp(w3, get_contract, assert_tx_failed, abi_encode, keccak, typ, val):
     code = f"""

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -2457,13 +2457,14 @@ def do_stuff(f: Foo) -> uint256:
 TEST_ADDR = b"".join(chr(i).encode("utf-8") for i in range(20)).hex()
 
 
-@pytest.mark.parametrize("typ,val",
+@pytest.mark.parametrize(
+    "typ,val",
     [
         ("address", TEST_ADDR),
         ("uint256", 2 ** 256 - 1),
         ("int128", 2 ** 127 - 1),
         ("bool", True),
-    ]
+    ],
 )
 def test_calldata_clamp(w3, get_contract, assert_tx_failed, abi_encode, keccak, typ, val):
     code = f"""
@@ -2488,13 +2489,14 @@ def foo(a: {typ}):
     w3.eth.send_transaction({"to": c1.address, "data": data})
 
 
-@pytest.mark.parametrize("typ,val",
+@pytest.mark.parametrize(
+    "typ,val",
     [
         ("address", ([TEST_ADDR] * 3, "vyper")),
         ("uint256", ([1, 2, 3], "is")),
         ("int128", ([-1, -2, -3], "the")),
         ("bool", ([True, False, True], "best")),
-    ]
+    ],
 )
 def test_dynamic_calldata_clamp(w3, get_contract, assert_tx_failed, abi_encode, keccak, typ, val):
     code = f"""

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -2457,10 +2457,7 @@ def do_stuff(f: Foo) -> uint256:
 TEST_ADDR = b"".join(chr(i).encode("utf-8") for i in range(20)).hex()
 
 
-@pytest.mark.parametrize(
-    "typ,val",
-    [("address", TEST_ADDR), ("uint256", 2 ** 256 - 1), ("int128", 2 ** 127 - 1), ("bool", True)],
-)
+@pytest.mark.parametrize("typ,val", [("address", TEST_ADDR)])
 def test_calldata_clamp(w3, get_contract, assert_tx_failed, abi_encode, keccak, typ, val):
     code = f"""
 @external
@@ -2484,15 +2481,7 @@ def foo(a: {typ}):
     w3.eth.send_transaction({"to": c1.address, "data": data})
 
 
-@pytest.mark.parametrize(
-    "typ,val",
-    [
-        ("address", ([TEST_ADDR] * 3, "vyper")),
-        ("uint256", ([1, 2, 3], "is")),
-        ("int128", ([-1, -2, -3], "the")),
-        ("bool", ([True, False, True], "best")),
-    ],
-)
+@pytest.mark.parametrize("typ,val", [("address", ([TEST_ADDR] * 3, "vyper"))])
 def test_dynamic_calldata_clamp(w3, get_contract, assert_tx_failed, abi_encode, keccak, typ, val):
     code = f"""
 @external

--- a/tests/parser/functions/test_default_function.py
+++ b/tests/parser/functions/test_default_function.py
@@ -126,7 +126,7 @@ def __default__():
 
     logs = get_logs(
         # call blockHashAskewLimitary
-        w3.eth.send_transaction({"to": c.address, "value": 0, "data": "0x00000000"}),
+        w3.eth.send_transaction({"to": c.address, "value": 0, "data": "0x" + "00" * 36}),
         c,
         "Sent",
     )

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -89,7 +89,7 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature) -> List[A
         # ensure calldata is at least of minimum length
         args_abi_t = calldata_args_t.abi_type
         calldata_min_size = args_abi_t.min_size() + 4
-        if (args_abi_t.is_dynamic()):
+        if args_abi_t.is_dynamic():
             ret.append(["assert", ["ge", "calldatasize", calldata_min_size]])
         else:
             # stricter for static data

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -85,6 +85,7 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature) -> List[A
 
         # a sequence of statements to strictify kwargs into memory
         ret = ["seq"]
+        ret.append(["assert", ["ge", "calldatasize", calldata_args_t.abi_type.min_size() + 4]])
 
         # TODO optimize make_setter by using
         # TupleType(list(arg.typ for arg in calldata_kwargs + default_kwargs))

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -87,7 +87,13 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature) -> List[A
         ret = ["seq"]
 
         # ensure calldata is at least of minimum length
-        ret.append(["assert", ["ge", "calldatasize", calldata_args_t.abi_type.min_size() + 4]])
+        args_abi_t = calldata_args_t.abi_type
+        calldata_min_size = args_abi_t.min_size() + 4
+        if (args_abi_t.is_dynamic()):
+            ret.append(["assert", ["ge", "calldatasize", calldata_min_size]])
+        else:
+            # stricter for static data
+            ret.append(["assert", ["eq", "calldatasize", calldata_min_size]])
 
         # TODO optimize make_setter by using
         # TupleType(list(arg.typ for arg in calldata_kwargs + default_kwargs))

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -85,6 +85,8 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature) -> List[A
 
         # a sequence of statements to strictify kwargs into memory
         ret = ["seq"]
+
+        # ensure calldata is at least of minimum length
         ret.append(["assert", ["ge", "calldatasize", calldata_args_t.abi_type.min_size() + 4]])
 
         # TODO optimize make_setter by using


### PR DESCRIPTION
### What I did

Fix #1730.

### How I did it

Add a clamper for calldata to be at least of minimum ABI size + 4 bytes for method ID.

### How to verify it

See additional tests.

### Commit message

```
fix: ensure calldata is of minimum length

Added a clamper to calldata to ensure its length is at least 
equal to or greater than the minimum ABI size + 4 bytes for
method ID.

Fix #1730.
```

### Description for the changelog

Ensure calldata is at least of minimum length.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://is2-ssl.mzstatic.com/image/thumb/Purple115/v4/e8/fe/a1/e8fea118-be45-3e8a-9a05-614311473737/source/512x512bb.jpg)
