### PR TITLE
chore: fix typo in annotation.py

### DIFF
--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -179,7 +179,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         Python uses `Num` to represent floats and integers. Integers may also
         be given in binary, octal, decimal, or hexadecimal format. This method
-        modifies `ast_type` to seperate `Num` into more granular Vyper node
+        modifies `ast_type` to separate `Num` into more granular Vyper node
         classes.
         """
         # modify vyper AST type according to the format of the literal value


### PR DESCRIPTION


### What I did

Fixed typo.
```
seperate -> separate
```



### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/22633385/198870676-4d200a45-0cf7-41bf-96e4-a119238d3760.png)



