### PR TITLE
fix: trailing semicolon in compressed source map

### DIFF
--- a/tests/compiler/test_source_map.py
+++ b/tests/compiler/test_source_map.py
@@ -90,7 +90,7 @@ def foo() -> uint256:
     compressed = _compress_source_map(
         code, {"0": None, "2": (2, 0, 4, 13), "3": (2, 0, 2, 8), "5": (2, 0, 2, 8)}, {"3": "o"}, 2
     )
-    assert compressed == "-1:-1:2:-;1:45;:8::o;;"
+    assert compressed == "-1:-1:2:-;1:45;:8::o;"
 
 
 def test_expand_source_map():

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -214,7 +214,7 @@ def build_source_map_output(compiler_data: CompilerData) -> OrderedDict:
 
 def _compress_source_map(code, pos_map, jump_map, source_id):
     linenos = asttokens.LineNumbers(code)
-    compressed_map = f"-1:-1:{source_id}:-;"
+    ret = [f"-1:-1:{source_id}:-"]
     last_pos = [-1, -1, source_id]
 
     for pc in sorted(pos_map)[1:]:
@@ -234,9 +234,9 @@ def _compress_source_map(code, pos_map, jump_map, source_id):
             else:
                 current_pos[i] = ""
 
-        compressed_map += ":".join(str(i) for i in current_pos) + ";"
+        ret.append(":".join(str(i) for i in current_pos))
 
-    return compressed_map
+    return ";".join(ret)
 
 
 def build_bytecode_output(compiler_data: CompilerData) -> str:


### PR DESCRIPTION
the compressed source map had a trailing semicolon. (previously it was
moot because the runtime bytecode did not have any trailing
instructions, now it does because of the CBOR encoded metadata).

### What I did
fix #3022

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
