### PR TITLE
chore: optimize isqrt by rewriting in IR

### DIFF
--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -2199,6 +2199,8 @@ class ISqrt(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
+        # calculate isqrt using the babylonian method
+
         y, z = "y", "z"
         arg = args[0]
         with arg.cache_when_complex("x") as (b1, x):
@@ -2230,7 +2232,7 @@ class ISqrt(BuiltinFunction):
             for _ in range(7):
                 ret.append(["set", z, ["div", ["add", ["div", x, z], z], 2]])
 
-            # Performance note: If ``x+1`` is a perfect square, then the Babylonian
+            # note: If ``x+1`` is a perfect square, then the Babylonian
             # algorithm oscillates between floor(sqrt(x)) and ceil(sqrt(x)) in
             # consecutive iterations. return the floor value always.
 


### PR DESCRIPTION
### What I did
minimizes stack traffic. based on local benchmarks, reduces `isqrt` worst case performance from ~650 gas to ~500 gas.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
