### PR TITLE
fix: relax restriction on changing decimal precision

### DIFF
--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -1,3 +1,4 @@
+import warnings
 from decimal import ROUND_DOWN, Decimal, getcontext
 
 import pytest
@@ -7,9 +8,19 @@ from vyper.utils import DECIMAL_EPSILON, SizeLimits
 
 
 def test_decimal_override():
-    # consumers of vyper, even as a library, are not allowed to override Decimal precision
+    getcontext().prec = 78  # setting prec to 78 is ok
+
+    # consumers of vyper, even as a library, are not allowed to reduce Decimal precision
     with pytest.raises(DecimalOverrideException):
-        getcontext().prec = 100
+        getcontext().prec = 77
+
+    with warnings.catch_warnings(record=True) as w:
+        getcontext().prec = 79
+        # check warnings were issued
+        assert len(w) == 1
+        assert (
+            str(w[-1].message) == "Changing decimals precision could have unintended side effects!"
+        )
 
 
 def quantize(x: Decimal) -> Decimal:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -2,6 +2,7 @@ import binascii
 import decimal
 import sys
 import traceback
+import warnings
 from typing import List, Union
 
 from vyper.exceptions import DecimalOverrideException, InvalidLiteral
@@ -15,7 +16,7 @@ class DecimalContextOverride(decimal.Context):
                 raise DecimalOverrideException("Overriding decimal precision disabled")
             elif value > 78:
                 # not sure it's incorrect, might not be end of the world
-                warnings.warn(f"Changing decimals precision could have unintended side effects!")
+                warnings.warn("Changing decimals precision could have unintended side effects!")
             # else: no-op, is ok
 
         super().__setattr__(name, value)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -10,8 +10,14 @@ from vyper.exceptions import DecimalOverrideException, InvalidLiteral
 class DecimalContextOverride(decimal.Context):
     def __setattr__(self, name, value):
         if name == "prec":
-            # CMC 2022-03-27: should we raise a warning instead of an exception?
-            raise DecimalOverrideException("Overriding decimal precision disabled")
+            if value < 78:
+                # definitely don't want this to happen
+                raise DecimalOverrideException("Overriding decimal precision disabled")
+            elif value > 78:
+                # not sure it's incorrect, might not be end of the world
+                warnings.warn(f"Changing decimals precision could have unintended side effects!")
+            # else: no-op, is ok
+
         super().__setattr__(name, value)
 
 


### PR DESCRIPTION
some non-CPython stdlibs (i.e. pypy) trigger this in the decimal ctor.
relax the restriction so that no-op setattrs are ok

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
