### PR TITLE
test: fix typo in test_replace_in_tree.py

### DIFF
--- a/tests/ast/nodes/test_replace_in_tree.py
+++ b/tests/ast/nodes/test_replace_in_tree.py
@@ -5,12 +5,12 @@ from vyper.exceptions import CompilerPanic
 
 
 def test_assumptions():
-    # ASTs generated seperately from the same source should compare equal
+    # ASTs generated separately from the same source should compare equal
     test_tree = vy_ast.parse_to_ast("foo = 42")
     expected_tree = vy_ast.parse_to_ast("foo = 42")
     assert vy_ast.compare_nodes(test_tree, expected_tree)
 
-    # ASTs generated seperately with different source should compare not-equal
+    # ASTs generated separately with different source should compare not-equal
     test_tree = vy_ast.parse_to_ast("foo = 42")
     expected_tree = vy_ast.parse_to_ast("bar = 666")
     assert not vy_ast.compare_nodes(test_tree, expected_tree)


### PR DESCRIPTION
### What I did

Fixed typo.
```
seperately -> separately
```

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/22633385/213345510-4dd0bb0c-1480-4130-8fe8-4aaee2b6ea32.png)


