### PR TITLE
fix: update array length check to display location of error

### DIFF
--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -101,6 +101,10 @@ class _SequenceT(_SubscriptableT):
 
     def __init__(self, value_type: VyperType, length: int):
 
+        # this check added to the existing child classes DArrayT and SArrayT,
+        # in order to show the user source code for debugging.
+        # if you've hit this it is unexpected behavior and likely
+        # a new child class has been created which needs a similar check
         if not 0 < length < 2 ** 256:
             raise InvalidType("Array length is invalid")
 
@@ -192,6 +196,8 @@ class SArrayT(_SequenceT):
             raise StructureException(
                 "Arrays must be defined with base type and length, e.g. bool[5]", node
             )
+        if not 0 < node.slice.value.value < 2 ** 256:
+            raise InvalidType("Array length is invalid", node)
 
         value_type = type_from_annotation(node.value)
 
@@ -283,6 +289,9 @@ class DArrayT(_SequenceT):
                 "DynArray must be defined with base type and max length, e.g. DynArray[bool, 5]",
                 node,
             )
+
+        if not 0 < node.slice.value.elements[1].value < 2 ** 256:
+            raise InvalidType("Array length is invalid", node)
 
         value_type = type_from_annotation(node.slice.value.elements[0])
         if not value_type._as_darray:

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_DynamicArray, ABI_StaticArray, ABI_Tuple, ABIType
-from vyper.exceptions import ArrayIndexException, InvalidType, StructureException
+from vyper.exceptions import ArrayIndexException, CompilerPanic, InvalidType, StructureException
 from vyper.semantics.types.base import VyperType
 from vyper.semantics.types.primitives import IntegerT
 from vyper.semantics.types.shortcuts import UINT256_T

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -38,6 +38,8 @@ def type_from_abi(abi_type: Dict) -> VyperType:
             length = int(length_str.rstrip("]"))
         except ValueError:
             raise UnknownType(f"ABI type has an invalid length: {type_string}") from None
+        if not 0 < length < 2 ** 256:
+            raise UnknownType(f"ABI contains an invalid array length: {length}") from None
         try:
             value_type = type_from_abi({"type": value_type_string})
         except UnknownType:


### PR DESCRIPTION
### What I did
fix #3150. added array length check to child classes SArrayT and DArrayT so that user can see where the error was made

### How I did it

### How to verify it

### Commit message
add array length check to SArrayT and DArrayT to display location of error

### Description for the changelog
This is the fix I came up with to display the location of the error to the user, as requested in #3150.
However, I left the original check in in case it gets accessed from somewhere else, or importantly if another child class of _SequenceT gets added and the maintainer doesn't explicitly add the check into the child class.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
