### PR TITLE
fix: change tokenURL to tokenURI, according to EIP-721

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -364,5 +364,5 @@ def burn(_tokenId: uint256):
 
 @view
 @external
-def tokenURL(tokenId: uint256) -> String[132]:
+def tokenURI(tokenId: uint256) -> String[132]:
     return concat(self.baseURL, uint2str(tokenId))


### PR DESCRIPTION
In EIP-721, the ERC-721 Non-Fungible Token Standard, optional metadata extension.  Defined a function called "tokenURI"

`
function tokenURI(uint256 _tokenId) external view returns (string);
`


https://eips.ethereum.org/EIPS/eip-721

### What I did

I changed "tokenURL" to "tokenURI"

