### PR TITLE
fix: avoid dirty byte edge case in uint2str

### DIFF
--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -2094,7 +2094,7 @@ class Uint2Str(_SimpleBuiltinFunction):
             ret = [
                 "if",
                 ["eq", val, 0],
-                ["seq", ["mstore", buf + 1, 0x0130], buf],
+                ["seq", ["mstore", buf + 1, ord("0")], ["mstore", buf, 1], buf],
                 ["seq", ret, val],
             ]
 


### PR DESCRIPTION
the existing implementation used a single mstore, but the first byte of
the length might be dirty. to ensure the entire bytestring is clean, use
two mstores.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/174184934-d3dfe948-04ca-4353-981e-e81e32703cd8.png)
