### PR TITLE
allow "nonreentrant" on view functions

### DIFF
--- a/tests/signatures/test_invalid_function_decorators.py
+++ b/tests/signatures/test_invalid_function_decorators.py
@@ -6,7 +6,7 @@ from vyper.exceptions import StructureException
 FAILING_CONTRACTS = [
     """
 @external
-@view
+@pure
 @nonreentrant('lock')
 def nonreentrant_foo() -> uint256:
     return 1

--- a/vyper/codegen/function_definitions/utils.py
+++ b/vyper/codegen/function_definitions/utils.py
@@ -1,8 +1,16 @@
+from vyper.semantics.types.function import StateMutability
+
+
 def get_nonreentrant_lock(func_type):
     if not func_type.nonreentrant:
         return ["pass"], ["pass"]
 
     nkey = func_type.reentrancy_key_position.position
-    nonreentrant_pre = [["seq", ["assert", ["iszero", ["sload", nkey]]], ["sstore", nkey, 1]]]
-    nonreentrant_post = [["sstore", nkey, 0]]
-    return nonreentrant_pre, nonreentrant_post
+
+    if func_type.mutability == StateMutability.VIEW:
+        return [["assert", ["iszero", ["sload", nkey]]]], [["seq"]]
+
+    else:
+        nonreentrant_pre = [["seq", ["assert", ["iszero", ["sload", nkey]]], ["sstore", nkey, 1]]]
+        nonreentrant_post = [["sstore", nkey, 0]]
+        return nonreentrant_pre, nonreentrant_post

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -297,11 +297,8 @@ class ContractFunction(BaseTypeDefinition):
             # Assume nonpayable if not set at all (cannot accept Ether, but can modify state)
             kwargs["state_mutability"] = StateMutability.NONPAYABLE
 
-        if (
-            kwargs["state_mutability"] in (StateMutability.VIEW, StateMutability.PURE)
-            and "nonreentrant" in kwargs
-        ):
-            raise StructureException("Cannot use reentrancy guard on view or pure functions", node)
+        if kwargs["state_mutability"] == StateMutability.PURE and "nonreentrant" in kwargs:
+            raise StructureException("Cannot use reentrancy guard on pure functions", node)
 
         # call arguments
         if node.args.defaults and node.name == "__init__":


### PR DESCRIPTION
on view functions, the sstores are not issued, but the sload check is

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/174490126-25b9c537-caa7-4745-9c64-091207a6bf5b.png)
