### PR TITLE
feat: introduce `block.prevrandao` as alias for `block.difficulty`

### DIFF
--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -11,11 +11,12 @@ Environment variables always exist in the namespace and are primarily used to pr
 Block and Transaction Properties
 --------------------------------
 
-==================== ================ =============================================
+==================== ================ =========================================================
 Name                 Type             Value
-==================== ================ =============================================
+==================== ================ =========================================================
 ``block.coinbase``   ``address``      Current block miner’s address
 ``block.difficulty`` ``uint256``      Current block difficulty
+``block.prevrandao`` ``uint256``      Current block difficulty (alias for ``block.difficulty``)
 ``block.number``     ``uint256``      Current block number
 ``block.prevhash``   ``bytes32``      Equivalent to ``blockhash(block.number - 1)``
 ``block.timestamp``  ``uint256``      Current block epoch timestamp
@@ -26,7 +27,7 @@ Name                 Type             Value
 ``msg.value``        ``uint256``      Number of wei sent with the message
 ``tx.origin``        ``address``      Sender of the transaction (full call chain)
 ``tx.gasprice``      ``uint256``      Gas price of current transaction in wei
-==================== ================ =============================================
+==================== ================ =========================================================
 
 .. note::
 

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -31,6 +31,10 @@ Name                 Type             Value
 
 .. note::
 
+    ``block.prevrandao`` is an alias for ``block.difficulty``, and will be removed in a future version.
+
+.. note::
+
     ``msg.data`` requires the usage of :func:`slice <slice>` to explicitly extract a section of calldata. If the extracted section exceeds the bounds of calldata, this will throw. You can check the size of ``msg.data`` using :func:`len <len>`.
 
 .. _constants-self:

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -14,9 +14,9 @@ Block and Transaction Properties
 ==================== ================ =========================================================
 Name                 Type             Value
 ==================== ================ =========================================================
-``block.coinbase``   ``address``      Current block miner’s address
+``block.coinbase``   ``address``      Current block miner's address
 ``block.difficulty`` ``uint256``      Current block difficulty
-``block.prevrandao`` ``uint256``      Current block difficulty (alias for ``block.difficulty``)
+``block.prevrandao`` ``uint256``      Current randomness beacon provided by the beacon chain
 ``block.number``     ``uint256``      Current block number
 ``block.prevhash``   ``bytes32``      Equivalent to ``blockhash(block.number - 1)``
 ``block.timestamp``  ``uint256``      Current block epoch timestamp
@@ -31,7 +31,7 @@ Name                 Type             Value
 
 .. note::
 
-    ``block.prevrandao`` is an alias for ``block.difficulty``, and will be removed in a future version.
+    ``block.prevrandao`` is an alias for ``block.difficulty``. Since ``block.difficulty`` is considered deprecated according to [EIP-4399] (https://eips.ethereum.org/EIPS/eip-4399) after "The Merge", it will be removed in a future version.
 
 .. note::
 

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -31,7 +31,7 @@ Name                 Type             Value
 
 .. note::
 
-    ``block.prevrandao`` is an alias for ``block.difficulty``. Since ``block.difficulty`` is considered deprecated according to `EIP-4399 <https://eips.ethereum.org/EIPS/eip-4399>`_ after "The Merge", it will be removed in a future version.
+    ``block.prevrandao`` is an alias for ``block.difficulty``. Since ``block.difficulty`` is considered deprecated according to `EIP-4399 <https://eips.ethereum.org/EIPS/eip-4399>`_ after "The Merge" (Paris hard fork), we recommend using ``block.prevrandao``.
 
 .. note::
 

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -31,7 +31,7 @@ Name                 Type             Value
 
 .. note::
 
-    ``block.prevrandao`` is an alias for ``block.difficulty``. Since ``block.difficulty`` is considered deprecated according to [EIP-4399] (https://eips.ethereum.org/EIPS/eip-4399) after "The Merge", it will be removed in a future version.
+    ``block.prevrandao`` is an alias for ``block.difficulty``. Since ``block.difficulty`` is considered deprecated according to `EIP-4399 <https://eips.ethereum.org/EIPS/eip-4399>`_ after "The Merge", it will be removed in a future version.
 
 .. note::
 

--- a/tests/compiler/test_opcodes.py
+++ b/tests/compiler/test_opcodes.py
@@ -43,7 +43,7 @@ def test_version_check(evm_version):
 
 def test_get_opcodes(evm_version):
     op = opcodes.get_opcodes()
-    if evm_version == "berlin":
+    if evm_version in ("paris", "berlin"):
         assert "CHAINID" in op
         assert op["SLOAD"][-1] == 2100
     elif evm_version == "istanbul":

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -138,6 +138,13 @@ def foo():
     """,
     """
 @external
+def foo():
+    x: uint256 = block.prevrandao + 185
+    if tx.origin == self:
+        y: Bytes[35] = concat(block.prevhash, b"dog")
+    """,
+    """
+@external
 def foo() -> uint256:
     return tx.gasprice
     """,

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -280,8 +280,7 @@ class Expr:
             elif key == "msg.gas":
                 return IRnode.from_list(["gas"], typ="uint256")
             elif key == "block.prevrandao":
-                # TODO: Change this post-merge to `from_list(["prevrandao"]`
-                return IRnode.from_list(["difficulty"], typ="uint256")
+                return IRnode.from_list(["prevrandao"], typ="uint256")
             elif key == "block.difficulty":
                 return IRnode.from_list(["difficulty"], typ="uint256")
             elif key == "block.timestamp":

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -279,6 +279,8 @@ class Expr:
                 return IRnode.from_list(["callvalue"], typ=BaseType("uint256"))
             elif key == "msg.gas":
                 return IRnode.from_list(["gas"], typ="uint256")
+            elif key == "block.prevrandao":
+                return IRnode.from_list(["difficulty"], typ="uint256")
             elif key == "block.difficulty":
                 return IRnode.from_list(["difficulty"], typ="uint256")
             elif key == "block.timestamp":

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -280,6 +280,7 @@ class Expr:
             elif key == "msg.gas":
                 return IRnode.from_list(["gas"], typ="uint256")
             elif key == "block.prevrandao":
+                # TODO: Change this post-merge to `from_list(["prevrandao"]`
                 return IRnode.from_list(["difficulty"], typ="uint256")
             elif key == "block.difficulty":
                 return IRnode.from_list(["difficulty"], typ="uint256")

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 from vyper.exceptions import CompilerPanic
 from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRulesetValue, OpcodeValue
 
-active_evm_version: int = 3
+active_evm_version: int = 4
 
 # EVM version rules work as follows:
 # 1. Fork rules go from oldest (lowest value) to newest (highest value).
@@ -24,11 +24,12 @@ EVM_VERSIONS: Dict[str, int] = {
     "petersburg": 1,
     "istanbul": 2,
     "berlin": 3,
+    "paris": 4,
     # ETC Forks
     "atlantis": 0,
     "agharta": 1,
 }
-DEFAULT_EVM_VERSION: str = "berlin"
+DEFAULT_EVM_VERSION: str = "paris"
 
 
 # opcode as hex value

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -84,6 +84,7 @@ OPCODES: OpcodeMap = {
     "TIMESTAMP": (0x42, 0, 1, 2),
     "NUMBER": (0x43, 0, 1, 2),
     "DIFFICULTY": (0x44, 0, 1, 2),
+    "PREVRANDAO": (0x44, 0, 1, 2),
     "GASLIMIT": (0x45, 0, 1, 2),
     "CHAINID": (0x46, 0, 1, (None, None, 2)),
     "SELFBALANCE": (0x47, 0, 1, (None, None, 5)),

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -11,6 +11,7 @@ CONSTANT_ENVIRONMENT_VARS: Dict[str, Dict[str, type]] = {
     "block": {
         "coinbase": AddressDefinition,
         "difficulty": Uint256Definition,
+        "prevrandao": Uint256Definition,
         "number": Uint256Definition,
         "gaslimit": Uint256Definition,
         "basefee": Uint256Definition,


### PR DESCRIPTION
### What I did

[EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) renames the `DIFFICULTY (0x44)` opcode to `PREVRANDAO (0x44)`. The return value of the `DIFFICULTY (0x44)` instruction after this change is the output of the randomness beacon provided by the beacon chain.

### How I did it

With my brain.

### How to verify it

Ask Vitalik's masternode.

### Commit message
```
feat: add `block.prevrandao` as alias for `block.difficulty`

per paris merge, EIP-4399 renames the `DIFFICULTY (0x44)` opcode to
`PREVRANDAO (0x44)`. the return value of the `DIFFICULTY (0x44)`
instruction after this change is the output of the randomness beacon
provided by the beacon chain.
```

### Description for the changelog

Add  `block.prevrandao` as alias for `block.difficulty`.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/188713306-96457039-0abe-4907-88da-324457b6f14b.png)
