### PR TITLE
fix: guard against iterating over empty list in for loop

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -658,6 +658,20 @@ def foo():
     for i in range(0):
         pass
     """,
+    """
+@external
+def foo():
+    for i in []:
+        pass
+    """,
+    """
+FOO: constant(DynArray[uint256, 3]) = []
+
+@external
+def foo():
+    for i in FOO:
+        pass
+    """,
     (
         """
 @external

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -383,6 +383,9 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
 
         else:
             # iteration over a variable or literal list
+            if isinstance(node.iter, vy_ast.List) and len(node.iter.elements) == 0:
+                raise StructureException("For loop must have at least 1 iteration", node.iter)
+
             type_list = [
                 i.value_type
                 for i in get_possible_types_from_node(node.iter)


### PR DESCRIPTION
### What I did

Fix #3144.

### How I did it

Check for an empty `elements` list if `iter` is a `List` node.

### How to verify it

See tests.

### Commit message

```
fix: guard against iterating over empty list in for loop
```

### Description for the changelog

Guard against iterating over empty list in for loop

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/2f/bb/6d/2fbb6d4941704d53b41d3994e27204c7.jpg)
