### PR TITLE
docs: fix docs of blockhash to reflect revert behaviour

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -891,7 +891,7 @@ Utilities
 
     .. note::
 
-        The EVM only provides access to the most recent 256 blocks. This function returns ``EMPTY_BYTES32`` if the block number is greater than or equal to the current block number or more than 256 blocks behind the current block.
+        The EVM only provides access to the most recent 256 blocks. This function reverts if the block number is greater than or equal to the current block number or more than 256 blocks behind the current block.
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did
Improved documentation of the blockhash built-in to describe its behaviour.
The blockhash function clamps its input and will thus revert if it is out of bounds. It will not return `EMPTY_BYTES32` as was previously described.

### How I did it
Updated the docs

### How to verify it
See [blockhash code](https://github.com/vyperlang/vyper/blob/master/vyper/builtins/functions.py#L1273)

### Commit message

docs: fix docs of blockhash to reflect revert behaviour

### Description for the changelog

Update the documentation of the blockhash to accurately reflect its revert behaviour. 

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/b7/fd/50/b7fd5034687d97caef748b0fe3e62f36.jpg)
