### PR TITLE
fix: support `append` as unreserved keywords

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -107,6 +107,15 @@ m1: HashMap[uint8, uint8]
 def __init__():
     self.m1 = 234
     """,
+    """
+interface Foo:
+    def pop(): payable
+
+@external
+def foo(x: address):
+    a: Foo = Foo(x)
+    a.pop()
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_functions_call.py
+++ b/tests/parser/syntax/test_functions_call.py
@@ -66,16 +66,6 @@ def setup(token_addr: address):
     self.token = ERC20(token_addr)
     assert self.factory.getExchange(self.token.address) == self
     """,
-    """
-@internal
-def pop() -> uint256:
-    return 5
-
-@external
-def get_pop() -> uint256:
-    b: uint256 = self.pop()
-    return b
-    """,
 ]
 
 

--- a/tests/parser/syntax/test_functions_call.py
+++ b/tests/parser/syntax/test_functions_call.py
@@ -66,6 +66,16 @@ def setup(token_addr: address):
     self.token = ERC20(token_addr)
     assert self.factory.getExchange(self.token.address) == self
     """,
+    """
+@internal
+def append():
+    pass
+
+@external
+def foo():
+    self.append()
+
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_functions_call.py
+++ b/tests/parser/syntax/test_functions_call.py
@@ -66,6 +66,16 @@ def setup(token_addr: address):
     self.token = ERC20(token_addr)
     assert self.factory.getExchange(self.token.address) == self
     """,
+    """
+@internal
+def pop() -> uint256:
+    return 5
+
+@external
+def get_pop() -> uint256:
+    b: uint256 = self.pop()
+    return b
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -180,6 +180,21 @@ interface MyInterface:
 
 kickers: HashMap[address, MyInterface]
     """,
+    """
+interface Foo:
+    def append(a: uint256): payable
+    def pop(): payable
+
+@external
+def bar(x: address):
+    a: Foo = Foo(x)
+    a.append(1)
+
+@external
+def foo(x: address):
+    a: Foo = Foo(x)
+    a.pop()
+    """,
 ]
 
 

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -183,17 +183,11 @@ kickers: HashMap[address, MyInterface]
     """
 interface Foo:
     def append(a: uint256): payable
-    def pop(): payable
 
 @external
 def bar(x: address):
     a: Foo = Foo(x)
     a.append(1)
-
-@external
-def foo(x: address):
-    a: Foo = Foo(x)
-    a.pop()
     """,
 ]
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -648,13 +648,14 @@ class Expr:
                 return arg_ir
 
         elif isinstance(self.expr.func, vy_ast.Attribute) and self.expr.func.attr == "pop":
-            # TODO consider moving this to builtins
-            darray = Expr(self.expr.func.value, self.context).ir_node
-            assert len(self.expr.args) == 0
-            assert isinstance(darray.typ, DArrayT)
-            return pop_dyn_array(darray, return_popped_item=True)
+            parent = Expr(self.expr.func.value, self.context).ir_node
 
-        elif (
+            if isinstance(parent.typ, DArrayT):
+                darray = parent
+                assert len(self.expr.args) == 0
+                return pop_dyn_array(darray, return_popped_item=True)
+
+        if (
             # TODO use expr.func.type.is_internal once
             # type annotations are consistently available
             isinstance(self.expr.func, vy_ast.Attribute)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -648,14 +648,13 @@ class Expr:
                 return arg_ir
 
         elif isinstance(self.expr.func, vy_ast.Attribute) and self.expr.func.attr == "pop":
-            parent = Expr(self.expr.func.value, self.context).ir_node
+            # TODO consider moving this to builtins
+            darray = Expr(self.expr.func.value, self.context).ir_node
+            assert len(self.expr.args) == 0
+            assert isinstance(darray.typ, DArrayT)
+            return pop_dyn_array(darray, return_popped_item=True)
 
-            if isinstance(parent.typ, DArrayT):
-                darray = parent
-                assert len(self.expr.args) == 0
-                return pop_dyn_array(darray, return_popped_item=True)
-
-        if (
+        elif (
             # TODO use expr.func.type.is_internal once
             # type annotations are consistently available
             isinstance(self.expr.func, vy_ast.Attribute)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -123,24 +123,25 @@ class Stmt:
             "append",
             "pop",
         ):
-            # TODO: consider moving this to builtins
-            darray = Expr(self.stmt.func.value, self.context).ir_node
-            args = [Expr(x, self.context).ir_node for x in self.stmt.args]
-            if self.stmt.func.attr == "append":
-                # sanity checks
-                assert len(args) == 1
-                arg = args[0]
-                assert isinstance(darray.typ, DArrayT)
-                check_assign(
-                    dummy_node_for_type(darray.typ.value_type), dummy_node_for_type(arg.typ)
-                )
+            parent = Expr(self.stmt.func.value, self.context).ir_node
+            
+            if isinstance(parent.typ, DArrayT):
+                darray = parent
+                args = [Expr(x, self.context).ir_node for x in self.stmt.args]
+                if self.stmt.func.attr == "append":
+                    # sanity checks
+                    assert len(args) == 1
+                    arg = args[0]
+                    check_assign(
+                        dummy_node_for_type(darray.typ.value_type), dummy_node_for_type(arg.typ)
+                    )
 
-                return append_dyn_array(darray, arg)
-            else:
-                assert len(args) == 0
-                return pop_dyn_array(darray, return_popped_item=False)
+                    return append_dyn_array(darray, arg)
+                else:
+                    assert len(args) == 0
+                    return pop_dyn_array(darray, return_popped_item=False)
 
-        elif is_self_function:
+        if is_self_function:
             return self_call.ir_for_self_call(self.stmt, self.context)
         else:
             return external_call.ir_for_external_call(self.stmt, self.context)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -25,6 +25,7 @@ from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
 from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure
 from vyper.semantics.types import DArrayT
+from vyper.semantics.types.function import MemberFunctionT
 from vyper.semantics.types.shortcuts import INT256_T, UINT256_T
 
 
@@ -123,15 +124,15 @@ class Stmt:
             "append",
             "pop",
         ):
-            parent = Expr(self.stmt.func.value, self.context).ir_node
-
-            if isinstance(parent.typ, DArrayT):
-                darray = parent
+            func_type = self.stmt.func._metadata["type"]
+            if isinstance(func_type, MemberFunctionT):
+                darray = Expr(self.stmt.func.value, self.context).ir_node
                 args = [Expr(x, self.context).ir_node for x in self.stmt.args]
                 if self.stmt.func.attr == "append":
                     # sanity checks
                     assert len(args) == 1
                     arg = args[0]
+                    assert isinstance(darray.typ, DArrayT)
                     check_assign(
                         dummy_node_for_type(darray.typ.value_type), dummy_node_for_type(arg.typ)
                     )

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -24,8 +24,7 @@ from vyper.codegen.core import (
 from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
 from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure
-from vyper.semantics.types import DArrayT
-from vyper.semantics.types.function import MemberFunctionT
+from vyper.semantics.types import DArrayT, MemberFunctionT
 from vyper.semantics.types.shortcuts import INT256_T, UINT256_T
 
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -124,7 +124,7 @@ class Stmt:
             "pop",
         ):
             parent = Expr(self.stmt.func.value, self.context).ir_node
-            
+
             if isinstance(parent.typ, DArrayT):
                 darray = parent
                 args = [Expr(x, self.context).ir_node for x in self.stmt.args]

--- a/vyper/semantics/types/__init__.py
+++ b/vyper/semantics/types/__init__.py
@@ -1,6 +1,7 @@
 from . import primitives, subscriptable, user
 from .base import TYPE_T, KwargSettings, VyperType, is_type_t
 from .bytestrings import BytesT, StringT, _BytestringT
+from .function import MemberFunctionT
 from .primitives import AddressT, BoolT, BytesM_T, DecimalT, IntegerT
 from .subscriptable import DArrayT, HashMapT, SArrayT, TupleT
 from .user import EnumT, EventT, InterfaceT, StructT


### PR DESCRIPTION
### What I did

Fix #3227.

### How I did it

Change the assertion for `append` to conditional `if`.

### How to verify it

See tests.

### Commit message

```
fix: support `append` as unreserved keyword
```

### Description for the changelog

Support `append` as unreserved keyword

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Llamas%2C_Vernagt-Stausee%2C_Italy.jpg/1200px-Llamas%2C_Vernagt-Stausee%2C_Italy.jpg)
