### PR TITLE
feat: add `code_offset=` kwarg to `create_from_factory`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       run: pip install tox
 
     - name: Run Tox
-      run: TOXENV=py${{ matrix.python-version[1] }}-${{ matrix.flag }} tox -r -- --reruns 10 --reruns-delay 1 -r aR tests/
+      run: TOXENV=py${{ matrix.python-version[1] }}-${{ matrix.flag }} tox -r -- --reruns 10 --reruns-delay 5 -r aR tests/
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       run: pip install tox
 
     - name: Run Tox
-      run: TOXENV=py${{ matrix.python-version[1] }}-${{ matrix.flag }} tox -r -- --reruns 10 --reruns-delay 5 -r aR tests/
+      run: TOXENV=py${{ matrix.python-version[1] }}-${{ matrix.flag }} tox -r -- --reruns 10 --reruns-delay 1 -r aR tests/
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v1

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -3,7 +3,7 @@ import rlp
 from eth_abi import encode_single
 from hexbytes import HexBytes
 
-from vyper.utils import checksum_encode, keccak256, EIP_170_LIMIT
+from vyper.utils import EIP_170_LIMIT, checksum_encode, keccak256
 
 
 # initcode used by create_minimal_proxy_to
@@ -147,7 +147,13 @@ def test(_salt: bytes32) -> address:
 # contract, and 0xfe65766d is an old magic from EIP154
 @pytest.mark.parametrize("factory_prefix", [b"", b"\xfe", b"\xfe\x65\x76\x6d"])
 def test_create_from_factory(
-    get_contract, deploy_factory_for, w3, keccak, create2_address_of, assert_tx_failed, factory_prefix
+    get_contract,
+    deploy_factory_for,
+    w3,
+    keccak,
+    create2_address_of,
+    assert_tx_failed,
+    factory_prefix,
 ):
     code = """
 @external
@@ -196,14 +202,16 @@ def test2(target: address, salt: bytes32):
 
     # check if the create2 address matches our offchain calculation
     initcode = w3.eth.get_code(f.address)
-    initcode = initcode[len(factory_prefix):]  # strip the prefix
+    initcode = initcode[len(factory_prefix) :]  # strip the prefix
     assert HexBytes(test.address) == create2_address_of(d.address, salt, initcode)
 
     # can't collide addresses
     assert_tx_failed(lambda: d.test2(f.address, salt))
 
 
-def test_create_from_factory_bad_code_offset(get_contract, get_contract_from_ir, deploy_factory_for, w3, assert_tx_failed):
+def test_create_from_factory_bad_code_offset(
+    get_contract, get_contract_from_ir, deploy_factory_for, w3, assert_tx_failed
+):
     deployer_code = """
 FACTORY: immutable(address)
 
@@ -220,7 +228,7 @@ def test(code_ofst: uint256) -> address:
     # (as any STOP instruction returns valid code, split up with
     # jumpdests as optimization fence)
     initcode_len = 100
-    f = get_contract_from_ir(["deploy", 0, ["seq"] + ["jumpdest", "stop"] * (initcode_len//2), 0])
+    f = get_contract_from_ir(["deploy", 0, ["seq"] + ["jumpdest", "stop"] * (initcode_len // 2), 0])
     factory_code = w3.eth.get_code(f.address)
     print(factory_code)
 

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -1,3 +1,4 @@
+import pytest
 import rlp
 from eth_abi import encode_single
 from hexbytes import HexBytes
@@ -142,8 +143,11 @@ def test(_salt: bytes32) -> address:
     assert_tx_failed(lambda: c.test(salt, transact={}))
 
 
+# test factory with various prefixes - 0xfe would block calls to the factory
+# contract, and 0xfe65766d is an old magic from EIP154
+@pytest.mark.parametrize("factory_prefix", [b"", b"\xfe", b"\xfe\x65\x76\x6d"])
 def test_create_from_factory(
-    get_contract, deploy_factory_for, w3, keccak, create2_address_of, assert_tx_failed
+    get_contract, deploy_factory_for, w3, keccak, create2_address_of, assert_tx_failed, factory_prefix
 ):
     code = """
 @external
@@ -151,27 +155,26 @@ def foo() -> uint256:
     return 123
     """
 
-    deployer_code = """
+    prefix_len = len(factory_prefix)
+    deployer_code = f"""
 created_address: public(address)
 
 @external
 def test(target: address):
-    self.created_address = create_from_factory(target)
+    self.created_address = create_from_factory(target, code_offset={prefix_len})
 
 @external
 def test2(target: address, salt: bytes32):
-    self.created_address = create_from_factory(target, salt=salt)
+    self.created_address = create_from_factory(target, code_offset={prefix_len}, salt=salt)
     """
 
     # deploy a foo so we can compare its bytecode with factory deployed version
     foo_contract = get_contract(code)
     expected_runtime_code = w3.eth.get_code(foo_contract.address)
 
-    f, FooContract = deploy_factory_for(code)
+    f, FooContract = deploy_factory_for(code, initcode_prefix=factory_prefix)
 
     d = get_contract(deployer_code)
-
-    initcode = w3.eth.get_code(f.address)
 
     d.test(f.address, transact={})
 
@@ -180,7 +183,8 @@ def test2(target: address, salt: bytes32):
     assert test.foo() == 123
 
     # extcodesize check
-    assert_tx_failed(lambda: d.test("0x" + "00" * 20))
+    zero_address = "0x" + "00" * 20
+    assert_tx_failed(lambda: d.test(zero_address))
 
     # now same thing but with create2
     salt = keccak(b"vyper")
@@ -190,6 +194,9 @@ def test2(target: address, salt: bytes32):
     assert w3.eth.get_code(test.address) == expected_runtime_code
     assert test.foo() == 123
 
+    # check if the create2 address matches our offchain calculation
+    initcode = w3.eth.get_code(f.address)
+    initcode = initcode[len(factory_prefix):]  # strip the prefix
     assert HexBytes(test.address) == create2_address_of(d.address, salt, initcode)
 
     # can't collide addresses

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -240,7 +240,7 @@ def test(code_ofst: uint256) -> address:
     # deploy with code_ofst=len(factory) - 1 fine
     d.test(initcode_len - 1)
 
-    # code_offset=len(factory_code) NOT fine! would deploy contract with no code
+    # code_offset=len(factory_code) NOT fine! would EXTCODECOPY empty initcode
     assert_tx_failed(lambda: d.test(initcode_len))
 
     # code_offset=EIP_170_LIMIT definitely not fine!

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1878,8 +1878,8 @@ class CreateFromFactory(_CreateBase):
             ), msize.cache_when_complex("mem_ofst") as (b5, mem_ofst):
                 ir = ["seq"]
 
-                # make sure there is code at the target.
-                ir.append(["assert", codesize])
+                # make sure there is code at the target, and that code_ofst <= (extcodesize target)
+                ir.append(["assert", ["sgt", codesize, 0]])
 
                 # copy the target code into memory.
                 # layout starting from mem_ofst:

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1880,10 +1880,13 @@ class CreateFromFactory(_CreateBase):
             ), msize.cache_when_complex("mem_ofst") as (b5, mem_ofst):
                 ir = ["seq"]
 
-                # make sure there is code at the target, and that code_ofst <= (extcodesize target)
-                # (note if code_ofst > (extcodesize target), would be OOG on the EXTCODECOPY)
-                # (code_ofst == (extcodesize target) would be empty initcode, which we disallow
-                # for hygiene reasons - same as `create_copy_of` on an empty target).
+                # make sure there is code at the target, and that
+                # code_ofst <= (extcodesize target).
+                # (note if code_ofst > (extcodesize target), would be
+                # OOG on the EXTCODECOPY)
+                # (code_ofst == (extcodesize target) would be empty
+                # initcode, which we disallow for hygiene reasons -
+                # same as `create_copy_of` on an empty target).
                 ir.append(["assert", ["sgt", codesize, 0]])
 
                 # copy the target code into memory.

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1881,6 +1881,9 @@ class CreateFromFactory(_CreateBase):
                 ir = ["seq"]
 
                 # make sure there is code at the target, and that code_ofst <= (extcodesize target)
+                # (note if code_ofst > (extcodesize target), would be OOG on the EXTCODECOPY)
+                # (code_ofst == (extcodesize target) would be empty initcode, which we disallow
+                # for hygiene reasons - same as `create_copy_of` on an empty target).
                 ir.append(["assert", ["sgt", codesize, 0]])
 
                 # copy the target code into memory.

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1867,7 +1867,9 @@ class CreateFromFactory(_CreateBase):
         # (since the abi encoder could write to fresh memory).
         # it would be good to not require the memory copy, but need
         # to evaluate memory safety.
-        with target.cache_when_complex("create_target") as (b1, target), argslen.cache_when_complex("encoded_args_len") as ( b2, encoded_args_len), code_offset.cache_when_complex("code_ofst") as (b3, codeofst):
+        with target.cache_when_complex("create_target") as (b1, target), argslen.cache_when_complex(
+            "encoded_args_len"
+        ) as (b2, encoded_args_len), code_offset.cache_when_complex("code_ofst") as (b3, codeofst):
             codesize = IRnode.from_list(["sub", ["extcodesize", target], codeofst])
             # copy code to memory starting from msize. we are clobbering
             # unused memory so it's safe.

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1709,13 +1709,11 @@ class _CreateBase(BuiltinFunction):
         # errmsg something like "Cannot use {self._id} in pure fn"
         context.check_is_not_constant("use {self._id}", expr)
 
-        value = kwargs["value"]
-        salt = kwargs["salt"]
         should_use_create2 = "salt" in [kwarg.arg for kwarg in expr.keywords]
         if not should_use_create2:
-            salt = None
+            kwargs["salt"] = None
 
-        ir_builder = self._build_create_IR(expr, args, value, salt, context)
+        ir_builder = self._build_create_IR(expr, args, context, **kwargs)
 
         add_gas_estimate = self._add_gas_estimate(args, should_use_create2)
 
@@ -1738,7 +1736,7 @@ class CreateMinimalProxyTo(_CreateBase):
         bytecode_len = 20 + len(b) + len(c)
         return _create_addl_gas_estimate(bytecode_len, should_use_create2)
 
-    def _build_create_IR(self, expr, args, value, salt, context):
+    def _build_create_IR(self, expr, args, context, value, salt):
 
         target_address = args[0]
 
@@ -1795,7 +1793,7 @@ class CreateCopyOf(_CreateBase):
         # max possible runtime length + preamble length
         return _create_addl_gas_estimate(EIP_170_LIMIT + self._preamble_len, should_use_create2)
 
-    def _build_create_IR(self, expr, args, value, salt, context):
+    def _build_create_IR(self, expr, args, context, value, salt):
         target = args[0]
 
         with target.cache_when_complex("create_target") as (b1, target):
@@ -1832,6 +1830,11 @@ class CreateFromFactory(_CreateBase):
 
     _id = "create_from_factory"
     _inputs = [("target", AddressDefinition())]
+    _kwargs = {
+        "value": KwargSettings(Uint256Definition(), zero_value),
+        "salt": KwargSettings(Bytes32Definition(), empty_value),
+        "code_offset": KwargSettings(Uint256Definition(), zero_value),
+    }
     _has_varargs = True
 
     def _add_gas_estimate(self, args, should_use_create2):
@@ -1840,7 +1843,7 @@ class CreateFromFactory(_CreateBase):
         maxlen = EIP_170_LIMIT + ctor_args.typ.abi_type.size_bound()
         return _create_addl_gas_estimate(maxlen, should_use_create2)
 
-    def _build_create_IR(self, expr, args, value, salt, context):
+    def _build_create_IR(self, expr, args, context, value, salt, code_offset):
         target = args[0]
         ctor_args = args[1:]
 
@@ -1864,18 +1867,15 @@ class CreateFromFactory(_CreateBase):
         # (since the abi encoder could write to fresh memory).
         # it would be good to not require the memory copy, but need
         # to evaluate memory safety.
-        with argslen.cache_when_complex("encoded_args_len") as (
-            b1,
-            encoded_args_len,
-        ), target.cache_when_complex("create_target") as (b2, target):
-            codesize = IRnode.from_list(["extcodesize", target])
+        with target.cache_when_complex("create_target") as (b1, target), argslen.cache_when_complex("encoded_args_len") as ( b2, encoded_args_len), code_offset.cache_when_complex("code_ofst") as (b3, codeofst):
+            codesize = IRnode.from_list(["sub", ["extcodesize", target], codeofst])
             # copy code to memory starting from msize. we are clobbering
             # unused memory so it's safe.
             msize = IRnode.from_list(["msize"], location=MEMORY)
             with codesize.cache_when_complex("target_codesize") as (
-                b3,
+                b4,
                 codesize,
-            ), msize.cache_when_complex("mem_ofst") as (b4, mem_ofst):
+            ), msize.cache_when_complex("mem_ofst") as (b5, mem_ofst):
                 ir = ["seq"]
 
                 # make sure there is code at the target.
@@ -1884,7 +1884,7 @@ class CreateFromFactory(_CreateBase):
                 # copy the target code into memory.
                 # layout starting from mem_ofst:
                 # 00...00 (22 0's) | preamble | bytecode
-                ir.append(["extcodecopy", target, mem_ofst, 0, codesize])
+                ir.append(["extcodecopy", target, mem_ofst, codeofst, codesize])
 
                 ir.append(copy_bytes(add_ofst(mem_ofst, codesize), argbuf, encoded_args_len, bufsz))
 
@@ -1899,7 +1899,7 @@ class CreateFromFactory(_CreateBase):
 
                 ir.append(_create_ir(value, mem_ofst, length, salt))
 
-                return b1.resolve(b2.resolve(b3.resolve(b4.resolve(ir))))
+                return b1.resolve(b2.resolve(b3.resolve(b4.resolve(b5.resolve(ir)))))
 
 
 class _UnsafeMath(BuiltinFunction):


### PR DESCRIPTION
### What I did
as title. the motivation for this is that people might deploy factories with custom prefixes (e.g. `0xFE` INVALID to prevent execution of the factory as a standalone/runtime contract, or as part of an EOF container). this enables that usage by adding a `code_offset` which allows people to offset into the factory contract address for the EXTCODECOPY. (implementation note: the implementation does check that `code_offset < extcodesize target`).

### How I did it

### How to verify it
see tests

### Commit message

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/175044137-a53f9a16-08a6-4ef4-aa61-87414e06be5c.png)
(By Yathin S Krishnappa - Own work, CC BY-SA 3.0, https://commons.wikimedia.org/w/index.php?curid=24224663)