### PR TITLE
fix: allow static array of dynamic array

### DIFF
--- a/tests/functional/context/types/test_type_from_annotation.py
+++ b/tests/functional/context/types/test_type_from_annotation.py
@@ -74,7 +74,9 @@ def test_base_types_as_multidimensional_arrays(build_node, namespace, type_str):
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
 def test_invalid_index(build_node, idx, type_str):
     node = build_node(f"{type_str}[{idx}]")
-    with pytest.raises((ArrayIndexException, InvalidType, StructureException, UndeclaredDefinition)):
+    with pytest.raises(
+        (ArrayIndexException, InvalidType, StructureException, UndeclaredDefinition)
+    ):
         get_type_from_annotation(node, DataLocation.STORAGE)
 
 

--- a/tests/functional/context/types/test_type_from_annotation.py
+++ b/tests/functional/context/types/test_type_from_annotation.py
@@ -74,7 +74,7 @@ def test_base_types_as_multidimensional_arrays(build_node, namespace, type_str):
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
 def test_invalid_index(build_node, idx, type_str):
     node = build_node(f"{type_str}[{idx}]")
-    with pytest.raises((ArrayIndexException, InvalidType, UndeclaredDefinition)):
+    with pytest.raises((ArrayIndexException, InvalidType, StructureException, UndeclaredDefinition)):
         get_type_from_annotation(node, DataLocation.STORAGE)
 
 

--- a/tests/grammar/vyper.lark
+++ b/tests/grammar/vyper.lark
@@ -80,7 +80,7 @@ enum_body: _NEWLINE _INDENT (enum_member _NEWLINE)+ _DEDENT
 enum_def: _ENUM_DECL NAME ":" enum_body
 
 // Types
-array_def: (NAME | array_def) "[" (DEC_NUMBER | NAME) "]"
+array_def: (NAME | array_def | dyn_array_def) "[" (DEC_NUMBER | NAME) "]"
 dyn_array_def: "DynArray" "[" (NAME | array_def | dyn_array_def) "," (DEC_NUMBER | NAME) "]"
 tuple_def: "(" ( NAME | array_def | dyn_array_def | tuple_def ) ( "," ( NAME | array_def | dyn_array_def | tuple_def ) )* [","] ")"
 // NOTE: Map takes a basic type and maps to another type (can be non-basic, including maps)

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -514,6 +514,46 @@ def foo() -> (uint256, uint256[3], uint256[2]):
     assert c.foo() == [666, [1, 2, 3], [88, 12]]
 
 
+def test_list_of_dynarray(get_contract):
+    code = """
+@external
+def bar(x: int128) -> DynArray[int128, 2][2]:
+    a: DynArray[int128, 2][2] = [[x, x * 2], [x * 3, x * 4]]
+    return a
+
+@external
+def foo(x: int128) -> int128:
+    a: DynArray[int128, 2][2] = [[x, x * 2], [x * 3, x * 4]]
+    return a[0][0] * a[1][1]
+    """
+    c = get_contract(code)
+    assert c.bar(7) == [[7, 14], [21, 28]]
+    assert c.foo(7) == 196
+
+
+def test_list_of_nested_dynarray(get_contract):
+    code = """
+@external
+def bar(x: int128) -> DynArray[int128, 2][2][2]:
+    a: DynArray[int128, 2][2][2] = [
+        [[x, x * 2], [x * 3, x * 4]],
+        [[x * 5, x * 6], [x * 7, x * 8]],
+    ]
+    return a
+
+@external
+def foo(x: int128) -> int128:
+    a: DynArray[int128, 2][2][2] = [
+        [[x, x * 2], [x * 3, x * 4]],
+        [[x * 5, x * 6], [x * 7, x * 8]],
+    ]
+    return a[0][0][0] * a[1][1][1]
+    """
+    c = get_contract(code)
+    assert c.bar(7) == [[[7, 14], [21, 28]], [[35, 42], [49, 56]]]
+    assert c.foo(7) == 392
+
+
 def test_list_of_structs_arg(get_contract):
     code = """
 struct Foo:

--- a/vyper/semantics/types/indexable/sequence.py
+++ b/vyper/semantics/types/indexable/sequence.py
@@ -218,6 +218,7 @@ class DynamicArrayPrimitive(BasePrimitive):
     _id = "DynArray"
     _type = DynamicArrayDefinition
     _valid_literal = (vy_ast.List,)
+    _as_array = True
 
     @classmethod
     def from_annotation(

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -8,7 +8,6 @@ from vyper.exceptions import (
     StructureException,
     UndeclaredDefinition,
     UnknownType,
-    VyperException,
     VyperInternalException,
 )
 from vyper.semantics.namespace import get_namespace
@@ -184,19 +183,18 @@ def get_type_from_annotation(
             f"No builtin or user-defined type named '{type_name}'. {suggestions_str}", node
         ) from None
 
-    if (getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript)):
+    if (
+        getattr(type_obj, "_as_array", False)
+        and isinstance(node, vy_ast.Subscript)
+        and not isinstance(node.slice.value, vy_ast.Tuple)
+    ):
         # TODO: handle `is_immutable` for arrays
         # if type can be an array and node is a subscript, create an `ArrayDefinition`
-        try:
-            value_type = get_type_from_annotation(
-                node.value, location, is_constant, False, is_immutable
-            )
-            length = get_index_value(node.slice)
-            return ArrayDefinition(value_type, length, location, is_constant, is_public, is_immutable)
-
-        except StructureException:
-            # Plain dynamic arrays will raise a structure exception
-            pass
+        length = get_index_value(node.slice)
+        value_type = get_type_from_annotation(
+            node.value, location, is_constant, False, is_immutable
+        )
+        return ArrayDefinition(value_type, length, location, is_constant, is_public, is_immutable)
 
     try:
         return type_obj.from_annotation(node, location, is_constant, is_public, is_immutable)

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -183,7 +183,7 @@ def get_type_from_annotation(
             f"No builtin or user-defined type named '{type_name}'. {suggestions_str}", node
         ) from None
 
-    if getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript):
+    if getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript) and not isinstance(node.slice.value, vy_ast.Tuple):
         # TODO: handle `is_immutable` for arrays
         # if type can be an array and node is a subscript, create an `ArrayDefinition`
         length = get_index_value(node.slice)

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -8,6 +8,7 @@ from vyper.exceptions import (
     StructureException,
     UndeclaredDefinition,
     UnknownType,
+    VyperException,
     VyperInternalException,
 )
 from vyper.semantics.namespace import get_namespace
@@ -183,7 +184,7 @@ def get_type_from_annotation(
             f"No builtin or user-defined type named '{type_name}'. {suggestions_str}", node
         ) from None
 
-    if getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript):
+    if (getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript)):
         # TODO: handle `is_immutable` for arrays
         # if type can be an array and node is a subscript, create an `ArrayDefinition`
         try:
@@ -191,9 +192,7 @@ def get_type_from_annotation(
                 node.value, location, is_constant, False, is_immutable
             )
             length = get_index_value(node.slice)
-            return ArrayDefinition(
-                value_type, length, location, is_constant, is_public, is_immutable
-            )
+            return ArrayDefinition(value_type, length, location, is_constant, is_public, is_immutable)
 
         except StructureException:
             # Plain dynamic arrays will raise a structure exception

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -183,7 +183,11 @@ def get_type_from_annotation(
             f"No builtin or user-defined type named '{type_name}'. {suggestions_str}", node
         ) from None
 
-    if getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript) and not isinstance(node.slice.value, vy_ast.Tuple):
+    if (
+        getattr(type_obj, "_as_array", False)
+        and isinstance(node, vy_ast.Subscript)
+        and not isinstance(node.slice.value, vy_ast.Tuple)
+    ):
         # TODO: handle `is_immutable` for arrays
         # if type can be an array and node is a subscript, create an `ArrayDefinition`
         length = get_index_value(node.slice)

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -186,7 +186,7 @@ def get_type_from_annotation(
     if (
         getattr(type_obj, "_as_array", False)
         and isinstance(node, vy_ast.Subscript)
-        and not isinstance(node.slice.value, vy_ast.Tuple)
+        and node.value.get("id") != "DynArray"
     ):
         # TODO: handle `is_immutable` for arrays
         # if type can be an array and node is a subscript, create an `ArrayDefinition`

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -8,7 +8,6 @@ from vyper.exceptions import (
     StructureException,
     UndeclaredDefinition,
     UnknownType,
-    VyperException,
     VyperInternalException,
 )
 from vyper.semantics.namespace import get_namespace
@@ -184,7 +183,7 @@ def get_type_from_annotation(
             f"No builtin or user-defined type named '{type_name}'. {suggestions_str}", node
         ) from None
 
-    if (getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript)):
+    if getattr(type_obj, "_as_array", False) and isinstance(node, vy_ast.Subscript):
         # TODO: handle `is_immutable` for arrays
         # if type can be an array and node is a subscript, create an `ArrayDefinition`
         try:
@@ -192,7 +191,9 @@ def get_type_from_annotation(
                 node.value, location, is_constant, False, is_immutable
             )
             length = get_index_value(node.slice)
-            return ArrayDefinition(value_type, length, location, is_constant, is_public, is_immutable)
+            return ArrayDefinition(
+                value_type, length, location, is_constant, is_public, is_immutable
+            )
 
         except StructureException:
             # Plain dynamic arrays will raise a structure exception


### PR DESCRIPTION
### What I did

Fix #2951.

### How I did it

Set `_as_array` to `True` for `DynamicArrayPrimitive`, and add condition that `Subscript.slice.value` must not be `vy_ast.Tuple` for array type in `get_type_from_annotation` to exclude plain dynamic arrays.

### How to verify it

See new tests.

### Commit message

```
fix: allow static arrays of dynamic arrays

Allows static arrays of dynamic arrays.

Fix #2951.
```

### Description for the changelog

Allow static arrays of dynamic arrays.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/photos/alpacas-picture-id532529153?k=20&m=532529153&s=612x612&w=0&h=OBZDgABGLmDpsjT9zRct0aRj5bMq4hR5NzCxoLC1UYo=)
