### PR TITLE
fix: ast.AST node corruption

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -2,6 +2,7 @@ import ast as python_ast
 import decimal
 import operator
 import sys
+import copy
 from typing import Any, Optional, Union
 
 from vyper.compiler.settings import VYPER_ERROR_CONTEXT_LINES, VYPER_ERROR_LINE_NUMBERS
@@ -54,6 +55,13 @@ def get_node(
     """
     if not isinstance(ast_struct, dict):
         ast_struct = ast_struct.__dict__
+
+        # workaround: some third party module (ex. ipython) might insert
+        # a "parent" member into the node, creating a duplicate kwarg
+        # error below when calling vy_class()
+        if "parent" in ast_struct:
+            ast_struct = copy.copy(ast_struct)
+            del ast_struct["parent"]
 
     vy_class = getattr(sys.modules[__name__], ast_struct["ast_type"], None)
     if not vy_class:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1,8 +1,8 @@
 import ast as python_ast
+import copy
 import decimal
 import operator
 import sys
-import copy
 from typing import Any, Optional, Union
 
 from vyper.compiler.settings import VYPER_ERROR_CONTEXT_LINES, VYPER_ERROR_LINE_NUMBERS


### PR DESCRIPTION
in IPython, if an exception is thrown, apparently certain AST nodes can
get annotated with a `.parent` member. this later collides with the
`parent=` kwargs when constructing vyper nodes.

### What I did

### How I did it

### How to verify it

### Commit message

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/177178185-fa3d7798-1b2b-4b51-85e1-d14dca9196a5.png)
