### PR TITLE
Replace broken link to npm semver docs

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -12,7 +12,7 @@ This section provides a quick overview of the types of data present within a con
 Version Pragma
 ==============
 
-Vyper supports a version pragma to ensure that a contract is only compiled by the intended compiler version, or range of versions. Version strings use `NPM <https://docs.npmjs.com/misc/semver>`_ style syntax.
+Vyper supports a version pragma to ensure that a contract is only compiled by the intended compiler version, or range of versions. Version strings use `NPM <https://docs.npmjs.com/about-semantic-versioning>`_ style syntax.
 
 .. code-block:: python
 


### PR DESCRIPTION
### What I did

See #2997.

### Commit message

`Replace broken link to npm semver docs`

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1594472180763-b90788942f84?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1064&q=80)
