### PR TITLE
fix: improve error message for conflicting methods IDs

### DIFF
--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -529,5 +529,9 @@ def validate_unique_method_ids(functions: List) -> None:
     method_ids = [x for i in functions for x in i.method_ids.values()]
     collision = next((i for i in method_ids if method_ids.count(i) > 1), None)
     if collision:
-        collision_str = ", ".join(x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == collision)
-        raise StructureException(f"Methods produce colliding method ID `{hex(collision)}`: {collision_str}")
+        collision_str = ", ".join(
+            x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == collision
+        )
+        raise StructureException(
+            f"Methods produce colliding method ID `{hex(collision)}`: {collision_str}"
+        )

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -529,5 +529,5 @@ def validate_unique_method_ids(functions: List) -> None:
     method_ids = [x for i in functions for x in i.method_ids.values()]
     collision = next((i for i in method_ids if method_ids.count(i) > 1), None)
     if collision:
-        collision_str = ", ".join(i.name for i in functions if collision in i.method_ids)
+        collision_str = ", ".join(i.name for i in functions if collision in i.method_ids.values())
         raise StructureException(f"Methods have conflicting IDs: {collision_str}")

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -29,7 +29,7 @@ from vyper.semantics.types.value.address import AddressDefinition
 from vyper.semantics.types.value.boolean import BoolDefinition
 from vyper.semantics.types.value.bytes_fixed import Bytes20Definition  # type: ignore
 from vyper.semantics.validation.levenshtein_utils import get_levenshtein_error_suggestions
-from vyper.utils import checksum_encode
+from vyper.utils import checksum_encode, int_to_fourbytes
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -532,6 +532,7 @@ def validate_unique_method_ids(functions: List) -> None:
         collision_str = ", ".join(
             x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == collision
         )
+        collision_hex = int_to_fourbytes(collision).hex()
         raise StructureException(
-            f"Methods produce colliding method ID `{hex(collision)}`: {collision_str}"
+            f"Methods produce colliding method ID `0x{collision_hex}`: {collision_str}"
         )

--- a/vyper/semantics/validation/utils.py
+++ b/vyper/semantics/validation/utils.py
@@ -529,5 +529,5 @@ def validate_unique_method_ids(functions: List) -> None:
     method_ids = [x for i in functions for x in i.method_ids.values()]
     collision = next((i for i in method_ids if method_ids.count(i) > 1), None)
     if collision:
-        collision_str = ", ".join(i.name for i in functions if collision in i.method_ids.values())
-        raise StructureException(f"Methods have conflicting IDs: {collision_str}")
+        collision_str = ", ".join(x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == collision)
+        raise StructureException(f"Methods produce colliding method ID `{hex(collision)}`: {collision_str}")

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -50,7 +50,7 @@ def fourbytes_to_int(inp):
 
 
 # Converts an integer to four bytes
-def int_to_fourbytes(n: int):
+def int_to_fourbytes(n: int) -> bytes:
     assert n < 2 ** 32
     return n.to_bytes(4, byteorder="big")
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -49,6 +49,12 @@ def fourbytes_to_int(inp):
     return (inp[0] << 24) + (inp[1] << 16) + (inp[2] << 8) + inp[3]
 
 
+# Converts an integer to four bytes
+def int_to_fourbytes(n: int):
+    assert n < 2 ** 32
+    return n.to_bytes(4, byteorder="big")
+
+
 def signed_to_unsigned(int_, bits, strict=False):
     """
     Reinterpret a signed integer with n bits as an unsigned integer.


### PR DESCRIPTION
### What I did
Fix #3133 

### How I did it
I modified `collision_str` in `validate_unique_method_ids` so that we look for the collision ID in lists of IDs instead of looking for it in lists of function signature

### How to verify it
Trying to compile the following contract will now output the name of the functions having a collision:
```Vyper
@external
def OwnerTransferV7b711143(a : uint256) : 
    pass
@external
def withdraw(a : uint256):
    pass

```
### Commit message
fix: improve error message for conflicting methods IDs

### Description for the changelog
Improve error message for conflicting methods IDs

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/5xd9tf1wfi681.jpg?width=960&crop=smart&auto=webp&s=52432dffb939742855f9ffa0cf5eb9b2c31263e7)
