### PR TITLE
Remove slice() length documentation caveats

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -508,7 +508,7 @@ Data Manipulation
 
     * ``b``: value being sliced
     * ``start``: start position of the slice
-    * ``length``: length of the slice, must be constant. Immutables and variables are not supported.
+    * ``length``: length of the slice
 
     If the value being sliced is a ``Bytes`` or ``bytes32``, the return type is ``Bytes``.  If it is a ``String``, the return type is ``String``.
 

--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -185,6 +185,23 @@ def dice() -> Bytes[1]:
     assert c.dice() == b"A"
 
 
+def test_slice_immutable_length_arg(get_contract_with_gas_estimation):
+    code = """
+LENGTH: immutable(uint256)
+
+@external
+def __init__():
+    LENGTH = 5
+
+@external
+def do_slice(inp: Bytes[50]) -> Bytes[50]:
+    return slice(inp, 0, LENGTH)
+    """
+    c = get_contract_with_gas_estimation(code)
+    x = c.do_slice(b"abcdefghijklmnopqrstuvwxyz1234")
+    assert x == b"abcde", x
+
+
 def test_slice_at_end(get_contract):
     code = """
 @external


### PR DESCRIPTION
### What I did

Removed the caveats on not being allowed to use variables/immutables as length arguments for `slice()`

I think these applied in a previous version of Vyper, but as of at least v0.3.7 the restriction doesn't seem to apply anymore

### How to verify it

Tests with variables for length arguments exist already in `tests/parser/functions/test_slice.py`, such as `test_basic_slice()`

A `test_slice_immutable_length_arg()` was also added to demonstrate that the functionality is available

### Commit message

Remove slice() length documentation caveats

### Description for the changelog

Remove `slice()` length documentation caveats

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.etsystatic.com/16945464/r/il/e7beb0/3030201470/il_570xN.3030201470_hwum.jpg)
