### PR TITLE
chore: loosen and upgrade semantic version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     install_requires=[
         "asttokens==2.0.5",
         "pycryptodome>=3.5.1,<4",
-        "semantic-version==2.8.5",
+        "semantic-version>=2.10,<3",
         "cached-property==1.5.2 ; python_version<'3.8'",
         "importlib-metadata ; python_version<'3.8'",
         "wheel",


### PR DESCRIPTION
### What I did

fixes: #3103

* Upgrade semantic version to 2.10
* Loosen pin to include a wider range

### How I did it

Was:

```python
        "semantic-version==2.8.5",
```

Now:

```python
        "semantic-version>=2.10,<3",
```

### How to verify it

Test it out on 2.10

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

Change `semantic-version` library requirement from `==2.8.5` to `>=2.10,<3`.

### Cute Animal Picture

🐍
