### PR TITLE
docs: update base type for arrays

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -443,7 +443,7 @@ Fixed-size Lists
 
 Fixed-size lists hold a finite number of elements which belong to a specified type.
 
-Lists can be declared with ``_name: _ValueType[_Integer]``.
+Lists can be declared with ``_name: _ValueType[_Integer]``, except ``Bytes[N]``, ``String[N]`` and enums.
 
 .. code-block:: python
 
@@ -480,7 +480,7 @@ A two dimensional list can be declared with ``_name: _ValueType[inner_size][oute
 Dynamic Arrays
 ----------------
 
-Dynamic arrays represent bounded arrays whose length can be modified at runtime, up to a bound specified in the type. They can be declared with ``_name: DynArray[_Type, _Integer]``, where ``_Type`` can be of value type (except ``Bytes[N]`` and ``String[N]``) or reference type (except mappings).
+Dynamic arrays represent bounded arrays whose length can be modified at runtime, up to a bound specified in the type. They can be declared with ``_name: DynArray[_Type, _Integer]``, where ``_Type`` can be of value type or reference type (except mappings).
 
 .. code-block:: python
 
@@ -507,7 +507,7 @@ Dynamic arrays represent bounded arrays whose length can be modified at runtime,
     Attempting to access data past the runtime length of an array, ``pop()`` an empty array or ``append()`` to a full array will result in a runtime ``REVERT``. Attempting to pass an array in calldata which is larger than the array bound will result in a runtime ``REVERT``.
 
 .. note::
-    To keep code easy to reason about, modifying an array while using it as an iterator it is disallowed by the language. For instance, the following usage is not allowed:
+    To keep code easy to reason about, modifying an array while using it as an iterator is disallowed by the language. For instance, the following usage is not allowed:
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did

Update base type for static and dynamic arrays.

Dynamic arrays support bytestrings, strings and enums, but not arrays.

### How I did it

Update docs.

### How to verify it

See docs.

### Commit message

```
docs: update base type for arrays
```

### Description for the changelog

Update base type for arrays in documentation.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/65535/51534590697_616cb6c9ab_c.jpg)
