### PR TITLE
fix: add some missing error messages

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -281,7 +281,7 @@ def append_dyn_array(darray_node, elem_node):
         len_ = get_dyn_array_count(darray_node)
         with len_.cache_when_complex("old_darray_len") as (b2, len_):
             assertion = ["assert", ["lt", len_, darray_node.typ.count]]
-            ret.append(assertion, error_msg=f"{darray_node.typ} bounds check")
+            ret.append(IRnode.from_list(assertion, error_msg=f"{darray_node.typ} bounds check"))
             ret.append(STORE(darray_node, ["add", len_, 1]))
             # NOTE: typechecks elem_node
             # NOTE skip array bounds check bc we already asserted len two lines up

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -995,7 +995,8 @@ def int_clamp(ir_node, bits, signed=False):
     if bits >= 256:
         raise CompilerPanic(f"invalid clamp: {bits}>=256 ({ir_node})")  # pragma: notest
 
-    msg = f"{ir_node.typ} bounds check"
+    u = "u" if not signed else ""
+    msg = f"{u}int{bits} bounds check"
     with ir_node.cache_when_complex("val") as (b, val):
         if signed:
             # example for bits==128:
@@ -1018,7 +1019,7 @@ def int_clamp(ir_node, bits, signed=False):
 def bytes_clamp(ir_node: IRnode, n_bytes: int) -> IRnode:
     if not (0 < n_bytes <= 32):
         raise CompilerPanic(f"bad type: bytes{n_bytes}")
-    msg = f"{ir_node.typ} bounds check"
+    msg = f"bytes{n_bytes} bounds check"
     with ir_node.cache_when_complex("val") as (b, val):
         assertion = ["assert", ["iszero", shl(n_bytes * 8, val)]]
         assertion = IRnode.from_list(assertion, error_msg=msg)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1021,8 +1021,7 @@ def bytes_clamp(ir_node: IRnode, n_bytes: int) -> IRnode:
         raise CompilerPanic(f"bad type: bytes{n_bytes}")
     msg = f"bytes{n_bytes} bounds check"
     with ir_node.cache_when_complex("val") as (b, val):
-        assertion = ["assert", ["iszero", shl(n_bytes * 8, val)]]
-        assertion = IRnode.from_list(assertion, error_msg=msg)
+        assertion = IRnode.from_list(["assert", ["iszero", shl(n_bytes * 8, val)]], error_msg=msg)
         ret = b.resolve(["seq", assertion, val])
 
     return IRnode.from_list(ret, annotation=msg)


### PR DESCRIPTION
### What I did
`convert(x, uint64)` didn't produce an error message. this adds some missing messages

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/182038493-2ca1fce1-1ffd-40e0-9e7f-beea33901d0b.png)
