### PR TITLE
fix: `self` in pure functions

### DIFF
--- a/tests/parser/features/decorators/test_pure.py
+++ b/tests/parser/features/decorators/test_pure.py
@@ -83,6 +83,20 @@ def foo() -> uint256:
     )
 
 
+def test_invalid_self_access(get_contract, assert_compile_failed):
+    assert_compile_failed(
+        lambda: get_contract(
+            """
+@pure
+@external
+def foo() -> address:
+    return self
+    """
+        ),
+        StateAccessViolation,
+    )
+
+
 def test_invalid_call(get_contract, assert_compile_failed):
     assert_compile_failed(
         lambda: get_contract(

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -197,7 +197,9 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
             # Add references to `self` as standalone address
             self_references = fn_node.get_descendants(vy_ast.Name, {"id": "self"})
-            standalone_self = [n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)]
+            standalone_self = [
+                n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)
+            ]
             node_list.extend(standalone_self)
 
             for node in node_list:

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -197,8 +197,10 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
             # Add references to `self` as standalone address
             self_references = fn_node.get_descendants(vy_ast.Name, {"id": "self"})
-            standalone_self = [n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)]
-            node_list.extend(standalone_self)
+            standalone_self = [
+                n for n in self_references if n.get_ancestor(vy_ast.Attribute) is None
+            ]
+            node_list.extend(standalone_self)  # type: ignore
 
             for node in node_list:
                 t = node._metadata.get("type")

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -197,10 +197,8 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
             # Add references to `self` as standalone address
             self_references = fn_node.get_descendants(vy_ast.Name, {"id": "self"})
-            standalone_self = [
-                n for n in self_references if n.get_ancestor(vy_ast.Attribute) is None
-            ]
-            node_list.extend(standalone_self)  # type: ignore
+            standalone_self = [n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)]
+            node_list.extend(standalone_self)
 
             for node in node_list:
                 t = node._metadata.get("type")

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -194,6 +194,12 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                     )
                 },
             )
+
+            # Add references to `self` as standalone address
+            self_references = fn_node.get_descendants(vy_ast.Name, {"id": "self"})
+            standalone_self = [n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)]
+            node_list.extend(standalone_self)
+
             for node in node_list:
                 t = node._metadata.get("type")
                 if isinstance(t, ContractFunction) and t.mutability == StateMutability.PURE:

--- a/vyper/semantics/validation/local.py
+++ b/vyper/semantics/validation/local.py
@@ -200,7 +200,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             standalone_self = [
                 n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)
             ]
-            node_list.extend(standalone_self)
+            node_list.extend(standalone_self)  # type: ignore
 
             for node in node_list:
                 t = node._metadata.get("type")


### PR DESCRIPTION
### What I did

Fix for #3021 

### How I did it

Check for standalone accesses to `self` by filtering out `Name` nodes with an ancestor that is not an `Attribute` node.

### How to verify it

See test

### Commit message

```
fix: access to `self` in pure functions
```

### Description for the changelog

Disable access to `self` in pure functions

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.freepik.com/premium-photo/cute-capybara-farm-is-eating_361141-840.jpg?w=2000)
