### PR TITLE
chore: rename --debug flag to --verbose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,7 +16,7 @@ Please include information like:
 * full output of the error you received
 * what command you ran
 * the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
-* please try running your example with the --debug flag turned on
+* please try running your example with the `--verbose` flag turned on
 
 
 ### How can it be fixed?

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -133,7 +133,7 @@ def _parse_args(argv):
         sys.tracebacklimit = args.traceback_limit
     elif VYPER_TRACEBACK_LIMIT is not None:
         sys.tracebacklimit = VYPER_TRACEBACK_LIMIT
-    elif args.debug:
+    elif args.verbose:
         sys.tracebacklimit = 1000
     else:
         # Python usually defaults sys.tracebacklimit to 1000.  We use a default

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -110,8 +110,8 @@ def _parse_args(argv):
         type=int,
     )
     parser.add_argument(
-        "--debug",
-        help="Turn on compiler debug information. "
+        "--verbose",
+        help="Turn on compiler verbose output. "
         "Currently an alias for --traceback-limit but "
         "may add more information in the future",
         action="store_true",


### PR DESCRIPTION

### What I did

### How I did it

### How to verify it

### Commit message
```
the `--debug` flag is a bit confusing since it sounds like it turns on a
debugger mode for the compiler, when in fact it just tells the compiler
to be more verbose in its output.

this rename will also be helpful if we add a true debugger mode to the
compiler in the (near?) future.
```
### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/179018149-e475e830-2cbd-438a-838b-79effb5b6b19.png)

