### PR TITLE
Add support for all base types when importing interface from ABI

### DIFF
--- a/vyper/ast/signatures/interface.py
+++ b/vyper/ast/signatures/interface.py
@@ -7,6 +7,7 @@ import vyper.builtin_interfaces
 from vyper import ast as vy_ast
 from vyper.ast.signatures.function_signature import FunctionSignature
 from vyper.codegen.global_context import GlobalContext
+from vyper.codegen.types import BYTES_M_TYPES, INTEGER_TYPES
 from vyper.exceptions import StructureException
 
 
@@ -26,7 +27,7 @@ def get_builtin_interfaces():
 
 
 def abi_type_to_ast(atype, expected_size):
-    if atype in ("int128", "uint256", "bool", "address", "bytes32"):
+    if atype in {"address", "bool"} | BYTES_M_TYPES | INTEGER_TYPES:
         return vy_ast.Name(id=atype)
     elif atype == "fixed168x10":
         return vy_ast.Name(id="decimal")


### PR DESCRIPTION
### What I did

Importing interfaces from ABI failed with some types such as `uint8`.
For instance, importing the following interface:

```
[
    {
      "constant": true,
      "inputs": [],
      "name": "decimals",
      "outputs": [{ "name": "", "type": "uint8" }],
      "payable": false,
      "stateMutability": "view",
      "type": "function"
    }
  ]
```

Will cause an error: `vyper.exceptions.StructureException: Type uint8 not supported by vyper.`

### How I did it

Changed supported types in ast to abi conversion in `interface.py` from `("int128", "uint256", "bool", "address", "bytes32")` to `{"address", "bool"} | BYTES_M_TYPES | INTEGER_TYPES`. 

### How to verify it

Importing the interface from the snippet above.

### Commit message

Add support for all base types when importing interface from ABI

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/203233724-a0b7dbd7-9aad-47f9-b143-c65a83ed68e2.png)

