### PR TITLE
docs: add details on nonreentrant implementation

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -82,7 +82,11 @@ You can optionally declare a function's mutability by using a :ref:`decorator <f
         # this function can receive ether
         ...
 
-Functions default to nonpayable when no mutability decorator is used.
+Functions default to ``nonpayable`` when no mutability decorator is used.
+
+Functions marked with ``@view`` cannot call mutable (``payable`` or ``nonpayable``) functions. Any external calls are made using the special ``STATICCALL`` opcode, which prevents state changes at the EVM level.
+
+Functions marked with ``@pure`` cannot call non-``pure`` functions.
 
 Re-entrancy Locks
 -----------------
@@ -99,7 +103,19 @@ The ``@nonreentrant(<key>)`` decorator places a lock on a function, and all func
 
 You can put the ``@nonreentrant(<key>)`` decorator on a ``__default__`` function but we recommend against it because in most circumstances it will not work in a meaningful way.
 
-The `__default__` Function
+Nonreentrancy keys work by setting a specially allocated storage slot to a ``<locked>`` value on function entrance, and setting it to an ``<unlocked>`` value on function exit. On function entrance, if the storage slot is detected to be the ``<locked>`` value, execution reverts.
+
+You cannot put the ``@nonreentrant`` decorator on a ``pure`` function. You can put it on a ``view`` function, but it only checks that the function is not in a callback (the storage slot is not in the ``<locked>`` state), as ``view`` functions can only read the state, not change it.
+
+.. note::
+    A mutable function can protect a ``view`` function from being called back into (which is useful for instance, if a ``view`` function would return inconsistent state during a mutable function), but a ``view`` function cannot protect itself from being called back into. Note that mutable functions can never be called from a ``view`` function because all external calls out from a ``view`` function are protected by the use of the ``STATICCALL`` opcode.
+
+.. note::
+
+    A nonreentrant lock has an ``<unlocked>`` value of 3, and a ``<locked>`` value of 2. Nonzero values are used to take advantage of net gas metering - as of the Berlin hard fork, the net cost for utilizing a nonreentrant lock is 2300 gas. Prior to v0.3.4, the ``<unlocked>`` and ``<locked>`` values were 0 and 1, respectively.
+
+
+The ``__default__`` Function
 --------------------------
 
 A contract can also have a default function, which is executed on a call to the contract if no other functions match the given function identifier (or if none was supplied at all, such as through someone sending it Eth). It is the same construct as fallback functions `in Solidity <https://solidity.readthedocs.io/en/latest/contracts.html?highlight=fallback#fallback-function>`_.
@@ -139,7 +155,7 @@ Lastly, although the default function receives no arguments, it can still access
     * the amount of ETH sent (``msg.value``)
     * the gas provided (``msg.gas``).
 
-The `__init__` Function
+The ``__init__`` Function
 -----------------------
 
 ``__init__`` is a special initialization function that may only be called at the time of deploying a contract. It can be used to set initial values for storage variables. A common use case is to set an ``owner`` variable with the creator the contract:

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -103,7 +103,7 @@ The ``@nonreentrant(<key>)`` decorator places a lock on a function, and all func
 
 You can put the ``@nonreentrant(<key>)`` decorator on a ``__default__`` function but we recommend against it because in most circumstances it will not work in a meaningful way.
 
-Nonreentrancy keys work by setting a specially allocated storage slot to a ``<locked>`` value on function entrance, and setting it to an ``<unlocked>`` value on function exit. On function entrance, if the storage slot is detected to be the ``<locked>`` value, execution reverts.
+Nonreentrancy locks work by setting a specially allocated storage slot to a ``<locked>`` value on function entrance, and setting it to an ``<unlocked>`` value on function exit. On function entrance, if the storage slot is detected to be the ``<locked>`` value, execution reverts.
 
 You cannot put the ``@nonreentrant`` decorator on a ``pure`` function. You can put it on a ``view`` function, but it only checks that the function is not in a callback (the storage slot is not in the ``<locked>`` state), as ``view`` functions can only read the state, not change it.
 


### PR DESCRIPTION
- nonreentrant storage slots
- view function restrictions
- what nonreentrant on view function means
- gas costs for storage slots
- other formatting fixes

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/174609034-8bfe2ffc-6c11-400d-b13f-daf55eb1fbb8.png)
