### PR TITLE
chore: refactor eth_abi encode_single and decode_single

### DIFF
--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1087,7 +1087,7 @@ def foo(a: Bytes[36], b: int128, c: String[7]):
     topic1 = f"0x{keccak256(b'bar').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode('int128', 1).hex()}"
+    topic2 = f"0x{encode(['int128'], [1]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'weird').hex()}"
@@ -1132,7 +1132,7 @@ def foo():
     topic1 = f"0x{keccak256(b'potato').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode('int128', -777).hex()}"
+    topic2 = f"0x{encode(['int128'], [-777]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'why hello, neighbor! how are you today?').hex()}"
@@ -1186,7 +1186,7 @@ def foo():
     topic1 = f"0x{keccak256(b'zonk').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode('int128', -2109).hex()}"
+    topic2 = f"0x{encode(['int128'], [-2109]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'yessir').hex()}"
@@ -1228,7 +1228,7 @@ def foo():
     topic1 = f"0x{keccak256(b'wow').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode('int128', 666).hex()}"
+    topic2 = f"0x{encode(['int128'], [666]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'madness!').hex()}"

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 import pytest
-from eth_abi import encode
+import eth_abi as abi_utils
 
 from vyper.exceptions import (
     ArgumentException,
@@ -1087,7 +1087,7 @@ def foo(a: Bytes[36], b: int128, c: String[7]):
     topic1 = f"0x{keccak256(b'bar').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode(['int128'], [1]).hex()}"
+    topic2 = f"0x{abi_utils.encode(['int128'], [1]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'weird').hex()}"
@@ -1132,7 +1132,7 @@ def foo():
     topic1 = f"0x{keccak256(b'potato').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode(['int128'], [-777]).hex()}"
+    topic2 = f"0x{abi_utils.encode(['int128'], [-777]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'why hello, neighbor! how are you today?').hex()}"
@@ -1186,7 +1186,7 @@ def foo():
     topic1 = f"0x{keccak256(b'zonk').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode(['int128'], [-2109]).hex()}"
+    topic2 = f"0x{abi_utils.encode(['int128'], [-2109]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'yessir').hex()}"
@@ -1228,7 +1228,7 @@ def foo():
     topic1 = f"0x{keccak256(b'wow').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{encode(['int128'], [666]).hex()}"
+    topic2 = f"0x{abi_utils.encode(['int128'], [666]).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'madness!').hex()}"

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-import eth_abi
+from eth_abi import encode, decode
 import pytest
 
 from vyper.exceptions import (
@@ -1087,7 +1087,7 @@ def foo(a: Bytes[36], b: int128, c: String[7]):
     topic1 = f"0x{keccak256(b'bar').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode('int128', 1).hex()}"
+    topic2 = f"0x{encode('int128', 1).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'weird').hex()}"
@@ -1132,7 +1132,7 @@ def foo():
     topic1 = f"0x{keccak256(b'potato').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode('int128', -777).hex()}"
+    topic2 = f"0x{encode('int128', -777).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'why hello, neighbor! how are you today?').hex()}"
@@ -1186,7 +1186,7 @@ def foo():
     topic1 = f"0x{keccak256(b'zonk').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode('int128', -2109).hex()}"
+    topic2 = f"0x{encode('int128', -2109).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'yessir').hex()}"
@@ -1228,7 +1228,7 @@ def foo():
     topic1 = f"0x{keccak256(b'wow').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode('int128', 666).hex()}"
+    topic2 = f"0x{encode('int128', 666).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'madness!').hex()}"

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1087,7 +1087,7 @@ def foo(a: Bytes[36], b: int128, c: String[7]):
     topic1 = f"0x{keccak256(b'bar').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode_single('int128', 1).hex()}"
+    topic2 = f"0x{eth_abi.encode('int128', 1).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'weird').hex()}"
@@ -1132,7 +1132,7 @@ def foo():
     topic1 = f"0x{keccak256(b'potato').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode_single('int128', -777).hex()}"
+    topic2 = f"0x{eth_abi.encode('int128', -777).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'why hello, neighbor! how are you today?').hex()}"
@@ -1186,7 +1186,7 @@ def foo():
     topic1 = f"0x{keccak256(b'zonk').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode_single('int128', -2109).hex()}"
+    topic2 = f"0x{eth_abi.encode('int128', -2109).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'yessir').hex()}"
@@ -1228,7 +1228,7 @@ def foo():
     topic1 = f"0x{keccak256(b'wow').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
 
-    topic2 = f"0x{eth_abi.encode_single('int128', 666).hex()}"
+    topic2 = f"0x{eth_abi.encode('int128', 666).hex()}"
     assert receipt["logs"][0]["topics"][2] == topic2
 
     topic3 = f"0x{keccak256(b'madness!').hex()}"

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
-import pytest
 import eth_abi as abi_utils
+import pytest
 
 from vyper.exceptions import (
     ArgumentException,

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
-from eth_abi import encode, decode
 import pytest
+from eth_abi import encode
 
 from vyper.exceptions import (
     ArgumentException,

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
 
+import eth_abi as abi_utils
 import eth_abi.exceptions
 import pytest
-import eth_abi as abi_utils
 
 from vyper.codegen.types import (
     BASE_TYPES,

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import eth_abi.exceptions
 import pytest
-from eth_abi import decode_single, encode_single
+from eth_abi import decode, encode
 
 from vyper.codegen.types import (
     BASE_TYPES,
@@ -277,7 +277,7 @@ def _from_bits(val_bits, o_typ):
     # o_typ: the type to convert to
     detail = _parse_type(o_typ)
     try:
-        return decode_single(detail.abi_type, val_bits)
+        return decode(detail.abi_type, val_bits)
     except eth_abi.exceptions.NonEmptyPaddingBytes:
         raise _OutOfBounds() from None
 
@@ -285,7 +285,7 @@ def _from_bits(val_bits, o_typ):
 def _to_bits(val, i_typ):
     # i_typ: the type to convert from
     detail = _parse_type(i_typ)
-    return encode_single(detail.abi_type, val)
+    return encode(detail.abi_type, val)
 
 
 def _signextend(val_bytes, bits):

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import eth_abi.exceptions
 import pytest
-from eth_abi import decode, encode
+import eth_abi as abi_utils
 
 from vyper.codegen.types import (
     BASE_TYPES,
@@ -277,7 +277,7 @@ def _from_bits(val_bits, o_typ):
     # o_typ: the type to convert to
     detail = _parse_type(o_typ)
     try:
-        return decode([detail.abi_type], [val_bits])
+        return abi_utils.decode([detail.abi_type], [val_bits])
     except eth_abi.exceptions.NonEmptyPaddingBytes:
         raise _OutOfBounds() from None
 
@@ -285,7 +285,7 @@ def _from_bits(val_bits, o_typ):
 def _to_bits(val, i_typ):
     # i_typ: the type to convert from
     detail = _parse_type(i_typ)
-    return encode([detail.abi_type], [val])
+    return abi_utils.encode([detail.abi_type], [val])
 
 
 def _signextend(val_bytes, bits):

--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -277,7 +277,7 @@ def _from_bits(val_bits, o_typ):
     # o_typ: the type to convert to
     detail = _parse_type(o_typ)
     try:
-        return decode(detail.abi_type, val_bits)
+        return decode([detail.abi_type], [val_bits])
     except eth_abi.exceptions.NonEmptyPaddingBytes:
         raise _OutOfBounds() from None
 
@@ -285,7 +285,7 @@ def _from_bits(val_bits, o_typ):
 def _to_bits(val, i_typ):
     # i_typ: the type to convert from
     detail = _parse_type(i_typ)
-    return encode(detail.abi_type, val)
+    return encode([detail.abi_type], [val])
 
 
 def _signextend(val_bytes, bits):

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -1,6 +1,6 @@
 import pytest
 import rlp
-from eth_abi import encode
+import eth_abi as abi_utils
 from hexbytes import HexBytes
 
 from vyper.utils import EIP_170_LIMIT, checksum_encode, keccak256
@@ -330,7 +330,7 @@ def should_fail(target: address, arg1: String[129], arg2: Bar):
     assert test.foo() == FOO
     assert test.bar() == BAR
 
-    encoded_args = encode(["(string,(string))"], [(FOO, BAR)])
+    encoded_args = abi_utils.encode(["(string,(string))"], [(FOO, BAR)])
     assert HexBytes(test.address) == create2_address_of(d.address, salt, initcode + encoded_args)
 
     d.test3(f.address, encoded_args, transact={})

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -1,6 +1,6 @@
+import eth_abi as abi_utils
 import pytest
 import rlp
-import eth_abi as abi_utils
 from hexbytes import HexBytes
 
 from vyper.utils import EIP_170_LIMIT, checksum_encode, keccak256

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -34,7 +34,7 @@ def test() -> address:
 
     address_bits = int(c.address, 16)
     nonce = 1
-    rlp_encoded = rlp.encode([address_bits, nonce])
+    rlp_encoded = rlp.encode([address_bits], [nonce])
     expected_create_address = keccak256(rlp_encoded)[12:].rjust(20, b"\x00")
     assert c.test() == checksum_encode("0x" + expected_create_address.hex())
 
@@ -330,7 +330,7 @@ def should_fail(target: address, arg1: String[129], arg2: Bar):
     assert test.foo() == FOO
     assert test.bar() == BAR
 
-    encoded_args = encode("(string,(string))", (FOO, BAR))
+    encoded_args = encode(["(string,(string))"], [(FOO, BAR)])
     assert HexBytes(test.address) == create2_address_of(d.address, salt, initcode + encoded_args)
 
     d.test3(f.address, encoded_args, transact={})

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -1,6 +1,6 @@
 import pytest
 import rlp
-from eth_abi import encode_single
+from eth_abi import encode
 from hexbytes import HexBytes
 
 from vyper.utils import EIP_170_LIMIT, checksum_encode, keccak256
@@ -330,7 +330,7 @@ def should_fail(target: address, arg1: String[129], arg2: Bar):
     assert test.foo() == FOO
     assert test.bar() == BAR
 
-    encoded_args = encode_single("(string,(string))", (FOO, BAR))
+    encoded_args = encode("(string,(string))", (FOO, BAR))
     assert HexBytes(test.address) == create2_address_of(d.address, salt, initcode + encoded_args)
 
     d.test3(f.address, encoded_args, transact={})


### PR DESCRIPTION
### What I did

following: https://github.com/ethereum/eth-abi/issues/84

`encode_single` and `decode_single` are deprecated in favor of `encode` and `decode`. So just replaced it.

### How I did it

Just replace the signatures

### How to verify it

check `eth_abi` issue, run tests as normal (since `eth_abi` was mostly used in tests).

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

chore: refactor eth_abi encode_single and decode_single calls

### Description for the changelog

Refactored code calling `encode_single` and `decode_single`, since: https://github.com/ethereum/eth-abi/issues/84

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/NijRI9l.jpeg)
