### PR TITLE
feat: error map

### DIFF
--- a/tests/compiler/test_source_map.py
+++ b/tests/compiler/test_source_map.py
@@ -68,6 +68,19 @@ def test_pos_map_offsets():
             )
 
 
+def test_error_map():
+    code = """
+foo: uint256
+
+@external
+def update_foo():
+    self.foo += 1
+    """
+    error_map = compile_code(code, ["source_map"])["source_map"]["error_map"]
+    assert "safeadd" in list(error_map.values())
+    assert "fallback function" in list(error_map.values())
+
+
 def test_compress_source_map():
     code = """
 @external

--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -155,7 +155,8 @@ def safe_add(x, y):
             # TODO push down into optimizer rules.
             ok = ["ge", res, x]
 
-        ret = IRnode.from_list(["seq", ["assert", ok], res])
+        check = IRnode.from_list(["assert", ok], error_msg="safeadd")
+        ret = IRnode.from_list(["seq", check, res])
         return b1.resolve(ret)
 
 
@@ -184,7 +185,8 @@ def safe_sub(x, y):
             # TODO push down into optimizer rules.
             ok = ["le", res, x]
 
-        ret = IRnode.from_list(["seq", ["assert", ok], res])
+        check = IRnode.from_list(["assert", ok], error_msg="safesub")
+        ret = IRnode.from_list(["seq", check, res])
         return b1.resolve(ret)
 
 
@@ -250,7 +252,8 @@ def safe_mul(x, y):
         # (if bits == 256, clamp_basetype is a no-op)
         res = clamp_basetype(res)
 
-        res = IRnode.from_list(["seq", ["assert", ok], res], typ=res.typ)
+        check = IRnode.from_list(["assert", ok], error_msg="safediv")
+        res = IRnode.from_list(["seq", check, res], typ=res.typ)
 
         return b1.resolve(res)
 
@@ -308,7 +311,7 @@ def safe_div(x, y):
             # TODO maybe use safe_mul
             res = clamp_basetype(res)
 
-        check = ["assert", ok]
+        check = IRnode.from_list(["assert", ok], error_msg="safemul")
         return IRnode.from_list(b1.resolve(["seq", check, res]))
 
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1024,15 +1024,16 @@ def promote_signed_int(x, bits):
 # general clamp function for all ops and numbers
 def clamp(op, arg, bound):
     with IRnode.from_list(arg).cache_when_complex("clamp_arg") as (b1, arg):
-        assertion = ["assert", [op, arg, bound]]
-        ret = ["seq", assertion, arg]
+        check = IRnode.from_list(["assert", [op, arg, bound]], error_msg=f"clamp {op} {bound}")
+        ret = ["seq", check, arg]
         return IRnode.from_list(b1.resolve(ret), typ=arg.typ)
 
 
 def clamp_nonzero(arg):
     # TODO: use clamp("ne", arg, 0) once optimizer rules can handle it
     with IRnode.from_list(arg).cache_when_complex("should_nonzero") as (b1, arg):
-        ret = ["seq", ["assert", arg], arg]
+        check = IRnode.from_list(["assert", arg], error_msg="clamp_nonzero")
+        ret = ["seq", check, arg]
         return IRnode.from_list(b1.resolve(ret), typ=arg.typ)
 
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -976,7 +976,7 @@ def clamp_basetype(ir_node):
     else:  # pragma: nocover
         raise CompilerPanic(f"{t} passed to clamp_basetype")
 
-    return IRnode.from_list(ret, typ=ir_node.typ)
+    return IRnode.from_list(ret, typ=ir_node.typ, error_msg=f"validate {t}")
 
 
 def int_clamp(ir_node, bits, signed=False):

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -528,13 +528,14 @@ class IRnode:
                 annotation=annotation,
                 mutable=mutable,
                 add_gas_estimate=add_gas_estimate,
+                source_pos=source_pos,
                 encoding=encoding,
                 error_msg=error_msg,
             )
         else:
             return cls(
                 obj[0],
-                [cls.from_list(o, source_pos=source_pos, error_msg=error_msg) for o in obj[1:]],
+                [cls.from_list(o, source_pos=source_pos) for o in obj[1:]],
                 typ,
                 location=location,
                 annotation=annotation,

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -115,6 +115,7 @@ class IRnode:
         location: Optional[AddrSpace] = None,
         source_pos: Optional[Tuple[int, int]] = None,
         annotation: Optional[str] = None,
+        error_msg: Optional[str] = None,
         mutable: bool = True,
         add_gas_estimate: int = 0,
         encoding: Encoding = Encoding.VYPER,
@@ -129,6 +130,7 @@ class IRnode:
         self.typ = typ
         self.location = location
         self.source_pos = source_pos
+        self.error_msg = error_msg
         self.annotation = annotation
         self.mutable = mutable
         self.add_gas_estimate = add_gas_estimate
@@ -494,6 +496,7 @@ class IRnode:
         location: Optional[AddrSpace] = None,
         source_pos: Optional[Tuple[int, int]] = None,
         annotation: Optional[str] = None,
+        error_msg: Optional[str] = None,
         mutable: bool = True,
         add_gas_estimate: int = 0,
         encoding: Encoding = Encoding.VYPER,
@@ -512,6 +515,8 @@ class IRnode:
                 obj.location = location
             if obj.encoding is None:
                 obj.encoding = encoding
+            if obj.error_msg is None:
+                obj.error_msg = error_msg
 
             return obj
         elif not isinstance(obj, list):
@@ -524,11 +529,12 @@ class IRnode:
                 mutable=mutable,
                 add_gas_estimate=add_gas_estimate,
                 encoding=encoding,
+                error_msg=error_msg,
             )
         else:
             return cls(
                 obj[0],
-                [cls.from_list(o, source_pos=source_pos) for o in obj[1:]],
+                [cls.from_list(o, source_pos=source_pos, error_msg=error_msg) for o in obj[1:]],
                 typ,
                 location=location,
                 annotation=annotation,
@@ -536,4 +542,5 @@ class IRnode:
                 source_pos=source_pos,
                 add_gas_estimate=add_gas_estimate,
                 encoding=encoding,
+                error_msg=error_msg,
             )

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -150,7 +150,9 @@ def _runtime_ir(runtime_functions, all_sigs, global_ctx):
             default_function, all_sigs, global_ctx, skip_nonpayable_check
         )
     else:
-        fallback_ir = IRnode.from_list(["revert", 0, 0], annotation="Default function")
+        fallback_ir = IRnode.from_list(
+            ["revert", 0, 0], annotation="Default function", error_msg="fallback function"
+        )
 
     # ensure the external jumptable section gets closed out
     # (for basic block hygiene and also for zksync interpreter)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -160,7 +160,7 @@ class Stmt:
 
     def _assert_reason(self, test_expr, msg):
         if isinstance(msg, vy_ast.Name) and msg.id == "UNREACHABLE":
-            return IRnode.from_list(["assert_unreachable", test_expr])
+            return IRnode.from_list(["assert_unreachable", test_expr], error_msg="assert unreachable")
 
         # set constant so that revert reason str is well behaved
         try:
@@ -209,7 +209,7 @@ class Stmt:
         else:
             ir_node = revert_seq
 
-        return IRnode.from_list(ir_node)
+        return IRnode.from_list(ir_node, error_msg="user revert with reason")
 
     def parse_Assert(self):
         test_expr = Expr.parse_value_expr(self.stmt.test, self.context)
@@ -217,13 +217,13 @@ class Stmt:
         if self.stmt.msg:
             return self._assert_reason(test_expr, self.stmt.msg)
         else:
-            return IRnode.from_list(["assert", test_expr])
+            return IRnode.from_list(["assert", test_expr], error_msg="user assert")
 
     def parse_Raise(self):
         if self.stmt.exc:
             return self._assert_reason(None, self.stmt.exc)
         else:
-            return IRnode.from_list(["revert", 0, 0])
+            return IRnode.from_list(["revert", 0, 0], error_msg="user raise")
 
     def _check_valid_range_constant(self, arg_ast_node):
         with self.context.range_scope():

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -160,7 +160,9 @@ class Stmt:
 
     def _assert_reason(self, test_expr, msg):
         if isinstance(msg, vy_ast.Name) and msg.id == "UNREACHABLE":
-            return IRnode.from_list(["assert_unreachable", test_expr], error_msg="assert unreachable")
+            return IRnode.from_list(
+                ["assert_unreachable", test_expr], error_msg="assert unreachable"
+            )
 
         # set constant so that revert reason str is well behaved
         try:

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -424,6 +424,7 @@ def _optimize(node: IRnode, parent: Optional[IRnode]) -> Tuple[bool, IRnode]:
     typ = node.typ
     location = node.location
     source_pos = node.source_pos
+    error_msg = node.error_msg
     annotation = node.annotation
     add_gas_estimate = node.add_gas_estimate
 
@@ -445,6 +446,7 @@ def _optimize(node: IRnode, parent: Optional[IRnode]) -> Tuple[bool, IRnode]:
             typ=typ,
             location=location,
             source_pos=source_pos,
+            error_msg=error_msg,
             annotation=annotation,
             add_gas_estimate=add_gas_estimate,
         )


### PR DESCRIPTION
### What I did
add an error map to source_map output. this makes it easier for downstream tooling to detect why a revert was issued (without having to rely on heuristics or explicit returndata). this also paves the way for brownie-style dev revert strings to be supported by at the language level.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/176983553-cda17f4f-e135-43b2-88d1-0bd19b438dd0.png)
