### PR TITLE
optimize runtime values for nonreentrant slots

### DIFF
--- a/vyper/codegen/function_definitions/utils.py
+++ b/vyper/codegen/function_definitions/utils.py
@@ -1,3 +1,4 @@
+from vyper.evm.opcodes import version_check
 from vyper.semantics.types.function import StateMutability
 
 
@@ -7,10 +8,17 @@ def get_nonreentrant_lock(func_type):
 
     nkey = func_type.reentrancy_key_position.position
 
+    if version_check(begin="berlin"):
+        final_value, temp_value = 1, 2
+    else:
+        final_value, temp_value = 0, 1
+
+    check_notset = ["assert", ["ne", temp_value, ["sload", nkey]]]
+
     if func_type.mutability == StateMutability.VIEW:
-        return [["assert", ["iszero", ["sload", nkey]]]], [["seq"]]
+        return [check_notset], [["seq"]]
 
     else:
-        nonreentrant_pre = [["seq", ["assert", ["iszero", ["sload", nkey]]], ["sstore", nkey, 1]]]
-        nonreentrant_post = [["sstore", nkey, 0]]
-        return nonreentrant_pre, nonreentrant_post
+        pre = ["seq", check_notset, ["sstore", nkey, temp_value]]
+        post = ["sstore", nkey, final_value]
+        return [pre], [post]

--- a/vyper/codegen/function_definitions/utils.py
+++ b/vyper/codegen/function_definitions/utils.py
@@ -9,7 +9,10 @@ def get_nonreentrant_lock(func_type):
     nkey = func_type.reentrancy_key_position.position
 
     if version_check(begin="berlin"):
-        final_value, temp_value = 1, 2
+        # any nonzero values would work here (see pricing as of net gas
+        # metering); these values are chosen so that downgrading to the
+        # 0,1 scheme (if it is somehow necessary) is safe.
+        final_value, temp_value = 3, 2
     else:
         final_value, temp_value = 0, 1
 


### PR DESCRIPTION
after berlin (istanbul?), it is cheaper to use a nonzero slot. this brings the total
cost of a nonreentrancy lock down from 4400 gas to 2300 gas.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/3867501/174507883-836c8437-7989-47b9-b3c3-ef871e487873.png)

