### PR TITLE
fix: update literal bounds for shift

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -90,7 +90,7 @@ Bitwise Operations
 
   This function has been deprecated from version 0.3.4 onwards. Please use the ``^`` operator instead.
 
-.. py:function:: shift(x: uint256, _shift: int128) -> uint256
+.. py:function:: shift(x: Union[int256, uint256], _shift: integer) -> uint256
 
     Return ``x`` with the bits shifted ``_shift`` places. A positive ``_shift`` value equals a left shift, a negative value is a right shift.
 
@@ -250,10 +250,10 @@ Vyper has three built-ins for contract creation; all three contract creation bui
             response: Bytes[32] = b""
             x: uint256 = 123
             success, response = raw_call(
-                _target, 
-                _abi_encode(x, method_id=method_id("someMethodName(uint256)")), 
+                _target,
+                _abi_encode(x, method_id=method_id("someMethodName(uint256)")),
                 max_outsize=32,
-                value=msg.value, 
+                value=msg.value,
                 revert_on_failure=False
                 )
             assert success
@@ -459,7 +459,7 @@ Data Manipulation
     Returns a value of the type specified by ``type_``.
 
     For more details on available type conversions, see :ref:`type_conversions`.
-    
+
 .. py:function:: uint2str(value: unsigned integer) -> String
 
     Returns an unsigned integer's string representation.
@@ -683,7 +683,7 @@ Math
 
 .. py:function:: isqrt(x: uint256) -> uint256
 
-    Return the (integer) square root of the provided integer number, using the Babylonian square root algorithm. The rounding mode is to round down to the nearest integer. For instance, ``isqrt(101) == 10``.    
+    Return the (integer) square root of the provided integer number, using the Babylonian square root algorithm. The rounding mode is to round down to the nearest integer. For instance, ``isqrt(101) == 10``.
 
     .. code-block:: python
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -90,7 +90,7 @@ Bitwise Operations
 
   This function has been deprecated from version 0.3.4 onwards. Please use the ``^`` operator instead.
 
-.. py:function:: shift(x: Union[int256, uint256], _shift: integer) -> uint256
+.. py:function:: shift(x: int256 | uint256, _shift: integer) -> uint256
 
     Return ``x`` with the bits shifted ``_shift`` places. A positive ``_shift`` value equals a left shift, a negative value is a right shift.
 

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -141,7 +141,7 @@ def foo(x: uint8, y: int128) -> uint256:
         """
 @external
 def foo() -> uint256:
-    return shift(2, 2560012123124)
+    return shift(2, 257)
     """,
         InvalidLiteral,
     ),
@@ -149,7 +149,7 @@ def foo() -> uint256:
         """
 @external
 def foo() -> uint256:
-    return shift(2, -2560012123124)
+    return shift(2, -257)
     """,
         InvalidLiteral,
     ),

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -2,7 +2,7 @@ import pytest
 
 from vyper.compiler import compile_code
 from vyper.evm.opcodes import EVM_VERSIONS
-from vyper.exceptions import TypeMismatch
+from vyper.exceptions import InvalidLiteral, TypeMismatch
 
 code = """
 @external
@@ -136,7 +136,23 @@ def foo(x: uint8, y: int128) -> uint256:
     return shift(x, y)
     """,
         TypeMismatch,
-    )
+    ),
+    (
+        """
+@external
+def foo() -> uint256:
+    return shift(2, 2560012123124)
+    """,
+        InvalidLiteral,
+    ),
+    (
+        """
+@external
+def foo() -> uint256:
+    return shift(2, -2560012123124)
+    """,
+        InvalidLiteral,
+    ),
 ]
 
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -64,7 +64,7 @@ from vyper.exceptions import (
     UnfoldableNode,
     ZeroDivisionException,
 )
-from vyper.semantics.analysis.base import StateMutability, VarInfo
+from vyper.semantics.analysis.base import VarInfo
 from vyper.semantics.analysis.utils import (
     get_common_types,
     get_exact_type_from_node,
@@ -1275,7 +1275,6 @@ class BlockHash(BuiltinFunction):
     _id = "blockhash"
     _inputs = [("block_num", UINT256_T)]
     _return_type = BYTES32_T
-    mutability = StateMutability.VIEW
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, contact):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1479,8 +1479,8 @@ class Shift(BuiltinFunction):
         value, shift = [i.value for i in node.args]
         if value < 0 or value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
-        if shift < -255 or shift > 255:
-            raise InvalidLiteral("Shift must be between -255 and 255", node.args[1])
+        if shift < -256 or shift > 256:
+            raise InvalidLiteral("Shift must be between -256 and 256", node.args[1])
 
         if shift < 0:
             value = value >> -shift

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1481,7 +1481,7 @@ class Shift(BuiltinFunction):
         if value < 0 or value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
         if shift < -255 or shift > 255:
-            raise InvalidLiteral(f"Shift must be between -255 and 255", node.args[1])
+            raise InvalidLiteral("Shift must be between -255 and 255", node.args[1])
 
         if shift < 0:
             value = value >> -shift

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1480,6 +1480,9 @@ class Shift(BuiltinFunction):
         if value < 0 or value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
         if shift < -256 or shift > 256:
+            # this validation is performed to prevent the compiler from hanging
+            # rather than for correctness because the post-folded constant would
+            # have been validated anyway
             raise InvalidLiteral("Shift must be between -256 and 256", node.args[1])
 
         if shift < 0:

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -64,7 +64,7 @@ from vyper.exceptions import (
     UnfoldableNode,
     ZeroDivisionException,
 )
-from vyper.semantics.analysis.base import VarInfo
+from vyper.semantics.analysis.base import StateMutability, VarInfo
 from vyper.semantics.analysis.utils import (
     get_common_types,
     get_exact_type_from_node,
@@ -1275,6 +1275,7 @@ class BlockHash(BuiltinFunction):
     _id = "blockhash"
     _inputs = [("block_num", UINT256_T)]
     _return_type = BYTES32_T
+    mutability = StateMutability.VIEW
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, contact):
@@ -1479,8 +1480,8 @@ class Shift(BuiltinFunction):
         value, shift = [i.value for i in node.args]
         if value < 0 or value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
-        if shift < -(2 ** 127) or shift >= 2 ** 127:
-            raise InvalidLiteral("Value out of range for int128", node.args[1])
+        if shift < -255 or shift > 255:
+            raise InvalidLiteral(f"Shift must be between -255 and 255", node.args[1])
 
         if shift < 0:
             value = value >> -shift


### PR DESCRIPTION
### What I did

Fix #3159.

### How I did it

Update the bounds check for `shift` when folding.

### How to verify it

See tests.

### Commit message

```
fix: update literal bounds for shift
```

### Description for the changelog

Update literal bounds for shift

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSKdXssKg1Cp5XoOcRPRxAq3VahjhtVcCBoUQ&usqp=CAU)
