### PR TITLE
drop 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [["3.7", "37"], ["3.8", "38"], ["3.9", "39"], ["3.10", "310"]]
+        python-version: [["3.8", "38"], ["3.9", "39"], ["3.10", "310"]]
         # run in default (optimized) and --no-optimize mode
         flag: ["core", "no-opt"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 # Specify label-schema specific arguments and labels.
 ARG BUILD_DATE

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ setup(
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{core,no-opt}
+    py{38,39,310}-{core,no-opt}
     lint
     mypy
     docs
@@ -11,7 +11,6 @@ commands =
     core: pytest -m "not fuzzing" --showlocals {posargs:tests/}
     no-opt: pytest -m "not fuzzing" --showlocals --no-optimize {posargs:tests/}
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10


### PR DESCRIPTION
### What I did
drop tests for 3.7 since isqrt does not exist in 3.8. note that vyper can still be installed on 3.7 but we no longer officially test it.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
