### PR TITLE
index `id` param in `URI` event of `ERC1155ownable`

### DIFF
--- a/examples/tokens/ERC1155ownable.vy
+++ b/examples/tokens/ERC1155ownable.vy
@@ -91,7 +91,7 @@ event ApprovalForAll:
 event URI:
     # This emits when the URI gets changed
     value: String[MAX_URI_LENGTH]
-    id: uint256
+    id: indexed(uint256)
 
 ############### interfaces ###############
 implements: ERC165


### PR DESCRIPTION
### What I did

The ERC-1155 event `URI` is defined like that:

```sol
event URI(string _value, uint256 indexed _id);
```

Fix the missing index in the example contract `ERC1155ownable`.

### How to verify it

Check here: https://eips.ethereum.org/EIPS/eip-1155.

### Commit message

index `id` param in `URI` event of `ERC1155ownable`

### Description for the changelog

Index `id` param in `URI` event of example contract `ERC1155ownable`.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/208478794-67a242e5-fab5-4531-852e-dd6a9e151c08.png)

