### PR TITLE
chore: improve error message for non-checksummed address literal

### DIFF
--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -1,7 +1,5 @@
 import pytest
-from pytest import raises
 
-from vyper import compiler
 from vyper.exceptions import InvalidType, UnknownType
 
 fail_list = [
@@ -25,9 +23,8 @@ struct A:
 
 
 @pytest.mark.parametrize("bad_code", fail_list)
-def test_unknown_type_exception(bad_code):
-    with raises(UnknownType):
-        compiler.compile_code(bad_code)
+def test_unknown_type_exception(bad_code, get_contract, assert_compile_failed):
+    assert_compile_failed(lambda: get_contract(bad_code), UnknownType)
 
 
 invalid_list = [
@@ -68,10 +65,13 @@ x: int128[3.5]
     """
 b: HashMap[(int128, decimal), int128]
     """,
+    # Address literal must be checksummed
+    """
+a: constant(address) = 0x3cd751e6b0078be393132286c442345e5dc49699
+    """,
 ]
 
 
 @pytest.mark.parametrize("bad_code", invalid_list)
-def test_invalid_type_exception(bad_code):
-    with raises(InvalidType):
-        compiler.compile_code(bad_code)
+def test_invalid_type_exception(bad_code, get_contract, assert_compile_failed):
+    assert_compile_failed(lambda: get_contract(bad_code), InvalidType)

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -472,7 +472,7 @@ def validate_expected_type(node, expected_type):
         raise InvalidType(
             (
                 f"Expected {expected_str} but literal can only be cast as {given_str}. "
-                f"{suggestions_str}",
+                f"{suggestions_str}"
             ),
             node,
         )

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -25,8 +25,11 @@ from vyper.semantics.types.indexable.sequence import (
     DynamicArrayDefinition,
     TupleDefinition,
 )
+from vyper.semantics.types.value.address import AddressDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
+from vyper.semantics.types.value.bytes_fixed import Bytes20Definition
 from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
+from vyper.utils import checksum_encode
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -456,9 +459,22 @@ def validate_expected_type(node, expected_type):
             types_str = sorted(str(i) for i in given_types)
             given_str = f"{', '.join(types_str[:1])} or {types_str[-1]}"
 
+        suggestions_str = ""
+        if (
+            len(expected_type) == 1
+            and isinstance(expected_type[0], AddressDefinition)
+            and len(given_types) == 1
+            and isinstance(given_types[0], Bytes20Definition)
+        ):
+            suggestions_str = f"Did you mean {checksum_encode(node.value)}?"
+
         # CMC 2022-02-14 maybe TypeMismatch would make more sense here
         raise InvalidType(
-            f"Expected {expected_str} but literal can only be cast as {given_str}", node
+            (
+                f"Expected {expected_str} but literal can only be cast as {given_str}. "
+                f"{suggestions_str}",
+            ),
+            node,
         )
 
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -460,10 +460,7 @@ def validate_expected_type(node, expected_type):
             given_str = f"{', '.join(types_str[:1])} or {types_str[-1]}"
 
         suggestions_str = ""
-        if (
-            len(expected_type) == 1
-            and isinstance(expected_type[0], AddressDefinition)
-            and len(given_types) == 1
+        if (isinstance(expected_type[0], AddressDefinition)
             and isinstance(given_types[0], Bytes20Definition)
         ):
             suggestions_str = f"Did you mean {checksum_encode(node.value)}?"

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -27,7 +27,7 @@ from vyper.semantics.types.indexable.sequence import (
 )
 from vyper.semantics.types.value.address import AddressDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
-from vyper.semantics.types.value.bytes_fixed import Bytes20Definition
+from vyper.semantics.types.value.bytes_fixed import Bytes20Definition  # type: ignore
 from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.utils import checksum_encode
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -459,18 +459,15 @@ def validate_expected_type(node, expected_type):
             types_str = sorted(str(i) for i in given_types)
             given_str = f"{', '.join(types_str[:1])} or {types_str[-1]}"
 
-        suggestions_str = ""
+        suggestion_str = ""
         if isinstance(expected_type[0], AddressDefinition) and isinstance(
             given_types[0], Bytes20Definition
         ):
-            suggestions_str = f" Did you mean {checksum_encode(node.value)}?"
+            suggestion_str = f" Did you mean {checksum_encode(node.value)}?"
 
         # CMC 2022-02-14 maybe TypeMismatch would make more sense here
         raise InvalidType(
-            (
-                f"Expected {expected_str} but literal can only be cast as {given_str}."
-                f"{suggestions_str}"
-            ),
+            f"Expected {expected_str} but literal can only be cast as {given_str}.{suggestion_str}",
             node,
         )
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -460,8 +460,8 @@ def validate_expected_type(node, expected_type):
             given_str = f"{', '.join(types_str[:1])} or {types_str[-1]}"
 
         suggestions_str = ""
-        if (isinstance(expected_type[0], AddressDefinition)
-            and isinstance(given_types[0], Bytes20Definition)
+        if isinstance(expected_type[0], AddressDefinition) and isinstance(
+            given_types[0], Bytes20Definition
         ):
             suggestions_str = f"Did you mean {checksum_encode(node.value)}?"
 

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -463,12 +463,12 @@ def validate_expected_type(node, expected_type):
         if isinstance(expected_type[0], AddressDefinition) and isinstance(
             given_types[0], Bytes20Definition
         ):
-            suggestions_str = f"Did you mean {checksum_encode(node.value)}?"
+            suggestions_str = f" Did you mean {checksum_encode(node.value)}?"
 
         # CMC 2022-02-14 maybe TypeMismatch would make more sense here
         raise InvalidType(
             (
-                f"Expected {expected_str} but literal can only be cast as {given_str}. "
+                f"Expected {expected_str} but literal can only be cast as {given_str}."
                 f"{suggestions_str}"
             ),
             node,


### PR DESCRIPTION
### What I did

QOL improvement for #3062. 

When declaring an address literal, the compiler throws an `InvalidType` exception if it is not checksummed. This PR improves the error message by checking if the user meant the checksummed value.

### How I did it

Add an error message if expected type is address and the only possible type is bytes20.

### How to verify it

NA

### Commit message

```
chore: improve error message for non-checksummed address literal
```

### Description for the changelog

Improve error message for non-checksummed address literal

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/tczu24sbrxn61.jpg?auto=webp&s=3844e2f72262c976ddf1b4204ebd1cacb6bb3e90)
