### PR TITLE
fix: enforce that loop's iterators are valid names

### DIFF
--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -1,6 +1,26 @@
 import pytest
 
 from vyper import compiler
+from vyper.exceptions import StructureException
+
+fail_list = [
+    (
+        """
+@external
+def foo():
+    for a[1] in range(10):
+        pass
+    """,
+        StructureException,
+    )
+]
+
+
+@pytest.mark.parametrize("bad_code", fail_list)
+def test_range_fail(bad_code):
+    with pytest.raises(bad_code[1]):
+        compiler.compile_code(bad_code[0])
+
 
 valid_list = [
     """

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -434,6 +434,9 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                         )
         self.expr_visitor.visit(node.iter)
 
+        if not isinstance(node.target, vy_ast.Name):
+            raise StructureException("Invalid syntax for loop iterator", node.target)
+
         for_loop_exceptions = []
         iter_name = node.target.id
         for type_ in type_list:


### PR DESCRIPTION
### What I did
Fixed #3241 
### How I did it
Added a check to raise an exception if the iterator of a loop is not a `Name`.
### How to verify it
See test
### Commit message

    fix: enforce that loop's iterators are valid names

### Description for the changelog

Enforce that loop's iterators are valid names

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/IRdivT8pcl4/maxresdefault.jpg)
