### PR TITLE
capitalize words in interface name

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -35,7 +35,10 @@ def build_userdoc(compiler_data: CompilerData) -> dict:
 
 def build_external_interface_output(compiler_data: CompilerData) -> str:
     interface = compiler_data.vyper_module_folded._metadata["type"]
-    name = Path(compiler_data.contract_name).stem.capitalize()
+    stem = Path(compiler_data.contract_name).stem
+    # capitalize words separated by '_'
+    # ex: test_interface.vy -> TestInterface
+    name = ''.join([x.capitalize() for x in stem.split('_')])
     out = f"\n# External Interfaces\ninterface {name}:\n"
 
     for func in interface.members.values():


### PR DESCRIPTION
for example, the interface for test_interface.vy should be TestInterface instead of Testinterface (current output)

### What I did

capitalized words by chunks instead of all at once

### How I did it

### How to verify it

```
> vyper -f external_interface examples/auctions/blind_auction.vy 

# External Interfaces
interface BlindAuction:
    def bid(_blindedBid: bytes32): payable
    def reveal(_numBids: int128, _values: uint256[128], _fakes: bool[128], _secrets: bytes32[128]): nonpayable
    def withdraw(): nonpayable
    def auctionEnd(): nonpayable
    def beneficiary() -> address: view
    def biddingEnd() -> uint256: view
    def revealEnd() -> uint256: view
    def ended() -> bool: view
    def highestBid() -> uint256: view
    def highestBidder() -> address: view
```

### Commit message


### Description for the changelog

Output external interface names with capitalized words

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.natgeofe.com/n/fe913953-7892-4df9-9a06-87b54fd9d4f5/74646.jpg)
