### PR TITLE
feat: ecrecover copy solidity interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ be a bit behind the latest version found in the master branch of this repository
 
 (Complete [installation steps](https://vyper.readthedocs.io/en/latest/installing-vyper.html) first.)
 
-```bas
+```bash
 make dev-init
 python setup.py test
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ be a bit behind the latest version found in the master branch of this repository
 
 (Complete [installation steps](https://vyper.readthedocs.io/en/latest/installing-vyper.html) first.)
 
-```bash
+```bas
+make dev-init
 python setup.py test
 ```
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -349,7 +349,7 @@ Cryptography
             19321533766552368860946552437480515441416830039777911637913418824951667761761,
         ]
 
-.. py:function:: ecrecover(hash: bytes32, v: uint8, r: bytes32, s: bytes32) -> address
+.. py:function:: ecrecover(hash: bytes32, v: uint256 | uint8, r: uint256 | bytes32, s: uint256 | bytes32) -> address
 
     Recover the address associated with the public key from the given elliptic curve signature.
 
@@ -366,6 +366,11 @@ Cryptography
         def foo(hash: bytes32, v: uint8, r:bytes32, s:bytes32) -> address:
             return ecrecover(hash, v, r, s)
 
+
+        @external
+        @view
+        def foo(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
+            return ecrecover(hash, v, r, s)
     .. code-block:: python
 
         >>> ExampleContract.foo('0x6c9c5e133b8aafb2ea74f524a5263495e7ae5701c7248805f7b511d973dc7055',

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -349,7 +349,7 @@ Cryptography
             19321533766552368860946552437480515441416830039777911637913418824951667761761,
         ]
 
-.. py:function:: ecrecover(hash: bytes32, v: uint256, r: uint256, s: uint256) -> address
+.. py:function:: ecrecover(hash: bytes32, v: uint8, r: bytes32, s: bytes32) -> address
 
     Recover the address associated with the public key from the given elliptic curve signature.
 
@@ -363,7 +363,7 @@ Cryptography
 
         @external
         @view
-        def foo(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
+        def foo(hash: bytes32, v: uint8, r:bytes32, s:bytes32) -> address:
             return ecrecover(hash, v, r, s)
 
     .. code-block:: python

--- a/examples/wallet/wallet.vy
+++ b/examples/wallet/wallet.vy
@@ -18,7 +18,7 @@ def __init__(_owners: address[5], _threshold: int128):
 
 
 @external
-def testEcrecover(h: bytes32, v:uint256, r:uint256, s:uint256) -> address:
+def testEcrecover(h: bytes32, v:uint8, r:bytes32, s:bytes32) -> address:
     return ecrecover(h, v, r, s)
 
 
@@ -47,7 +47,7 @@ def approve(_seq: int128, to: address, _value: uint256, data: Bytes[4096], sigda
     for i in range(5):
         if sigdata[i][0] != 0:
             # If an invalid signature is given for an owner then the contract throws
-            assert ecrecover(h2, sigdata[i][0], sigdata[i][1], sigdata[i][2]) == self.owners[i]
+            assert ecrecover(h2, convert(sigdata[i][0], uint8), convert(sigdata[i][1], bytes32), convert(sigdata[i][2], bytes32)) == self.owners[i]
             # For every valid signature increase the number of approvals by 1
             approvals += 1
     # Throw if the number of approvals is less then the number of approvals required (the threshold)

--- a/examples/wallet/wallet.vy
+++ b/examples/wallet/wallet.vy
@@ -47,6 +47,8 @@ def approve(_seq: int128, to: address, _value: uint256, data: Bytes[4096], sigda
     for i in range(5):
         if sigdata[i][0] != 0:
             # If an invalid signature is given for an owner then the contract throws
+            assert ecrecover(h2, sigdata[i][0], sigdata[i][1], sigdata[i][2]) == self.owners[i]
+            # ecrecover handles multiple types
             assert ecrecover(h2, convert(sigdata[i][0], uint8), convert(sigdata[i][1], bytes32), convert(sigdata[i][2], bytes32)) == self.owners[i]
             # For every valid signature increase the number of approvals by 1
             approvals += 1

--- a/tests/parser/functions/test_ecrecover.py
+++ b/tests/parser/functions/test_ecrecover.py
@@ -5,7 +5,11 @@ from eth_account._utils.signing import to_bytes32
 def test_ecrecover_test(get_contract_with_gas_estimation):
     ecrecover_test = """
 @external
-def test_ecrecover(h: bytes32, v:uint8, r:bytes32, s:bytes32) -> address:
+def test_ecrecover(h: bytes32, v: uint8, r: bytes32, s: bytes32) -> address:
+    return ecrecover(h, v, r, s)
+
+@external
+def test_ecrecover_uints(h: bytes32, v: uint256, r: uint256, s: uint256) -> address:
     return ecrecover(h, v, r, s)
 
 @external
@@ -14,6 +18,14 @@ def test_ecrecover2() -> address:
                      28,
                      0x8bb954e648c468c01b6efba6cd4951929d16e5235077e2be43e81c0c139dbcdf,
                      0x0e8a97aa06cc123b77ccf6c85b123d299f3f477200945ef71a1e1084461cba8d)
+
+@external
+def test_ecrecover_uints2() -> address:
+    return ecrecover(0x3535353535353535353535353535353535353535353535353535353535353535,
+                     28,
+                     63198938615202175987747926399054383453528475999185923188997970550032613358815,
+                     6577251522710269046055727877571505144084475024240851440410274049870970796685)
+
     """
 
     c = get_contract_with_gas_estimation(ecrecover_test)
@@ -23,6 +35,8 @@ def test_ecrecover2() -> address:
     sig = local_account.signHash(h)
 
     assert c.test_ecrecover(h, sig.v, to_bytes32(sig.r), to_bytes32(sig.s)) == local_account.address
+    assert c.test_ecrecover_uints(h, sig.v, sig.r, sig.s) == local_account.address
     assert c.test_ecrecover2() == local_account.address
+    assert c.test_ecrecover_uints2() == local_account.address
 
     print("Passed ecrecover test")

--- a/tests/parser/functions/test_ecrecover.py
+++ b/tests/parser/functions/test_ecrecover.py
@@ -1,18 +1,19 @@
 from eth_account import Account
+from eth_account._utils.signing import to_bytes32
 
 
 def test_ecrecover_test(get_contract_with_gas_estimation):
     ecrecover_test = """
 @external
-def test_ecrecover(h: bytes32, v:uint256, r:uint256, s:uint256) -> address:
+def test_ecrecover(h: bytes32, v:uint8, r:bytes32, s:bytes32) -> address:
     return ecrecover(h, v, r, s)
 
 @external
 def test_ecrecover2() -> address:
     return ecrecover(0x3535353535353535353535353535353535353535353535353535353535353535,
                      28,
-                     63198938615202175987747926399054383453528475999185923188997970550032613358815,
-                     6577251522710269046055727877571505144084475024240851440410274049870970796685)
+                     0x8bb954e648c468c01b6efba6cd4951929d16e5235077e2be43e81c0c139dbcdf,
+                     0x0e8a97aa06cc123b77ccf6c85b123d299f3f477200945ef71a1e1084461cba8d)
     """
 
     c = get_contract_with_gas_estimation(ecrecover_test)
@@ -21,7 +22,7 @@ def test_ecrecover2() -> address:
     local_account = Account.privateKeyToAccount(b"\x46" * 32)
     sig = local_account.signHash(h)
 
-    assert c.test_ecrecover(h, sig.v, sig.r, sig.s) == local_account.address
+    assert c.test_ecrecover(h, sig.v, to_bytes32(sig.r), to_bytes32(sig.s)) == local_account.address
     assert c.test_ecrecover2() == local_account.address
 
     print("Passed ecrecover test")

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -778,9 +778,9 @@ class ECRecover(BuiltinFunction):
     _id = "ecrecover"
     _inputs = [
         ("hash", Bytes32Definition()),
-        ("v", [Uint256Definition(), Uint8Definition()]),
-        ("r", [Uint256Definition(), Bytes32Definition()]),
-        ("s", [Uint256Definition(), Bytes32Definition()]),
+        ("v", (Uint256Definition(), Uint8Definition())),
+        ("r", (Uint256Definition(), Bytes32Definition())),
+        ("s", (Uint256Definition(), Bytes32Definition())),
     ]
     _return_type = AddressDefinition()
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -784,6 +784,12 @@ class ECRecover(BuiltinFunction):
     ]
     _return_type = AddressDefinition()
 
+    def infer_arg_types(self, node):
+        self._validate_arg_types(node)
+        input_type_2 = get_possible_types_from_node(node.args[2]).pop()
+        input_type_3 = get_possible_types_from_node(node.args[3]).pop()
+        return [Bytes32Definition(), Uint8Definition(), input_type_2, input_type_3]
+
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         placeholder_node = IRnode.from_list(

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -93,6 +93,7 @@ from vyper.semantics.types.value.array_value import (
 from vyper.semantics.types.value.bytes_fixed import Bytes4Definition  # type: ignore
 from vyper.semantics.types.value.bytes_fixed import Bytes32Definition
 from vyper.semantics.types.value.numeric import Int256Definition  # type: ignore
+from vyper.semantics.types.value.numeric import Uint8Definition  # type: ignore
 from vyper.semantics.types.value.numeric import Uint256Definition  # type: ignore
 from vyper.semantics.types.value.numeric import DecimalDefinition
 from vyper.semantics.validation.utils import (
@@ -777,9 +778,9 @@ class ECRecover(BuiltinFunction):
     _id = "ecrecover"
     _inputs = [
         ("hash", Bytes32Definition()),
-        ("v", Uint256Definition()),
-        ("r", Uint256Definition()),
-        ("s", Uint256Definition()),
+        ("v", Uint8Definition()),
+        ("r", Bytes32Definition()),
+        ("s", Bytes32Definition()),
     ]
     _return_type = AddressDefinition()
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -786,9 +786,8 @@ class ECRecover(BuiltinFunction):
 
     def infer_arg_types(self, node):
         self._validate_arg_types(node)
-        input_type_2 = get_possible_types_from_node(node.args[2]).pop()
-        input_type_3 = get_possible_types_from_node(node.args[3]).pop()
-        return [Bytes32Definition(), Uint8Definition(), input_type_2, input_type_3]
+        v_t, r_t, s_t = [get_possible_types_from_node(arg).pop() for arg in node.args[1:]]
+        return [Bytes32Definition(), v_t, r_t, s_t]
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -778,9 +778,9 @@ class ECRecover(BuiltinFunction):
     _id = "ecrecover"
     _inputs = [
         ("hash", Bytes32Definition()),
-        ("v", Uint8Definition()),
-        ("r", Bytes32Definition()),
-        ("s", Bytes32Definition()),
+        ("v", [Uint256Definition(), Uint8Definition()]),
+        ("r", [Uint256Definition(), Bytes32Definition()]),
+        ("s", [Uint256Definition(), Bytes32Definition()]),
     ]
     _return_type = AddressDefinition()
 


### PR DESCRIPTION
### What I did

Since vyper has uint8 now, ecrecover v should be using uint8.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
