### PR TITLE
docs: add note on return value bounds in interfaces

### DIFF
--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -166,7 +166,6 @@ Vyper includes common built-in interfaces such as `ERC20 <https://eips.ethereum.
 
 You can see all the available built-in interfaces in the `Vyper GitHub <https://github.com/vyperlang/vyper/tree/master/vyper/builtins/interfaces>`_ repo.
 
-
 Implementing an Interface
 =========================
 
@@ -180,6 +179,10 @@ You can define an interface for your contract with the ``implements`` statement:
 
 
 This imports the defined interface from the vyper file at ``an_interface.vy`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20.
+
+Note
+
+Interfaces that implement functions with return values that require an upper bound (e.g. ``Bytes``, ``DynArray``, or ``String``), the upper bound defined in the interface represents the lower bound of the implementation. Assuming a function ``my_func`` returns a value ``String[1]`` in the interface, this would mean for the implementation function of ``my_func`` that the return value must have **at least** length 1. This behavior might change in the future.
 
 Extracting Interfaces
 =====================

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -180,9 +180,9 @@ You can define an interface for your contract with the ``implements`` statement:
 
 This imports the defined interface from the vyper file at ``an_interface.vy`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20.
 
-Note
+.. note::
 
-Interfaces that implement functions with return values that require an upper bound (e.g. ``Bytes``, ``DynArray``, or ``String``), the upper bound defined in the interface represents the lower bound of the implementation. Assuming a function ``my_func`` returns a value ``String[1]`` in the interface, this would mean for the implementation function of ``my_func`` that the return value must have **at least** length 1. This behavior might change in the future.
+  Interfaces that implement functions with return values that require an upper bound (e.g. ``Bytes``, ``DynArray``, or ``String``), the upper bound defined in the interface represents the lower bound of the implementation. Assuming a function ``my_func`` returns a value ``String[1]`` in the interface, this would mean for the implementation function of ``my_func`` that the return value must have **at least** length 1. This behavior might change in the future.
 
 Extracting Interfaces
 =====================


### PR DESCRIPTION
Fixes https://github.com/vyperlang/vyper/issues/3204.

### What I did

Add note on return value bounds in interfaces and the corresponding behavior in the implementation.

### Commit message

`docs: add a note on return value bounds in interfaces`

### Description for the changelog

docs: add a note on return value bounds in interfaces

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/209466769-cb75ba26-1611-42c9-89d8-e23186e85e52.png)
