### PR TITLE
Add explicit error message when specifying default_return_value on void function call

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -130,7 +130,7 @@ class ContractFunction(BaseTypeDefinition):
             "gas": KwargSettings(Uint256Definition(), "gas"),
             "value": KwargSettings(Uint256Definition(), 0),
             "skip_contract_check": KwargSettings(BoolDefinition(), False, require_literal=True),
-            "default_return_value": KwargSettings(return_type, None, require_return=True),
+            "default_return_value": KwargSettings(return_type, None),
         }
 
     def __repr__(self):
@@ -478,7 +478,7 @@ class ContractFunction(BaseTypeDefinition):
         for kwarg in node.keywords:
             if kwarg.arg in self.call_site_kwargs:
                 kwarg_settings = self.call_site_kwargs[kwarg.arg]
-                if kwarg_settings.require_return and self.return_type is None:
+                if kwarg.arg == "default_return_value" and self.return_type is None:
                     raise ArgumentException(
                         f"{kwarg.arg} specified but {self.name} is void", kwarg.value
                     )

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -480,7 +480,8 @@ class ContractFunction(BaseTypeDefinition):
                 kwarg_settings = self.call_site_kwargs[kwarg.arg]
                 if kwarg.arg == "default_return_value" and self.return_type is None:
                     raise ArgumentException(
-                        f"`{kwarg.arg}=` specified but {self.name}() does not return anything", kwarg.value
+                        f"`{kwarg.arg}=` specified but {self.name}() does not return anything",
+                        kwarg.value,
                     )
                 validate_expected_type(kwarg.value, kwarg_settings.typ)
                 if kwarg_settings.require_literal:

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -130,7 +130,7 @@ class ContractFunction(BaseTypeDefinition):
             "gas": KwargSettings(Uint256Definition(), "gas"),
             "value": KwargSettings(Uint256Definition(), 0),
             "skip_contract_check": KwargSettings(BoolDefinition(), False, require_literal=True),
-            "default_return_value": KwargSettings(return_type, None),
+            "default_return_value": KwargSettings(return_type, None, require_return=True),
         }
 
     def __repr__(self):
@@ -478,6 +478,10 @@ class ContractFunction(BaseTypeDefinition):
         for kwarg in node.keywords:
             if kwarg.arg in self.call_site_kwargs:
                 kwarg_settings = self.call_site_kwargs[kwarg.arg]
+                if kwarg_settings.require_return and self.return_type is None:
+                    raise ArgumentException(
+                        f"{kwarg.arg} specified but {self.name} is void", kwarg.value
+                    )
                 validate_expected_type(kwarg.value, kwarg_settings.typ)
                 if kwarg_settings.require_literal:
                     if not isinstance(kwarg.value, vy_ast.Constant):

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -480,7 +480,7 @@ class ContractFunction(BaseTypeDefinition):
                 kwarg_settings = self.call_site_kwargs[kwarg.arg]
                 if kwarg.arg == "default_return_value" and self.return_type is None:
                     raise ArgumentException(
-                        f"{kwarg.arg} specified but {self.name} is void", kwarg.value
+                        f"{kwarg.arg} specified but {self.name} does not return anything", kwarg.value
                     )
                 validate_expected_type(kwarg.value, kwarg_settings.typ)
                 if kwarg_settings.require_literal:

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -480,7 +480,7 @@ class ContractFunction(BaseTypeDefinition):
                 kwarg_settings = self.call_site_kwargs[kwarg.arg]
                 if kwarg.arg == "default_return_value" and self.return_type is None:
                     raise ArgumentException(
-                        f"{kwarg.arg} specified but {self.name} does not return anything", kwarg.value
+                        f"`{kwarg.arg}=` specified but {self.name}() does not return anything", kwarg.value
                     )
                 validate_expected_type(kwarg.value, kwarg_settings.typ)
                 if kwarg_settings.require_literal:

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -22,15 +22,12 @@ class KwargSettings:
     # contains the `default` value for the kwarg as a python value, and a
     # flag `require_literal`, which, when True, indicates that the kwarg
     # must be set to a compile-time constant at any call site.
-    # The `require_return` flag indicates that the call needs to return
-    # a value
     # (note that the kwarg processing machinery will return a
     # Python value instead of an AST or IRnode in this case).
-    def __init__(self, typ, default, require_literal=False, require_return=False):
+    def __init__(self, typ, default, require_literal=False):
         self.typ = typ
         self.default = default
         self.require_literal = require_literal
-        self.require_return = require_return
 
 
 class TypeTypeDefinition:

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -22,12 +22,15 @@ class KwargSettings:
     # contains the `default` value for the kwarg as a python value, and a
     # flag `require_literal`, which, when True, indicates that the kwarg
     # must be set to a compile-time constant at any call site.
+    # The `require_return` flag indicates that the call needs to return
+    # a value
     # (note that the kwarg processing machinery will return a
     # Python value instead of an AST or IRnode in this case).
-    def __init__(self, typ, default, require_literal=False):
+    def __init__(self, typ, default, require_literal=False, require_return=False):
         self.typ = typ
         self.default = default
         self.require_literal = require_literal
+        self.require_return = require_return
 
 
 class TypeTypeDefinition:


### PR DESCRIPTION
### What I did

When specifying the `default_return_value` on a call to a void external function, the compiler currently only returns the following error message `AttributeError: 'NoneType' object has no attribute 'compare_type'`. 
I added a more explicit exception so that the error can be caught and addressed more easily.

### How I did it

I added a check for a return type when `default_return_value` is set. If there's no return type, an `ArgumentException` is raised.

### How to verify it

Compiling this contract:

```
interface FooBar:
    def foo(): payable

@external
def bar():
    FooBar(empty(address)).foo(default_return_value=True)
```

will now generate the following error:

```
vyper.exceptions.ArgumentException: default_return_value specified but foo is void
  contract "dist/simple.vy:6", function "bar", line 6:52 
       5 def bar():
  ---> 6     FooBar(empty(address)).foo(default_return_value=True)
  -----------------------------------------------------------^
       7
```

### Commit message

Exception when setting default_return_value on void function call

### Description for the changelog

Add explicit error message when specifying default_return_value on void function call

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/195340764-8844881f-307e-44c4-99cc-1a089ee13029.png)

