### PR TITLE
updated tox to be compatible with multiple python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ extras =
 whitelist_externals = make
 
 [testenv:docs]
-basepython=python3.8
+basepython=python3
 deps =
     sphinx
     sphinx_rtd_theme
@@ -28,7 +28,7 @@ commands =
     sphinx-build {posargs:-E} -b html docs dist/docs -n -q --color
 
 [testenv:fuzzing]
-basepython = python3.8
+basepython = python3
 commands =
     pytest -m fuzzing {posargs:tests/}
 extras =
@@ -36,7 +36,7 @@ extras =
 whitelist_externals = make
 
 [testenv:memory]
-basepython = python3.8
+basepython = python3
 commands =
     pytest --memorymock {posargs:tests/}
 extras =
@@ -44,7 +44,7 @@ extras =
 whitelist_externals = make
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3
 extras = lint
 commands =
     black -C -t py38 {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
@@ -52,7 +52,7 @@ commands =
     isort {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
 
 [testenv:mypy]
-basepython = python3.8
+basepython = python3
 extras = lint
 commands =
     mypy --install-types --non-interactive --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p vyper


### PR DESCRIPTION
### What I did
updated tox to be compatible with python 3.9, 3.10

### How I did it
 by changing basepython from python3.8 to python3

### How to verify it

### Commit message

### Description for the changelog
tox breaks if user's machine does not have python 3.8
fixed by changing basepython = python3.8 to --> basepython = python3

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2014/03/cute-fluffy-animals-25.jpg)
