### PR TITLE
add cbor length metadata

### DIFF
--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -994,6 +994,7 @@ def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False):
     if insert_vyper_signature:
         # CBOR encoded: {"vyper": [major,minor,patch]}
         bytecode_suffix += b"\xa1\x65vyper\x83" + bytes(list(version_tuple))
+        bytecode_suffix += len(bytecode_suffix).to_bytes(2, "big")
 
     CODE_OFST_SIZE = 2  # size of a PUSH instruction for a code symbol
 


### PR DESCRIPTION
so disassemblers/analyzers can reliably detect where the code ends and
the CBOR metadata starts

### What I did
fix #3009

### How I did it

### How to verify it
compile a vyper contract and inspect last 13 bytes

### Commit message
```
add binary encoded length to the end of the CBOR metadata so
disassemblers can reliably detect where code ends and metadata starts
```

### Description for the changelog
add length to CBOR metadata so bytecode analysis can reliably demarcate it

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/181770866-0d803466-fe73-429f-99a5-5b729eb55a49.png)
