### PR TITLE
Update built-in-functions.rst

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -251,10 +251,7 @@ Vyper has three builtins for contract creation; all three contract creation buil
             x: uint256 = 123
             success, response = raw_call(
                 _target, 
-                concat(
-                    method_id("someMethodName(uint256)"), 
-                    convert(x, bytes32)
-                    ), 
+                _abi_encode(x, method_id=method_id("someMethodName(uint256)")), 
                 max_outsize=32,
                 value=msg.value, 
                 revert_on_failure=False

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -240,7 +240,7 @@ Vyper has three builtins for contract creation; all three contract creation buil
         @external
         @payable
         def foo(_target: address) -> Bytes[32]:
-            response: Bytes[32] = raw_call(_target, 0xa9059cbb, max_outsize=32, value=msg.value)
+            response: Bytes[32] = raw_call(_target, method_id("someMethodName()"), max_outsize=32, value=msg.value)
             return response
 
         @external
@@ -248,7 +248,17 @@ Vyper has three builtins for contract creation; all three contract creation buil
         def bar(_target: address) -> Bytes[32]:
             success: bool = False
             response: Bytes[32] = b""
-            success, response = raw_call(_target, 0xa9059cbb, max_outsize=32, value=msg.value, revert_on_failure=False)
+            x: uint256 = 123
+            success, response = raw_call(
+                _target, 
+                concat(
+                    method_id("someMethodName(uint256)"), 
+                    convert(x, bytes32)
+                    ), 
+                max_outsize=32,
+                value=msg.value, 
+                revert_on_failure=False
+                )
             assert success
             return response
 


### PR DESCRIPTION
Example for raw_call contained an error, the value for data was 0xa9059cbb. Trying the example with 0xa9059cbb could be very misleading because by using this with raw_call you ran into gas_errors (the real exception is: "vyper.exceptions.InvalidType: Expected Bytes[4] but literal can only be cast as bytes4", but this does not show up in the raw_call). So the content should have been b'\xa9\x05\x9c\xbb'. But i think it's better to show the use of method_id in this context.

### Commit message
improved  example for raw_call


