### PR TITLE
reduce compile time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
     # NOTE: if the tests get poorly distributed, run this and commit the resulting `.test_durations` file to the `vyper-test-durations` repo.
     # `TOXENV=fuzzing tox -r -- --store-durations --reruns 10 --reruns-delay 1 -r aR tests/`
     - name: Fetch test-durations
-      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/4d8398e581f183de986892c5a8d4ab3d05ccaab2/test_durations" -o .test_durations
+      run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/ac71e77863d7f4e7e7cd19a93cf50a8c39de4845/test_durations" -o .test_durations
 
     - name: Run Tox
       run: TOXENV=fuzzing tox -r -- --splits 60 --group ${{ matrix.group }} --splitting-algorithm least_duration --reruns 10 --reruns-delay 1 -r aR tests/

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -497,8 +497,8 @@ class Expr:
         # Compare other types.
         elif is_numeric_type(left.typ) and is_numeric_type(right.typ):
             if left.typ.typ == right.typ.typ == "uint256":
-                # this works because we only have one unsigned integer type
-                # in the future if others are added, this logic must be expanded
+                # signed comparison ops work for any integer
+                # type BESIDES uint256
                 op = self._signed_to_unsigned_comparision_op(op)
 
         elif isinstance(left.typ, BaseType) and isinstance(right.typ, BaseType):

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -335,7 +335,8 @@ class IRnode:
             and self.value.lower() not in do_not_cache
         )
 
-    # unused, but might be useful for analysis at some point
+    # get the unique symbols contained in this node, which provides
+    # sanity check invariants for the optimizer.
     @cached_property
     def unique_symbols(self):
         ret = set()

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -337,6 +337,11 @@ class IRnode:
 
     # get the unique symbols contained in this node, which provides
     # sanity check invariants for the optimizer.
+    # cache because it's a perf hotspot. note that this (and other cached
+    # properties!) can get borked if `self.args` are mutated in such a way
+    # which changes the child `.unique_symbols`. in the future it would
+    # be good to tighten down the hatches so it is harder to modify
+    # IRnode member variables.
     @cached_property
     def unique_symbols(self):
         ret = set()

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -336,6 +336,7 @@ class IRnode:
         )
 
     # unused, but might be useful for analysis at some point
+    @cached_property
     def unique_symbols(self):
         ret = set()
         if self.value == "unique_symbol":
@@ -345,7 +346,7 @@ class IRnode:
         if self.value == "deploy":
             children = [self.args[0], self.args[2]]
         for arg in children:
-            s = arg.unique_symbols()
+            s = arg.unique_symbols
             non_uniques = ret.intersection(s)
             assert len(non_uniques) == 0, f"non-unique symbols {non_uniques}"
             ret |= s

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -398,7 +398,7 @@ def _optimize_binop(binop, args, ann, parent_op):
 
 def _check_symbols(symbols, ir_node):
     # sanity check that no `unique_symbol`s got optimized out.
-    to_check = ir_node.unique_symbols()
+    to_check = ir_node.unique_symbols
     if symbols != to_check:
         raise CompilerPanic(f"missing symbols: {symbols - to_check}")
 
@@ -409,7 +409,7 @@ def optimize(node: IRnode) -> IRnode:
 
 
 def _optimize(node: IRnode, parent: Optional[IRnode]) -> Tuple[bool, IRnode]:
-    starting_symbols = node.unique_symbols()
+    starting_symbols = node.unique_symbols
 
     res = [_optimize(arg, node) for arg in node.args]
     argz: list

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -242,7 +242,7 @@ def _optimize_binop(binop, args, ann, parent_op):
     # ARITHMETIC AND BITWISE OPS
     ##
 
-    # for commutative or comparison ops, move the literal to the second
+    # for commutative ops, move the literal to the second
     # position to make the later logic cleaner
     if binop in COMMUTATIVE_OPS and _is_int(args[0]):
         args = [args[1], args[0]]

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -310,7 +310,7 @@ def _optimize_binop(binop, args, ann, parent_op):
             return finalize(args[0].value, args[0].args)
 
     # TODO: check me! reduce codesize for negative numbers
-    # if binop in {"add", "sub"} and _int(args[0], SIGNED) < 0:
+    # if binop in {"add", "sub"} and _int(args[1], SIGNED) < 0:
     #     flipped = "add" if binop == "sub" else "sub"
     #     return finalize(flipped, [args[0], -args[1]])
 


### PR DESCRIPTION
unique_symbols() (introduced in https://github.com/vyperlang/vyper/pull/2914) is a perf hotspot, apparently causing deadline timeouts for compile-time sensitive tests:
https://github.com/vyperlang/vyper/actions/runs/2536751038
https://github.com/vyperlang/vyper/actions/runs/2536641822
https://github.com/vyperlang/vyper/actions/runs/2542723731
https://github.com/vyperlang/vyper/actions/runs/2537669543

### What I did

### How I did it


### How to verify it

### Commit message
```
`unique_symbols()` (introduced 2fddbdeb49) is apparently a perf hotspot,
causing CI deadline timeouts. this commit reduces computation of
`unique_symbols()` by turning it into a `cached_property`
```
### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/175086619-1ed8564e-637a-4e5a-bac1-79b2a442e77f.png)
