### PR TITLE
Document optional kwargs for external calls

### DIFF
--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -73,7 +73,7 @@ The ``default_return_value`` parameter can be used to handle ERC20 tokens affect
 .. code-block:: python
 
     ERC20(USDT).transfer(msg.sender, 1, default_return_value=True) # returns True
-    ERC20(USDT).transfer(msg.sender, 1) # reverts
+    ERC20(USDT).transfer(msg.sender, 1) # reverts because nothing returned
 
 Importing Interfaces
 ====================

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -57,6 +57,24 @@ Specifying ``payable`` or ``nonpayable`` annotation indicates that the call made
         foobar.update()  # storage can be altered
         foobar.pay(value=1)  # storage can be altered, and value can be sent
 
+Vyper offers the option to set the following additional keyword arguments when making external calls:
+
+=============================== ===========================================================
+Keyword                         Description
+=============================== ===========================================================
+``gas``                         Specify gas value for the call
+``value``                       Specify amount of ether sent with the call
+``skip_contract_check``         Drop ``EXTCODESIZE`` and ``RETURNDATASIZE`` checks
+``default_return_value``        Specify a default return value if no value is returned
+=============================== ===========================================================
+
+The ``default_return_value`` parameter can be used to handle ERC20 tokens affected by the missing return value bug in a way similar to OpenZeppelin's ``safeTransfer`` for Solidity:
+
+.. code-block:: python
+
+    ERC20(USDT).transfer(msg.sender, 1, default_return_value=True) # returns True
+    ERC20(USDT).transfer(msg.sender, 1) # reverts
+
 Importing Interfaces
 ====================
 


### PR DESCRIPTION
### What I did

Added a description of the different kwargs that can be passed with an external call to the `Interfaces/Declaring and using Interfaces` section of the docs.

### How I did it

Edited `docs/interfaces.rst`

### Commit message

Document optional kwargs for external calls

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/195545453-9a1dcd0d-a341-4494-a036-af819682f4b0.png)