### PR TITLE
fixed the compiler panicking when a `break` is outside of a loop

### DIFF
--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -160,7 +160,7 @@ def _validate_msg_data_attribute(node: vy_ast.Attribute) -> None:
 
 class FunctionNodeVisitor(VyperNodeVisitorBase):
 
-    ignored_types = (vy_ast.Break, vy_ast.Constant, vy_ast.Pass)
+    ignored_types = (vy_ast.Constant, vy_ast.Pass)
     scope_name = "function"
 
     def __init__(
@@ -288,6 +288,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         for_node = node.get_ancestor(vy_ast.For)
         if for_node is None:
             raise StructureException("`continue` must be enclosed in a `for` loop", node)
+
+    def visit_Break(self, node):
+        for_node = node.get_ancestor(vy_ast.For)
+        if for_node is None:
+            raise StructureException("`break` must be enclosed in a `for` loop", node)
 
     def visit_Return(self, node):
         values = node.value


### PR DESCRIPTION
### What I did

Fixed #3176

### How I did it

Removed `vy.ast.Break` from `ignored_types` in `FunctionNodeVisitor` and created a function `Visit_Break` that behave similarly to `visit_Continue` to check that the `break` statement is enclosed in a loop.

### How to verify it

Compiling the following contract will now output ``vyper.exceptions.StructureException: `break` must be enclosed in a `for` loop`` instead of the compiler panicking.
```Vyper
@external
def foo():
    break
```
### Commit message

fix: improve error message for `break` statement outside of a loop

### Description for the changelog

Improve error message for `break` statement outside of a loop

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/hDJkFLnmFHU/mqdefault.jpg)
