### PR TITLE
fix: operator precedence in grammar

### DIFF
--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -194,6 +194,8 @@ dict: "{" "}" | "{" (NAME ":" _expr) ("," (NAME ":" _expr))* [","] "}"
 
 
 // Operators
+// This section needs to match Python's operator precedence:
+// See https://docs.python.org/3/reference/expressions.html#operator-precedence
 // NOTE: The recursive cycle here helps enforce operator precedence
 //       Precedence goes up the lower down you go
 ?operation: bool_or

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -213,7 +213,6 @@ _NOT: "not"
 
 ?bool_not: comparator
          | _NOT bool_not -> not
-         | _NOT bool_not -> not
 
 _POW: "**"
 _SHL: "<<"

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -252,15 +252,14 @@ _IN: "in"
 ?summation: product
           | summation "+"  product -> add
           | summation "-"  product -> sub
-?product: signed
-        | product "*"   signed -> mul
-        | product "/"   signed -> div
-        | product "%"   signed -> mod
-?signed: bitwise_not
-       | "+"  bitwise_not -> uadd
-       | "-"  bitwise_not -> usub
-?bitwise_not: power
-            | "~"  power -> invert
+?product: unary
+        | product "*"  unary -> mul
+        | product "/"  unary -> div
+        | product "%"  unary -> mod
+?unary: power
+       | "+"  power -> uadd
+       | "-"  power -> usub
+       | "~"  power -> invert
 ?power: atom
       | power _POW  atom -> pow
 

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -196,6 +196,7 @@ dict: "{" "}" | "{" (NAME ":" _expr) ("," (NAME ":" _expr))* [","] "}"
 // Operators
 // NOTE: The recursive cycle here helps enforce operator precedence
 //       Precedence goes up the lower down you go
+?operation: bool_or
 
 _AND: "and"
 _OR: "or"
@@ -210,8 +211,6 @@ _NOT: "not"
 
 ?bool_not: comparator
          | _NOT comparator -> not
-
-?operation: comparator
 
 _POW: "**"
 _SHL: "<<"

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -210,7 +210,8 @@ _NOT: "not"
          | bool_and _AND bool_not -> and
 
 ?bool_not: comparator
-         | _NOT comparator -> not
+         | _NOT bool_not -> not
+         | _NOT bool_not -> not
 
 _POW: "**"
 _SHL: "<<"
@@ -226,19 +227,19 @@ _LE: "<="
 _GE: ">="
 _IN: "in"
 ?comparator: bitwise_or
-           | comparator "<" atom ->  lt
-           | comparator ">" atom ->  gt
-           | comparator _EQ atom ->  eq
-           | comparator _NE atom ->  ne
-           | comparator _LE atom ->  le
-           | comparator _GE atom ->  ge
-           | comparator _IN atom ->  in
-           | comparator _NOT _IN atom ->  in
+           | comparator "<" bitwise_or ->  lt
+           | comparator ">" bitwise_or ->  gt
+           | comparator _EQ bitwise_or ->  eq
+           | comparator _NE bitwise_or ->  ne
+           | comparator _LE bitwise_or ->  le
+           | comparator _GE bitwise_or ->  ge
+           | comparator _IN bitwise_or ->  in
+           | comparator _NOT _IN bitwise_or ->  in
 
 // Binary Operations
 // NOTE: Keep these in sync with aug_assign above
 ?bitwise_or : bitwise_xor
-        | bitwise_or _BITOR  bitwise_xor -> bitor
+            | bitwise_or _BITOR  bitwise_xor -> bitor
 ?bitwise_xor: bitwise_and
             | bitwise_xor _BITXOR  bitwise_and -> bitxor
 ?bitwise_and: shift

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -196,7 +196,22 @@ dict: "{" "}" | "{" (NAME ":" _expr) ("," (NAME ":" _expr))* [","] "}"
 // Operators
 // NOTE: The recursive cycle here helps enforce operator precedence
 //       Precedence goes up the lower down you go
-?operation: bin_op
+
+_AND: "and"
+_OR: "or"
+_NOT: "not"
+
+// Boolean Operations
+?bool_or: bool_and
+        | bool_or _OR  bool_and -> or
+
+?bool_and: bool_not
+         | bool_and _AND bool_not -> and
+
+?bool_not: comparator
+         | _NOT comparator -> not
+
+?operation: comparator
 
 _POW: "**"
 _SHL: "<<"
@@ -204,39 +219,6 @@ _SHR: ">>"
 _BITAND: "&"
 _BITOR: "|"
 _BITXOR: "^"
-// Binary Operations
-// NOTE: Keep these in sync with aug_assign above
-?bin_op: product
-       | bin_op "+"  product -> add
-       | bin_op "-"  product -> sub
-// TODO fix precedence to match python operator precedence
-       | bin_op _SHL product -> shl
-       | bin_op _SHR product -> shr
-       | bin_op _BITAND product -> bitand
-       | bin_op _BITOR product -> bitor
-       | bin_op _BITXOR product -> bitxor
-?product: power
-        | product "*"   power -> mul
-        | product "/"   power -> div
-?power: bool_op
-      | power _POW  bool_op -> pow
-      | power "%"   bool_op -> mod
-
-_AND: "and"
-_OR: "or"
-_NOT: "not"
-
-// Boolean Operations
-?bool_op: unary_op
-        | bool_op _AND unary_op -> and
-        | bool_op _OR  unary_op -> or
-
-// Unary Operations
-?unary_op: comparator
-         | "+"  unary_op -> uadd
-         | "-"  unary_op -> usub
-         | "~"  unary_op -> invert
-         | _NOT unary_op -> not
 
 // Comparisions
 _EQ: "=="
@@ -244,7 +226,7 @@ _NE: "!="
 _LE: "<="
 _GE: ">="
 _IN: "in"
-?comparator: atom
+?comparator: bitwise_or
            | comparator "<" atom ->  lt
            | comparator ">" atom ->  gt
            | comparator _EQ atom ->  eq
@@ -254,6 +236,31 @@ _IN: "in"
            | comparator _IN atom ->  in
            | comparator _NOT _IN atom ->  in
 
+// Binary Operations
+// NOTE: Keep these in sync with aug_assign above
+?bitwise_or : bitwise_xor
+        | bitwise_or _BITOR  bitwise_xor -> bitor
+?bitwise_xor: bitwise_and
+            | bitwise_xor _BITXOR  bitwise_and -> bitxor
+?bitwise_and: shift
+            | bitwise_and _BITAND  shift -> bitand
+?shift: summation
+      | shift _SHL  summation -> shl
+      | shift _SHR  summation -> shr
+?summation: product
+          | summation "+"  product -> add
+          | summation "-"  product -> sub
+?product: signed
+        | product "*"   signed -> mul
+        | product "/"   signed -> div
+        | product "%"   signed -> mod
+?signed: bitwise_not
+       | "+"  bitwise_not -> uadd
+       | "-"  bitwise_not -> usub
+?bitwise_not: power
+            | "~"  power -> invert
+?power: atom
+      | power _POW  atom -> pow
 
 // special rule to handle types as "arguments" (for `empty` builtin)
 empty: "empty" "(" type ")"

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -84,9 +84,9 @@ def baz(a: uint256, b: uint256, c: uint256) -> (uint256, uint256):
     return (a + 8 | ~b & c * 2, (a  + 8 | ~b) & c * 2)
     """
     c = get_contract(code)
-    assert tuple(c.foo(1, 6, 14)) == (7, 6)
-    assert tuple(c.bar(1, 6, 14)) == (9, 8)
-    assert tuple(c.baz(1, 6, 14)) == (25, 24)
+    assert tuple(c.foo(1, 6, 14)) == (1 | 6 & 14, (1 | 6) & 14) == (7, 6)
+    assert tuple(c.bar(1, 6, 14)) == (1 | ~6 & 14, (1 | ~6) & 14) == (9, 8)
+    assert tuple(c.baz(1, 6, 14)) == (1 + 8 | ~6 & 14 * 2, (1 + 8 | ~6) & 14 * 2) == (25, 24)
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -69,6 +69,26 @@ def test_test_bitwise(get_contract_with_gas_estimation, evm_version):
     assert c._negatedShift(x, 256) == 0
 
 
+def test_precedence(get_contract):
+    code = """
+@external
+def foo(a: uint256, b: uint256, c: uint256) -> (uint256, uint256):
+    return (a | b & c, (a | b) & c)
+
+@external
+def bar(a: uint256, b: uint256, c: uint256) -> (uint256, uint256):
+    return (a | ~b & c, (a | ~b) & c)
+
+@external
+def baz(a: uint256, b: uint256, c: uint256) -> (uint256, uint256):
+    return (a + 8 | ~b & c * 2, (a  + 8 | ~b) & c * 2)
+    """
+    c = get_contract(code)
+    assert tuple(c.foo(1, 6, 14)) == (7, 6)
+    assert tuple(c.bar(1, 6, 14)) == (9, 8)
+    assert tuple(c.baz(1, 6, 14)) == (25, 24)
+
+
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
 def test_literals(get_contract, evm_version):
     code = """


### PR DESCRIPTION
### What I did

Fix operator precedence in test grammar.

### How I did it

Update test grammar according to the stipulated precedence.

### How to verify it

See new tests.

### Commit message

```
fix: operator precedence in grammar

Align operator precedence with python's grammar.
```

### Description for the changelog

Fix operator precedence in test grammar.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTA16xdNq510dp7uUgI2VmPsk6gd9W-341N3sgTTKinioZFdLZ0B9VjwCtQmoAMSTzhd0k&usqp=CAU)
