### PR TITLE
fix: block boolean not operator on numeric types

### DIFF
--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -63,24 +63,6 @@ def foo(a: address) -> bool:
     """,
         InvalidOperation,
     ),
-    """
-@external
-def foo() -> bool:
-    b: int128 = 0
-    return not b
-    """,
-    """
-@external
-def foo() -> bool:
-    b: uint256 = 0
-    return not b
-    """,
-    """
-@external
-def foo() -> bool:
-    b: uint256 = 0
-    return not b
-    """,
     (
         """
 @external

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -33,6 +33,16 @@ def foo(x: decimal, y: decimal) -> decimal:
     assert_compile_failed(lambda: get_contract(code), InvalidOperation)
 
 
+@pytest.mark.parametrize("op", ["not"])
+def test_invalid_unary_ops(get_contract, assert_compile_failed, op):
+    code = f"""
+@external
+def foo(x: decimal) -> decimal:
+    return {op} x
+    """
+    assert_compile_failed(lambda: get_contract(code), InvalidOperation)
+
+
 def quantize(x: Decimal) -> Decimal:
     return x.quantize(DECIMAL_EPSILON, rounding=ROUND_DOWN)
 

--- a/tests/parser/types/numbers/test_signed_ints.py
+++ b/tests/parser/types/numbers/test_signed_ints.py
@@ -4,7 +4,7 @@ import random
 
 import pytest
 
-from vyper.exceptions import InvalidType, OverflowException, ZeroDivisionException
+from vyper.exceptions import InvalidOperation, InvalidType, OverflowException, ZeroDivisionException
 from vyper.semantics.types import IntegerT
 from vyper.utils import evm_div, evm_mod
 
@@ -389,3 +389,14 @@ def foo(a: {typ}) -> {typ}:
     assert c.foo(-2) == 2
 
     assert_tx_failed(lambda: c.foo(lo))
+
+
+@pytest.mark.parametrize("typ", types)
+@pytest.mark.parametrize("op", ["not"])
+def test_invalid_unary_ops(get_contract, assert_compile_failed, typ, op):
+    code = f"""
+@external
+def foo(a: {typ}) -> {typ}:
+    return {op} a
+    """
+    assert_compile_failed(lambda: get_contract(code), InvalidOperation)

--- a/tests/parser/types/numbers/test_unsigned_ints.py
+++ b/tests/parser/types/numbers/test_unsigned_ints.py
@@ -4,7 +4,7 @@ import random
 
 import pytest
 
-from vyper.exceptions import InvalidType, OverflowException, ZeroDivisionException
+from vyper.exceptions import InvalidOperation, InvalidType, OverflowException, ZeroDivisionException
 from vyper.semantics.types import IntegerT
 from vyper.utils import evm_div, evm_mod
 
@@ -257,3 +257,14 @@ def test() -> {typ}:
 
     for val in bad_cases:
         assert_compile_failed(lambda: get_contract(code_template.format(typ=typ, val=val)))
+
+
+@pytest.mark.parametrize("typ", types)
+@pytest.mark.parametrize("op", ["not", "-"])
+def test_invalid_unary_ops(get_contract, assert_compile_failed, typ, op):
+    code = f"""
+@external
+def foo(a: {typ}) -> {typ}:
+    return {op} a
+    """
+    assert_compile_failed(lambda: get_contract(code), InvalidOperation)

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -219,9 +219,10 @@ class IntegerT(NumericT):
 
     @cached_property
     def _invalid_ops(self):
+        invalid_ops = (vy_ast.Not,)
         if not self.is_signed:
-            return (vy_ast.USub,)
-        return ()
+            return invalid_ops + (vy_ast.USub,)
+        return invalid_ops
 
     @classmethod
     # TODO maybe cache these three classmethods
@@ -265,7 +266,7 @@ class DecimalT(NumericT):
     _decimal_places = 10  # TODO generalize
     _id = "decimal"
     _is_signed = True
-    _invalid_ops = (vy_ast.Pow, vy_ast.BitAnd, vy_ast.BitOr, vy_ast.BitXor)
+    _invalid_ops = (vy_ast.Pow, vy_ast.BitAnd, vy_ast.BitOr, vy_ast.BitXor, vy_ast.Not)
     _valid_literal = (vy_ast.Decimal,)
 
     _equality_attrs = ("_bits", "_decimal_places")


### PR DESCRIPTION
### What I did

Fix #3217 

### How I did it

Added `vy_ast.Not` to `IntegerT` and `DecimalT`'s  `_invalid_ops`

### How to verify it

See tests.

### Commit message

    fix: block boolean not operator on numeric types

### Description for the changelog

Block boolean not operator on numeric types

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/157636471/photo/close-up-of-a-cute-raccoon-face.jpg?s=612x612&w=0&k=20&c=1XwqEuXVU_0zqSrkjEEZaL03cyg2cvufmwsm9aNzaOg=)
