### PR TITLE
Add atheris fuzzer

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder-python
+COPY . $SRC/vyper
+WORKDIR $SRC/vyper
+COPY .clusterfuzzlite/build.sh $SRC/
+

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+pip3 install --upgrade pip
+pip3 install .
+
+for fuzzer in $(find $SRC -name 'fuzz_*.py'); do
+  fuzzer_basename=$(basename -s .py $fuzzer)
+  fuzzer_package=${fuzzer_basename}.pkg
+  pyinstaller --distpath $OUT --onefile --name $fuzzer_package $fuzzer
+
+  # Create execution wrapper.
+  echo "#!/bin/sh
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+LD_PRELOAD=\$this_dir/sanitizer_with_fuzzer.so \
+ASAN_OPTIONS=\$ASAN_OPTIONS:symbolize=1:external_symbolizer_path=\$this_dir/llvm-symbolizer:detect_leaks=0 \
+\$this_dir/$fuzzer_package \$@" > $OUT/$fuzzer_basename
+  chmod +x $OUT/$fuzzer_basename
+done

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: python

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: python
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 400
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}

--- a/tests/ast/fuzz_parse_to_ast.py
+++ b/tests/ast/fuzz_parse_to_ast.py
@@ -1,0 +1,31 @@
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from vyper.ast import parse_to_ast
+    from vyper.exceptions import SyntaxException, ParserException, SyntaxException
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    try:
+        _ = parse_to_ast(fdp.ConsumeString(len(data)))
+    except SyntaxException:
+        None
+    except ValueError:
+        None
+    except IndentationError:
+        None
+    except ParserException:
+        None
+    except SyntaxException:
+        None
+
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Signed-off-by: AdamKorcz <Adam@adalogics.com>

### What I did

1. Added a fuzzer
2. Added [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/)

### How I did it

1. Added the fuzzer in `tests/ast`.
2. Added the ClusterfuzzLite in `.clusterfuzzlite`.
3. Added a `.yml` workflow file.

### How to verify it

1. By observing the CI jobs.

### Commit message

This PR adds a fuzzer for `parse_to_ast()`. The fuzzer passes a pseudo-random string, to `parse_to_ast()` to find possible crashes and catches a few exceptions. 
The PR also sets up the fuzzer to run in the CI via [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/).

### Description for the changelog

### Cute Animal Picture


