### PR TITLE
fix: prevent enum members to have unexpected structures

### DIFF
--- a/tests/parser/syntax/test_enum.py
+++ b/tests/parser/syntax/test_enum.py
@@ -76,6 +76,27 @@ def foo(x: Roles) -> bool:
     """,
         InvalidOperation,
     ),
+    (
+        """
+enum Functions:
+    def foo():nonpayable
+    """,
+        EnumDeclarationException,
+    ),
+    (
+        """
+enum Numbers:
+    a:constant(uint256) = a
+    """,
+        EnumDeclarationException,
+    ),
+    (
+        """
+enum Numbers:
+    12
+    """,
+        EnumDeclarationException,
+    ),
 ]
 
 

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -106,9 +106,12 @@ class EnumT(_UserType):
         members: Dict = {}
 
         if len(base_node.body) == 1 and isinstance(base_node.body[0], vy_ast.Pass):
-            raise EnumDeclarationException("Enum must have members")
+            raise EnumDeclarationException("Enum must have members", base_node)
 
         for i, node in enumerate(base_node.body):
+            if not isinstance(node, vy_ast.Expr) or not isinstance(node.value, vy_ast.Name):
+                raise EnumDeclarationException("Invalid syntax for enum member", node)
+
             member_name = node.value.id
             if member_name in members:
                 raise EnumDeclarationException(


### PR DESCRIPTION
### What I did
- Fixed #3239
- Added the node of the enum declaration to the exception raised when it is empty to indicate its location.
### How I did it

Added checks that the fields of an `enum` must be `Expr` statements with values that are `Name`

### How to verify it
See tests
### Commit message

    fix: prevent enum members to have unexpected structures

### Description for the changelog

Enforce enum members to be simple names

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rd.com/wp-content/uploads/2021/04/GettyImages-86146566.jpg)
