### PR TITLE
fix: relax check for statically sized calldata

### DIFF
--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -2473,12 +2473,11 @@ def foo(a: {typ}):
     malformed = data[:-2]
     assert_tx_failed(lambda: w3.eth.send_transaction({"to": c1.address, "data": malformed}))
 
-    # Static size exceeds by 1 byte
-    malformed = data + "ff"
-    assert_tx_failed(lambda: w3.eth.send_transaction({"to": c1.address, "data": malformed}))
-
     # Static size is exact
     w3.eth.send_transaction({"to": c1.address, "data": data})
+
+    # Static size exceeds by 1 byte, ok
+    w3.eth.send_transaction({"to": c1.address, "data": data + "ff"})
 
 
 @pytest.mark.parametrize("typ,val", [("address", ([TEST_ADDR] * 3, "vyper"))])

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -89,11 +89,7 @@ def _generate_kwarg_handlers(context: Context, sig: FunctionSignature) -> List[A
         # ensure calldata is at least of minimum length
         args_abi_t = calldata_args_t.abi_type
         calldata_min_size = args_abi_t.min_size() + 4
-        if args_abi_t.is_dynamic():
-            ret.append(["assert", ["ge", "calldatasize", calldata_min_size]])
-        else:
-            # stricter for static data
-            ret.append(["assert", ["eq", "calldatasize", calldata_min_size]])
+        ret.append(["assert", ["ge", "calldatasize", calldata_min_size]])
 
         # TODO optimize make_setter by using
         # TupleType(list(arg.typ for arg in calldata_kwargs + default_kwargs))


### PR DESCRIPTION
a37bbbca706 (https://github.com/vyperlang/vyper/pull/2911) introduced per-method calldatasize checks. however, for the case where calldata is statically sized (in the ABI sense), this check is too strict, since users might want to append extra bytes to the calldata and manipulate msg.data directly for some application-level reasons.

### What I did

### How I did it
change "eq" to "ge"

### How to verify it
see the tests

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
