### PR TITLE
fix: disable uadd operator

### DIFF
--- a/tests/parser/exceptions/test_syntax_exception.py
+++ b/tests/parser/exceptions/test_syntax_exception.py
@@ -74,6 +74,11 @@ def foo():
     """
 a: internal(uint256)
     """,
+    """
+@external
+def foo():
+    x: uint256 = +1  # test UAdd ast blocked
+    """,
 ]
 
 

--- a/vyper/ast/annotation.py
+++ b/vyper/ast/annotation.py
@@ -230,11 +230,6 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         """
         self.generic_visit(node)
 
-        # TODO once grammar is updated, remove this
-        # UAdd has no effect on the value of it's operand, so it is discarded
-        if isinstance(node.op, python_ast.UAdd):
-            return node.operand
-
         is_sub = isinstance(node.op, python_ast.USub)
         is_num = (
             hasattr(node.operand, "n")


### PR DESCRIPTION
it should have been disabled, but there was some code which was never removed which bypassed the check.

### What I did
fix #3173 

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
