### PR TITLE
Chore: Add tests to check public constants & immutable vars have getters

### DIFF
--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -32,6 +32,9 @@ z: public(Bytes[100])
 w: public(HashMap[int128, W])
 a: public(uint256[10][10])
 b: public(HashMap[uint256, HashMap[address, uint256[4]]])
+c: public(constant(uint256)) = 1
+d: public(immutable(uint256))
+e: public(immutable(uint256[2]))
 
 @external
 def __init__():
@@ -46,6 +49,8 @@ def __init__():
     self.w[3].g = 751
     self.a[1][4] = 666
     self.b[42][self] = [5,6,7,8]
+    d = 1729
+    e = [2, 3]
     """
 
     c = get_contract_with_gas_estimation_for_constants(getter_code)
@@ -60,6 +65,9 @@ def __init__():
     assert c.w(3)[5] == 751  # W.g
     assert c.a(1, 4) == 666
     assert c.b(42, c.address, 2) == 7
+    assert c.c() == 1
+    assert c.d() == 1729
+    assert c.e(0) == 2
 
 
 def test_getter_mutability(get_contract):
@@ -69,9 +77,17 @@ goo: public(String[69])
 bar: public(uint256[4][5])
 baz: public(HashMap[address, Bytes[100]])
 potatoes: public(HashMap[uint256, HashMap[bytes32, uint256[4]]])
+nyoro: public(constant(uint256)) = 2
+kune: public(immutable(uint256))
+
+@external
+def __init__():
+    kune = 2
 """
 
     contract = get_contract(code)
 
     for item in contract._classic_contract.abi:
+        if item["type"] == "constructor":
+            continue
         assert item["stateMutability"] == "view"

--- a/vyper/ast/grammar.lark
+++ b/vyper/ast/grammar.lark
@@ -33,14 +33,19 @@ import: _IMPORT DOT* _import_path [import_alias]
       | _import_from _IMPORT ( WILDCARD | _import_name [import_alias] )
       | _import_from _IMPORT "(" import_list ")"
 
-
 // Constant definitions
 // NOTE: Temporary until decorators used
-constant_def: NAME ":" "constant" "(" type ")" "=" _expr
+constant: "constant" "(" type ")"
+constant_private: NAME ":" constant
+constant_with_getter: NAME ":" "public" "(" constant ")"
+constant_def: (constant_private | constant_with_getter) "=" _expr
 
 // immutable definitions
 // NOTE: Temporary until decorators used
-immutable_def: NAME ":" "immutable" "(" type ")"
+immutable: "immutable" "(" type ")"
+immutable_private: NAME ":" immutable
+immutable_with_getter: NAME ":" "public" "(" immutable ")"
+immutable_def: immutable_private | immutable_with_getter
 
 variable: NAME ":" type
 // NOTE: Temporary until decorators used

--- a/vyper/ast/grammar.lark
+++ b/vyper/ast/grammar.lark
@@ -43,13 +43,11 @@ constant_def: (constant_private | constant_with_getter) "=" _expr
 // immutable definitions
 // NOTE: Temporary until decorators used
 immutable: "immutable" "(" type ")"
-immutable_private: NAME ":" immutable
-immutable_with_getter: NAME ":" "public" "(" immutable ")"
-immutable_def: immutable_private | immutable_with_getter
+immutable_def: NAME ":" immutable
 
 variable: NAME ":" type
 // NOTE: Temporary until decorators used
-variable_with_getter: NAME ":" "public" "(" type ")"
+variable_with_getter: NAME ":" "public" "(" (type | immutable) ")"
 variable_def: variable | variable_with_getter
 
 // A decorator "wraps" a method, modifying it's context.


### PR DESCRIPTION
### What I did

Add dynamic tests to check public constants & immutable vars have getters as per: https://github.com/vyperlang/vyper/pull/3024#pullrequestreview-1102266104

### How I did it

Added test cases to `tests/parser/globals/test_getters.py`, updated lark grammar to allow for the declaration of public immutable & constants.

### How to verify it

Run the tests

### Commit message

Add tests for public constant & immutable var getters

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/189507431-cf21ac60-5cb6-4a75-a2de-d383e422c6c8.png)
)
