### PR TITLE
fix: improve error message for immutable struct members modification

### DIFF
--- a/tests/parser/syntax/test_immutables.py
+++ b/tests/parser/syntax/test_immutables.py
@@ -156,6 +156,23 @@ def report():
     """,
         "'imm' is not a storage variable, it should not be prepended with self",
     ),
+    (
+        """
+struct Foo:
+    a : uint256
+
+x: immutable(Foo)
+
+@external
+def __init__():
+    x = Foo({a:1})
+
+@external
+def hello() :
+    x.a =  2
+    """,
+        "Immutable value cannot be written to",
+    ),
 ]
 
 

--- a/vyper/semantics/types/user/struct.py
+++ b/vyper/semantics/types/user/struct.py
@@ -80,6 +80,14 @@ class StructPrimitive:
     ) -> StructDefinition:
         if not isinstance(node, vy_ast.Name):
             raise StructureException("Invalid type assignment", node)
+
+        for _, member_type in self.members.items():
+            # Propagate `is_constant` and `is_immutable` to struct members
+            # `is_public` can be skipped because public getter does not need to be
+            # generated for struct member
+            member_type.is_constant = is_constant
+            member_type.is_immutable = is_immutable
+
         return StructDefinition(
             self._id, self.members, location, is_constant, is_public, is_immutable
         )


### PR DESCRIPTION
### What I did

Fix #3125 

### How I did it

Propagate `is_constant` and `is_immutable` from a struct definition to its member type definitions. `is_public` is skipped since we do not need to generate public getters for struct members even if they were public immutables.

### How to verify it

See added test.

### Commit message

fix: improve error message for immutable struct members modification

### Description for the changelog

Improve error message for immutable struct members modification

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.looper.com/img/gallery/gollums-entire-backstory-explained/intro-1584137078.jpg)
