### PR TITLE
chore: relax python version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "asttokens>=2.0.5,<3",
         "pycryptodome>=3.5.1,<4",
         "semantic-version>=2.10,<3",
-        "importlib-metadata ; python_version<'3.8'",
+        "importlib-metadata",
         "wheel",
     ],
     setup_requires=["pytest-runner", "setuptools_scm"],

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     keywords="ethereum evm smart contract language",
     include_package_data=True,
     packages=find_packages(exclude=("tests", "docs")),
-    python_requires=">=3.7,<3.11",
+    python_requires=">=3.8,<4",
     py_modules=["vyper"],
     install_requires=[
         "asttokens>=2.0.5,<3",


### PR DESCRIPTION
### What I did
relax the restriction that the python version required is <3.11

related to https://github.com/vyperlang/vyper/pull/3129, but instead of explicitly supporting 3.11 (i.e., does not add it to the test matrix), just stop restricting people from using it so they can try it.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3867501/207990083-2bb76f4a-c4aa-4190-b816-ab1d458b472b.png)
