### PR TITLE
chore: remove cached_property backport dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         "asttokens>=2.0.5,<3",
         "pycryptodome>=3.5.1,<4",
         "semantic-version>=2.10,<3",
-        "cached-property==1.5.2 ; python_version<'3.8'",
         "importlib-metadata ; python_version<'3.8'",
         "wheel",
     ],

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -1,5 +1,6 @@
 import math
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Dict, Optional, Tuple
 
 from vyper import ast as vy_ast
@@ -7,7 +8,7 @@ from vyper.address_space import MEMORY
 from vyper.codegen.ir_node import Encoding
 from vyper.codegen.types import NodeType
 from vyper.exceptions import StructureException
-from vyper.utils import MemoryPositions, cached_property, mkalphanum
+from vyper.utils import MemoryPositions, mkalphanum
 
 # dict from function names to signatures
 FunctionSignatures = Dict[str, "FunctionSignature"]

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Optional
 
 from vyper import ast as vy_ast
@@ -6,7 +7,6 @@ from vyper.codegen.types import parse_type
 from vyper.exceptions import CompilerPanic, InvalidType, StructureException
 from vyper.semantics.types import EnumT
 from vyper.typing import InterfaceImports
-from vyper.utils import cached_property
 
 
 # Datatype to store all global context information.

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum, auto
+from functools import cached_property
 from typing import Any, List, Optional, Tuple, Union
 
 from vyper.address_space import AddrSpace
@@ -7,7 +8,7 @@ from vyper.codegen.types import BaseType, NodeType, ceil32
 from vyper.compiler.settings import VYPER_COLOR_OUTPUT
 from vyper.evm.opcodes import get_ir_opcodes
 from vyper.exceptions import CodegenPanic, CompilerPanic
-from vyper.utils import VALID_IR_MACROS, cached_property
+from vyper.utils import VALID_IR_MACROS
 
 # Set default string representation for ints in IR output.
 AS_HEX_DEFAULT = False

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -1,5 +1,6 @@
 import copy
 import warnings
+from functools import cached_property
 from typing import Optional, Tuple
 
 from vyper import ast as vy_ast
@@ -10,7 +11,6 @@ from vyper.codegen.ir_node import IRnode
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics import set_data_positions, validate_semantics
 from vyper.typing import InterfaceImports, StorageLayout
-from vyper.utils import cached_property
 
 
 class CompilerData:

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Any, Dict, Optional, Tuple, Union
 
 from vyper import ast as vy_ast
@@ -12,7 +13,6 @@ from vyper.exceptions import (
 )
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.namespace import validate_identifier
-from vyper.utils import cached_property
 
 
 # Some fake type with an overridden `compare_type` which accepts any RHS

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -37,12 +37,6 @@ except ImportError:
 
     keccak256 = lambda x: _sha3.sha3_256(x).digest()  # noqa: E731
 
-try:
-    # available py3.8+
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property  # type: ignore
-
 
 # Converts four bytes to an integer
 def fourbytes_to_int(inp):
@@ -447,6 +441,3 @@ def annotate_source_code(
     cleanup_lines += [""] * (num_lines - len(cleanup_lines))
 
     return "\n".join(cleanup_lines)
-
-
-__all__ = ["cached_property"]


### PR DESCRIPTION
previously we used a backport for the `cached_property` decorator; since now we only support python3.8+, we no longer need the backport.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
