### PR TITLE
fix: add unreachable to reserved keywords

### DIFF
--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -158,6 +158,7 @@ RESERVED_KEYWORDS = {
     "assert",
     "raise",
     "throw",
+    "unreachable",
     # special functions (no name mangling)
     "init",
     "_init_",


### PR DESCRIPTION
### What I did
fix #3171: added unreachable to the list of reserved keywords so that UNREACHABLE can no longer act as a shadow variable.

### How I did it

### How to verify it

### Commit message

fix: add unreachable to reserved keywords

### Description for the changelog
Before, one could set UNREACHABLE as the name of a variable, then get surprised when calling assert or raise UNREACHABLE that it gets overshadowed by the custom semantic of UNREACHABLE, which reverts to the opcode INVALID. Now if you try to set UNREACHABLE as a variable you get a syntax exception that unreachable is a reserved keyword.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1201041782/photo/alpaca.jpg?s=612x612&w=0&k=20&c=aHFfLZMuyEyyiJux4OghXfdcc40Oa6L7_cE0D7zvbtY=)
