### PR TITLE
Fix compiler error with public constant lists

### DIFF
--- a/vyper/ast/expansion.py
+++ b/vyper/ast/expansion.py
@@ -42,6 +42,11 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
         # constants just return a value
         if node.is_constant:
             return_stmt = node.value
+            # if the constant is a List we'll need type metadata on
+            # the elements for the codegen
+            if isinstance(return_stmt, vy_ast.List):
+                for element in return_stmt.elements:
+                    element._metadata["type"] = return_type
         elif node.is_immutable:
             return_stmt = vy_ast.Name(id=func_type.name)
         else:

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -226,8 +226,8 @@ def generate_folded_ast(
 
     vyper_module_folded = copy.deepcopy(vyper_module)
     vy_ast.folding.fold(vyper_module_folded)
-    validate_semantics(vyper_module_folded, interface_codes)
     vy_ast.expansion.expand_annotated_ast(vyper_module_folded)
+    validate_semantics(vyper_module_folded, interface_codes)
     symbol_tables = set_data_positions(vyper_module_folded, storage_layout_overrides)
 
     return vyper_module_folded, symbol_tables

--- a/vyper/semantics/types/user/interface.py
+++ b/vyper/semantics/types/user/interface.py
@@ -201,13 +201,6 @@ def _get_module_definitions(base_node: vy_ast.Module) -> Tuple[OrderedDict, Dict
                     # only keep the `ContractFunction` with the longest set of input args
                     continue
             functions[node.name] = func
-    for node in base_node.get_children(vy_ast.VariableDecl, {"is_public": True}):
-        name = node.target.id
-        if name in functions:
-            raise NamespaceCollision(
-                f"Interface contains multiple functions named '{name}'", base_node
-            )
-        functions[name] = ContractFunction.getter_from_VariableDecl(node)
     for node in base_node.get_children(vy_ast.EventDef):
         name = node.name
         if name in functions or name in events:

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -94,7 +94,7 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
         module_node._metadata["type"] = interface
 
         # get list of internal function calls made by each function
-        function_defs = self.ast.get_children(vy_ast.FunctionDef)
+        function_defs = self.ast.get_children(vy_ast.FunctionDef, {'is_immutable': False})
         function_names = set(node.name for node in function_defs)
         for node in function_defs:
             calls_to_self = set(
@@ -241,7 +241,6 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
 
     def visit_FunctionDef(self, node):
         func = ContractFunction.from_FunctionDef(node)
-
         try:
             self.namespace["self"].add_member(func.name, func)
             node._metadata["type"] = func

--- a/vyper/semantics/validation/module.py
+++ b/vyper/semantics/validation/module.py
@@ -242,8 +242,10 @@ class ModuleNodeVisitor(VyperNodeVisitorBase):
     def visit_FunctionDef(self, node):
         func = ContractFunction.from_FunctionDef(node)
         try:
-            self.namespace["self"].add_member(func.name, func)
             node._metadata["type"] = func
+            # skip public getters
+            if not func.is_public:
+                self.namespace["self"].add_member(func.name, func)
         except VyperException as exc:
             raise exc.with_annotation(node) from None
 


### PR DESCRIPTION
### What I did

#3024 allowed the declaration of public constant and immutable variables, however declaring a public constant list like `f: public(constant(uint256[2])) = [1,2]` will cause a compiler error (`vyper.exceptions.CompilerPanic: Type of integer literal is unknown`).

The issue is that the elements of the public constant Lists do not have type information in their `_metadata` so the codegen fails when trying to parse the expressions of the list's elements. This doesn't affect all types. Declaring an array of `bytes1` will work because `parse_Hex` doesn't check the metadata for types (and does some sort of type inference instead). Using BUILTIN_CONSTANTS also works.

I tried to fix this.

### How I did it

I added type metadata for elements of public constant Lists during the creation of public getter functions, using the getter function's return type for the elements' type.

The current fix will not work if using empty values like `empty(address)` when assigning the initial values of the List. (I think I might need to handle this during folding though?)

### How to verify it

Create a contract with a public constant list of addresses or int.

### Commit message

Fix compiler error when declaring public constant lists

### Description for the changelog

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/25791237/193580436-1e4217a0-2d46-42d8-b98c-0588309f16a2.png)
