### PR TITLE
refactor: fix typo in bases.py

### DIFF
--- a/vyper/semantics/types/bases.py
+++ b/vyper/semantics/types/bases.py
@@ -285,7 +285,7 @@ class BaseTypeDefinition:
     def to_abi_dict(self, name: str = "") -> Dict[str, Any]:
         """
         The JSON ABI description of this type. Note for complex types,
-        the implementation is overriden to be compliant with the spec:
+        the implementation is overridden to be compliant with the spec:
         https://docs.soliditylang.org/en/v0.8.14/abi-spec.html#json
         > An object with members name, type and potentially components
           describes a typed variable. The canonical type is determined


### PR DESCRIPTION


### What I did

Fixed typo.
```
overriden -> overridden
```

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture
![temperament_kittens_Nov_RR_SB_LC](https://user-images.githubusercontent.com/22633385/181934433-cfc4521c-6213-40aa-816c-162466ddcbe7.jpg)


