### PR TITLE
unroll `in` and `not in` expressions

### DIFF
--- a/tests/ast/nodes/test_evaluate_compare.py
+++ b/tests/ast/nodes/test_evaluate_compare.py
@@ -55,6 +55,11 @@ def test_compare_in(left, right, get_contract):
 def foo(a: int128, b: int128[{len(right)}]) -> bool:
     c: int128[{len(right)}] = b
     return a in c
+
+@external
+def bar(a: int128) -> bool:
+    # note: codegen unrolls to a == right[0] or a == right[1] ...
+    return a in {right}
     """
     contract = get_contract(source)
 
@@ -62,7 +67,12 @@ def foo(a: int128, b: int128[{len(right)}]) -> bool:
     old_node = vyper_ast.body[0].value
     new_node = old_node.evaluate()
 
+    # check runtime == fully folded
     assert contract.foo(left, right) == new_node.value
+    # check unrolled runtime == fully folded
+    assert contract.bar(left) == new_node.value
+    # check folding matches python semantics
+    assert (left in right) == new_node.value
 
 
 @pytest.mark.fuzzing
@@ -74,6 +84,11 @@ def test_compare_not_in(left, right, get_contract):
 def foo(a: int128, b: int128[{len(right)}]) -> bool:
     c: int128[{len(right)}] = b
     return a not in c
+
+@external
+def bar(a: int128) -> bool:
+    # note: codegen unrolls to a != right[0] and a != right[1] ...
+    return a not in {right}
     """
     contract = get_contract(source)
 
@@ -81,7 +96,12 @@ def foo(a: int128, b: int128[{len(right)}]) -> bool:
     old_node = vyper_ast.body[0].value
     new_node = old_node.evaluate()
 
+    # check runtime == fully folded
     assert contract.foo(left, right) == new_node.value
+    # check unrolled runtime == fully folded
+    assert contract.bar(left) == new_node.value
+    # check folding matches python semantics
+    assert (left not in right) == new_node.value
 
 
 @pytest.mark.parametrize("op", ["==", "!=", "<", "<=", ">=", ">"])

--- a/tests/ast/nodes/test_evaluate_compare.py
+++ b/tests/ast/nodes/test_evaluate_compare.py
@@ -58,7 +58,7 @@ def foo(a: int128, b: int128[{len(right)}]) -> bool:
 
 @external
 def bar(a: int128) -> bool:
-    # note: codegen unrolls to a == right[0] or a == right[1] ...
+    # note: codegen unrolls to `a == right[0] or a == right[1] ...`
     return a in {right}
     """
     contract = get_contract(source)
@@ -87,7 +87,7 @@ def foo(a: int128, b: int128[{len(right)}]) -> bool:
 
 @external
 def bar(a: int128) -> bool:
-    # note: codegen unrolls to a != right[0] and a != right[1] ...
+    # note: codegen unrolls to `a != right[0] and a != right[1] ...`
     return a not in {right}
     """
     contract = get_contract(source)

--- a/tests/compiler/ir/test_optimize_ir.py
+++ b/tests/compiler/ir/test_optimize_ir.py
@@ -21,6 +21,7 @@ optimize_list = [
     # condition rewriter
     (["if", ["eq", "x", "y"], "pass"], ["if", ["iszero", ["xor", "x", "y"]], "pass"]),
     (["if", "cond", 1, 0], ["if", ["iszero", "cond"], 0, 1]),
+    (["if", ["ne", "x", 1], [1]], None),
     (["assert", ["eq", "x", "y"]], ["assert", ["iszero", ["xor", "x", "y"]]]),
     # nesting
     (["mstore", 0, ["eq", 1, 2]], ["mstore", 0, 0]),

--- a/tests/compiler/ir/test_optimize_ir.py
+++ b/tests/compiler/ir/test_optimize_ir.py
@@ -22,6 +22,8 @@ optimize_list = [
     (["if", ["eq", "x", "y"], "pass"], ["if", ["iszero", ["xor", "x", "y"]], "pass"]),
     (["if", "cond", 1, 0], ["if", ["iszero", "cond"], 0, 1]),
     (["if", ["ne", "x", 1], [1]], None),
+    # TODO: fix this perf regression
+    (["if", ["iszero", ["eq", "x", "y"]], [1]], ["if", ["iszero", ["iszero", ["xor", "x", "y"]]], 1]),
     (["assert", ["eq", "x", "y"]], ["assert", ["iszero", ["xor", "x", "y"]]]),
     # nesting
     (["mstore", 0, ["eq", 1, 2]], ["mstore", 0, 0]),

--- a/tests/compiler/ir/test_optimize_ir.py
+++ b/tests/compiler/ir/test_optimize_ir.py
@@ -22,12 +22,13 @@ optimize_list = [
     (["if", ["eq", "x", "y"], "pass"], ["if", ["iszero", ["xor", "x", "y"]], "pass"]),
     (["if", "cond", 1, 0], ["if", ["iszero", "cond"], 0, 1]),
     (["if", ["ne", "x", 1], [1]], None),
-    # TODO: fix this perf regression
     (
+        # TODO: this is perf issue (codegen should usually generate `if (ne x y)` though)
         ["if", ["iszero", ["eq", "x", "y"]], [1]],
         ["if", ["iszero", ["iszero", ["xor", "x", "y"]]], 1],
     ),
     (["assert", ["eq", "x", "y"]], ["assert", ["iszero", ["xor", "x", "y"]]]),
+    (["assert", ["ne", "x", "y"]], None),
     # nesting
     (["mstore", 0, ["eq", 1, 2]], ["mstore", 0, 0]),
     # conditions

--- a/tests/compiler/ir/test_optimize_ir.py
+++ b/tests/compiler/ir/test_optimize_ir.py
@@ -23,7 +23,10 @@ optimize_list = [
     (["if", "cond", 1, 0], ["if", ["iszero", "cond"], 0, 1]),
     (["if", ["ne", "x", 1], [1]], None),
     # TODO: fix this perf regression
-    (["if", ["iszero", ["eq", "x", "y"]], [1]], ["if", ["iszero", ["iszero", ["xor", "x", "y"]]], 1]),
+    (
+        ["if", ["iszero", ["eq", "x", "y"]], [1]],
+        ["if", ["iszero", ["iszero", ["xor", "x", "y"]]], 1],
+    ),
     (["assert", ["eq", "x", "y"]], ["assert", ["iszero", ["xor", "x", "y"]]]),
     # nesting
     (["mstore", 0, ["eq", 1, 2]], ["mstore", 0, 0]),

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1621,6 +1621,11 @@ def ix(i: uint256) -> decimal:
     assert_tx_failed(lambda: c.ix(len(some_good_primes) + 1))
 
 
+# CMC 2022-08-04 these are blocked due to typechecker bug; leaving as
+# negative tests so we know if/when the typechecker is fixed.
+# (don't consider it a high priority to fix since membership in
+# in empty list literal seems like something we should plausibly
+# reject at compile-time anyway)
 def test_empty_list_membership_fail(get_contract, assert_compile_failed):
     code = """
 @external

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -434,7 +434,7 @@ def check_not_in(s: uint128) -> bool:
     return a not in x
     """
     c = get_contract_with_gas_estimation(code)
-    for s in (0,1,2,3):
+    for s in (0, 1, 2, 3):
         assert c.check_in(s) is False
         assert c.check_not_in(s) is True
 

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1621,6 +1621,21 @@ def ix(i: uint256) -> decimal:
     assert_tx_failed(lambda: c.ix(len(some_good_primes) + 1))
 
 
+def test_empty_list_membership_fail(get_contract, assert_compile_failed):
+    code = """
+@external
+def foo(x: uint256) -> bool:
+    return x in []
+    """
+    assert_compile_failed(lambda: get_contract(code))
+    code = """
+@external
+def foo(x: uint256) -> bool:
+    return x not in []
+    """
+    assert_compile_failed(lambda: get_contract(code))
+
+
 # TODO test loops
 
 # Would be nice to put this somewhere accessible, like in vyper.types or something

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -418,6 +418,27 @@ def check(a: {type}) -> bool:
     assert c.check(false_value) is False
 
 
+@pytest.mark.parametrize("type_", ("uint256", "bytes32", "address"))
+def test_member_in_empty_list(get_contract_with_gas_estimation, type_):
+    code = f"""
+@external
+def check_in(s: uint128) -> bool:
+    a: {type_} = convert(s, {type_})
+    x: DynArray[{type_}, 2] = []
+    return a in x
+
+@external
+def check_not_in(s: uint128) -> bool:
+    a: {type_} = convert(s, {type_})
+    x: DynArray[{type_}, 2] = []
+    return a not in x
+    """
+    c = get_contract_with_gas_estimation(code)
+    for s in (0,1,2,3):
+        assert c.check_in(s) is False
+        assert c.check_not_in(s) is True
+
+
 @pytest.mark.parametrize(
     "type,values,false_values",
     [

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1108,6 +1108,8 @@ class Compare(VyperNode):
         if not isinstance(left, Constant):
             raise UnfoldableNode("Node contains invalid field(s) for evaluation")
 
+        # CMC 2022-08-04 we could probably remove these evaluation rules as they
+        # are taken care of in the IR optimizer now.
         if isinstance(self.op, (In, NotIn)):
             if not isinstance(right, List):
                 raise UnfoldableNode("Node contains invalid field(s) for evaluation")

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -11,7 +11,6 @@ from vyper.codegen.core import (
     get_dyn_array_count,
     get_element_ptr,
     getpos,
-    make_setter,
     pop_dyn_array,
     unwrap_location,
 )
@@ -525,6 +524,7 @@ class Expr:
         return IRnode.from_list([op, left, right], typ="bool")
 
     def parse_BoolOp(self):
+        values = []
         for value in self.expr.values:
             # Check for boolean operations with non-boolean inputs
             ir_val = Expr.parse_value_expr(value, self.context)
@@ -539,7 +539,7 @@ class Expr:
         if isinstance(self.expr.op, vy_ast.Or):
             return Expr._logical_or(values)
 
-        raise TypeCheckFailure(f"Unexpected boolean operator: {type(self.expr.op).__name__}")  # pragma: notest
+        raise TypeCheckFailure(f"Unexpected boolop: {self.expr.op}")  # pragma: notest
 
     @staticmethod
     def _logical_and(values):
@@ -556,7 +556,6 @@ class Expr:
 
         return IRnode.from_list(ir_node, typ="bool")
 
-
     @staticmethod
     def _logical_or(values):
         if len(values) == 1:
@@ -571,7 +570,6 @@ class Expr:
             ir_node = ["if", val, 1, ir_node]
 
         return IRnode.from_list(ir_node, typ="bool")
-
 
     # Unary operations (only "not" supported)
     def parse_UnaryOp(self):

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -427,7 +427,6 @@ class Expr:
                     checks = [["ne", left, val] for val in right.args]
                     return b1.resolve(b2.resolve(Expr._logical_and(checks)))
 
-
             # location of i'th item from list
             ith_element_ptr = get_element_ptr(right, i, array_bounds_check=False)
             ith_element = unwrap_location(ith_element_ptr)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -548,12 +548,14 @@ class Expr:
         # return the logical and of a list of IRnodes
 
         # create a nested if statement starting from the
-        # innermost node
+        # innermost node. note this also serves as the base case
+        # (`_logical_and([x]) == x`)
         ir_node = values[-1]
 
         # iterate backward through the remaining values,
         # nesting further at each step
         for val in values[-2::-1]:
+            # `x and y` => `if x { then y } { else 0 }`
             ir_node = ["if", val, ir_node, 0]
 
         return IRnode.from_list(ir_node, typ="bool")
@@ -563,12 +565,14 @@ class Expr:
         # return the logical or of a list of IRnodes
 
         # create a nested if statement starting from the
-        # innermost node
+        # innermost node. note this also serves as the base case
+        # (`_logical_or([x]) == x`)
         ir_node = values[-1]
 
         # iterate backward through the remaining values,
         # nesting further at each step
         for val in values[-2::-1]:
+            # `x or y` => `if x { then 1 } { else y }`
             ir_node = ["if", val, 1, ir_node]
 
         return IRnode.from_list(ir_node, typ="bool")

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -400,14 +400,12 @@ class Expr:
 
         left = unwrap_location(left)
 
-        # general case: loop over the list and check each element
-        # for equality
         if isinstance(self.expr.op, vy_ast.In):
             found, not_found = 1, 0
         elif isinstance(self.expr.op, vy_ast.NotIn):
             found, not_found = 0, 1
-        else:
-            return  # pragma: notest
+        else:  # pragma: no cover
+            return
 
         i = IRnode.from_list(self.context.fresh_varname("in_ix"), typ="uint256")
 
@@ -428,6 +426,9 @@ class Expr:
                 if isinstance(self.expr.op, vy_ast.NotIn):
                     checks = [["ne", left, val] for val in right.args]
                     return b1.resolve(b2.resolve(Expr._logical_and(checks)))
+
+            # general case: loop over the list and check each element
+            # for equality
 
             # location of i'th item from list
             ith_element_ptr = get_element_ptr(right, i, array_bounds_check=False)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -409,6 +409,8 @@ class Expr:
                 checks = [["ne", left, val] for val in right.args]
                 return Expr._logical_and(checks)
 
+        # general case: loop over the list and check each element
+        # for equality
         if isinstance(self.expr.op, vy_ast.In):
             found, not_found = 1, 0
         elif isinstance(self.expr.op, vy_ast.NotIn):
@@ -543,30 +545,30 @@ class Expr:
 
     @staticmethod
     def _logical_and(values):
-        if len(values) == 1:
-            return IRnode.from_list(values[0], typ="bool")
+        # return the logical and of a list of IRnodes
 
         # create a nested if statement starting from the
-        # innermost nesting
-        ir_node = ["if", values[-2], values[-1], 0]
+        # innermost node
+        ir_node = values[-1]
 
-        # iterate backward through the remaining values
-        for val in values[-3::-1]:
+        # iterate backward through the remaining values,
+        # nesting further at each step
+        for val in values[-2::-1]:
             ir_node = ["if", val, ir_node, 0]
 
         return IRnode.from_list(ir_node, typ="bool")
 
     @staticmethod
     def _logical_or(values):
-        if len(values) == 1:
-            return IRnode.from_list(values[0], typ="bool")
+        # return the logical or of a list of IRnodes
 
         # create a nested if statement starting from the
-        # innermost nesting
-        ir_node = ["if", values[-2], 1, values[-1]]
+        # innermost node
+        ir_node = values[-1]
 
-        # iterate backward through the remaining values
-        for val in values[-3::-1]:
+        # iterate backward through the remaining values,
+        # nesting further at each step
+        for val in values[-2::-1]:
             ir_node = ["if", val, 1, ir_node]
 
         return IRnode.from_list(ir_node, typ="bool")

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -420,6 +420,8 @@ class Expr:
         ) as (b2, right):
             # unroll the loop for compile-time list literals
             if right.value == "multi":
+                # empty list literals should be rejected at typechecking time
+                assert len(right.args) > 0
                 if isinstance(self.expr.op, vy_ast.In):
                     checks = [["eq", left, val] for val in right.args]
                     return b1.resolve(b2.resolve(Expr._logical_or(checks)))

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -544,7 +544,7 @@ class Expr:
     @staticmethod
     def _logical_and(values):
         if len(values) == 1:
-            return values[0]
+            return IRnode.from_list(values[0], typ="bool")
 
         # create a nested if statement starting from the
         # innermost nesting
@@ -559,7 +559,7 @@ class Expr:
     @staticmethod
     def _logical_or(values):
         if len(values) == 1:
-            return values[0]
+            return IRnode.from_list(values[0], typ="bool")
 
         # create a nested if statement starting from the
         # innermost nesting

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -376,7 +376,7 @@ def _optimize_binop(binop, args, ann, parent_op):
             # note that (xor (-1) x) has its own rule
             return finalize("iszero", [["xor", args[0], args[1]]])
 
-        if binop == "ne":
+        if binop == "ne" and parent_op == "iszero":
             # trigger other optimizations
             return finalize("iszero", [["eq", *args]])
 

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -519,7 +519,7 @@ def _optimize(node: IRnode, parent: Optional[IRnode]) -> Tuple[bool, IRnode]:
                 # return the first branch
                 return finalize("seq", [argz[1]])
 
-        elif len(argz) == 3 and argz[0].value != "iszero":
+        elif len(argz) == 3 and argz[0].value not in ("iszero", "ne"):
             # if(x) compiles to jumpi(_, iszero(x))
             # there is an asm optimization for the sequence ISZERO ISZERO..JUMPI
             # so we swap the branches here to activate that optimization.

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -376,8 +376,10 @@ def _optimize_binop(binop, args, ann, parent_op):
             # note that (xor (-1) x) has its own rule
             return finalize("iszero", [["xor", args[0], args[1]]])
 
-        if binop == "ne" and parent_op != "if":
-            # trigger other optimizations
+        if binop == "ne" and parent_op == "iszero":
+            # for iszero, trigger other optimizations
+            # (for `if` and `assert`, `ne` will generate two ISZEROs
+            # which will get optimized out during assembly)
             return finalize("iszero", [["eq", *args]])
 
         # TODO can we do this?

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -376,7 +376,7 @@ def _optimize_binop(binop, args, ann, parent_op):
             # note that (xor (-1) x) has its own rule
             return finalize("iszero", [["xor", args[0], args[1]]])
 
-        if binop == "ne" and parent_op == "iszero":
+        if binop == "ne" and parent_op != "if":
             # trigger other optimizations
             return finalize("iszero", [["eq", *args]])
 


### PR DESCRIPTION
for list literals, the following
```
x in [a, b, c]
```
can be unrolled to
```
x == a or x == b or x == c
```

likewise,
```
x not in [a, b, c]
```
can be unrolled to
```
x != a and x != b and x != c
```

this commit also slightly refactors the code for logical and and logical or
to make this easier

### What I did

### How I did it

### How to verify it
check tests still pass. may want to update the tests to ensure we are testing `in/not in` for both literals and non-literals.

comparison of before/after
```vyper
# tmp/in.vy
@external
def foo(x: uint256) -> bool:
    return x in [1,2,3,4,5]
```
```
In [1]: import boa; t = boa.load("tmp/in.vy")  # this branch

In [2]: t.foo(5); t._computation.get_gas_used()
Out[2]: 233
```
```
In [1]: import boa; t = boa.load("tmp/in.vy")  # v0.3.4

In [2]: t.foo(5); t._computation.get_gas_used()
Out[2]: 542
```

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/182034467-5dc50410-edc7-43b5-a3d2-8daea3e10762.png)
