### PR TITLE
chore: loosen dependency on asttokens

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     python_requires=">=3.7,<3.11",
     py_modules=["vyper"],
     install_requires=[
-        "asttokens==2.0.5",
+        "asttokens>=2.0.5,<3",
         "pycryptodome>=3.5.1,<4",
         "semantic-version>=2.10,<3",
         "cached-property==1.5.2 ; python_version<'3.8'",

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -1,7 +1,7 @@
 import ast as python_ast
 import tokenize
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, cast
 
 import asttokens
 
@@ -274,7 +274,7 @@ def annotate_python_ast(
         The annotated and optimized AST.
     """
 
-    tokens = asttokens.ASTTokens(source_code, tree=parsed_ast)
+    tokens = asttokens.ASTTokens(source_code, tree=cast(Optional[python_ast.Module], parsed_ast))
     visitor = AnnotatingVisitor(source_code, modification_offsets, tokens, source_id, contract_name)
     visitor.visit(parsed_ast)
 


### PR DESCRIPTION
### What I did
Loosen pin on [asttokens](https://github.com/gristlabs/asttokens) to include a wider range

### How I did it
Was
```json
        "asttoken==2.0.5",
```

Now
```json
        "asttokens>=2.0.5,<3"
```

### How to verify it
Build and pass tests.

### Commit message

Loosen dependency on asttokens to >=2.0.5,<3

Resolves: #3148

### Description for the changelog

Change `asttokens` library requirement from `==2.0.5` to `>=2.0.5,<3`.

### Cute Animal Picture

My new puppy:
![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/109751635/201215750-80f0575b-0186-4102-b236-1e245dc67312.jpeg)
