### PR TITLE
fix: change mutability of example ERC721 interface

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -15,7 +15,7 @@ interface ERC721Receiver:
             _from: address,
             _tokenId: uint256,
             _data: Bytes[1024]
-        ) -> bytes4: view
+        ) -> bytes4: nonpayable
 
 
 # @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are


### PR DESCRIPTION
Arose from #3066. Following EIP-721, the function onERC721Received from the interface should be a state-modifying callback.

### What I did
Replaced "view" mutability to "nonpayable" as the onERC721Received function should read from and write to the contract state.

### How I did it
^^

### How to verify it
Check the file changes. 

### Description for the changelog
Changed mutability of onERC721Received to nonpayable

### Cute Animal Picture

<img src="https://i.pinimg.com/originals/d7/bc/55/d7bc554d02de32a937de631a41050b2b.jpg" width="350" height="250">
