### PR TITLE
fix: import of interfaces with foldable builtin functions as kwargs

### DIFF
--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -269,12 +269,15 @@ def test():
     assert erc20.balanceOf(sender) == 1000
 
 
-@pytest.mark.parametrize("kwarg,typ,expected", [
-    ("max_value(uint256)", "uint256", 2 ** 256 - 1),
-    ("min_value(int128)", "int128", - (2 ** 127)),
-    ("empty(uint8[2])", "uint8[2]", [0, 0]),
-    ("method_id(\"vyper()\", output_type=bytes4)", "bytes4", b'\x82\xcbE\xfb'),
-])
+@pytest.mark.parametrize(
+    "kwarg,typ,expected",
+    [
+        ("max_value(uint256)", "uint256", 2 ** 256 - 1),
+        ("min_value(int128)", "int128", -(2 ** 127)),
+        ("empty(uint8[2])", "uint8[2]", [0, 0]),
+        ('method_id("vyper()", output_type=bytes4)', "bytes4", b"\x82\xcbE\xfb"),
+    ],
+)
 def test_external_call_to_interface_kwarg(get_contract, kwarg, typ, expected):
     code_a = f"""
 @external
@@ -294,7 +297,9 @@ def bar(a_address: address) -> {typ}:
 
     contract_a = get_contract(code_a)
     contract_b = get_contract(
-        code_b, *[contract_a.address], interface_codes={"ContractA": {"type": "vyper", "code": code_a}}
+        code_b,
+        *[contract_a.address],
+        interface_codes={"ContractA": {"type": "vyper", "code": code_a}},
     )
 
     assert contract_b.bar(contract_a.address) == expected

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -276,6 +276,7 @@ def test():
         ("min_value(int128)", "int128", -(2 ** 127)),
         ("empty(uint8[2])", "uint8[2]", [0, 0]),
         ('method_id("vyper()", output_type=bytes4)', "bytes4", b"\x82\xcbE\xfb"),
+        ("epsilon(decimal)", "decimal", Decimal("1E-10")),
     ],
 )
 def test_external_call_to_interface_kwarg(get_contract, kwarg, typ, expected):

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -269,6 +269,37 @@ def test():
     assert erc20.balanceOf(sender) == 1000
 
 
+@pytest.mark.parametrize("kwarg,typ,expected", [
+    ("max_value(uint256)", "uint256", 2 ** 256 - 1),
+    ("min_value(int128)", "int128", - (2 ** 127)),
+    ("empty(uint8[2])", "uint8[2]", [0, 0]),
+    ("method_id(\"vyper()\", output_type=bytes4)", "bytes4", b'\x82\xcbE\xfb'),
+])
+def test_external_call_to_interface_kwarg(get_contract, kwarg, typ, expected):
+    code_a = f"""
+@external
+@view
+def foo(_max: {typ} = {kwarg}) -> {typ}:
+    return _max
+    """
+
+    code_b = f"""
+import one as ContractA
+
+@external
+@view
+def bar(a_address: address) -> {typ}:
+    return ContractA(a_address).foo()
+    """
+
+    contract_a = get_contract(code_a)
+    contract_b = get_contract(
+        code_b, *[contract_a.address], interface_codes={"ContractA": {"type": "vyper", "code": code_a}}
+    )
+
+    assert contract_b.bar(contract_a.address) == expected
+
+
 def test_external_call_to_builtin_interface(w3, get_contract):
     token_code = """
 balanceOf: public(HashMap[address, uint256])

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -136,8 +136,7 @@ class TypenameFoldedFunction(FoldedFunction):
     # (2) should always be folded.
 
     # "TYPE_DEFINITION" is a placeholder value for a type definition string, and
-    # will be replaced by a `TypeTypeDefinition` object in `infer_arg_types`
-    # (note that it is ignored in `validate_args`)
+    # will be replaced by a `TypeTypeDefinition` object in `infer_arg_types`.
     _inputs = [("typename", "TYPE_DEFINITION")]
 
     def fetch_call_return(self, node):
@@ -899,7 +898,7 @@ class Extract32(BuiltinFunction):
     _inputs = [("b", BytesArrayPrimitive()), ("start", UnsignedIntegerAbstractType())]
     # "TYPE_DEFINITION" is a placeholder value for a type definition string, and
     # will be replaced by a `TypeTypeDefinition` object in `infer_kwarg_types`
-    # (note that it is ignored in validate_args)
+    # (note that it is ignored in `_validate_arg_types`)
     _kwargs = {"output_type": KwargSettings("TYPE_DEFINITION", "bytes32")}
     _return_type = None
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -125,17 +125,31 @@ SHA256_PER_WORD_GAS = 12
 class FoldedFunction(BuiltinFunction):
     # Base class for nodes which should always be folded
 
-    def fetch_call_return(self, node):  # pragma: no cover
-        raise CompilerPanic(f"{self._id} should always be folded")
+    # Since foldable builtin functions are not folded before semantics validation,
+    # this flag is used for `check_kwargable` in semantics validation.
+    _kwargable = True
 
-    def infer_arg_types(self, node):  # pragma: no cover
-        raise CompilerPanic(f"{self._id} should always be folded")
 
-    def infer_kwarg_types(self, node):  # pragma: no cover
-        raise CompilerPanic(f"{self._id} should always be folded")
+class TypenameFoldedFunction(FoldedFunction):
+    # Base class for builtin functions that:
+    # (1) take a typename as the only argument; and
+    # (2) should always be folded.
 
-    def build_IR(self, *args, **kwargs):  # pragma: no cover
-        raise CompilerPanic(f"{self._id} should always be folded")
+    # "TYPE_DEFINITION" is a placeholder value for a type definition string, and
+    # will be replaced by a `TypeTypeDefinition` object in `infer_arg_types`
+    # (note that it is ignored in `validate_args`)
+    _inputs = [("typename", "TYPE_DEFINITION")]
+
+    def fetch_call_return(self, node):
+        type_ = self.infer_arg_types(node)[0].typedef
+        return type_
+
+    def infer_arg_types(self, node):
+        validate_call_args(node, 1)
+        input_typedef = TypeTypeDefinition(
+            get_type_from_annotation(node.args[0], DataLocation.MEMORY)
+        )
+        return [input_typedef]
 
 
 class Floor(BuiltinFunction):
@@ -731,24 +745,32 @@ class MethodID(FoldedFunction):
         if " " in args[0].value:
             raise InvalidLiteral("Invalid function signature - no spaces allowed.")
 
+        return_type = self.infer_kwarg_types(node)
+        value = abi_method_id(args[0].value)
+
+        if isinstance(return_type, Bytes4Definition):
+            return vy_ast.Hex.from_node(node, value=hex(value))
+        else:
+            return vy_ast.Bytes.from_node(node, value=value.to_bytes(4, "big"))
+
+    def fetch_call_return(self, node):
+        validate_call_args(node, 1, ["output_type"])
+
+        type_ = self.infer_kwarg_types(node)
+        return type_
+
+    def infer_kwarg_types(self, node):
         if node.keywords:
             return_type = get_type_from_annotation(node.keywords[0].value, DataLocation.UNSET)
             if isinstance(return_type, Bytes4Definition):
-                is_bytes4 = True
+                return Bytes4Definition()
             elif isinstance(return_type, BytesArrayDefinition) and return_type.length == 4:
-                is_bytes4 = False
+                return BytesArrayDefinition(4)
             else:
                 raise ArgumentException("output_type must be Bytes[4] or bytes4", node.keywords[0])
         else:
             # If `output_type` is not given, default to `Bytes[4]`
-            is_bytes4 = False
-
-        value = abi_method_id(args[0].value)
-
-        if is_bytes4:
-            return vy_ast.Hex.from_node(node, value=hex(value))
-        else:
-            return vy_ast.Bytes.from_node(node, value=value.to_bytes(4, "big"))
+            return BytesArrayDefinition(4)
 
 
 class ECRecover(BuiltinFunction):
@@ -2264,28 +2286,9 @@ z = min(z, unsafe_div(x, z))
         )
 
 
-class Empty(BuiltinFunction):
+class Empty(TypenameFoldedFunction):
 
     _id = "empty"
-    # "TYPE_DEFINITION" is a placeholder value for a type definition string, and
-    # will be replaced by a `TypeTypeDefinition` object in `infer_arg_types`
-    # (note that it is ignored in `validate_args`)
-    _inputs = [("typename", "TYPE_DEFINITION")]
-
-    # Since `empty` is not folded before semantics validation, this flag is used
-    # for `check_kwargable` in semantics validation.
-    _kwargable = True
-
-    def fetch_call_return(self, node):
-        type_ = self.infer_arg_types(node)[0].typedef
-        return type_
-
-    def infer_arg_types(self, node):
-        validate_call_args(node, 1)
-        input_typedef = TypeTypeDefinition(
-            get_type_from_annotation(node.args[0], DataLocation.MEMORY)
-        )
-        return [input_typedef]
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
@@ -2599,9 +2602,7 @@ class ABIDecode(BuiltinFunction):
             )
 
 
-class _MinMaxValue(FoldedFunction):
-    _inputs = [("typename", "TYPE_DEFINITION")]
-
+class _MinMaxValue(TypenameFoldedFunction):
     def evaluate(self, node):
         self._validate_arg_types(node)
         input_type = get_type_from_annotation(node.args[0], DataLocation.UNSET)
@@ -2642,9 +2643,7 @@ class MaxValue(_MinMaxValue):
         return typinfo.decimal_bounds[1]
 
 
-class Epsilon(FoldedFunction):
-
-    _inputs = [("typename", "TYPE_DEFINITION")]
+class Epsilon(TypenameFoldedFunction):
     _id = "epsilon"
 
     def evaluate(self, node):

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -767,9 +767,9 @@ class MethodID(FoldedFunction):
                 return BytesArrayDefinition(4)
             else:
                 raise ArgumentException("output_type must be Bytes[4] or bytes4", node.keywords[0])
-        else:
-            # If `output_type` is not given, default to `Bytes[4]`
-            return BytesArrayDefinition(4)
+
+        # If `output_type` is not given, default to `Bytes[4]`
+        return BytesArrayDefinition(4)
 
 
 class ECRecover(BuiltinFunction):


### PR DESCRIPTION
### What I did

Fix #3077.

### How I did it

- Modify `FoldedFunction` class to set `_kwargable` attribute to True, and ensure `fetch_call_return` provides the return type.
- Add a new `TypenameFoldedFunction` for foldable builtin functions that take a single typename argument.

### How to verify it

See tests.

### Commit message

```
fix: import of interfaces with foldable builtin functions as kwargs

Fix import of interfaces with foldable builtin functions 
as kwargs.

Adds a new TypenameFoldedFunction class for 
empty, min_value and max_value.
```

### Description for the changelog

Fix import of interfaces with foldable builtin functions as kwargs.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/c6/f6/07/c6f607d25e00fb43abb52f4f4b1a28f6.jpg)
