### PR TITLE
adding a pre-release workflow

### DIFF
--- a/.github/changelog.json
+++ b/.github/changelog.json
@@ -1,0 +1,31 @@
+{
+  "categories": [
+    {
+      "title": "## Features",
+      "labels": ["Feature", "enhancement"]
+    },
+    {
+      "title": "## Fixes",
+      "labels": [
+        "bug - codegen",
+        "bug - documentation",
+        "bug - type 0",
+        "bug - type 1",
+        "bug - typechecker",
+        "bug - UX",
+        "bug"
+      ]
+    },
+    {
+      "title": "## Codegen",
+      "labels": ["codegen"]
+    },
+    {
+      "title": "## Tests",
+      "labels": ["Tests"]
+    }
+  ],
+  "template": "${{CHANGELOG}}\n## Other\n\n${{UNCATEGORIZED}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+  "empty_template": "- No changes"
+}

--- a/.github/scripts/create-or-update-ref.js
+++ b/.github/scripts/create-or-update-ref.js
@@ -1,0 +1,34 @@
+module.exports = async ({ github, context }, tagName) => {
+  try {
+    await github.rest.git.getRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${tagName}`,
+    });
+
+    await github.rest.git.updateRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${tagName}`,
+      sha: context.sha,
+      force: true,
+    });
+  } catch (err) {
+    console.log(
+      `⛔ Failed to update tag: ${tagName}. \n Attempting to create the tag ...`
+    );
+    console.log(err);
+    try {
+      await github.rest.git.createRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: `refs/tags/${tagName}`,
+        sha: context.sha,
+        force: true,
+      });
+    } catch (err) {
+      console.error(`⛔ Failed to create tag: ${tagName}`);
+      console.error(err);
+    }
+  }
+};

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -1,23 +1,30 @@
 module.exports = async ({github, context}) => {
-    console.log('Pruning old prereleases')
-  
-    const { data: releases } = await github.rest.repos.listReleases({
+  console.log('Pruning old prereleases')
+
+  const { data: releases } = await github.rest.repos.listReleases({
+    owner: context.repo.owner,
+    repo: context.repo.repo
+  })
+
+  let prereleases = releases.filter(
+    (release) => release.tag_name.includes('pre')
+  )
+
+  for (const prerelease of prereleases) {
+    console.log(`Deleting prerelase: ${prerelease.tag_name}`)
+    await github.rest.repos.deleteRelease({
       owner: context.repo.owner,
-      repo: context.repo.repo
+      repo: context.repo.repo,
+      release_id: prerelease.id
     })
-  
-    let prereleases = releases.filter(
-      (release) => release.tag_name.includes('pre-release')
-    )
-  
-    for (const prerelease of prereleases) {
-      console.log(`Deleting prerelase: ${prerelease.tag_name}`)
-      await github.rest.repos.deleteRelease({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        release_id: prerelease.id
-      })
-    }
-  
-    console.log('Done.')
+
+    console.log(`Deleting prerelase tag: ${prerelease.tag_name}`)
+    await github.rest.git.deleteRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${prerelease.tag_name}`
+    })
   }
+
+  console.log('Done.')
+}

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -1,0 +1,23 @@
+module.exports = async ({github, context}) => {
+    console.log('Pruning old prereleases')
+  
+    const { data: releases } = await github.rest.repos.listReleases({
+      owner: context.repo.owner,
+      repo: context.repo.repo
+    })
+  
+    let prereleases = releases.filter(
+      (release) => release.tag_name.includes('pre-release')
+    )
+  
+    for (const prerelease of prereleases) {
+      console.log(`Deleting prerelase: ${prerelease.tag_name}`)
+      await github.rest.repos.deleteRelease({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        release_id: prerelease.id
+      })
+    }
+  
+    console.log('Done.')
+  }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - '*'
     branches:
       - master
+  workflow_call:
+    
 
 defaults:
   run:
@@ -23,7 +25,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
             # grab the commit passed in via `tag`, if any
             ref: ${{ github.event.inputs.tag }}
@@ -42,7 +44,7 @@ jobs:
           make freeze
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: dist/vyper.*
 
@@ -50,7 +52,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
             # grab the commit passed in via `tag`, if any
             ref: ${{ github.event.inputs.tag }}
@@ -69,6 +71,6 @@ jobs:
           ./make.cmd freeze
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: dist/vyper.*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,6 +16,8 @@ jobs:
 
     outputs:
       change_log: ${{ steps.build_changelog.outputs.change_log }}
+      fromTag: ${{ steps.build_changelog.outputs.fromTag }}
+      pre-release_tag: ${{ steps.latest_tag.outputs.tag_name }}
 
     steps:
       - name: Checkout sources
@@ -23,21 +25,37 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Finding the latest tag
+        id: latest_tag
+        run: |
+          current_semver=$(git tag --list | grep '^v[0-9]*\.[0-9]*\.[0-9]*$' | tail -n 1)
+          current_major=$(echo $current_semver | sed -E 's/v([0-9]*)\.([0-9]*)\.([0-9]*)/\1/g')
+          current_minor=$(echo $current_semver | sed -E 's/v([0-9]*)\.([0-9]*)\.([0-9]*)/\2/g')
+          current_patch=$(echo $current_semver | sed -E 's/v([0-9]*)\.([0-9]*)\.([0-9]*)/\3/g')
+          next_patch=$((current_patch+1))
+          next_semver="v${current_major}.${current_minor}.${next_patch}-pre-release"
+          echo "current semver: $current_semver"
+          echo "next pre-release semver: $next_semver"
+          echo "::set-output name=tag_name::${next_semver}"
+        shell: bash
+
       - name: Create/Update pre-release tag
         uses: actions/github-script@v6
+        env:
+          TAG_NAME: ${{ steps.latest_tag.outputs.tag_name }}
         with:
           script: |
             const prunePrereleases = require('./.github/scripts/prune-prereleases.js')
             await prunePrereleases({github, context})
             const createOrUpdateTag = require('./.github/scripts/create-or-update-ref.js')
-            await createOrUpdateTag({github, context}, 'pre-release')
+            await createOrUpdateTag({github, context}, process.env.TAG_NAME)
 
       - name: Build changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2
         with:
           configuration: "./.github/changelog.json"
-          toTag: pre-release
+          toTag: ${{ steps.latest_tag.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,8 +80,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: 'Pre-release'
-          tag_name: 'pre-release'
+          tag_name: ${{ needs.prepare.outputs.pre-release_tag }}
           prerelease: true
-          body: ${{ needs.prepare.steps.build_changelog.outputs.change_log }}
+          body: ${{ needs.prepare.outputs.change_log }}
           files: |
             dist/artifact/vyper.*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,69 @@
+name: Build Pre-release
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+
+  push:
+    branches:
+      - master
+
+jobs:
+  prepare:
+    name: Prepare pre-release
+    runs-on: ubuntu-latest
+
+    outputs:
+      change_log: ${{ steps.build_changelog.outputs.change_log }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Create/Update pre-release tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prunePrereleases = require('./.github/scripts/prune-prereleases.js')
+            await prunePrereleases({github, context})
+            const createOrUpdateTag = require('./.github/scripts/create-or-update-ref.js')
+            await createOrUpdateTag({github, context}, 'pre-release')
+
+      - name: Build changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v2
+        with:
+          configuration: "./.github/changelog.json"
+          toTag: pre-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+  build-binaries:
+    name: Build binaries
+    needs: prepare
+    uses: ./.github/workflows/build.yml
+
+  update-pre-release:
+    name: Post process
+    needs: [prepare, build-binaries]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
+
+      - name: Update pre-release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: 'Pre-release'
+          tag_name: 'pre-release'
+          prerelease: true
+          body: ${{ needs.prepare.steps.build_changelog.outputs.change_log }}
+          files: |
+            dist/artifact/vyper.*

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "local_scheme": _local_version,
         "version_scheme": _global_version,
         "write_to": "vyper/version.py",
+        "tag_regex": r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^-\+]*)(?:[-\+].*)?$"
     },
     description="Vyper: the Pythonic Programming Language for the EVM",
     long_description=long_description,


### PR DESCRIPTION
### What I did

Added a new `GitHub` workflow to build pre-release binaries on pushes to the `master` branch.

### How I did it

Created an auxiliary workflow `pre-release.yml` and turned `build.yml` into a reusable workflow that `pre-release.yml` would tap into for creating the binary artifacts. The `pre-release` tag and release would get automatically updated to the latest commit pushed to the `master` branch.

This would close #2913 .

