### PR TITLE
fix: enum variables accessed via `self.`

### DIFF
--- a/tests/parser/types/test_enum.py
+++ b/tests/parser/types/test_enum.py
@@ -26,6 +26,25 @@ def cancel() -> Action:
     assert c.cancel() == 4
 
 
+def test_enum_storage(get_contract):
+    code = """
+enum Actions:
+    BUY
+    SELL
+    CANCEL
+
+action: Actions
+
+@external
+def get_and_set(a: Actions) -> Actions:
+    self.action = a
+    return self.action
+    """
+    c = get_contract(code)
+    for i in range(5):
+        assert c.get_and_set(i) == i
+
+
 def test_eq_neq(get_contract):
     code = """
 enum Roles:

--- a/tests/parser/types/test_enum.py
+++ b/tests/parser/types/test_enum.py
@@ -33,16 +33,18 @@ enum Actions:
     SELL
     CANCEL
 
-action: Actions
+action: public(Actions)
 
 @external
-def get_and_set(a: Actions) -> Actions:
+def set_and_get(a: Actions) -> Actions:
     self.action = a
     return self.action
     """
     c = get_contract(code)
     for i in range(5):
-        assert c.get_and_set(i) == i
+        assert c.set_and_get(i) == i
+        c.set_and_get(i, transact={})
+        assert c.action == i
 
 
 def test_eq_neq(get_contract):

--- a/tests/parser/types/test_enum.py
+++ b/tests/parser/types/test_enum.py
@@ -44,7 +44,7 @@ def set_and_get(a: Actions) -> Actions:
     for i in range(5):
         assert c.set_and_get(i) == i
         c.set_and_get(i, transact={})
-        assert c.action == i
+        assert c.action() == i
 
 
 def test_eq_neq(get_contract):

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -204,8 +204,9 @@ class Expr:
         typ = self.expr._metadata.get("type")
         if typ is not None:
             typ = new_type_to_old_type(typ)
-        if isinstance(typ, EnumType):
-            assert typ.name == self.expr.value.id
+
+        # MyEnum.foo
+        if isinstance(typ, EnumType) and typ.name == self.expr.value.id:
             # 0, 1, 2, .. 255
             enum_id = typ.members[self.expr.attr]
             value = 2 ** enum_id  # 0 => 0001, 1 => 0010, 2 => 0100, etc.


### PR DESCRIPTION
### What I did
UX fix: enum members accessed directly with `self` would throw a compiler panic

### How I did it
fix namespace detection in codegen

### How to verify it
see tests

### Commit message
enum members accessed directly with `self` would throw a compiler panic

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/181776235-f30ad3b9-8289-46f5-9f6b-8d6126d144f5.png)
