### PR TITLE
chore: rename factory to blueprint

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -122,10 +122,10 @@ Vyper has three builtins for contract creation; all three contract creation buil
     * Cheap to call (no ``DELEGATECALL`` overhead), expensive to create (200 gas per deployed byte)
     * Does not have the ability to call a constructor
     * Performs an ``EXTCODESIZE`` check to check there is code at ``target``
-* ``create_from_factory(target: address, ...)``
+* ``create_from_blueprint(target: address, ...)``
     * Deploys a contract using the initcode stored at ``target``
     * Cheap to call (no ``DELEGATECALL`` overhead), expensive to create (200 gas per deployed byte)
-    * Invokes constructor, requires a special "factory" contract to be deployed
+    * Invokes constructor, requires a special "blueprint" contract to be deployed
     * Performs an ``EXTCODESIZE`` check to check there is code at ``target``
 
 .. py:function:: create_minimal_proxy_to(target: address, value: uint256 = 0[, salt: bytes32]) -> address
@@ -179,11 +179,11 @@ Vyper has three builtins for contract creation; all three contract creation buil
     The implementation of ``create_copy_of`` assumes that the code at ``target`` is smaller than 16MB. While this is much larger than the EIP-170 constraint of 24KB, it is a conservative size limit intended to future-proof deployer contracts in case the EIP-170 constraint is lifted. If the code at ``target`` is larger than 16MB, the behavior of ``create_copy_of`` is undefined.
 
 
-.. py:function:: create_from_factory(target: address, *args, value: uint256 = 0, code_offset=0, [, salt: bytes32]) -> address
+.. py:function:: create_from_blueprint(target: address, *args, value: uint256 = 0, code_offset=0, [, salt: bytes32]) -> address
 
     Copy the code of ``target`` into memory and execute it as initcode. In other words, this operation interprets the code at ``target`` not as regular runtime code, but directly as initcode. The ``*args`` are interpreted as constructor arguments, and are ABI-encoded and included when executing the initcode.
 
-    * ``target``: Address of the factory contract to invoke
+    * ``target``: Address of the blueprint to invoke
     * ``*args``: Constructor arguments to forward to the initcode.
     * ``value``: The wei value to send to the new contract address (Optional, default 0)
     * ``code_offset``: The offset to start the ``EXTCODECOPY`` from (Optional, default 0)
@@ -194,25 +194,25 @@ Vyper has three builtins for contract creation; all three contract creation buil
     .. code-block:: python
 
         @external
-        def foo(factory: address) -> address:
+        def foo(blueprint: address) -> address:
             arg1: uint256 = 18
             arg2: String = "some string"
-            return create_from_factory(factory, arg1, arg2, code_offset=1)
+            return create_from_blueprint(blueprint, arg1, arg2, code_offset=1)
 
 .. note::
 
-    To properly deploy a factory contract, special deploy bytecode must be used. Deploying factory contracts is generally out of scope of this article, but the following preamble, prepended to regular deploy bytecode (output of ``vyper -f bytecode``), should deploy the factory contract in an ordinary contract creation transaction: ``deploy_preamble = "61" + <bytecode len in 4 hex characters> + "3d81600a3d39f3"``. To see an example of this, please see `the setup code for testing create_from_factory <https://github.com/vyperlang/vyper/blob/2adc34ffd3bee8b6dee90f552bbd9bb844509e19/tests/base_conftest.py#L130-L160>`_.
+    To properly deploy a blueprint contract, special deploy bytecode must be used. Deploying blueprint contracts is generally out of scope of this article, but the following preamble, prepended to regular deploy bytecode (output of ``vyper -f bytecode``), should deploy the blueprint in an ordinary contract creation transaction: ``deploy_preamble = "61" + <bytecode len in 4 hex characters> + "3d81600a3d39f3"``. To see an example of this, please see `the setup code for testing create_from_blueprint<https://github.com/vyperlang/vyper/blob/2adc34ffd3bee8b6dee90f552bbd9bb844509e19/tests/base_conftest.py#L130-L160>`_.
 
 .. warning::
 
-    It is recommended to deploy factory contracts with an opcode preamble like ``0xfe`` to guard them from being called as regular contracts. This is particularly important for factories where the constructor has side effects (including ``SELFDESTRUCT``!), as those could get executed by *anybody* calling the factory contract directly. The ``code_offset=`` kwarg is provided to enable this pattern:
+    It is recommended to deploy blueprints with the ERC5202 preamble ``0xfe7100`` to guard them from being called as regular contracts. This is particularly important for factories where the constructor has side effects (including ``SELFDESTRUCT``!), as those could get executed by *anybody* calling the blueprint contract directly. The ``code_offset=`` kwarg is provided to enable this pattern:
 
     .. code-block:: python
 
         @external
-        def foo(factory: address) -> address:
-            # `factory` is a factory contract with some known preamble b"abcd..."
-            return create_from_factory(factory, code_offset=<preamble length>)
+        def foo(blueprint: address) -> address:
+            # `blueprint` is a blueprint contract with some known preamble b"abcd..."
+            return create_from_blueprint(blueprint, code_offset=<preamble length>)
 
 .. py:function:: raw_call(to: address, data: Bytes, max_outsize: int = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False, is_static_call: bool = False, revert_on_failure: bool = True) -> Bytes[max_outsize]
 

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -127,7 +127,7 @@ def _get_contract(w3, source_code, no_optimize, *args, **kwargs):
     return w3.eth.contract(address, abi=abi, bytecode=bytecode, ContractFactoryClass=VyperContract)
 
 
-def _deploy_factory_for(w3, source_code, no_optimize, initcode_prefix=b"", **kwargs):
+def _deploy_blueprint_for(w3, source_code, no_optimize, initcode_prefix=b"", **kwargs):
     out = compiler.compile_code(
         source_code,
         ["abi", "bytecode"],
@@ -165,11 +165,11 @@ def _deploy_factory_for(w3, source_code, no_optimize, initcode_prefix=b"", **kwa
 
 
 @pytest.fixture(scope="module")
-def deploy_factory_for(w3, no_optimize):
-    def deploy_factory_for(source_code, *args, **kwargs):
-        return _deploy_factory_for(w3, source_code, no_optimize, *args, **kwargs)
+def deploy_blueprint_for(w3, no_optimize):
+    def deploy_blueprint_for(source_code, *args, **kwargs):
+        return _deploy_blueprint_for(w3, source_code, no_optimize, *args, **kwargs)
 
-    return deploy_factory_for
+    return deploy_blueprint_for
 
 
 @pytest.fixture(scope="module")

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1836,9 +1836,9 @@ class CreateCopyOf(_CreateBase):
                 return b1.resolve(b2.resolve(b3.resolve(ir)))
 
 
-class CreateFromFactory(_CreateBase):
+class CreateFromBlueprint(_CreateBase):
 
-    _id = "create_from_factory"
+    _id = "create_from_blueprint"
     _inputs = [("target", AddressDefinition())]
     _kwargs = {
         "value": KwargSettings(Uint256Definition(), zero_value),
@@ -2518,7 +2518,7 @@ DISPATCH_TABLE = {
     "create_minimal_proxy_to": CreateMinimalProxyTo(),
     "create_forwarder_to": CreateForwarderTo(),
     "create_copy_of": CreateCopyOf(),
-    "create_from_factory": CreateFromFactory(),
+    "create_from_blueprint": CreateFromBlueprint(),
     "min": Min(),
     "max": Max(),
     "empty": Empty(),
@@ -2535,7 +2535,7 @@ STMT_DISPATCH_TABLE = {
     "create_minimal_proxy_to": CreateMinimalProxyTo(),
     "create_forwarder_to": CreateForwarderTo(),
     "create_copy_of": CreateCopyOf(),
-    "create_from_factory": CreateFromFactory(),
+    "create_from_blueprint": CreateFromBlueprint(),
 }
 
 BUILTIN_FUNCTIONS = {**STMT_DISPATCH_TABLE, **DISPATCH_TABLE}.keys()


### PR DESCRIPTION
based on the premise that factory is already overloaded with other
meanings

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
