### PR TITLE
feat: optionally disable metadata in bytecode

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -37,7 +37,7 @@ ir                 - Intermediate representation in list format
 ir_json            - Intermediate representation in JSON format
 hex-ir             - Output IR and assembly constants in hex instead of decimal
 no-optimize        - Do not optimize (don't use this for production code)
-no-vyper-signature - Do not add vyper signature to bytecode
+no-bytecode-metadata - Do not add metadata to bytecode
 """
 
 combined_json_outputs = [
@@ -106,7 +106,7 @@ def _parse_args(argv):
         dest="evm_version",
     )
     parser.add_argument("--no-optimize", help="Do not optimize", action="store_true")
-    parser.add_argument("--no-vyper-signature", help="Do not add vyper signature to bytecode", action="store_true")
+    parser.add_argument("--no-bytecode-metadata", help="Do not add metadata to bytecode", action="store_true")
     parser.add_argument(
         "--traceback-limit",
         help="Set the traceback limit for error messages reported by the compiler",
@@ -157,7 +157,7 @@ def _parse_args(argv):
         args.evm_version,
         args.no_optimize,
         args.storage_layout,
-        args.no_vyper_signature
+        args.no_bytecode_metadata
     )
 
     if args.output_path:
@@ -253,7 +253,7 @@ def compile_files(
     evm_version: str = DEFAULT_EVM_VERSION,
     no_optimize: bool = False,
     storage_layout: Iterable[str] = None,
-    no_vyper_signature: bool = False,
+    no_bytecode_metadata: bool = False,
 ) -> OrderedDict:
 
     root_path = Path(root_folder).resolve()
@@ -298,7 +298,7 @@ def compile_files(
         no_optimize=no_optimize,
         storage_layouts=storage_layouts,
         show_gas_estimates=show_gas_estimates,
-        no_vyper_signature=no_vyper_signature,
+        no_bytecode_metadata=no_bytecode_metadata,
     )
     if show_version:
         compiler_data["version"] = vyper.__version__

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -106,7 +106,9 @@ def _parse_args(argv):
         dest="evm_version",
     )
     parser.add_argument("--no-optimize", help="Do not optimize", action="store_true")
-    parser.add_argument("--no-bytecode-metadata", help="Do not add metadata to bytecode", action="store_true")
+    parser.add_argument(
+        "--no-bytecode-metadata", help="Do not add metadata to bytecode", action="store_true"
+    )
     parser.add_argument(
         "--traceback-limit",
         help="Set the traceback limit for error messages reported by the compiler",
@@ -157,7 +159,7 @@ def _parse_args(argv):
         args.evm_version,
         args.no_optimize,
         args.storage_layout,
-        args.no_bytecode_metadata
+        args.no_bytecode_metadata,
     )
 
     if args.output_path:

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -37,6 +37,7 @@ ir                 - Intermediate representation in list format
 ir_json            - Intermediate representation in JSON format
 hex-ir             - Output IR and assembly constants in hex instead of decimal
 no-optimize        - Do not optimize (don't use this for production code)
+no-vyper-signature - Do not add vyper signature to bytecode
 """
 
 combined_json_outputs = [
@@ -105,6 +106,7 @@ def _parse_args(argv):
         dest="evm_version",
     )
     parser.add_argument("--no-optimize", help="Do not optimize", action="store_true")
+    parser.add_argument("--no-vyper-signature", help="Do not add vyper signature to bytecode", action="store_true")
     parser.add_argument(
         "--traceback-limit",
         help="Set the traceback limit for error messages reported by the compiler",
@@ -155,6 +157,7 @@ def _parse_args(argv):
         args.evm_version,
         args.no_optimize,
         args.storage_layout,
+        args.no_vyper_signature
     )
 
     if args.output_path:
@@ -250,6 +253,7 @@ def compile_files(
     evm_version: str = DEFAULT_EVM_VERSION,
     no_optimize: bool = False,
     storage_layout: Iterable[str] = None,
+    no_vyper_signature: bool = False,
 ) -> OrderedDict:
 
     root_path = Path(root_folder).resolve()
@@ -294,6 +298,7 @@ def compile_files(
         no_optimize=no_optimize,
         storage_layouts=storage_layouts,
         show_gas_estimates=show_gas_estimates,
+        no_vyper_signature=no_vyper_signature,
     )
     if show_version:
         compiler_data["version"] = vyper.__version__

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -55,7 +55,7 @@ def compile_codes(
     no_optimize: bool = False,
     storage_layouts: Dict[ContractPath, StorageLayout] = None,
     show_gas_estimates: bool = False,
-    no_vyper_signature: bool = False,
+    no_bytecode_metadata: bool = False,
 ) -> OrderedDict:
     """
     Generate compiler output(s) from one or more contract source codes.
@@ -89,8 +89,8 @@ def compile_codes(
 
         * Interface definitions are formatted as: `{'type': "json/vyper", 'code': "interface code"}`
         * JSON interfaces are given as lists, vyper interfaces as strings
-    no_vyper_signature: bool, optional
-        Do not add vyper signature to bytecode. Defaults to False
+    no_bytecode_metadata: bool, optional
+        Do not add metadata to bytecode. Defaults to False
 
     Returns
     -------
@@ -128,7 +128,7 @@ def compile_codes(
             no_optimize,
             storage_layout_override,
             show_gas_estimates,
-            no_vyper_signature,
+            no_bytecode_metadata,
         )
         for output_format in output_formats[contract_name]:
             if output_format not in OUTPUT_FORMATS:

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -55,6 +55,7 @@ def compile_codes(
     no_optimize: bool = False,
     storage_layouts: Dict[ContractPath, StorageLayout] = None,
     show_gas_estimates: bool = False,
+    no_vyper_signature: bool = False,
 ) -> OrderedDict:
     """
     Generate compiler output(s) from one or more contract source codes.
@@ -88,6 +89,8 @@ def compile_codes(
 
         * Interface definitions are formatted as: `{'type': "json/vyper", 'code': "interface code"}`
         * JSON interfaces are given as lists, vyper interfaces as strings
+    no_vyper_signature: bool, optional
+        Do not add vyper signature to bytecode. Defaults to False
 
     Returns
     -------
@@ -125,6 +128,7 @@ def compile_codes(
             no_optimize,
             storage_layout_override,
             show_gas_estimates,
+            no_vyper_signature,
         )
         for output_format in output_formats[contract_name]:
             if output_format not in OUTPUT_FORMATS:

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -198,7 +198,7 @@ def _build_asm(asm_list):
 
 def build_source_map_output(compiler_data: CompilerData) -> OrderedDict:
     _, line_number_map = compile_ir.assembly_to_evm(
-        compiler_data.assembly_runtime, insert_vyper_signature=True
+        compiler_data.assembly_runtime, insert_vyper_signature=True, disable_vyper_signature=compiler_data.no_vyper_signature
     )
     # Sort line_number_map
     out = OrderedDict()

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -198,7 +198,9 @@ def _build_asm(asm_list):
 
 def build_source_map_output(compiler_data: CompilerData) -> OrderedDict:
     _, line_number_map = compile_ir.assembly_to_evm(
-        compiler_data.assembly_runtime, insert_vyper_signature=True, disable_bytecode_metadata=compiler_data.no_bytecode_metadata
+        compiler_data.assembly_runtime,
+        insert_vyper_signature=True,
+        disable_bytecode_metadata=compiler_data.no_bytecode_metadata,
     )
     # Sort line_number_map
     out = OrderedDict()

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -198,7 +198,7 @@ def _build_asm(asm_list):
 
 def build_source_map_output(compiler_data: CompilerData) -> OrderedDict:
     _, line_number_map = compile_ir.assembly_to_evm(
-        compiler_data.assembly_runtime, insert_vyper_signature=True, disable_vyper_signature=compiler_data.no_vyper_signature
+        compiler_data.assembly_runtime, insert_vyper_signature=True, disable_bytecode_metadata=compiler_data.no_bytecode_metadata
     )
     # Sort line_number_map
     out = OrderedDict()

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -52,6 +52,7 @@ class CompilerData:
         no_optimize: bool = False,
         storage_layout: StorageLayout = None,
         show_gas_estimates: bool = False,
+        no_vyper_signature: bool = False,
     ) -> None:
         """
         Initialization method.
@@ -72,6 +73,8 @@ class CompilerData:
             Turn off optimizations. Defaults to False
         show_gas_estimates: bool, optional
             Show gas estimates for abi and ir output modes
+        no_vyper_signature: bool, optional
+            Do not add vyper signature to bytecode. Defaults to False
         """
         self.contract_name = contract_name
         self.source_code = source_code
@@ -80,6 +83,7 @@ class CompilerData:
         self.no_optimize = no_optimize
         self.storage_layout_override = storage_layout
         self.show_gas_estimates = show_gas_estimates
+        self.no_vyper_signature = no_vyper_signature
 
     @cached_property
     def vyper_module(self) -> vy_ast.Module:
@@ -142,11 +146,11 @@ class CompilerData:
 
     @cached_property
     def bytecode(self) -> bytes:
-        return generate_bytecode(self.assembly, is_runtime=False)
+        return generate_bytecode(self.assembly, is_runtime=False, no_vyper_signature=self.no_vyper_signature)
 
     @cached_property
     def bytecode_runtime(self) -> bytes:
-        return generate_bytecode(self.assembly_runtime, is_runtime=True)
+        return generate_bytecode(self.assembly_runtime, is_runtime=True, no_vyper_signature=self.no_vyper_signature)
 
     @cached_property
     def blueprint_bytecode(self) -> bytes:
@@ -307,7 +311,7 @@ def _find_nested_opcode(assembly, key):
         return any(_find_nested_opcode(x, key) for x in sublists)
 
 
-def generate_bytecode(assembly: list, is_runtime: bool = False) -> bytes:
+def generate_bytecode(assembly: list, is_runtime: bool = False, no_vyper_signature: bool = False) -> bytes:
     """
     Generate bytecode from assembly instructions.
 
@@ -321,4 +325,4 @@ def generate_bytecode(assembly: list, is_runtime: bool = False) -> bytes:
     bytes
         Final compiled bytecode.
     """
-    return compile_ir.assembly_to_evm(assembly, insert_vyper_signature=is_runtime)[0]
+    return compile_ir.assembly_to_evm(assembly, insert_vyper_signature=is_runtime, disable_vyper_signature=no_vyper_signature)[0]

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -146,11 +146,15 @@ class CompilerData:
 
     @cached_property
     def bytecode(self) -> bytes:
-        return generate_bytecode(self.assembly, is_runtime=False, no_bytecode_metadata=self.no_bytecode_metadata)
+        return generate_bytecode(
+            self.assembly, is_runtime=False, no_bytecode_metadata=self.no_bytecode_metadata
+        )
 
     @cached_property
     def bytecode_runtime(self) -> bytes:
-        return generate_bytecode(self.assembly_runtime, is_runtime=True, no_bytecode_metadata=self.no_bytecode_metadata)
+        return generate_bytecode(
+            self.assembly_runtime, is_runtime=True, no_bytecode_metadata=self.no_bytecode_metadata
+        )
 
     @cached_property
     def blueprint_bytecode(self) -> bytes:
@@ -311,7 +315,9 @@ def _find_nested_opcode(assembly, key):
         return any(_find_nested_opcode(x, key) for x in sublists)
 
 
-def generate_bytecode(assembly: list, is_runtime: bool = False, no_bytecode_metadata: bool = False) -> bytes:
+def generate_bytecode(
+    assembly: list, is_runtime: bool = False, no_bytecode_metadata: bool = False
+) -> bytes:
     """
     Generate bytecode from assembly instructions.
 
@@ -325,4 +331,6 @@ def generate_bytecode(assembly: list, is_runtime: bool = False, no_bytecode_meta
     bytes
         Final compiled bytecode.
     """
-    return compile_ir.assembly_to_evm(assembly, insert_vyper_signature=is_runtime, disable_bytecode_metadata=no_bytecode_metadata)[0]
+    return compile_ir.assembly_to_evm(
+        assembly, insert_vyper_signature=is_runtime, disable_bytecode_metadata=no_bytecode_metadata
+    )[0]

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -52,7 +52,7 @@ class CompilerData:
         no_optimize: bool = False,
         storage_layout: StorageLayout = None,
         show_gas_estimates: bool = False,
-        no_vyper_signature: bool = False,
+        no_bytecode_metadata: bool = False,
     ) -> None:
         """
         Initialization method.
@@ -73,8 +73,8 @@ class CompilerData:
             Turn off optimizations. Defaults to False
         show_gas_estimates: bool, optional
             Show gas estimates for abi and ir output modes
-        no_vyper_signature: bool, optional
-            Do not add vyper signature to bytecode. Defaults to False
+        no_bytecode_metadata: bool, optional
+            Do not add metadata to bytecode. Defaults to False
         """
         self.contract_name = contract_name
         self.source_code = source_code
@@ -83,7 +83,7 @@ class CompilerData:
         self.no_optimize = no_optimize
         self.storage_layout_override = storage_layout
         self.show_gas_estimates = show_gas_estimates
-        self.no_vyper_signature = no_vyper_signature
+        self.no_bytecode_metadata = no_bytecode_metadata
 
     @cached_property
     def vyper_module(self) -> vy_ast.Module:
@@ -146,11 +146,11 @@ class CompilerData:
 
     @cached_property
     def bytecode(self) -> bytes:
-        return generate_bytecode(self.assembly, is_runtime=False, no_vyper_signature=self.no_vyper_signature)
+        return generate_bytecode(self.assembly, is_runtime=False, no_bytecode_metadata=self.no_bytecode_metadata)
 
     @cached_property
     def bytecode_runtime(self) -> bytes:
-        return generate_bytecode(self.assembly_runtime, is_runtime=True, no_vyper_signature=self.no_vyper_signature)
+        return generate_bytecode(self.assembly_runtime, is_runtime=True, no_bytecode_metadata=self.no_bytecode_metadata)
 
     @cached_property
     def blueprint_bytecode(self) -> bytes:
@@ -311,7 +311,7 @@ def _find_nested_opcode(assembly, key):
         return any(_find_nested_opcode(x, key) for x in sublists)
 
 
-def generate_bytecode(assembly: list, is_runtime: bool = False, no_vyper_signature: bool = False) -> bytes:
+def generate_bytecode(assembly: list, is_runtime: bool = False, no_bytecode_metadata: bool = False) -> bytes:
     """
     Generate bytecode from assembly instructions.
 
@@ -325,4 +325,4 @@ def generate_bytecode(assembly: list, is_runtime: bool = False, no_vyper_signatu
     bytes
         Final compiled bytecode.
     """
-    return compile_ir.assembly_to_evm(assembly, insert_vyper_signature=is_runtime, disable_vyper_signature=no_vyper_signature)[0]
+    return compile_ir.assembly_to_evm(assembly, insert_vyper_signature=is_runtime, disable_bytecode_metadata=no_bytecode_metadata)[0]

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -967,7 +967,7 @@ def adjust_pc_maps(pc_maps, ofst):
     return ret
 
 
-def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_vyper_signature=False):
+def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_bytecode_metadata=False):
     """
     Assembles assembly into EVM
 
@@ -991,7 +991,7 @@ def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_v
     runtime_code, runtime_code_start, runtime_code_end = None, None, None
 
     bytecode_suffix = b""
-    if (not disable_vyper_signature) and insert_vyper_signature:
+    if (not disable_bytecode_metadata) and insert_vyper_signature:
         # CBOR encoded: {"vyper": [major,minor,patch]}
         bytecode_suffix += b"\xa1\x65vyper\x83" + bytes(list(version_tuple))
         bytecode_suffix += len(bytecode_suffix).to_bytes(2, "big")
@@ -1008,7 +1008,7 @@ def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_v
     for i, item in enumerate(assembly):
         if isinstance(item, list):
             assert runtime_code is None, "Multiple subcodes"
-            runtime_code, runtime_map = assembly_to_evm(item, insert_vyper_signature=True, disable_vyper_signature=disable_vyper_signature)
+            runtime_code, runtime_map = assembly_to_evm(item, insert_vyper_signature=True, disable_bytecode_metadata=disable_bytecode_metadata)
 
             assert item[0].startswith("_DEPLOY_MEM_OFST_")
             assert ctor_mem_size is None

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -967,7 +967,7 @@ def adjust_pc_maps(pc_maps, ofst):
     return ret
 
 
-def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False):
+def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_vyper_signature=False):
     """
     Assembles assembly into EVM
 
@@ -991,7 +991,7 @@ def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False):
     runtime_code, runtime_code_start, runtime_code_end = None, None, None
 
     bytecode_suffix = b""
-    if insert_vyper_signature:
+    if (not disable_vyper_signature) and insert_vyper_signature:
         # CBOR encoded: {"vyper": [major,minor,patch]}
         bytecode_suffix += b"\xa1\x65vyper\x83" + bytes(list(version_tuple))
         bytecode_suffix += len(bytecode_suffix).to_bytes(2, "big")
@@ -1008,7 +1008,7 @@ def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False):
     for i, item in enumerate(assembly):
         if isinstance(item, list):
             assert runtime_code is None, "Multiple subcodes"
-            runtime_code, runtime_map = assembly_to_evm(item, insert_vyper_signature=True)
+            runtime_code, runtime_map = assembly_to_evm(item, insert_vyper_signature=True, disable_vyper_signature=disable_vyper_signature)
 
             assert item[0].startswith("_DEPLOY_MEM_OFST_")
             assert ctor_mem_size is None

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -967,7 +967,9 @@ def adjust_pc_maps(pc_maps, ofst):
     return ret
 
 
-def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_bytecode_metadata=False):
+def assembly_to_evm(
+    assembly, pc_ofst=0, insert_vyper_signature=False, disable_bytecode_metadata=False
+):
     """
     Assembles assembly into EVM
 
@@ -1008,7 +1010,11 @@ def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False, disable_b
     for i, item in enumerate(assembly):
         if isinstance(item, list):
             assert runtime_code is None, "Multiple subcodes"
-            runtime_code, runtime_map = assembly_to_evm(item, insert_vyper_signature=True, disable_bytecode_metadata=disable_bytecode_metadata)
+            runtime_code, runtime_map = assembly_to_evm(
+                item,
+                insert_vyper_signature=True,
+                disable_bytecode_metadata=disable_bytecode_metadata,
+            )
 
             assert item[0].startswith("_DEPLOY_MEM_OFST_")
             assert ctor_mem_size is None


### PR DESCRIPTION
### What I did

Optionally disable metadata in bytecode

### How I did it

Added the flag `--no-bytecode-metadata` to the cli and pass the parameters in the respective components

### How to verify it

Compile a contract with and without the flag. Bytecode produced will include or not the metadata (e.g. vyper signature) at the end

### Commit message

feat: optionally disable metadata in bytecode

### Description for the changelog

cli: optionally disable metadata in bytecode with `--no-bytecode-metadata`

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8052911/192379144-5b412624-b7ae-49ef-a501-7ebcd512919b.png)

