### PR TITLE
fix: add bytecode metadata option to vyper-json

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -208,6 +208,9 @@ The following example describes the expected input format of ``vyper-json``. Com
             // optional, whether or not optimizations are turned on
             // defaults to true
             "optimize": true,
+            // optional, whether or not the bytecode should include Vyper's signature
+            // defaults to true
+            "bytecodeMetadata": true,
             // The following is used to select desired outputs based on file names.
             // File names are given as keys, a star as a file name matches all files.
             // Outputs can also follow the Solidity format where second level keys

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -354,6 +354,7 @@ def compile_from_input_dict(
 
     evm_version = get_evm_version(input_dict)
     no_optimize = not input_dict["settings"].get("optimize", True)
+    no_bytecode_metadata = not input_dict["settings"].get("bytecodeMetadata", True)
 
     contract_sources: ContractCodes = get_input_dict_contracts(input_dict)
     interface_sources = get_input_dict_interfaces(input_dict)
@@ -377,6 +378,7 @@ def compile_from_input_dict(
                     initial_id=id_,
                     no_optimize=no_optimize,
                     evm_version=evm_version,
+                    no_bytecode_metadata=no_bytecode_metadata,
                 )
             except Exception as exc:
                 return exc_handler(contract_path, exc, "compiler"), {}

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -69,10 +69,6 @@ def _parse_args(argv):
         action="store_true",
     )
 
-    parser.add_argument(
-        "--no-bytecode-metadata", help="Do not add metadata to bytecode.", action="store_true"
-    )
-
     args = parser.parse_args(argv)
     if args.input_file:
         with Path(args.input_file).open() as fh:
@@ -84,9 +80,7 @@ def _parse_args(argv):
 
     exc_handler = exc_handler_raises if args.traceback else exc_handler_to_dict
     output_json = json.dumps(
-        compile_json(
-            input_json, exc_handler, args.root_folder, json_path, args.no_bytecode_metadata
-        ),
+        compile_json(input_json, exc_handler, args.root_folder, json_path),
         indent=2 if args.pretty_json else None,
         sort_keys=True,
         default=str,
@@ -472,9 +466,7 @@ def compile_json(
             input_dict = input_json
 
         try:
-            compiler_data, warn_data = compile_from_input_dict(
-                input_dict, exc_handler, root_path, no_bytecode_metadata
-            )
+            compiler_data, warn_data = compile_from_input_dict(input_dict, exc_handler, root_path)
             if "errors" in compiler_data:
                 return compiler_data
         except KeyError as exc:

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -342,7 +342,6 @@ def compile_from_input_dict(
     input_dict: Dict,
     exc_handler: Callable = exc_handler_raises,
     root_folder: Union[str, None] = None,
-    no_bytecode_metadata: bool = False,
 ) -> Tuple[Dict, Dict]:
     root_path = None
     if root_folder is not None:
@@ -378,7 +377,6 @@ def compile_from_input_dict(
                     initial_id=id_,
                     no_optimize=no_optimize,
                     evm_version=evm_version,
-                    no_bytecode_metadata=no_bytecode_metadata,
                 )
             except Exception as exc:
                 return exc_handler(contract_path, exc, "compiler"), {}
@@ -451,7 +449,6 @@ def compile_json(
     exc_handler: Callable = exc_handler_raises,
     root_path: Union[str, None] = None,
     json_path: Union[str, None] = None,
-    no_bytecode_metadata: bool = False,
 ) -> Dict:
     try:
         if isinstance(input_json, str):

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -69,7 +69,9 @@ def _parse_args(argv):
         action="store_true",
     )
 
-    parser.add_argument("--no-bytecode-metadata", help="Do not add metadata to bytecode.", action="store_true")
+    parser.add_argument(
+        "--no-bytecode-metadata", help="Do not add metadata to bytecode.", action="store_true"
+    )
 
     args = parser.parse_args(argv)
     if args.input_file:
@@ -82,7 +84,9 @@ def _parse_args(argv):
 
     exc_handler = exc_handler_raises if args.traceback else exc_handler_to_dict
     output_json = json.dumps(
-        compile_json(input_json, exc_handler, args.root_folder, json_path, args.no_bytecode_metadata),
+        compile_json(
+            input_json, exc_handler, args.root_folder, json_path, args.no_bytecode_metadata
+        ),
         indent=2 if args.pretty_json else None,
         sort_keys=True,
         default=str,
@@ -468,7 +472,9 @@ def compile_json(
             input_dict = input_json
 
         try:
-            compiler_data, warn_data = compile_from_input_dict(input_dict, exc_handler, root_path, no_bytecode_metadata)
+            compiler_data, warn_data = compile_from_input_dict(
+                input_dict, exc_handler, root_path, no_bytecode_metadata
+            )
             if "errors" in compiler_data:
                 return compiler_data
         except KeyError as exc:


### PR DESCRIPTION
### What I did

Fix #3110.

### How I did it

Add "bytecodeMetadata" as a field under "settings" in JSON files.

### How to verify it

Compile JSON file with and without the "bytecodeMetadata" field under "settings".

### Commit message

```
fix: optionally disable metadata in bytecode for json input
```

### Description for the changelog

Add bytecode matadata option for vyper-json.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.freepik.com/premium-photo/cute-capybara-farm-is-taking-bath_361141-902.jpg?w=2000)
