### PR TITLE
Add missing `ERC165` function `supportsInterface` to built-in `ERC721` interface

### DIFF
--- a/vyper/builtins/interfaces/ERC721.py
+++ b/vyper/builtins/interfaces/ERC721.py
@@ -20,6 +20,11 @@ event ApprovalForAll:
 
 @view
 @external
+def supportsInterface(interface_id: bytes4) -> bool:
+    pass
+
+@view
+@external
 def balanceOf(_owner: address) -> uint256:
     pass
 


### PR DESCRIPTION
### What I did

As title.

### How I did it

Added the missing `ERC165` function `supportsInterface` to built-in `ERC721` interface.

### How to verify it

https://eips.ethereum.org/EIPS/eip-721#specification.

> Every ERC-721 compliant contract must implement the ERC721 and ERC165 interfaces (subject to “caveats” below):

### Commit message

Add missing `ERC165` function `supportsInterface` to built-in `ERC721` interface

### Description for the changelog

Add missing `ERC165` function `supportsInterface` to built-in `ERC721` interface

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/212067509-819bdde6-82fc-4a37-8fc2-2420a9c1fbd5.png)
