### PR TITLE
fix: public DynArray getters

### DIFF
--- a/tests/ast/nodes/test_evaluate_compare.py
+++ b/tests/ast/nodes/test_evaluate_compare.py
@@ -47,7 +47,7 @@ def foo(a: uint128, b: uint128) -> bool:
 
 
 @pytest.mark.fuzzing
-@settings(max_examples=20, deadline=500)
+@settings(max_examples=20, deadline=1000)
 @given(left=st.integers(), right=st.lists(st.integers(), min_size=1, max_size=16))
 def test_compare_in(left, right, get_contract):
     source = f"""
@@ -76,7 +76,7 @@ def bar(a: int128) -> bool:
 
 
 @pytest.mark.fuzzing
-@settings(max_examples=20, deadline=500)
+@settings(max_examples=20, deadline=1000)
 @given(left=st.integers(), right=st.lists(st.integers(), min_size=1, max_size=16))
 def test_compare_not_in(left, right, get_contract):
     source = f"""

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1622,7 +1622,7 @@ def ix(i: uint256) -> decimal:
 
 
 def test_public_dynarray(get_contract):
-    code = f"""
+    code = """
 my_list: public(DynArray[uint256, 5])
 @external
 def __init__():
@@ -1630,7 +1630,7 @@ def __init__():
     """
     c = get_contract(code)
 
-    for i, t in enumerate([1,2,3]):
+    for i, t in enumerate([1, 2, 3]):
         assert c.my_list(i) == t
 
 
@@ -1643,7 +1643,7 @@ def __init__():
     """
     c = get_contract(code)
 
-    for i, t in enumerate([1,2,3]):
+    for i, t in enumerate([1, 2, 3]):
         assert c.my_list(0, i) == t
 
 

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1600,7 +1600,33 @@ def ix(i: uint256) -> decimal:
     assert_tx_failed(lambda: c.ix(len(some_good_primes) + 1))
 
 
-# TODO test loops
+def test_public_dynarray(get_contract):
+    code = f"""
+my_list: public(DynArray[uint256, 5])
+@external
+def __init__():
+    self.my_list = [1,2,3]
+    """
+    c = get_contract(code)
+
+    for i, t in enumerate([1,2,3]):
+        assert c.my_list(i) == t
+
+
+def test_nested_public_dynarray(get_contract):
+    code = """
+my_list: public(DynArray[DynArray[uint256, 5], 5])
+@external
+def __init__():
+    self.my_list = [[1,2,3]]
+    """
+    c = get_contract(code)
+
+    for i, t in enumerate([1,2,3]):
+        assert c.my_list(0, i) == t
+
+
+# TODO test negative public(DynArray) cases?
 
 # Would be nice to put this somewhere accessible, like in vyper.types or something
 integer_types = ["uint8", "int128", "int256", "uint256"]

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1643,8 +1643,9 @@ def __init__():
     """
     c = get_contract(code)
 
-    for i, t in enumerate([1, 2, 3]):
-        assert c.my_list(0, i) == t
+    for i, l in enumerate([[1, 2, 3]]):
+        for j, t in enumerate(l):
+            assert c.my_list(i, j) == t
 
 
 # TODO test negative public(DynArray) cases?

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -53,6 +53,9 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
             if annotation.value.get("id") == "HashMap":  # type: ignore
                 # for a HashMap, split the key/value types and use the key type as the next arg
                 arg, annotation = annotation.slice.value.elements  # type: ignore
+            elif annotation.value.get("id") == "DynArray":
+                arg = vy_ast.Name(id=type_._id)
+                annotation = annotation.slice.value.elements[0]
             else:
                 # for other types, build an input arg node from the expected type
                 # and remove the outer `Subscript` from the annotation
@@ -66,7 +69,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
             )
 
         # after iterating the input types, the remaining annotation node is our return type
-        return_node = annotation
+        return_node = copy.copy(annotation)
 
         # join everything together as a new `FunctionDef` node, annotate it
         # with the type, and append it to the existing `Module` node

--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -55,7 +55,7 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
                 arg, annotation = annotation.slice.value.elements  # type: ignore
             elif annotation.value.get("id") == "DynArray":
                 arg = vy_ast.Name(id=type_._id)
-                annotation = annotation.slice.value.elements[0]
+                annotation = annotation.slice.value.elements[0]  # type: ignore
             else:
                 # for other types, build an input arg node from the expected type
                 # and remove the outer `Subscript` from the annotation


### PR DESCRIPTION
### What I did
fix #3016 

### How I did it

### How to verify it
see tests

### Commit message
```
DynArray getter AST expansion had a regression in be2c59a604. the
removed lines 70-73 modified the return node ID, which incidentally
patched the fact that the type unpacking logic in the previous lines
didn't account for DynArrays properly. this commit handles the DynArray
case properly
```
Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
