### PR TITLE
Raise clearer exception when using a yet undeclared variable in a type annotation

### DIFF
--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -307,7 +307,11 @@ class _ExprAnalyser:
     def types_from_Name(self, node):
         # variable name, e.g. `foo`
         name = node.id
-        if name not in self.namespace and name in self.namespace["self"].typ.members:
+        if (
+            name not in self.namespace
+            and "self" in self.namespace
+            and name in self.namespace["self"].typ.members
+        ):
             raise InvalidReference(
                 f"'{name}' is a storage variable, access it as self.{name}", node
             )


### PR DESCRIPTION
### What I did

As per #3214, trying to reference a yet undeclared constant variable in the type annotation of another variable's declaration results in a fairly unhelpful error message: `vyper.exceptions.UndeclaredDefinition: 'self' has not been declared. `
This fix ensures that a more detailed exception is raised.

### How I did it

The exception is raised when trying to check whether the variable is a storage variable by checking if its name is in `self.namespace["self"].typ.members`. 
However this check can happen before `self` is added to the namespace. When the constant variable is referenced in a type annotation, the check will happen during folding and before validation, so there will be no `self` key in namespace, leading to the previous exception being raised.
A simple check on whether the key is present suffices to prevent this exception from being raised and to instead raise another detailed `UndeclaredDefinition` exception containing the undeclared variable's name and line number of the error.

### How to verify it

Compiling the following contract:

```
PRECISIONS: constant(uint256[N_COINS]) = [
    1000000000000,
    10000000000,
    1,
]
N_COINS: constant(int128) = 3
```

Now raises the following exception:
```
vyper.exceptions.UndeclaredDefinition: 'N_COINS' has not been declared. 
  contract "***.vy:1", line 1:29 
  ---> 1 PRECISIONS: constant(uint256[N_COINS]) = [
  ------------------------------------^
       2     1000000000000,

```
### Commit message

Raise clearer exception when using a yet undeclared variable in a type annotation

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/210568266-a00cd6f1-a549-4956-a5ea-fe14f5edbbfb.png)