### PR TITLE
doc: updated shadowing section of the doc

### DIFF
--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -146,25 +146,27 @@ Values that are declared in the module scope of a contract, such as storage vari
 Name Shadowing
 **************
 
-It is not permitted for a memory or calldata variable to shadow the name of a storage variable. The following examples will not compile:
+It is not permitted for a memory or calldata variable to shadow the name of an immutable or constant variable. The following examples will not compile:
 
 .. code-block:: python
 
-    a: int128
+    a: constant(bool) = True
 
     @external
-    def foo() -> int128:
-        # memory variable cannot have the same name as a storage variable
-        a: int128 = self.a
+    def foo() -> bool:
+        # memory variable cannot have the same name as a constant or immutable variable
+        a: bool = False
         return a
-
 .. code-block:: python
 
-    a: int128
+    a: immutable(bool)
 
     @external
-    def foo(a: int128) -> int128:
-        # input argument cannot have the same name as a storage variable
+    def __init__():
+        a = True
+    @external
+    def foo(a:bool) -> bool:
+        # input argument cannot have the same name as a constant or immutable variable
         return a
 
 Function Scope

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -146,7 +146,7 @@ Values that are declared in the module scope of a contract, such as storage vari
 Name Shadowing
 **************
 
-It is not permitted for a memory or calldata variable to shadow the name of an immutable or constant variable. The following examples will not compile:
+It is not permitted for a memory or calldata variable to shadow the name of an immutable or constant value. The following examples will not compile:
 
 .. code-block:: python
 


### PR DESCRIPTION
### What I did

Fixed #3139

### How I did it

Changed the section to reflect the latest Vyper's semantics regarding shadowing:

- It is now possible to shadow storage variable's name with calldata or memory variables.
- It is not possible to shadow constant or immutable variable with calldata or memory variables.

### How to verify it

The compiler would fail to compile the examples in the doc as expected.

### Commit message

docs: fix docs of shadowing to reflect current behaviours

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.tasteofhome.com/wp-content/uploads/2020/10/close-up-of-ginger-cat-by-christmas-tree-944199692.jpg?fit=700,800)
