### PR TITLE
feat: add epsilon builtin

### DIFF
--- a/tests/functions/folding/test_epsilon.py
+++ b/tests/functions/folding/test_epsilon.py
@@ -1,0 +1,19 @@
+import pytest
+
+from vyper import ast as vy_ast
+from vyper import builtin_functions as vy_fn
+
+@pytest.mark.parametrize("typ_name", ["decimal"])
+def test_epsilon(get_contract, typ_name):
+    source = f"""
+@external
+def foo() -> {typ_name}:
+    return epsilon({typ_name})
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"epsilon({typ_name})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE['epsilon'].evaluate(old_node)
+
+    assert contract.foo() == new_node.value

--- a/tests/functions/folding/test_epsilon.py
+++ b/tests/functions/folding/test_epsilon.py
@@ -3,6 +3,7 @@ import pytest
 from vyper import ast as vy_ast
 from vyper import builtin_functions as vy_fn
 
+
 @pytest.mark.parametrize("typ_name", ["decimal"])
 def test_epsilon(get_contract, typ_name):
     source = f"""
@@ -14,6 +15,6 @@ def foo() -> {typ_name}:
 
     vyper_ast = vy_ast.parse_to_ast(f"epsilon({typ_name})")
     old_node = vyper_ast.body[0].value
-    new_node = vy_fn.DISPATCH_TABLE['epsilon'].evaluate(old_node)
+    new_node = vy_fn.DISPATCH_TABLE["epsilon"].evaluate(old_node)
 
     assert contract.foo() == new_node.value

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -2586,6 +2586,8 @@ class Epsilon(FoldedFunction):
             typinfo = parse_decimal_info(str(input_type))
             return vy_ast.Decimal.from_node(node, value=typinfo.epsilon)
 
+        raise CompilerPanic("unreachable")
+
 
 DISPATCH_TABLE = {
     "_abi_encode": ABIEncode(),

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -2586,7 +2586,7 @@ class Epsilon(FoldedFunction):
             typinfo = parse_decimal_info(str(input_type))
             return vy_ast.Decimal.from_node(node, value=typinfo.epsilon)
 
-        raise CompilerPanic("unreachable")
+        raise CompilerPanic("unreachable")  # pragma: notest
 
 
 DISPATCH_TABLE = {

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -124,7 +124,6 @@ SHA256_PER_WORD_GAS = 12
 
 class FoldedFunction(BuiltinFunction):
     # Base class for nodes which should always be folded
-    _id = ""
 
     def fetch_call_return(self, node):  # pragma: no cover
         raise CompilerPanic(f"{self._id} should always be folded")
@@ -2584,12 +2583,8 @@ class Epsilon(FoldedFunction):
         # this check seems redundant, but sets a pattern to be followed
         # when new decimal types are created
         if isinstance(input_type, DecimalDefinition):
-            val = self._eval_decimal(input_type)
-            return vy_ast.Decimal.from_node(node, value=val)
-
-    def _eval_decimal(self, type_):
-        typinfo = parse_decimal_info(str(type_))
-        return typinfo.epsilon
+            typinfo = parse_decimal_info(str(input_type))
+            return vy_ast.Decimal.from_node(node, value=typinfo.epsilon)
 
 
 DISPATCH_TABLE = {

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -75,11 +75,11 @@ from vyper.semantics.types import (
 from vyper.semantics.types.abstract import (
     ArrayValueAbstractType,
     BytesAbstractType,
+    FixedAbstractType,
     IntegerAbstractType,
     NumericAbstractType,
     SignedIntegerAbstractType,
     UnsignedIntegerAbstractType,
-    FixedAbstractType,
 )
 from vyper.semantics.types.bases import DataLocation
 from vyper.semantics.types.utils import KwargSettings, TypeTypeDefinition, get_type_from_annotation
@@ -120,6 +120,7 @@ from .signatures import BuiltinFunction, process_inputs
 SHA256_ADDRESS = 2
 SHA256_BASE_GAS = 60
 SHA256_PER_WORD_GAS = 12
+
 
 class FoldedFunction(BuiltinFunction):
     # Base class for nodes which should always be folded


### PR DESCRIPTION
### What I did
Added an epsilon() builtin which returns the smallest non-zero value for a decimal type.

Closes #2992

### How I did it

In `vyper/builtin_functions/functions.py` I implemented a new class `Epsilon`. The function that this class represents should always be folded. 

Instead of adding to the duplication between MinMaxValue and MethodID, I created a new base class `FoldedFunction` which contains all the logic for enforcing a function should always be folded.

In `Epsilon`'s `evaluate` function, we check the type that was passed in, ensure it is a `FixedAbstractType` (which is the parent class for Decimal and any other decimal classes to be supported later).

Then we call the appropriate `_eval_<type>` function after checking which type was passed in. This currently only supports "decimal" but sets up a pattern for adding support for other decimal types in the future.

### How to verify it

Run the new test, which checks a compiled contract's return value against a folded node.

### Commit message

Implement `epsilon` for decimal types

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://earthjustice.org/sites/default/files/styles/image_800x600/public/pika_david-kingham-800.jpg?itok=KEuF1teA)
