### PR TITLE
Fix typo in selfdestruct description

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -292,7 +292,7 @@ Vyper has three built-ins for contract creation; all three contract creation bui
 
     .. warning::
 
-        This method delete the contract from the blockchain. All non-ether assets associated with this contract are "burned" and the contract is no longer accessible.
+        This method deletes the contract from the blockchain. All non-ether assets associated with this contract are "burned" and the contract is no longer accessible.
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did

Corrected a `delete` to `deletes` in the documentation for `selfdestruct()`

### Commit message

Correct typo in `selfdestruct()` documentation

### Description for the changelog

Correct typo in `selfdestruct()` documentation

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.wsj.net/im-140534/?width=639&size=1.4080604534005037)
