### PR TITLE
feat: add lineno at the end of exception string pointing to file

### DIFF
--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -104,7 +104,7 @@ class VyperException(Exception):
             if isinstance(node, vy_ast.VyperNode):
                 module_node = node.get_ancestor(vy_ast.Module)
                 if module_node.get("name") not in (None, "<unknown>"):
-                    node_msg = f'{node_msg}contract "{module_node.name}", '
+                    node_msg = f'{node_msg}contract "{module_node.name}:{node.lineno}", '
 
                 fn_node = node.get_ancestor(vy_ast.FunctionDef)
                 if fn_node:


### PR DESCRIPTION
### What I did

Added lineno at the end of the part of the exception that mentions the contract throwing the error. This is similar to how python does exceptions, for example:

```
venv/lib/python3.10/site-packages/vyper/semantics/validation/local.py:66: in validate_functions
    err_list.raise_if_not_empty()
```

The added advantage of this is that it allows IDEs to navigate directly to the line that invokes the exception via `cmd+click` or `ctrl+click` (on, for example, VSCode).

### How I did it

Just add `node.lineno` in the exception string where the contract's dir is printed.

### How to verify it

you'll need to have a contract that borks. The exception will look something like:

```
vyper.exceptions.VyperException: Compilation failed with the following errors:
E           
E           StructureException: Value is not callable
E             contract "contracts/SomeExampleContract.vy:1069", function "some_function", line 1069:16 
```

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

Adds line number at the end of exception string. The exceptions format conforms a bit better with how python exceptions are usually printed. An added use-case is that this allows IDEs to offer better code navigation, which improves devex.

### Description for the changelog

Adds lineno at the end of exceptions string.

### Cute Animal Picture

The most ferocious land animal ... or is it a good boi?

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/gemBxRp.jpg)
