### PR TITLE
add factory decorator

### DIFF
--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -228,7 +228,7 @@ def generate_ir_for_module(global_ctx: GlobalContext) -> Tuple[IRnode, IRnode, F
         deploy_code.append(["deploy", 0, runtime, 0])
 
     if init_function and init_function._metadata["type"].is_factory:
-        # inception
+        # initception
         runtime = deploy_code
         deploy_code = ["deploy", 0, deploy_code, 0]
 

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -227,4 +227,9 @@ def generate_ir_for_module(global_ctx: GlobalContext) -> Tuple[IRnode, IRnode, F
             raise CompilerPanic("unreachable")
         deploy_code.append(["deploy", 0, runtime, 0])
 
+    if init_function and init_function._metadata["type"].is_factory:
+        # inception
+        runtime = deploy_code
+        deploy_code = ["deploy", 0, deploy_code, 0]
+
     return IRnode.from_list(deploy_code), IRnode.from_list(runtime), sigs

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -101,6 +101,7 @@ class ContractFunction(BaseTypeDefinition):
         function_visibility: FunctionVisibility,
         state_mutability: StateMutability,
         nonreentrant: Optional[str] = None,
+        is_factory: bool = False,
     ) -> None:
         super().__init__(
             # A function definition type only exists while compiling
@@ -121,6 +122,8 @@ class ContractFunction(BaseTypeDefinition):
         self.visibility = function_visibility
         self.mutability = state_mutability
         self.nonreentrant = nonreentrant
+
+        self.is_factory = is_factory
 
         # a list of internal functions this function calls
         self.called_functions: Set["ContractFunction"] = set()
@@ -263,6 +266,11 @@ class ContractFunction(BaseTypeDefinition):
                                 f"Mutability is already set to: {kwargs['state_mutability']}", node
                             )
                         kwargs["state_mutability"] = StateMutability(decorator.id)
+                    elif decorator.id == "factory":
+                        if node.name != "__init__":
+                            msg = "Factory decorator only allowed on `__init__`"
+                            raise FunctionDeclarationException(msg, decorator)
+                        kwargs["is_factory"] = True
 
                     else:
                         if decorator.id == "constant":


### PR DESCRIPTION
this will make it easier to deploy factory contracts and verify them on etherscan

also implements a portion of #2891 

### What I did
add factory decorator to init functions

### How I did it
add it to function type metadata; in the codegen, if init function is marked as factory, wrap it in another `deploy` operation. this generates the correct initcode.

### How to verify it
check code for this contract
```vyper
FOO: immutable(uint256)

@external
@factory
def __init__(arg: uint256):
    FOO = arg

@external
def foo() -> uint256:
    return FOO
```
tests tbd

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/174194624-d37d943f-2e4c-4531-a818-23b7415baa52.png)
