### PR TITLE
Option to add an upper bound check on returndatasize with raw_call

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -226,10 +226,11 @@ Vyper has three built-ins for contract creation; all three contract creation bui
     * ``is_delegate_call``: If ``True``, the call will be sent as ``DELEGATECALL`` (Optional, default ``False``)
     * ``is_static_call``: If ``True``, the call will be sent as ``STATICCALL`` (Optional, default ``False``)
     * ``revert_on_failure``: If ``True``, the call will revert on a failure, otherwise ``success`` will be returned (Optional, default ``True``)
+    * ``revert_on_excess``: If ``True``, the call will revert when the size of the return data exceeds that of the receiving variable, otherwise the return value will be returned (Optional, default ``False``)
 
     .. note::
 
-        Returns the data returned by the call as a ``Bytes`` list, with ``max_outsize`` as the max length. The actual size of the returned data may be less than ``max_outsize``. You can use ``len`` to obtain the actual size.
+        Returns the data returned by the call as a ``Bytes`` list, with ``max_outsize`` as the max length. The actual size of the returned data may be less than ``max_outsize``. You can use ``len`` to obtain the actual size. You can use ``revert_on_excess`` to force the call to fail if the return data exceeds ``max_outsize``.
 
         Returns nothing if ``max_outsize`` is omitted or set to ``0``.
 

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -39,6 +39,17 @@ def foo() -> Bytes[3]:
     assert c.foo() == b"moo"
 
 
+def test_returndatasize_reverts_on_excess(get_contract, assert_tx_failed):
+    source_code = """
+@external
+def foo() -> Bytes[3]:
+    return raw_call(0x0000000000000000000000000000000000000004,
+    b"moose", max_outsize=3, revert_on_excess=True)
+    """
+    c = get_contract(source_code)
+    assert_tx_failed(lambda: c.foo())
+
+
 def test_returndatasize_matches_max_outsize(get_contract):
     source_code = """
 @external

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -45,9 +45,15 @@ def test_returndatasize_reverts_on_excess(get_contract, assert_tx_failed):
 def foo() -> Bytes[3]:
     return raw_call(0x0000000000000000000000000000000000000004,
     b"moose", max_outsize=3, revert_on_excess=True)
+
+@external
+def bar() -> Bytes[3]:
+    return raw_call(0x0000000000000000000000000000000000000004,
+    b"mo", max_outsize=3, revert_on_excess=True)
     """
     c = get_contract(source_code)
     assert_tx_failed(lambda: c.foo())
+    assert c.bar() == b"mo"
 
 
 def test_returndatasize_matches_max_outsize(get_contract):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1226,6 +1226,7 @@ class RawCall(BuiltinFunction):
                         error_msg="returndatasize larger than receiving variable",
                     )
                 )
+                size = "returndatasize"
             store_output_size.append(["mstore", output_node, size])
             store_output_size.append(output_node)
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1002,13 +1002,13 @@ class AsWeiValue(BuiltinFunction):
 
     wei_denoms = {
         ("wei",): 1,
-        ("femtoether", "kwei", "babbage"): 10**3,
-        ("picoether", "mwei", "lovelace"): 10**6,
-        ("nanoether", "gwei", "shannon"): 10**9,
-        ("microether", "szabo"): 10**12,
-        ("milliether", "finney"): 10**15,
-        ("ether",): 10**18,
-        ("kether", "grand"): 10**21,
+        ("femtoether", "kwei", "babbage"): 10 ** 3,
+        ("picoether", "mwei", "lovelace"): 10 ** 6,
+        ("nanoether", "gwei", "shannon"): 10 ** 9,
+        ("microether", "szabo"): 10 ** 12,
+        ("milliether", "finney"): 10 ** 15,
+        ("ether",): 10 ** 18,
+        ("kether", "grand"): 10 ** 21,
     }
 
     def get_denomination(self, node):
@@ -1036,9 +1036,9 @@ class AsWeiValue(BuiltinFunction):
         if value < 0:
             raise InvalidLiteral("Negative wei value not allowed", node.args[0])
 
-        if isinstance(value, int) and value >= 2**256:
+        if isinstance(value, int) and value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
-        if isinstance(value, Decimal) and value >= 2**127:
+        if isinstance(value, Decimal) and value >= 2 ** 127:
             raise InvalidLiteral("Value out of range for decimal", node.args[0])
 
         return vy_ast.Int.from_node(node, value=int(value * denom))
@@ -1390,7 +1390,7 @@ class BitwiseAnd(BuiltinFunction):
         for arg in node.args:
             if not isinstance(arg, vy_ast.Num):
                 raise UnfoldableNode
-            if arg.value < 0 or arg.value >= 2**256:
+            if arg.value < 0 or arg.value >= 2 ** 256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
 
         value = node.args[0].value & node.args[1].value
@@ -1417,7 +1417,7 @@ class BitwiseOr(BuiltinFunction):
         for arg in node.args:
             if not isinstance(arg, vy_ast.Num):
                 raise UnfoldableNode
-            if arg.value < 0 or arg.value >= 2**256:
+            if arg.value < 0 or arg.value >= 2 ** 256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
 
         value = node.args[0].value | node.args[1].value
@@ -1444,7 +1444,7 @@ class BitwiseXor(BuiltinFunction):
         for arg in node.args:
             if not isinstance(arg, vy_ast.Num):
                 raise UnfoldableNode
-            if arg.value < 0 or arg.value >= 2**256:
+            if arg.value < 0 or arg.value >= 2 ** 256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
 
         value = node.args[0].value ^ node.args[1].value
@@ -1472,10 +1472,10 @@ class BitwiseNot(BuiltinFunction):
             raise UnfoldableNode
 
         value = node.args[0].value
-        if value < 0 or value >= 2**256:
+        if value < 0 or value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
 
-        value = (2**256 - 1) - value
+        value = (2 ** 256 - 1) - value
         return vy_ast.Int.from_node(node, value=value)
 
     @process_inputs
@@ -1494,7 +1494,7 @@ class Shift(BuiltinFunction):
         if [i for i in node.args if not isinstance(i, vy_ast.Num)]:
             raise UnfoldableNode
         value, shift = [i.value for i in node.args]
-        if value < 0 or value >= 2**256:
+        if value < 0 or value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
         if shift < -256 or shift > 256:
             # this validation is performed to prevent the compiler from hanging
@@ -1505,7 +1505,7 @@ class Shift(BuiltinFunction):
         if shift < 0:
             value = value >> -shift
         else:
-            value = (value << shift) % (2**256)
+            value = (value << shift) % (2 ** 256)
         return vy_ast.Int.from_node(node, value=value)
 
     def fetch_call_return(self, node):
@@ -1545,7 +1545,7 @@ class _AddMulMod(BuiltinFunction):
         for arg in node.args:
             if not isinstance(arg, vy_ast.Num):
                 raise UnfoldableNode
-            if arg.value < 0 or arg.value >= 2**256:
+            if arg.value < 0 or arg.value >= 2 ** 256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
 
         value = self._eval_fn(node.args[0].value, node.args[1].value) % node.args[2].value
@@ -1585,7 +1585,7 @@ class PowMod256(BuiltinFunction):
         if left.value < 0 or right.value < 0:
             raise UnfoldableNode
 
-        value = pow(left.value, right.value, 2**256)
+        value = pow(left.value, right.value, 2 ** 256)
         return vy_ast.Int.from_node(node, value=value)
 
     def build_IR(self, expr, context):
@@ -2009,7 +2009,7 @@ class _UnsafeMath(BuiltinFunction):
             else:
                 # e.g. uint8 -> (mod (add x y) 256)
                 # TODO mod_bound could be a really large literal
-                ret = ["mod", ret, 2**int_info.bits]
+                ret = ["mod", ret, 2 ** int_info.bits]
 
         return IRnode.from_list(ret, typ=otyp)
 
@@ -2045,10 +2045,10 @@ class _MinMax(BuiltinFunction):
 
         left, right = (i.value for i in node.args)
         if isinstance(left, Decimal) and (
-            min(left, right) < -(2**127) or max(left, right) >= 2**127
+            min(left, right) < -(2 ** 127) or max(left, right) >= 2 ** 127
         ):
             raise InvalidType("Decimal value is outside of allowable range", node)
-        if isinstance(left, int) and (min(left, right) < 0 and max(left, right) >= 2**127):
+        if isinstance(left, int) and (min(left, right) < 0 and max(left, right) >= 2 ** 127):
             raise TypeMismatch("Cannot perform action between dislike numeric types", node)
 
         value = self._eval_fn(left, right)
@@ -2270,7 +2270,7 @@ class ISqrt(BuiltinFunction):
                     ["seq", ["set", y, shr(16, y)], ["set", z, shl(8, z)]],
                 ],
             ]
-            ret.append(["set", z, ["div", ["mul", z, ["add", y, 2**16]], 2**18]])
+            ret.append(["set", z, ["div", ["mul", z, ["add", y, 2 ** 16]], 2 ** 18]])
 
             for _ in range(7):
                 ret.append(["set", z, ["div", ["add", ["div", x, z], z], 2]])


### PR DESCRIPTION
### What I did

Added an optional argument to `raw_call` to allow for a safety check on the size of the return data. When `revert_on_excess` is set to True, the call will revert if the receiving variable is smaller than the returned data. (This is the default behavior already on external calls, but I set the default value to `False` here).

### How I did it

Added an assert comparing `returndatasize` and `max_outsize` when `revert_on_excess` is set to `True`. 

### How to verify it

Run the updated tests in `test_raw_call.py`

### Commit message

Option to add an upper bound check on returndatasize with raw_call

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/209962361-41713dec-1a53-4148-92f2-78f8194ae8fb.png)
