### PR TITLE
fix: empty nested dynamic arrays

### DIFF
--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1648,6 +1648,21 @@ def __init__():
             assert c.my_list(i, j) == t
 
 
+@pytest.mark.parametrize("typ,val", [
+    ("DynArray[DynArray[uint256, 5], 5]", [[], []]),
+    ("DynArray[DynArray[DynArray[uint256, 5], 5], 5]", [[[], []], []]),
+])
+def test_empty_nested_dynarray(get_contract, typ, val):
+    code = f"""
+@external
+def foo() -> {typ}:
+    a: {typ} = {val}
+    return a
+    """
+    c = get_contract(code)
+    assert c.foo() == val
+
+
 # TODO test negative public(DynArray) cases?
 
 # CMC 2022-08-04 these are blocked due to typechecker bug; leaving as

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1648,10 +1648,13 @@ def __init__():
             assert c.my_list(i, j) == t
 
 
-@pytest.mark.parametrize("typ,val", [
-    ("DynArray[DynArray[uint256, 5], 5]", [[], []]),
-    ("DynArray[DynArray[DynArray[uint256, 5], 5], 5]", [[[], []], []]),
-])
+@pytest.mark.parametrize(
+    "typ,val",
+    [
+        ("DynArray[DynArray[uint256, 5], 5]", [[], []]),
+        ("DynArray[DynArray[DynArray[uint256, 5], 5], 5]", [[[], []], []]),
+    ],
+)
 def test_empty_nested_dynarray(get_contract, typ, val):
     code = f"""
 @external

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -295,7 +295,8 @@ class _ExprTypeChecker:
 
 def _is_empty_list(node):
     """
-    Checks if a node is a `List` node with an empty list for `elements`, including any nested `List` nodes.
+    Checks if a node is a `List` node with an empty list for `elements`,
+    including any nested `List` nodes.
 
     Arguments
     ---------

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -294,20 +294,9 @@ class _ExprTypeChecker:
 
 
 def _is_empty_list(node):
-    """
-    Checks if a node is a `List` node with an empty list for `elements`,
-    including any nested `List` nodes.
-
-    Arguments
-    ---------
-    node: vy_ast.VyperNode
-        A Vyper node
-
-    Returns
-    -------
-    bool
-        Boolean value indicating if the node is an empty `List` node.
-    """
+    # Checks if a node is a `List` node with an empty list for `elements`,
+    # including any nested `List` nodes. ex. `[]` or `[[]]` will return True,
+    # [1] will return False.
     if not isinstance(node, vy_ast.List):
         return False
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -295,7 +295,7 @@ class _ExprTypeChecker:
 
 def _is_empty_list(node):
     """
-    Check if a list is completely empty, including nested lists which are completely empty.
+    Checks if a node is a `List` node with an empty list for `elements`, including any nested `List` nodes.
 
     Arguments
     ---------
@@ -305,7 +305,7 @@ def _is_empty_list(node):
     Returns
     -------
     bool
-        Boolean value indicating if the `List` node is empty.
+        Boolean value indicating if the node is an empty `List` node.
     """
     if not isinstance(node, vy_ast.List):
         return False

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -236,6 +236,7 @@ class _ExprTypeChecker:
         raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node)
 
     def types_from_List(self, node):
+
         # literal array
         if _is_empty_list(node):
             # empty list literal `[]`
@@ -244,7 +245,6 @@ class _ExprTypeChecker:
             # 1 is minimum possible length for dynarray, assignable to anything
             ret = [DynamicArrayDefinition(v, 1) for v in types_list.values()]
             return ret
-
         types_list = get_common_types(*node.elements)
 
         if len(types_list) > 0:

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -309,7 +309,7 @@ def _is_empty_list(node):
     """
     if not isinstance(node, vy_ast.List):
         return False
-        
+
     if any(isinstance(i, vy_ast.List) for i in node.elements):
         return any(_is_empty_list(i) for i in node.elements)
     return all(isinstance(i, vy_ast.List) and not i.elements for i in node.elements)

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -299,14 +299,17 @@ def _is_empty_list(node):
 
     Arguments
     ---------
-    node: vy_ast.List
-        A `List` node
+    node: vy_ast.VyperNode
+        A Vyper node
 
     Returns
     -------
     bool
         Boolean value indicating if the `List` node is empty.
     """
+    if not isinstance(node, vy_ast.List):
+        return False
+        
     if any(isinstance(i, vy_ast.List) for i in node.elements):
         return any(_is_empty_list(i) for i in node.elements)
     return all(isinstance(i, vy_ast.List) and not i.elements for i in node.elements)

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -311,9 +311,9 @@ def _is_empty_list(node):
     if not isinstance(node, vy_ast.List):
         return False
 
-    if any(isinstance(i, vy_ast.List) for i in node.elements):
-        return any(_is_empty_list(i) for i in node.elements)
-    return all(isinstance(i, vy_ast.List) and not i.elements for i in node.elements)
+    if not node.elements:
+        return True
+    return all(_is_empty_list(t) for t in node.elements)
 
 
 def _is_type_in_list(obj, types_list):


### PR DESCRIPTION
### What I did

Fix #3048. 

Check for empty dynamic arrays recursively.

### How I did it

Add a helper function `_is_empty_list` to recursively determine if a literal list is empty.

### How to verify it

See tests.

### Commit message

```
fix: allow variable length empty dynamic arrays
```

### Description for the changelog

Allow variable length empty dynamic arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://sites.google.com/site/seaottersaresocute/_/rsrc/1497005034542/home/seaottersdancing.jpg)
