### PR TITLE
tune arithmetic ops CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
 
     strategy:
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]
 
     steps:
     - uses: actions/checkout@v1
@@ -134,7 +134,7 @@ jobs:
       run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/4d8398e581f183de986892c5a8d4ab3d05ccaab2/test_durations" -o .test_durations
 
     - name: Run Tox
-      run: TOXENV=fuzzing tox -r -- --splits 45 --group ${{ matrix.group }} --splitting-algorithm least_duration --reruns 10 --reruns-delay 1 -r aR tests/
+      run: TOXENV=fuzzing tox -r -- --splits 60 --group ${{ matrix.group }} --splitting-algorithm least_duration --reruns 10 --reruns-delay 1 -r aR tests/
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v1

--- a/tests/parser/types/numbers/test_signed_ints.py
+++ b/tests/parser/types/numbers/test_signed_ints.py
@@ -217,7 +217,7 @@ def foo() -> {typ}:
 
     # note: (including special cases, roughly 8k cases total generated)
 
-    NUM_CASES = 10
+    NUM_CASES = 5
     # poor man's fuzzing - hypothesis doesn't make it easy
     # with the parametrized strategy
     xs += [random.randrange(lo, hi) for _ in range(NUM_CASES)]

--- a/tests/parser/types/numbers/test_unsigned_ints.py
+++ b/tests/parser/types/numbers/test_unsigned_ints.py
@@ -90,7 +90,7 @@ def foo() -> {typ}:
     special_cases = [0, 1, 2, 3, hi // 2 - 1, hi // 2, hi // 2 + 1, hi - 2, hi - 1, hi]
     xs = special_cases.copy()
     ys = special_cases.copy()
-    NUM_CASES = 10
+    NUM_CASES = 5
     # poor man's fuzzing - hypothesis doesn't make it easy
     # with the parametrized strategy
     xs += [random.randrange(lo, hi) for _ in range(NUM_CASES)]


### PR DESCRIPTION
### What I did
bring CI from ~60 minutes back down to ~30 minutes

### How I did it
tuning, reduce # of fuzzer cases and increase # workers

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/174355289-4424d316-c9d3-44ca-b292-a4a6850c0ca3.png)
