### PR TITLE
fix: empty builtin in kwargs and constants

### DIFF
--- a/tests/parser/functions/test_default_parameters.py
+++ b/tests/parser/functions/test_default_parameters.py
@@ -290,6 +290,20 @@ struct Bar:
 @external
 def foo(bar: Bar = Bar({a: msg.sender, b: Baz({c: block.coinbase, d: -10})})): pass
     """,
+    """
+A: public(address)
+
+@external
+def foo(a: address = empty(address)):
+    self.A = a
+    """,
+    """
+A: public(int112)
+
+@external
+def foo(a: int112 = min_value(int112)):
+    self.A = a
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -147,6 +147,9 @@ test_a : constant(int128) = 2188824287183927522224640574525
 test_a: constant(uint256) = max_value(uint256)
     """,
     """
+test_a: constant(address) = empty(address)
+    """,
+    """
 TEST_C: constant(uint256) = 1
 TEST_WEI: constant(uint256) = 1
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -2183,6 +2183,10 @@ class Empty(BuiltinFunction):
     # (note that it is ignored in `validate_args`)
     _inputs = [("typename", "TYPE_DEFINITION")]
 
+    # Since `empty` is not folded before semantics validation, this flag is used
+    # for `check_kwargable` in semantics validation.
+    _kwargable = True
+
     def fetch_call_return(self, node):
         type_ = self.infer_arg_types(node)[0].typedef
         return type_

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -7,7 +7,6 @@ from vyper.exceptions import (
     InvalidType,
     StructureException,
     UndeclaredDefinition,
-    UnfoldableNode,
     UnknownType,
     VyperInternalException,
 )

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -7,6 +7,7 @@ from vyper.exceptions import (
     InvalidType,
     StructureException,
     UndeclaredDefinition,
+    UnfoldableNode,
     UnknownType,
     VyperInternalException,
 )
@@ -226,6 +227,10 @@ def check_constant(node: vy_ast.VyperNode) -> bool:
         if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
             return all(check_constant(v) for v in args[0].values)
 
+        call_type = get_exact_type_from_node(node.func)
+        if getattr(call_type, "_kwargable", False):
+            return True
+
     return False
 
 
@@ -241,6 +246,10 @@ def check_kwargable(node: vy_ast.VyperNode) -> bool:
         args = node.args
         if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
             return all(check_kwargable(v) for v in args[0].values)
+
+        call_type = get_exact_type_from_node(node.func)
+        if getattr(call_type, "_kwargable", False):
+            return True
 
     value_type = get_exact_type_from_node(node)
     # is_constant here actually means not_assignable, and is to be renamed


### PR DESCRIPTION
### What I did

Fix #3004. Also fixes `empty` for constant.

### How I did it

Add `_kwargable` attribute to `Empty` builtin.

### How to verify it

See tests.

### Commit message

```
fix: allow empty builtin in kwargs and constants
```

### Description for the changelog

Allow empty builtin in kwargs and constants.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rainforest-alliance.org/wp-content/uploads/2021/06/capybara-square-1.jpg.optimal.jpg)
