### PR TITLE
fix: skip enum members in folding of user-defined constants

### DIFF
--- a/tests/parser/syntax/test_enum.py
+++ b/tests/parser/syntax/test_enum.py
@@ -121,7 +121,7 @@ a: constant(uint256) = 1
 
 enum A:
     a
-    """
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_enum.py
+++ b/tests/parser/syntax/test_enum.py
@@ -116,6 +116,12 @@ def run() -> Order:
         })
     """,
     "enum Foo:\n" + "\n".join([f"    member{i}" for i in range(256)]),
+    """
+a: constant(uint256) = 1
+
+enum A:
+    a
+    """
 ]
 
 

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -284,6 +284,10 @@ def replace_constant(
             if assign and node in assign.target.get_descendants(include_self=True):
                 continue
 
+        # do not replace enum members
+        if node.get_ancestor(vy_ast.EnumDef):
+            continue
+
         try:
             # note: _replace creates a copy of the replacement_node
             new_node = _replace(node, replacement_node, type_=type_)


### PR DESCRIPTION
### What I did

Fix #3233.

### How I did it

Do not replace a `Name` node during folding of user-defined constants if it has an `EnumDef` node as its parent.

### How to verify it

See test.

### Commit message

```
fix: skip enum members in folding of user-defined constants
```

### Description for the changelog

Skip enum members in in folding of user-defined constants

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT4ghtF9HVJC4_prVL1h-YXEstTETBjkqvyYA&usqp=CAU)
