### PR TITLE
fix: powmod256 crash for large literal exponents

### DIFF
--- a/tests/builtins/folding/test_powmod.py
+++ b/tests/builtins/folding/test_powmod.py
@@ -5,7 +5,7 @@ from hypothesis import strategies as st
 from vyper import ast as vy_ast
 from vyper.builtins import functions as vy_fn
 
-st_uint256 = st.integers(min_value=0, max_value=256)
+st_uint256 = st.integers(min_value=0, max_value=2**256)
 
 
 @pytest.mark.fuzzing

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1568,7 +1568,7 @@ class PowMod256(BuiltinFunction):
         if left.value < 0 or right.value < 0:
             raise UnfoldableNode
 
-        value = (left.value ** right.value) % (2 ** 256)
+        value = pow(left.value, right.value, 2 ** 256)
         return vy_ast.Int.from_node(node, value=value)
 
     def build_IR(self, expr, context):


### PR DESCRIPTION
### What I did
fix: https://github.com/vyperlang/vyper/issues/3159#issuecomment-1328225892

### How I did it
use python builtin powmod (`powmod(x,y,z)` - which is more efficient because it uses constant space memory) instead of calculating `x ** y % z`.

### How to verify it
see updated range for test strategy.

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
