### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /code
 RUN git reset --hard
 
 # Using "test" optional to include test dependencies in built docker-image
-RUN pip install .[test] && \
+RUN pip install --no-cache-dir .[test] && \
     apt-get purge -y --auto-remove apt-utils gcc libc6-dev libc-dev libssl-dev
 
 ENTRYPOINT ["/usr/local/bin/vyper"]


### PR DESCRIPTION
Hi there,

### What I did

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

### How I did it

* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 453.77 MB
* Image size after repair: 429.87 MB
* Difference: 23.9 MB (5.27%)


### How to verify it
- Apply the patch and verify that the image still build

### Commit message

chore: remove pip cache from the Docker image

### Description for the changelog

Remove the `pip` cache from the Docker image to reduce its size by 23.9 MB

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.
