### PR TITLE
fix: restrict STATICCALL to @view

### DIFF
--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1161,6 +1161,12 @@ class RawCall(BuiltinFunction):
                 " use `is_static_call=True` to perform this action",
                 expr,
             )
+        print(f'this is context: {context.sig.mutability}')
+        if static_call and context.sig.mutability != "view":
+            print("you reached the right place")
+            raise StateAccessViolation(
+                    f"Functions that use STATICCALL must be declared as view"
+                    )
 
         if data.value == "~calldata":
             call_ir = ["with", "mem_ofst", "msize"]

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1161,12 +1161,10 @@ class RawCall(BuiltinFunction):
                 " use `is_static_call=True` to perform this action",
                 expr,
             )
-        print(f'this is context: {context.sig.mutability}')
         if static_call and context.sig.mutability != "view":
-            print("you reached the right place")
             raise StateAccessViolation(
-                    f"Functions that use STATICCALL must be declared as view"
-                    )
+                "Functions that use STATICCALL must be declared as view", expr
+            )  # to include expr or not?
 
         if data.value == "~calldata":
             call_ir = ["with", "mem_ofst", "msize"]

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -209,8 +209,7 @@ def _external_call_helper(contract_address, args_ir, call_kwargs, call_expr, con
     gas = call_kwargs.gas
     value = call_kwargs.value
 
-    use_staticcall = fn_type.mutability in (StateMutability.VIEW)
-    # , StateMutability.PURE): this should be removed, right?
+    use_staticcall = fn_type.mutability in (StateMutability.VIEW, StateMutability.PURE)
     if context.is_constant():
         assert use_staticcall, "typechecker missed this"
 

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -210,7 +210,7 @@ def _external_call_helper(contract_address, args_ir, call_kwargs, call_expr, con
     value = call_kwargs.value
 
     use_staticcall = fn_type.mutability in (StateMutability.VIEW)
-    #, StateMutability.PURE): this should be removed, right?
+    # , StateMutability.PURE): this should be removed, right?
     if context.is_constant():
         assert use_staticcall, "typechecker missed this"
 

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -209,7 +209,8 @@ def _external_call_helper(contract_address, args_ir, call_kwargs, call_expr, con
     gas = call_kwargs.gas
     value = call_kwargs.value
 
-    use_staticcall = fn_type.mutability in (StateMutability.VIEW, StateMutability.PURE)
+    use_staticcall = fn_type.mutability in (StateMutability.VIEW)
+    #, StateMutability.PURE): this should be removed, right?
     if context.is_constant():
         assert use_staticcall, "typechecker missed this"
 


### PR DESCRIPTION
### What I did
fix #3093. Restricted mutability of raw_call to @view when STATICCALL is used

### How I did it

### How to verify it

### Commit message
restricted mutability of raw_call to @view when STATICCALL is used

Functions that make use of the STATICCALL opcode must be declared as view.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/843324804/photo/fur-seal-antarctica.jpg?s=612x612&w=0&k=20&c=PEtE215c0To5j39_5vDMvK19XVpobDZHl_Dg4bY1NlU=)
