### PR TITLE
docs: improve uint256_addmod and uint256_mulmod documentation

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -687,7 +687,7 @@ Math
 
 .. py:function:: uint256_addmod(a: uint256, b: uint256, c: uint256) -> uint256
 
-    Return the modulo of ``(a + b) % c``. Reverts if ``c == 0``. The intermediate result of the addition can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
+    Return the modulo of ``(a + b) % c``. Reverts if ``c == 0``. The result of the addition can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
 
     .. code-block:: python
 
@@ -705,7 +705,7 @@ Math
 
 .. py:function:: uint256_mulmod(a: uint256, b: uint256, c: uint256) -> uint256
 
-    Return the modulo from ``(a * b) % c``. Reverts if ``c == 0``. The intermediate result of the multiplication can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
+    Return the modulo from ``(a * b) % c``. Reverts if ``c == 0``. The result of the multiplication can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
 
     .. code-block:: python
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -687,7 +687,7 @@ Math
 
 .. py:function:: uint256_addmod(a: uint256, b: uint256, c: uint256) -> uint256
 
-    Return the modulo of ``(a + b) % c``. Reverts if ``c == 0``.
+    Return the modulo of ``(a + b) % c``. Reverts if ``c == 0``. The intermediate result of the addition can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
 
     .. code-block:: python
 
@@ -705,7 +705,7 @@ Math
 
 .. py:function:: uint256_mulmod(a: uint256, b: uint256, c: uint256) -> uint256
 
-    Return the modulo from ``(a * b) % c``. Reverts if ``c == 0``.
+    Return the modulo from ``(a * b) % c``. Reverts if ``c == 0``. The intermediate result of the multiplication can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
 
     .. code-block:: python
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -686,8 +686,7 @@ Math
         10
 
 .. py:function:: uint256_addmod(a: uint256, b: uint256, c: uint256) -> uint256
-
-    Return the modulo of ``(a + b) % c``. Reverts if ``c == 0``. The result of the addition can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
+    Return the modulo of ``(a + b) % c``. Reverts if ``c == 0``. As this built-in function is intended to provides access to the underlying ``ADDMOD`` opcode, all intermediate calculations of this operation are not subject to the ``2 ** 256`` modulo according to the EVM specifications.
 
     .. code-block:: python
 
@@ -705,7 +704,7 @@ Math
 
 .. py:function:: uint256_mulmod(a: uint256, b: uint256, c: uint256) -> uint256
 
-    Return the modulo from ``(a * b) % c``. Reverts if ``c == 0``. The result of the multiplication can exceed the bounds of the ``uint256`` type. In such case, it will not be wrapped.
+    Return the modulo from ``(a * b) % c``. Reverts if ``c == 0``. As this built-in function is intended to provides access to the underlying ``MULMOD`` opcode, all intermediate calculations of this operation are not subject to the ``2 ** 256`` modulo according to the EVM specifications.
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did

Improved the documentation to reflect the fact that the intermediate results of `uint256_addmod` and `uint256_mulmod` can exceed the bounds of the type `uint256` and are not wrapped. 

### How I did it

Modified the documentation.

### How to verify it

This behavior come from the fact that the two builtin functions replicates the semantics of their respective homonymous EVM opcode.
It can be verified by evaluating `unsafe_add(max_value(uint256), 3) % 10` which should evaluate to `2` and not `8` which `uint256_addmod(max_value(uint256), 3, 10)` evaluates to.

### Commit message

docs: improve the doc of uint256_addmod and uint256_mulmod

### Description for the changelog

Updated uint256_addmod and uint256_mulmod documentation.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1595433707802-6b2626ef1c91?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxleHBsb3JlLWZlZWR8MXx8fGVufDB8fHx8&w=1000&q=80)
