### PR TITLE
feat: make built-in `ERC721` interface functions `payable`

### DIFF
--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -236,6 +236,7 @@ def _transferFrom(_from: address, _to: address, _tokenId: uint256, _sender: addr
 ### TRANSFER FUNCTIONS ###
 
 @external
+@payable
 def transferFrom(_from: address, _to: address, _tokenId: uint256):
     """
     @dev Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
@@ -253,6 +254,7 @@ def transferFrom(_from: address, _to: address, _tokenId: uint256):
 
 
 @external
+@payable
 def safeTransferFrom(
         _from: address,
         _to: address,
@@ -281,6 +283,7 @@ def safeTransferFrom(
 
 
 @external
+@payable
 def approve(_approved: address, _tokenId: uint256):
     """
     @dev Set or reaffirm the approved address for an NFT. The zero address indicates there is no approved address.

--- a/vyper/builtin_interfaces/ERC721.py
+++ b/vyper/builtin_interfaces/ERC721.py
@@ -39,18 +39,22 @@ def isApprovedForAll(_owner: address, _operator: address) -> bool:
     pass
 
 @external
+@payable
 def transferFrom(_from: address, _to: address, _tokenId: uint256):
     pass
 
 @external
+@payable
 def safeTransferFrom(_from: address, _to: address, _tokenId: uint256):
     pass
 
 @external
+@payable
 def safeTransferFrom(_from: address, _to: address, _tokenId: uint256, _data: Bytes[1024]):
     pass
 
 @external
+@payable
 def approve(_approved: address, _tokenId: uint256):
     pass
 


### PR DESCRIPTION
### What I did

In the official [EIP-721](https://eips.ethereum.org/EIPS/eip-721), the following functions are declared as `payable`:

```solidity
function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
function approve(address _approved, uint256 _tokenId) external payable;
```

### How I did it

I changed the functions `safeTransferFrom(address,address,uint256)`, `safeTransferFrom(address,address,uint256,bytes)`, `transferFrom(address,address,uint256)`, and `approve(address,uint256)` to be `payable`.

Fixes https://github.com/vyperlang/vyper/issues/3096.

### How to verify it

Check the built-in interface and example code.

### Commit message

```
💵 feat: make built-in `ERC721` interface functions `payable`

The built-in `ERC721` interface functions `safeTransferFrom(address,address,uint256)`,
`safeTransferFrom(address,address,uint256,bytes)`, `transferFrom(address,address,uint256)`,
and `approve(address,uint256)` are now `payable`.
```

### Description for the changelog

The built-in `ERC721` interface functions `safeTransferFrom(address,address,uint256)`, `safeTransferFrom(address,address,uint256,bytes)`, `transferFrom(address,address,uint256)`, and `approve(address,uint256)` are now `payable`.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/189988561-b1c92a32-9a6f-4930-9a52-103228eb59f0.png)
