### PR TITLE
Update lark grammar to parse single line control flow statements

### DIFF
--- a/vyper/ast/grammar.lark
+++ b/vyper/ast/grammar.lark
@@ -105,7 +105,8 @@ interface_def: _INTERFACE_DECL NAME ":" _NEWLINE _INDENT ( interface_function _N
 // Conversely, the rest of the statements require a newline to be considered complete
 // (as they do not create a new block)
 _stmt: ( if_stmt | for_stmt ) [COMMENT]
-     | (declaration
+     | _simple_stmt
+_simple_stmt: (declaration
        | assign
        | aug_assign
        | return_stmt
@@ -160,7 +161,7 @@ assert_stmt: _ASSERT _expr -> assert
            | _ASSERT _expr "," _expr -> assert_with_reason
            | _ASSERT _expr "," _UNREACHABLE -> assert_unreachable
 
-body: _NEWLINE _INDENT ([COMMENT] _NEWLINE | _stmt)+ _DEDENT
+body: _simple_stmt | _NEWLINE _INDENT ([COMMENT] _NEWLINE | _stmt)+ _DEDENT
 cond_exec: _expr ":" body
 default_exec: body
 if_stmt: "if" cond_exec ("elif" cond_exec)* ["else" ":" default_exec]


### PR DESCRIPTION
### What I did

Vyper allows to write single line control flow statements like `for i in range(5): b += 1` or `if b == 1: return False`. The lark grammar is currently unable to parse those as it expects a newline + indent between the first statement and the ensuing code block.

### How I did it

Expanded the definition of `body` in the grammar to be either a simple statement (`pass`, `continue`, `_expr`... but not `if` or `for`) or a series of indented statements (`_stmt`)

### How to verify it

One can now parse the following code:

```
@internal
def a() -> bool:
    b: uint256 = 0
    for i in range(5): b += 1
    for i in range(5):
        if b == 0: break
        elif b == 2: pass
        else: continue
    if b == 0: pass
    if b == 1: return False
    if b == 2: assert 3 == b
    if b == 3: raise "test"
    return False

@internal
def c() -> bool: return True
```

into:

```
Tree(Token('RULE', 'module'), [Tree(Token('RULE', 'function_def'), [Tree(Token('RULE', 'decorators'), [Tree(Token('RULE', 'decorator'), [Token('NAME', 'internal')])]), Tree(Token('RULE', 'function_sig'), [Token('NAME', 'a'), Tree(Token('RULE', 'returns'), [Tree(Token('RULE', 'type'), [Token('NAME', 'bool')])])]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'declaration'), [Tree(Token('RULE', 'variable'), [Token('NAME', 'b'), Tree(Token('RULE', 'type'), [Token('NAME', 'uint256')])]), Token('DEC_NUMBER', '0')]), Tree(Token('RULE', 'for_stmt'), [Tree(Token('RULE', 'loop_variable'), [Token('NAME', 'i')]), Tree(Token('RULE', 'loop_iterator'), [Tree(Token('RULE', 'call'), [Tree('get_var', [Token('NAME', 'range')]), Tree(Token('RULE', 'arguments'), [Tree(Token('RULE', 'arg'), [Token('DEC_NUMBER', '5')])])])]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'aug_assign'), [Tree('get_var', [Token('NAME', 'b')]), Tree('add', []), Token('DEC_NUMBER', '1')])])]), Tree(Token('RULE', 'for_stmt'), [Tree(Token('RULE', 'loop_variable'), [Token('NAME', 'i')]), Tree(Token('RULE', 'loop_iterator'), [Tree(Token('RULE', 'call'), [Tree('get_var', [Token('NAME', 'range')]), Tree(Token('RULE', 'arguments'), [Tree(Token('RULE', 'arg'), [Token('DEC_NUMBER', '5')])])])]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'if_stmt'), [Tree(Token('RULE', 'cond_exec'), [Tree('eq', [Tree('get_var', [Token('NAME', 'b')]), Token('DEC_NUMBER', '0')]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'break_stmt'), [])])]), Tree(Token('RULE', 'cond_exec'), [Tree('eq', [Tree('get_var', [Token('NAME', 'b')]), Token('DEC_NUMBER', '2')]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'pass_stmt'), [])])]), Tree(Token('RULE', 'default_exec'), [Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'continue_stmt'), [])])])])])]), Tree(Token('RULE', 'if_stmt'), [Tree(Token('RULE', 'cond_exec'), [Tree('eq', [Tree('get_var', [Token('NAME', 'b')]), Token('DEC_NUMBER', '0')]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'pass_stmt'), [])])])]), Tree(Token('RULE', 'if_stmt'), [Tree(Token('RULE', 'cond_exec'), [Tree('eq', [Tree('get_var', [Token('NAME', 'b')]), Token('DEC_NUMBER', '1')]), Tree(Token('RULE', 'body'), [Tree(Token('RULE', 'return_stmt'), [Token('BOOL', 'False')])])])]), Tree(Token('RULE', 'if_stmt'), [Tree(Token('RULE', 'cond_exec'), [Tree('eq', [Tree('get_var', [Token('NAME', 'b')]), Token('DEC_NUMBER', '2')]), Tree(Token('RULE', 'body'), [Tree('assert', [Tree('eq', [Token('DEC_NUMBER', '0'), Tree('get_var', [Token('NAME', 'b')])])])])])]), Tree(Token('RULE', 'if_stmt'), [Tree(Token('RULE', 'cond_exec'), [Tree('eq', [Tree('get_var', [Token('NAME', 'b')]), Token('DEC_NUMBER', '3')]), Tree(Token('RULE', 'body'), [Tree('raise_with_reason', [Token('STRING', '"test"')])])])]), Tree(Token('RULE', 'return_stmt'), [Token('BOOL', 'True')])])])])
```

### Commit message

Update lark grammar to parse single line control flow statements

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/199500142-ffc2ebf7-716c-4a4c-8793-35243cba8ca9.png)
