### PR TITLE
perf: remove compiler hotspots

### DIFF
--- a/tests/ast/nodes/test_replace_in_tree.py
+++ b/tests/ast/nodes/test_replace_in_tree.py
@@ -58,16 +58,6 @@ def test_parents_children():
     assert new_node in test_tree.get_descendants()
 
 
-def test_node_does_not_exist():
-    test_tree = vy_ast.parse_to_ast("foo = 42")
-    old_node = test_tree.body[0].target
-
-    new_node = vy_ast.parse_to_ast("42").body[0].value
-
-    with pytest.raises(CompilerPanic):
-        test_tree.replace_in_tree(new_node, old_node)
-
-
 def test_cannot_replace_twice():
     test_tree = vy_ast.parse_to_ast("foo = 42")
     old_node = test_tree.body[0].target

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -80,6 +80,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
             returns=return_node,
         )
         expanded._metadata["type"] = func_type
+        return_node.set_parent(expanded)
         vyper_module.add_to_body(expanded)
 
 

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -67,10 +67,6 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         # after iterating the input types, the remaining annotation node is our return type
         return_node = annotation
-        if isinstance(return_node, vy_ast.Name) and return_node.id != return_type._id:
-            # special case when the return type is an interface
-            # TODO allow interfaces as return types and remove this
-            return_node.id = return_type._id
 
         # join everything together as a new `FunctionDef` node, annotate it
         # with the type, and append it to the existing `Module` node

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -1,5 +1,3 @@
-import copy
-
 from vyper import ast as vy_ast
 from vyper.exceptions import CompilerPanic
 
@@ -37,7 +35,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         # use the annotation node as a base to build the input args and return type
         # starting with `args[0]` to remove the surrounding `public()` call`
-        annotation = copy.copy(node.annotation.args[0])
+        annotation = vy_ast.VyperNode.from_node(node.annotation.args[0])
 
         # the base return statement is an `Attribute` node, e.g. `self.<var_name>`
         # for each input type we wrap it in a `Subscript` to access a specific member

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -37,7 +37,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         # use the annotation node as a base to build the input args and return type
         # starting with `args[0]` to remove the surrounding `public()` call`
-        annotation = copy.deepcopy(node.annotation.args[0])
+        annotation = copy.copy(node.annotation.args[0])
 
         # the base return statement is an `Attribute` node, e.g. `self.<var_name>`
         # for each input type we wrap it in a `Subscript` to access a specific member

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -1,3 +1,5 @@
+import copy
+
 from vyper import ast as vy_ast
 from vyper.exceptions import CompilerPanic
 
@@ -35,7 +37,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         # use the annotation node as a base to build the input args and return type
         # starting with `args[0]` to remove the surrounding `public()` call`
-        annotation = vy_ast.VyperNode.from_node(node.annotation.args[0])
+        annotation = copy.copy(node.annotation.args[0])
 
         # the base return statement is an `Attribute` node, e.g. `self.<var_name>`
         # for each input type we wrap it in a `Subscript` to access a specific member

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -37,7 +37,6 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         # use the annotation node as a base to build the input args and return type
         # starting with `args[0]` to remove the surrounding `public()` call`
-        # probably don't need to copy but just be a bit defensive
         annotation = copy.copy(node.annotation.args[0])
 
         # the base return statement is an `Attribute` node, e.g. `self.<var_name>`

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -37,6 +37,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         # use the annotation node as a base to build the input args and return type
         # starting with `args[0]` to remove the surrounding `public()` call`
+        # probably don't need to copy but just be a bit defensive
         annotation = copy.copy(node.annotation.args[0])
 
         # the base return statement is an `Attribute` node, e.g. `self.<var_name>`

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Union
 
 from vyper.ast import nodes as vy_ast

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Union
 
 from vyper.ast import nodes as vy_ast
@@ -286,7 +285,7 @@ def replace_constant(
                 continue
 
         try:
-            replacement_node = copy.copy(replacement_node)
+            replacement_node = replacement_node
             new_node = _replace(node, replacement_node, type_=type_)
         except UnfoldableNode:
             if raise_on_error:

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -286,8 +286,6 @@ def replace_constant(
                 continue
 
         try:
-            # Codegen may mutate AST (particularly structs).
-            replacement_node = copy.deepcopy(replacement_node)
             new_node = _replace(node, replacement_node, type_=type_)
         except UnfoldableNode:
             if raise_on_error:

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Union
 
 from vyper.ast import nodes as vy_ast
@@ -285,6 +286,7 @@ def replace_constant(
                 continue
 
         try:
+            replacement_node = copy.copy(replacement_node)
             new_node = _replace(node, replacement_node, type_=type_)
         except UnfoldableNode:
             if raise_on_error:

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -285,7 +285,7 @@ def replace_constant(
                 continue
 
         try:
-            replacement_node = replacement_node
+            # note: _replace creates a copy of the replacement_node
             new_node = _replace(node, replacement_node, type_=type_)
         except UnfoldableNode:
             if raise_on_error:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -288,7 +288,7 @@ class VyperNode:
     def set_parent(self, parent: "VyperNode"):
         self._parent = parent
         self._depth = getattr(parent, "_depth", -1) + 1
- 
+
     @classmethod
     def from_node(cls, node: "VyperNode", **kwargs) -> "VyperNode":
         """

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -588,8 +588,7 @@ class Module(TopLevel):
         Parameters
         ----------
         old_node : VyperNode
-            Node object to be replaced. If the node does not currently exist
-            within the AST, a `CompilerPanic` is raised.
+            Node object to be replaced.
         new_node : VyperNode
             Node object to replace new_node.
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -598,8 +598,6 @@ class Module(TopLevel):
         None
         """
         parent = old_node._parent
-        if old_node not in self.get_descendants(type(old_node)):
-            raise CompilerPanic("Node to be replaced does not exist within the tree")
 
         if old_node not in parent._children:
             raise CompilerPanic("Node to be replaced does not exist within parent children")

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -248,8 +248,7 @@ class VyperNode:
         **kwargs : dict
             Dictionary of fields to be included within the node.
         """
-        self._parent = parent
-        self._depth = getattr(parent, "_depth", -1) + 1
+        self.set_parent(parent)
         self._children: set = set()
         self._metadata: dict = {}
 
@@ -285,6 +284,11 @@ class VyperNode:
         if parent is not None:
             parent._children.add(self)
 
+    # set parent, can be useful when inserting copied nodes into the AST
+    def set_parent(self, parent: "VyperNode"):
+        self._parent = parent
+        self._depth = getattr(parent, "_depth", -1) + 1
+ 
     @classmethod
     def from_node(cls, node: "VyperNode", **kwargs) -> "VyperNode":
         """

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -4,6 +4,9 @@ import sys
 import traceback
 import warnings
 from typing import List, Union
+import functools
+import time
+import contextlib
 
 from vyper.exceptions import DecimalOverrideException, InvalidLiteral
 
@@ -335,6 +338,26 @@ def indent(text: str, indent_chars: Union[str, List[str]] = " ", level: int = 1)
         raise ValueError("Unrecognized indentation characters value")
 
     return "".join(indented_lines)
+
+
+def timeit(func):
+    @functools.wraps(func)
+    def timeit_wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        total_time = end_time - start_time
+        print(f'Function {func.__name__} Took {total_time:.4f} seconds')
+        return result
+    return timeit_wrapper
+
+
+@contextlib.contextmanager
+def timer(msg):
+    t0 = time.time()
+    yield
+    t1 = time.time()
+    print(f"{msg} took {t1 - t0}s")
 
 
 def annotate_source_code(

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -1,12 +1,12 @@
 import binascii
+import contextlib
 import decimal
+import functools
 import sys
+import time
 import traceback
 import warnings
 from typing import List, Union
-import functools
-import time
-import contextlib
 
 from vyper.exceptions import DecimalOverrideException, InvalidLiteral
 
@@ -347,8 +347,9 @@ def timeit(func):
         result = func(*args, **kwargs)
         end_time = time.perf_counter()
         total_time = end_time - start_time
-        print(f'Function {func.__name__} Took {total_time:.4f} seconds')
+        print(f"Function {func.__name__} Took {total_time:.4f} seconds")
         return result
+
     return timeit_wrapper
 
 


### PR DESCRIPTION
### What I did
reduce build time.

time vyper Vault.vy went from `0m13.121s` to `0m3.521s`
time vyper CurveCryptoSwap2.vy went from `0m53.054s` to `0m5.259s`

### How I did it
investigating the time spent in various compiler phases, turns out 90% was spent in just three places.

the relevant lines triggered re-traversals of the entire AST, resulting
in O(n^2) build times. for non-trivial contracts near the 24KB limit,
this resulted in near-minute long build times.

this commit also adds timer utility functions so that the profiling can be easily done again.

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/180620075-190d5459-4314-4602-9e02-76d64b844d99.png)
