### PR TITLE
fix: guard against writing to calldata array

### DIFF
--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -99,7 +99,17 @@ def test_statefulness_violations(bad_code):
         """
 @external
 def foo(x: int128):
-    x = 5"""
+    x = 5""",
+        """
+@external
+def test(a: uint256[4]):
+    a[0] = 1
+        """,
+        """
+@external
+def test(a: uint256[4][4]):
+    a[0][1] = 1
+        """,
     ],
 )
 def test_immutability_violations(bad_code):

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -111,6 +111,15 @@ def test(a: uint256[4]):
 def test(a: uint256[4][4]):
     a[0][1] = 1
         """,
+        """
+struct Foo:
+    a: DynArray[DynArray[uint256, 2], 2]
+
+@external
+def foo(f: Foo) -> Foo:
+    f.a[1] = [0, 1]
+    return f
+        """,
     ],
 )
 def test_immutability_violations(bad_code):

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -99,7 +99,8 @@ def test_statefulness_violations(bad_code):
         """
 @external
 def foo(x: int128):
-    x = 5""",
+    x = 5
+        """,
         """
 @external
 def test(a: uint256[4]):

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -1565,10 +1565,11 @@ def _foo2() -> Foo:
 
 @internal
 def _foo3(f: Foo) -> Foo:
-    f.b1[0][1][0].a1[0][0] = [0, 0]
-    f.b1[1][0][0].a1[0][1] = [0, 0]
-    f.b1[1][1][0].a1[1][1] = [0, 0]
-    return f
+    new_f: Foo = f
+    new_f.b1[0][1][0].a1[0][0] = [0, 0]
+    new_f.b1[1][0][0].a1[0][1] = [0, 0]
+    new_f.b1[1][1][0].a1[1][1] = [0, 0]
+    return new_f
 
 @external
 def bar() -> DynArray[DynArray[DynArray[uint256, 2], 2], 2]:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -95,6 +95,16 @@ class _ExprAnalyser:
             is_constant = any((getattr(i, "is_constant", False) for i in types))
 
             return ExprInfo(t, location=location, is_constant=is_constant)
+            
+        # If it's a Subscript, propagate the subscriptable varinfo
+        if isinstance(node, vy_ast.Subscript):
+            varinfo = self.get_expr_info(node.value)
+            return ExprInfo(
+                t,
+                location=varinfo.location,
+                is_constant=varinfo.is_constant,
+                is_immutable=varinfo.is_immutable,
+            )
 
         return ExprInfo(t)
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -98,13 +98,8 @@ class _ExprAnalyser:
 
         # If it's a Subscript, propagate the subscriptable varinfo
         if isinstance(node, vy_ast.Subscript):
-            varinfo = self.get_expr_info(node.value)
-            return ExprInfo(
-                t,
-                location=varinfo.location,
-                is_constant=varinfo.is_constant,
-                is_immutable=varinfo.is_immutable,
-            )
+            info = self.get_expr_info(node.value)
+            return info.copy_with_type(t)
 
         return ExprInfo(t)
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -95,7 +95,7 @@ class _ExprAnalyser:
             is_constant = any((getattr(i, "is_constant", False) for i in types))
 
             return ExprInfo(t, location=location, is_constant=is_constant)
-            
+
         # If it's a Subscript, propagate the subscriptable varinfo
         if isinstance(node, vy_ast.Subscript):
             varinfo = self.get_expr_info(node.value)


### PR DESCRIPTION
### What I did

Fix #3225 

### How I did it

Add a branch to `get_expr_info` for `Subscript` nodes, and propagate the info from `Subscript.value`.

### How to verify it

See tests.

### Commit message

```
fix: guard against writing to calldata array
```

### Description for the changelog

Guard against writing to calldata array

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS22EJszP0Pc7tSlLGlEatSP1hO1lKvKfoHNg&usqp=CAU)
