### PR TITLE
fix: missing pc map for empty functions

### DIFF
--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -214,4 +214,4 @@ def generate_ir_for_external_function(code, sig, context, skip_nonpayable_check)
         # TODO rethink this / make it clearer
         ret[-1][-1].append(func_common_ir)
 
-    return IRnode.from_list(ret)
+    return IRnode.from_list(ret, source_pos=getpos(sig.func_ast_code))


### PR DESCRIPTION
the IR generated inside of a function (that is not generated in stmt.py or expr.py) was not annotated with the source pos. this annotates the root node of the function with the source pos as the fallback.

### What I did
fix #3200

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
