### PR TITLE
Raise exception on internal payable function declaration

### DIFF
--- a/tests/parser/features/decorators/test_payable.py
+++ b/tests/parser/features/decorators/test_payable.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vyper.exceptions import CallViolation
+from vyper.exceptions import CallViolation, FunctionDeclarationException
 
 
 @pytest.mark.parametrize(
@@ -368,4 +368,18 @@ def __default__():
     w3.eth.send_transaction({"to": c.address, "value": 0, "data": "0x12345678"})
     assert_tx_failed(
         lambda: w3.eth.send_transaction({"to": c.address, "value": 100, "data": "0x12345678"})
+    )
+
+
+def test_invalid_conflicting_decorators(get_contract, assert_compile_failed):
+    assert_compile_failed(
+        lambda: get_contract(
+            """
+@internal
+@payable
+def foo():
+    pass
+    """
+        ),
+        FunctionDeclarationException,
     )

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -300,6 +300,12 @@ class ContractFunction(BaseTypeDefinition):
         if kwargs["state_mutability"] == StateMutability.PURE and "nonreentrant" in kwargs:
             raise StructureException("Cannot use reentrancy guard on pure functions", node)
 
+        if (
+            kwargs["state_mutability"] == StateMutability.PAYABLE
+            and kwargs["function_visibility"] == FunctionVisibility.INTERNAL
+        ):
+            raise FunctionDeclarationException("Internal functions can't be payable", node)
+
         # call arguments
         if node.args.defaults and node.name == "__init__":
             raise FunctionDeclarationException(


### PR DESCRIPTION
### What I did

Added an exception when a function is declared as both `payable` and `internal` as reported in #3099 (`pure` functions are also mentioned in the issue but are now already prevented from being declared `payable`).

### How I did it

Check function visibility and state mutability during validation and raise a `FunctionDeclarationException` exception if a function is found to be both `payable` and `internal`.

### How to verify it

Run the `test_invalid_conflicting_decorators` test added to `tests/parser/features/decorators/test_payable.py`.

### Commit message

Raise exception on internal payable function declaration

### Description for the changelog

Prevent internal functions from being declared as payable

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/195583385-3075316c-5768-4c92-b503-91c32bf093f1.png)

