### PR TITLE
fix: folding of bitwise not literals

### DIFF
--- a/tests/builtins/folding/test_bitwise.py
+++ b/tests/builtins/folding/test_bitwise.py
@@ -40,9 +40,9 @@ def foo(a: uint256) -> uint256:
     """
     contract = get_contract(source)
 
-    vyper_ast = vy_ast.parse_to_ast(f"bitwise_not({value})")
+    vyper_ast = vy_ast.parse_to_ast(f"~{value}")
     old_node = vyper_ast.body[0].value
-    new_node = vy_fn.BitwiseNot().evaluate(old_node)
+    new_node = old_node.evaluate()
 
     assert contract.foo(value) == new_node.value
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -939,7 +939,7 @@ class Invert(Operator):
     _pretty = "~"
 
     def _op(self, value):
-        return value ^ (2 ** 256 - 1)
+        return (2 ** 256 - 1) - value
 
 
 class BinOp(ExprNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -937,7 +937,9 @@ class Invert(Operator):
     __slots__ = ()
     _description = "bitwise not"
     _pretty = "~"
-    _op = operator.inv
+
+    def _op(self, value):
+        return value ^ (2 ** 256 - 1)
 
 
 class BinOp(ExprNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -939,7 +939,7 @@ class Invert(Operator):
     _pretty = "~"
 
     def _op(self, value):
-        return (2 ** 256 - 1) - value
+        return (2 ** 256 - 1) ^ value
 
 
 class BinOp(ExprNode):


### PR DESCRIPTION
### What I did

Fix #3218. 

### How I did it

Reuse `(2 ** 256 - 1) - value` from `BitwiseNot` instead of `operator.inv`, which can return a negative number.

### How to verify it

See updated tests.

### Commit message

```
fix: folding of bitwise not literals
```

### Description for the changelog

Fix folding of bitwise not literals.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://modernfarmer.com/wp-content/uploads/2014/02/llama-hero.jpg)
