### PR TITLE
Use _expr in array definitions

### DIFF
--- a/vyper/ast/grammar.lark
+++ b/vyper/ast/grammar.lark
@@ -80,8 +80,8 @@ enum_body: _NEWLINE _INDENT (enum_member _NEWLINE)+ _DEDENT
 enum_def: _ENUM_DECL NAME ":" enum_body
 
 // Types
-array_def: (NAME | array_def | dyn_array_def) "[" (DEC_NUMBER | NAME) "]"
-dyn_array_def: "DynArray" "[" (NAME | array_def | dyn_array_def) "," (DEC_NUMBER | NAME) "]"
+array_def: (NAME | array_def | dyn_array_def) "[" _expr "]"
+dyn_array_def: "DynArray" "[" (NAME | array_def | dyn_array_def) "," _expr "]"
 tuple_def: "(" ( NAME | array_def | dyn_array_def | tuple_def ) ( "," ( NAME | array_def | dyn_array_def | tuple_def ) )* [","] ")"
 // NOTE: Map takes a basic type and maps to another type (can be non-basic, including maps)
 _MAP: "HashMap"


### PR DESCRIPTION
### What I did

Modified the lark grammar to support expressions when specifying array length on definition.
For instance trying to parse the following valid Vyper code with lark:

```a: public((uint256[4 & 4]))```

or 

```
B: constant(uint256) = 2
c: DynArray[uint256, B**2]

@external
def __init__(
    initial_prices: uint256[3+B-2%1]
):
    pass
```

Will currently raise an `UnexpectedToken` exception

### How I did it

Replaced `(DEC_NUMBER | NAME)` with `_expr` in `grammar.lark` for `array_def` and `dyn_array_def`

### How to verify it

Parsing the following code:
```
a: public((uint256[4 & 4]))
B: constant(uint256) = 2
c: DynArray[uint256, B**2]

@external
def __init__(
    initial_prices: uint256[3+B-2%1]
):
    pass
```

Properly returns the following tree:

```
Tree(Token('RULE', 'module'), [Tree(Token('RULE', 'variable_def'), [Tree(Token('RULE', 'variable_with_getter'), [Token('NAME', 'a'), Tree(Token('RULE', 'type'), [Tree(Token('RULE', 'tuple_def'), [Tree(Token('RULE', 'array_def'), [Token('NAME', 'uint256'), Tree('bitand', [Token('DEC_NUMBER', '4'), Token('DEC_NUMBER', '4')])])])])])]), Tree(Token('RULE', 'constant_def'), [Tree(Token('RULE', 'constant_private'), [Token('NAME', 'B'), Tree(Token('RULE', 'constant'), [Tree(Token('RULE', 'type'), [Token('NAME', 'uint256')])])]), Token('DEC_NUMBER', '2')]), Tree(Token('RULE', 'variable_def'), [Tree(Token('RULE', 'variable'), [Token('NAME', 'c'), Tree(Token('RULE', 'type'), [Tree(Token('RULE', 'dyn_array_def'), [Token('NAME', 'uint256'), Tree('pow', [Tree('get_var', [Token('NAME', 'B')]), Token('DEC_NUMBER', '2')])])])])]), Tree(Token('RULE', 'function_def'), [Tree(Token('RULE', 'decorators'), [Tree(Token('RULE', 'decorator'), [Token('NAME', 'external')])]), Tree(Token('RULE', 'function_sig'), [Token('NAME', '__init__'), Tree(Token('RULE', 'parameters'), [Tree(Token('RULE', 'parameter'), [Token('NAME', 'initial_prices'), Tree(Token('RULE', 'type'), [Tree(Token('RULE', 'array_def'), [Token('NAME', 'uint256'), Tree('sub', [Tree('add', [Token('DEC_NUMBER', '3'), Tree('get_var', [Token('NAME', 'B')])]), Tree('mod', [Token('DEC_NUMBER', '2'), Token('DEC_NUMBER', '1')])])])])])])]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'pass_stmt'), [])])])])
```

### Commit message

Use _expr in array definitions in lark grammar

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/198283174-16f4fd1c-3751-4d82-8f24-d40b3c6bbce2.png)
