### PR TITLE
add blueprint bytecode output

### DIFF
--- a/tests/cli/vyper_compile/test_compile_files.py
+++ b/tests/cli/vyper_compile/test_compile_files.py
@@ -11,6 +11,7 @@ def test_combined_json_keys(tmp_path):
     combined_keys = {
         "bytecode",
         "bytecode_runtime",
+        "blueprint_bytecode",
         "abi",
         "source_map",
         "layout",

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -42,6 +42,7 @@ no-optimize        - Do not optimize (don't use this for production code)
 combined_json_outputs = [
     "bytecode",
     "bytecode_runtime",
+    "blueprint_bytecode",
     "abi",
     "layout",
     "source_map",

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -39,6 +39,7 @@ OUTPUT_FORMATS = {
     # requires bytecode
     "bytecode": output.build_bytecode_output,
     "bytecode_runtime": output.build_bytecode_runtime_output,
+    "blueprint_bytecode": output.build_blueprint_bytecode_output,
     "opcodes": output.build_opcodes_output,
     "opcodes_runtime": output.build_opcodes_runtime_output,
 }

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -243,6 +243,10 @@ def build_bytecode_output(compiler_data: CompilerData) -> str:
     return f"0x{compiler_data.bytecode.hex()}"
 
 
+def build_blueprint_bytecode_output(compiler_data: CompilerData) -> str:
+    return f"0x{compiler_data.blueprint_bytecode.hex()}"
+
+
 # EIP-170. Ref: https://eips.ethereum.org/EIPS/eip-170
 EIP170_CONTRACT_SIZE_LIMIT: int = 2 ** 14 + 2 ** 13
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -150,7 +150,7 @@ class CompilerData:
 
     @cached_property
     def blueprint_bytecode(self) -> bytes:
-        blueprint_preamble=b"\xFE\x71\x00"  # ERC5202 preamble
+        blueprint_preamble = b"\xFE\x71\x00"  # ERC5202 preamble
         blueprint_bytecode = blueprint_preamble + self.bytecode
 
         # the length of the deployed code in bytes

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -148,6 +148,17 @@ class CompilerData:
     def bytecode_runtime(self) -> bytes:
         return generate_bytecode(self.assembly_runtime, is_runtime=True)
 
+    @cached_property
+    def blueprint_bytecode(self) -> bytes:
+        blueprint_preamble=b"\xFE\x71\x00"  # ERC5202 preamble
+        blueprint_bytecode = blueprint_preamble + self.bytecode
+
+        # the length of the deployed code in bytes
+        len_bytes = len(blueprint_bytecode).to_bytes(2, "big")
+        deploy_bytecode = b"\x61" + len_bytes + b"\x3d\x81\x60\x0a\x3d\x39\xf3"
+
+        return deploy_bytecode + blueprint_bytecode
+
 
 def generate_ast(source_code: str, source_id: int, contract_name: str) -> vy_ast.Module:
     """


### PR DESCRIPTION
### What I did
add output format which deploys blueprint contracts

### How I did it
futz around with codecopy

### How to verify it
try `vyper -f blueprint_bytecode <foo.vy>`

### Commit message

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
