### PR TITLE
fix: guard against `pop` in iter `for` range

### DIFF
--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper import compiler
+from vyper.exceptions import StateAccessViolation
 
 valid_list = [
     """
@@ -37,3 +38,30 @@ def kick_foos():
 @pytest.mark.parametrize("good_code", valid_list)
 def test_range_success(good_code):
     assert compiler.compile_code(good_code) is not None
+
+
+fail_list = [
+    # Cannot call `pop()` in for range because it modifies state
+    (
+        """
+arr: DynArray[uint256, 10]
+
+@external
+def test()-> (DynArray[uint256, 6], DynArray[uint256, 10]):
+    b: DynArray[uint256, 6] = []
+
+    self.arr = [1,0]
+
+    for i in range(self.arr.pop(), self.arr.pop() + 2):
+        b.append(i)
+
+    return b, self.arr
+    """,
+        StateAccessViolation,
+    ),
+]
+
+
+@pytest.mark.parametrize("bad_code,exc", fail_list)
+def test_range_fail(assert_compile_failed, get_contract_with_gas_estimation, bad_code, exc):
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(bad_code), exc)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -19,7 +19,7 @@ from vyper.codegen.types import (
     is_integer_type,
 )
 from vyper.evm.opcodes import version_check
-from vyper.exceptions import CompilerPanic, StructureException, StateAccessViolation, TypeCheckFailure, TypeMismatch
+from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure, TypeMismatch
 from vyper.utils import GAS_CALLDATACOPY_WORD, GAS_CODECOPY_WORD, GAS_IDENTITY, GAS_IDENTITYWORD
 
 
@@ -291,13 +291,9 @@ def append_dyn_array(darray_node, elem_node):
             return IRnode.from_list(b1.resolve(b2.resolve(ret)))
 
 
-def pop_dyn_array(stmt_node, context, darray_node, return_popped_item):
+def pop_dyn_array(darray_node, return_popped_item):
     assert isinstance(darray_node.typ, DArrayType)
     assert darray_node.encoding == Encoding.VYPER
-
-    if context.is_constant():
-        raise StateAccessViolation(f"May not call `pop()` within {context.pp_constancy()}", stmt_node)
-
     ret = ["seq"]
     with darray_node.cache_when_complex("darray") as (b1, darray_node):
         old_len = clamp("gt", get_dyn_array_count(darray_node), 0)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -670,7 +670,7 @@ class Expr:
             darray = Expr(self.expr.func.value, self.context).ir_node
             assert len(self.expr.args) == 0
             assert isinstance(darray.typ, DArrayType)
-            return pop_dyn_array(darray, return_popped_item=True)
+            return pop_dyn_array(self.expr, self.context, darray, return_popped_item=True)
 
         elif (
             # TODO use expr.func.type.is_internal once

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -673,7 +673,9 @@ class Expr:
             assert isinstance(darray.typ, DArrayType)
 
             if self.context.is_constant():
-                raise StateAccessViolation(f"May not call `pop()` within {self.context.pp_constancy()}", self.expr)
+                raise StateAccessViolation(
+                    f"May not call `pop()` within {self.context.pp_constancy()}", self.expr
+                )
 
             return pop_dyn_array(darray, return_popped_item=True)
 


### PR DESCRIPTION
### What I did

Fix #3172.

### How I did it

Pass context to `pop_dyn_array` and check constancy.

### How to verify it

See tests

### Commit message

```
fix: guard against `pop` in iter `for` range
```

### Description for the changelog

Guard against `pop` in iter `for` range

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i1.sndcdn.com/artworks-000655825720-xwncjl-t500x500.jpg)
