### PR TITLE
Raw revert for custom errors

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -259,7 +259,7 @@ Vyper has three built-ins for contract creation; all three contract creation bui
             assert success
             return response
 
-.. py:function:: raw_log(topics: bytes32[4], data: Union[Bytes, bytes32]) -> None
+.. py:function:: raw_log(data: Union[Bytes, bytes32]) -> None
 
     Provides low level access to the ``LOG`` opcodes, emitting a log without having to specify an ABI type.
 
@@ -271,6 +271,18 @@ Vyper has three built-ins for contract creation; all three contract creation bui
         @external
         def foo(_topic: bytes32, _data: Bytes[100]):
             raw_log([_topic], _data)
+
+.. py:function:: raw_revert(topics: bytes32[4], data: Bytes) -> None
+
+    Provides low level access to the ``REVERT`` opcode, reverting execution with the specified data returned.
+
+    * ``data``: Data representing the error message causing the revert.
+
+    .. code-block:: python
+
+        @external
+        def foo(_data: Bytes[100]):
+            raw_revert(_data)
 
 .. py:function:: selfdestruct(to: address) -> None
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -259,7 +259,7 @@ Vyper has three built-ins for contract creation; all three contract creation bui
             assert success
             return response
 
-.. py:function:: raw_log(data: Union[Bytes, bytes32]) -> None
+.. py:function:: raw_log(topics: bytes32[4], data: Union[Bytes, bytes32]) -> None
 
     Provides low level access to the ``LOG`` opcodes, emitting a log without having to specify an ABI type.
 
@@ -272,7 +272,7 @@ Vyper has three built-ins for contract creation; all three contract creation bui
         def foo(_topic: bytes32, _data: Bytes[100]):
             raw_log([_topic], _data)
 
-.. py:function:: raw_revert(topics: bytes32[4], data: Bytes) -> None
+.. py:function:: raw_revert(data: Bytes) -> None
 
     Provides low level access to the ``REVERT`` opcode, reverting execution with the specified data returned.
 

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -1,10 +1,47 @@
+import re
+
 import pytest
+from eth_abi import encode
 from eth_tester.exceptions import TransactionFailed
+
+from vyper.utils import keccak256
 
 pytestmark = pytest.mark.usefixtures("memory_mocker")
 
 
+def build_revert_bytestring(errorDecl, *data):
+    # revert bytes should be 4-byte selector (from keccak of error definition)
+    # followed by abi-encoded data
+    error_selector = keccak256(bytes(errorDecl, "utf-8"))[:4]
+    match = re.search(r"\((.*?)\)", errorDecl)  # .group(1)
+    if match and match.group(1) != "":
+        arg_types = match.group(1)
+        encoded_data = encode(arg_types.split(","), data)
+        return b"".join([error_selector, encoded_data])
+    else:
+        return error_selector
+
+
 def test_revert_reason(w3, assert_tx_failed, tester, keccak, get_contract_with_gas_estimation):
+    reverty_code = """
+@external
+def foo():
+    data: Bytes[4] = method_id("NoFives()")
+    raw_revert(data)
+    """
+
+    revert_bytes = build_revert_bytestring("NoFives()")
+
+    assert_tx_failed(
+        lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),
+        TransactionFailed,
+        exc_text=f"execution reverted: {revert_bytes}",
+    )
+
+
+def test_revert_reason_typed(
+    w3, assert_tx_failed, tester, keccak, get_contract_with_gas_estimation
+):
     reverty_code = """
 @external
 def foo():
@@ -13,14 +50,10 @@ def foo():
     raw_revert(data)
     """
 
+    revert_bytes = build_revert_bytestring("NoFives(uint256)", 5)
+
     assert_tx_failed(
         lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),
         TransactionFailed,
-        exc_text=(
-            "execution reverted: "
-            "b'.\\x7f\\xb9\\x1f"
-            "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00"
-            "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00"
-            "\\x00\\x00\\x00\\x05'"
-        ),
+        exc_text=f"execution reverted: {revert_bytes}",
     )

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -1,11 +1,6 @@
-from decimal import Decimal
-
-import eth_abi
 import pytest
 
 from eth_tester.exceptions import TransactionFailed
-
-from vyper.utils import keccak256
 
 pytestmark = pytest.mark.usefixtures("memory_mocker")
 
@@ -22,5 +17,11 @@ def foo():
     assert_tx_failed(
         lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),
         TransactionFailed,
-        exc_text="execution reverted: b'.\\x7f\\xb9\\x1f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05'",
+        exc_text=(
+            "execution reverted: "
+            "b'.\\x7f\\xb9\\x1f"
+            "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00"
+            "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00"
+            "\\x00\\x00\\x00\\x05'"
+        ),
     )

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -1,13 +1,10 @@
 import pytest
+from eth_abi import encode_single
 from eth_tester.exceptions import TransactionFailed
 
-from vyper.utils import keccak256
+from vyper.utils import method_id
 
 pytestmark = pytest.mark.usefixtures("memory_mocker")
-
-
-def method_id(method_str: str) -> bytes:
-    return keccak256(bytes(method_str, "utf-8"))[:4]
 
 
 def test_revert_reason(w3, assert_tx_failed, get_contract_with_gas_estimation):
@@ -53,7 +50,7 @@ def foo():
     raw_revert(_abi_encode(val, method_id=method_id("NoFives(uint256)")))
     """
 
-    revert_bytes = method_id("NoFives(uint256)") + (5).to_bytes(32, "big")
+    revert_bytes = method_id("NoFives(uint256)") + encode_single("(uint256)", [5])
 
     assert_tx_failed(
         lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -43,3 +43,20 @@ def foo():
         TransactionFailed,
         exc_text=f"execution reverted: {revert_bytes}",
     )
+
+
+def test_revert_reason_typed_no_variable(w3, assert_tx_failed, get_contract_with_gas_estimation):
+    reverty_code = """
+@external
+def foo():
+    val: uint256 = 5
+    raw_revert(_abi_encode(val, method_id=method_id("NoFives(uint256)")))
+    """
+
+    revert_bytes = method_id("NoFives(uint256)") + (5).to_bytes(32, "big")
+
+    assert_tx_failed(
+        lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),
+        TransactionFailed,
+        exc_text=f"execution reverted: {revert_bytes}",
+    )

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -1,5 +1,4 @@
 import pytest
-
 from eth_tester.exceptions import TransactionFailed
 
 pytestmark = pytest.mark.usefixtures("memory_mocker")

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -33,7 +33,7 @@ def foo():
     raw_revert(data)
     """
 
-    revert_bytes = method_id("NoFives(uint256)") + (5).to_bytes(32, "big")
+    revert_bytes = method_id("NoFives(uint256)") + encode_single("(uint256)", [5])
 
     assert_tx_failed(
         lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),

--- a/tests/parser/features/test_reverting.py
+++ b/tests/parser/features/test_reverting.py
@@ -1,0 +1,26 @@
+from decimal import Decimal
+
+import eth_abi
+import pytest
+
+from eth_tester.exceptions import TransactionFailed
+
+from vyper.utils import keccak256
+
+pytestmark = pytest.mark.usefixtures("memory_mocker")
+
+
+def test_revert_reason(w3, assert_tx_failed, tester, keccak, get_contract_with_gas_estimation):
+    reverty_code = """
+@external
+def foo():
+    val: uint256 = 5
+    data: Bytes[100] = _abi_encode(val, method_id=method_id("NoFives(uint256)"))
+    raw_revert(data)
+    """
+
+    assert_tx_failed(
+        lambda: get_contract_with_gas_estimation(reverty_code).foo(transact={}),
+        TransactionFailed,
+        exc_text="execution reverted: b'.\\x7f\\xb9\\x1f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05'",
+    )

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1312,10 +1312,11 @@ class RawRevert(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        input_buf = ensure_in_memory(args[0], context)
+        error_data_buf = ensure_in_memory(args[0], context)
+        data = bytes_data_ptr(error_data_buf)
+        len_ = get_bytearray_length(error_data_buf)
         return IRnode.from_list(
-            ["with", "_sub", input_buf
-             ["revert", ["add", "_sub", 32], ["mload", "_sub"]]]
+           ["revert", data, len_]
         )
 
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1310,6 +1310,11 @@ class RawRevert(BuiltinFunction):
     def fetch_call_return(self, node):
         return None
 
+    def infer_arg_types(self, node):
+        self._validate_arg_types(node)
+        data_type = get_possible_types_from_node(node.args[0]).pop()
+        return [data_type]
+
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as (

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1317,12 +1317,9 @@ class RawRevert(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as (
-            b,
-            error_data_buf,
-        ):
-            data = bytes_data_ptr(error_data_buf)
-            len_ = get_bytearray_length(error_data_buf)
+        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as (b, buf):
+            data = bytes_data_ptr(buf)
+            len_ = get_bytearray_length(buf)
             return b.resolve(IRnode.from_list(["revert", data, len_]))
 
 

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1312,7 +1312,12 @@ class RawRevert(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        pass
+        input_buf = ensure_in_memory(args[0], context)
+        return IRnode.from_list(
+            ["with", "_sub", input_buf
+             ["revert", ["add", "_sub", 32], ["mload", "_sub"]]]
+        )
+
 
 class RawLog(BuiltinFunction):
 
@@ -2711,6 +2716,7 @@ STMT_DISPATCH_TABLE = {
     "selfdestruct": SelfDestruct(),
     "raw_call": RawCall(),
     "raw_log": RawLog(),
+    "raw_revert": RawRevert(),
     "create_minimal_proxy_to": CreateMinimalProxyTo(),
     "create_forwarder_to": CreateForwarderTo(),
     "create_copy_of": CreateCopyOf(),

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1312,10 +1312,10 @@ class RawRevert(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as error_data_buf:
-            data = bytes_data_ptr(error_data_buf[1])
-            len_ = get_bytearray_length(error_data_buf[1])
-            return IRnode.from_list(["revert", data, len_])
+        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as (b, error_data_buf):
+            data = bytes_data_ptr(error_data_buf)
+            len_ = get_bytearray_length(error_data_buf)
+            return b.resolve(IRnode.from_list(["revert", data, len_]))
 
 
 class RawLog(BuiltinFunction):

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1312,7 +1312,10 @@ class RawRevert(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as (b, error_data_buf):
+        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as (
+            b,
+            error_data_buf,
+        ):
             data = bytes_data_ptr(error_data_buf)
             len_ = get_bytearray_length(error_data_buf)
             return b.resolve(IRnode.from_list(["revert", data, len_]))

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1315,9 +1315,7 @@ class RawRevert(BuiltinFunction):
         error_data_buf = ensure_in_memory(args[0], context)
         data = bytes_data_ptr(error_data_buf)
         len_ = get_bytearray_length(error_data_buf)
-        return IRnode.from_list(
-           ["revert", data, len_]
-        )
+        return IRnode.from_list(["revert", data, len_])
 
 
 class RawLog(BuiltinFunction):

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1305,17 +1305,17 @@ class BlockHash(BuiltinFunction):
 class RawRevert(BuiltinFunction):
 
     _id = "raw_revert"
-    _inputs = [("data", BytesAbstractType())]
+    _inputs = [("data", ArrayValueAbstractType())]
 
     def fetch_call_return(self, node):
         return None
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        error_data_buf = ensure_in_memory(args[0], context)
-        data = bytes_data_ptr(error_data_buf)
-        len_ = get_bytearray_length(error_data_buf)
-        return IRnode.from_list(["revert", data, len_])
+        with ensure_in_memory(args[0], context).cache_when_complex("err_buf") as error_data_buf:
+            data = bytes_data_ptr(error_data_buf[1])
+            len_ = get_bytearray_length(error_data_buf[1])
+            return IRnode.from_list(["revert", data, len_])
 
 
 class RawLog(BuiltinFunction):

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -1302,6 +1302,18 @@ class BlockHash(BuiltinFunction):
         )
 
 
+class RawRevert(BuiltinFunction):
+
+    _id = "raw_revert"
+    _inputs = [("data", BytesAbstractType())]
+
+    def fetch_call_return(self, node):
+        return None
+
+    @process_inputs
+    def build_IR(self, expr, args, kwargs, context):
+        pass
+
 class RawLog(BuiltinFunction):
 
     _id = "raw_log"

--- a/vyper/builtin_functions/functions.py
+++ b/vyper/builtin_functions/functions.py
@@ -108,11 +108,11 @@ from vyper.utils import (
     SHA3_PER_WORD,
     MemoryPositions,
     SizeLimits,
-    abi_method_id,
     bytes_to_int,
     ceil32,
     fourbytes_to_int,
     keccak256,
+    method_id_int,
     vyper_warn,
 )
 
@@ -746,7 +746,7 @@ class MethodID(FoldedFunction):
             raise InvalidLiteral("Invalid function signature - no spaces allowed.")
 
         return_type = self.infer_kwarg_types(node)
-        value = abi_method_id(args[0].value)
+        value = method_id_int(args[0].value)
 
         if isinstance(return_type, Bytes4Definition):
             return vy_ast.Hex.from_node(node, value=hex(value))
@@ -2345,7 +2345,7 @@ class Print(BuiltinFunction):
         sig = "log" + "(" + ",".join([arg.typ.abi_type.selector_name() for arg in args]) + ")"
 
         if kwargs["hardhat_compat"] is True:
-            method_id = abi_method_id(sig)
+            method_id = method_id_int(sig)
             buflen = 32 + args_abi_t.size_bound()
 
             # 32 bytes extra space for the method id
@@ -2356,7 +2356,7 @@ class Print(BuiltinFunction):
             encode = abi_encode(buf + 32, args_as_tuple, context, buflen, returns_len=True)
 
         else:
-            method_id = abi_method_id("log(string,bytes)")
+            method_id = method_id_int("log(string,bytes)")
             schema = args_abi_t.selector_name().encode("utf-8")
             if len(schema) > 32:
                 raise CompilerPanic("print signature too long: {schema}")

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -69,7 +69,7 @@ def _pack_arguments(fn_type, args, context):
     # to buf (and also keep code size small) by using
     # (mstore buf (shl signature.method_id 224))
     pack_args = ["seq"]
-    pack_args.append(["mstore", buf, util.abi_method_id(abi_signature)])
+    pack_args.append(["mstore", buf, util.method_id_int(abi_signature)])
 
     if len(args) != 0:
         pack_args.append(abi_encode(buf + 32, args_as_tuple, context, bufsz=buflen))

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -55,7 +55,7 @@ def _register_function_args(context: Context, sig: FunctionSignature) -> List[IR
 
 
 def _annotated_method_id(abi_sig):
-    method_id = util.abi_method_id(abi_sig)
+    method_id = util.method_id_int(abi_sig)
     annotation = f"{hex(method_id)}: {abi_sig}"
     return IRnode(method_id, annotation=annotation)
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -190,7 +190,7 @@ class Stmt:
             instantiate_msg = msg_ir
 
         # offset of bytes in (bytes,)
-        method_id = util.abi_method_id("Error(string)")
+        method_id = util.method_id_int("Error(string)")
 
         # abi encode method_id + bytestring
         assert buf >= 36, "invalid buffer"

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -107,7 +107,8 @@ def vyper_warn(msg, prefix="Warning: ", file_=sys.stderr):
 # converts a signature like Func(bool,uint256,address) to its 4 byte method ID
 # TODO replace manual calculations in codebase with this
 def method_id_int(method_sig: str) -> int:
-    return fourbytes_to_int(keccak256(bytes(method_sig, "utf-8"))[:4])
+    method_id_bytes = method_id(method_sig)
+    return fourbytes_to_int(method_id_bytes)
 
 
 def method_id(method_str: str) -> bytes:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -106,7 +106,7 @@ def vyper_warn(msg, prefix="Warning: ", file_=sys.stderr):
 
 # converts a signature like Func(bool,uint256,address) to its 4 byte method ID
 # TODO replace manual calculations in codebase with this
-def method_id_int(method_sig) -> int:
+def method_id_int(method_sig: str) -> int:
     return fourbytes_to_int(keccak256(bytes(method_sig, "utf-8"))[:4])
 
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -110,6 +110,10 @@ def abi_method_id(method_sig):
     return fourbytes_to_int(keccak256(bytes(method_sig, "utf-8"))[:4])
 
 
+def method_id(method_str: str) -> bytes:
+    return keccak256(bytes(method_str, "utf-8"))[:4]
+
+
 # map a string to only-alphanumeric chars
 def mkalphanum(s):
     return "".join([c if c.isalnum() else "_" for c in s])

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -106,7 +106,7 @@ def vyper_warn(msg, prefix="Warning: ", file_=sys.stderr):
 
 # converts a signature like Func(bool,uint256,address) to its 4 byte method ID
 # TODO replace manual calculations in codebase with this
-def abi_method_id(method_sig):
+def method_id_int(method_sig) -> int:
     return fourbytes_to_int(keccak256(bytes(method_sig, "utf-8"))[:4])
 
 


### PR DESCRIPTION
### What I did
Added `raw_revert` as a builtin function, working similarly to `raw_log` and `raw_call`

### How I did it
Created a new `RawRevert` class. This represents a built-in function that stores any data passed to it to memory, and then passes the right `offset` and `size` to `revert` in IR.

### How to verify it
Run ` ./quicktest.sh tests/parser/features/test_reverting.py`

I also tested this in Foundry using VyperDeployer and verified that custom errors coming from solidity and the equivalent vyper `raw_revert` arguments created the same error data

### Commit message

Implement `raw_revert` built-in function

### Description for the changelog

Add `raw_revert`

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.squarespace-cdn.com/content/v1/5b7d4626f2e6b181437ede20/1628877962791-AEA5IMZOCB9S227WKPTF/pikapie2.jpg?format=1000w)
