### PR TITLE
docs: raw_call function cleaning

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -231,7 +231,7 @@ Vyper has three builtins for contract creation; all three contract creation buil
         
         Returns the data returned by the call as a ``Bytes`` list, with ``max_outsize`` as the max length. The actual size of the returned data may be less than ``max_outsize``. You can use ``len`` to obtain the actual size.
 
-        Returns ``None`` if ``max_outsize`` is omitted or set to ``0``.
+        Returns nothing if ``max_outsize`` is omitted or set to ``0``.
 
         Returns ``success`` in a tuple if ``revert_on_failure`` is set to ``False``.
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -233,7 +233,7 @@ Vyper has three builtins for contract creation; all three contract creation buil
 
         Returns nothing if ``max_outsize`` is omitted or set to ``0``.
 
-        Returns ``success`` in a tuple if ``revert_on_failure`` is set to ``False``.
+        Returns ``success`` in a tuple with return value if ``revert_on_failure`` is set to ``False``.
 
     .. code-block:: python
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -227,17 +227,13 @@ Vyper has three builtins for contract creation; all three contract creation buil
     * ``is_static_call``: If ``True``, the call will be sent as ``STATICCALL`` (Optional, default ``False``)
     * ``revert_on_failure``: If ``True``, the call will revert on a failure, otherwise ``success`` will be returned (Optional, default ``True``)
 
-    Returns the data returned by the call as a ``Bytes`` list, with ``max_outsize`` as the max length.
-
-    Returns ``None`` if ``max_outsize`` is omitted or set to ``0``.
-
-    Returns ``success`` in a tuple if ``revert_on_failure`` is set to ``False``.
-
     .. note::
+        
+        Returns the data returned by the call as a ``Bytes`` list, with ``max_outsize`` as the max length. The actual size of the returned data may be less than ``max_outsize``. You can use ``len`` to obtain the actual size.
 
-        The actual size of the returned data may be less than ``max_outsize``. You can use ``len`` to obtain the actual size.
+        Returns ``None`` if ``max_outsize`` is omitted or set to ``0``.
 
-        Returns the address of the duplicated contract.
+        Returns ``success`` in a tuple if ``revert_on_failure`` is set to ``False``.
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did

Changing a part of the doc about the `raw_call` function

### How I did it

* Removed a line about "a duplicated contract", which has nothing to do with the `raw_call` function
* Tried to re-arrange the paragraph

### How to verify it



### Commit message

docs: raw_call function cleaning

### Description for the changelog

Cleaning a line from the raw_call function documentation

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/1/12/Cylon_Centurion.jpg)
