### PR TITLE
docs: fix typos

### DIFF
--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -14,7 +14,7 @@ Vyper has different groups that are considered "users":
 
 Each set of users must understand which changes to the compiler may require their
 attention, and how these changes may impact their use of the compiler.
-This guide defines what scope each compiler change may have, it's potential impact based
+This guide defines what scope each compiler change may have, and its potential impact based
 on the type of user, so that users can stay informed about the progress of Vyper.
 
 +-------------+----------------------------------------------+
@@ -30,10 +30,10 @@ on the type of user, so that users can stay informed about the progress of Vyper
 A big part of Vyper's "public API" is the language grammar.
 The syntax of the language is the main touchpoint all parties have with Vyper,
 so it's important to discuss changes to the language from the viewpoint of dependability.
-Users expect that all contracts written in an earlier version of Vyper will work seemlessly
+Users expect that all contracts written in an earlier version of Vyper will work seamlessly
 with later versions, or that they will be reasonably informed when this isn't possible.
-The Vyper package itself and it's CLI utilities also has a fairly well-defined public API,
-which consists of the available features in Vyper's 
+The Vyper package itself and its CLI utilities also has a fairly well-defined public API,
+which consists of the available features in Vyper's
 `exported package <https://github.com/vyperlang/vyper/blob/master/vyper/__init__.py>`_,
 the top level modules under the package, and all CLI scripts.
 
@@ -94,7 +94,7 @@ Patch Release ``x.y.Z``
 Patch version releases will be released to fix documentation issues, usage bugs,
 and ``minor`` or ``informational`` vulnerabilities found in Vyper.
 Patch releases should only update error messages and documentation issues
-relating to it's external API.
+relating to its external API.
 
 +-------------+----------------------------------------------+
 | Group       |               Look For                       |
@@ -113,7 +113,7 @@ As Vyper develops, it is very likely that we will encounter inconsistencies in h
 language features can be used, and software bugs in the code the compiler generates.
 Some of them may be quite serious, and can render a user's compiled contract vulnerable to
 exploitation for financial gain.
-As we become aware of these vunlerabilities, we will work according to our
+As we become aware of these vulnerabilities, we will work according to our
 `security policy <https://github.com/vyperlang/vyper/security/policy>`_ to resolve these issues,
 and eventually will publish the details of all reported vulnerabilities
 `here <https://github.com/vyperlang/vyper/security/advisories?state=published>`_.
@@ -122,7 +122,7 @@ Fixes for these issues will also be noted in the :ref:`Release Notes<release-not
 Vyper *Next*
 ------------
 
-There may be multiple Major versions in process of development.
+There may be multiple Major versions in the process of development.
 Work on new features that break compatibility with the existing grammar can
 be maintained on a separate branch called ``next`` and represents the next
 Major release of Vyper (provided in an unaudited state without Release Notes).

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -14,7 +14,7 @@ Vyper has different groups that are considered "users":
 
 Each set of users must understand which changes to the compiler may require their
 attention, and how these changes may impact their use of the compiler.
-This guide defines what scope each compiler change may have, and its potential impact based
+This guide defines what scope each compiler change may have and its potential impact based
 on the type of user, so that users can stay informed about the progress of Vyper.
 
 +-------------+----------------------------------------------+


### PR DESCRIPTION
### What I did

Fix typos in docs.

### How I did it

See changes.

### How to verify it

Read the changes.

### Commit message

docs: fix typos in versioning

### Description for the changelog

Fix typos in versioning.rst

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/photos/cat-reader-picture-id530414873?k=20&m=530414873&s=612x612&w=0&h=3t8NNu9S9zLJbRkrlmFz6U7yufzm0fshOpvJW4ACkYE=)
