### PR TITLE
fix: allow accessing members of constant address

### DIFF
--- a/tests/parser/features/test_address_balance.py
+++ b/tests/parser/features/test_address_balance.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def test_constant_address_balance(w3, get_contract_with_gas_estimation):
+    code = """
+a: constant(address) = 0x0000000000000000000000000000000000000123
+
+@external
+def foo() -> uint256:
+    x: uint256 = a.balance
+    return x
+    """
+    address = "0x0000000000000000000000000000000000000123"
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.foo() == 0
+
+    w3.eth.send_transaction({"to": address, "value": 1337})
+
+    assert c.foo() == 1337

--- a/tests/parser/features/test_address_balance.py
+++ b/tests/parser/features/test_address_balance.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_constant_address_balance(w3, get_contract_with_gas_estimation):
     code = """
 a: constant(address) = 0x776Ba14735FF84789320718cf0aa43e91F7A8Ce1

--- a/tests/parser/features/test_address_balance.py
+++ b/tests/parser/features/test_address_balance.py
@@ -3,14 +3,14 @@ import pytest
 
 def test_constant_address_balance(w3, get_contract_with_gas_estimation):
     code = """
-a: constant(address) = 0x0000000000000000000000000000000000000123
+a: constant(address) = 0x776Ba14735FF84789320718cf0aa43e91F7A8Ce1
 
 @external
 def foo() -> uint256:
     x: uint256 = a.balance
     return x
     """
-    address = "0x0000000000000000000000000000000000000123"
+    address = "0x776Ba14735FF84789320718cf0aa43e91F7A8Ce1"
 
     c = get_contract_with_gas_estimation(code)
 

--- a/vyper/semantics/analysis/annotation.py
+++ b/vyper/semantics/analysis/annotation.py
@@ -112,7 +112,10 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_Attribute(self, node, type_):
         type_ = get_exact_type_from_node(node)
         node._metadata["type"] = type_
-        self.visit(node.value, None)
+
+        # fetch the propagated type for constants, if any
+        value_type = node.value._metadata.get("type", None)
+        self.visit(node.value, value_type)
 
     def visit_BinOp(self, node, type_):
         if type_ is None:

--- a/vyper/semantics/analysis/annotation.py
+++ b/vyper/semantics/analysis/annotation.py
@@ -112,10 +112,7 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_Attribute(self, node, type_):
         type_ = get_exact_type_from_node(node)
         node._metadata["type"] = type_
-
-        # fetch the propagated type for constants, if any
-        value_type = node.value._metadata.get("type", None)
-        self.visit(node.value, value_type)
+        self.visit(node.value, None)
 
     def visit_BinOp(self, node, type_):
         if type_ is None:
@@ -130,9 +127,6 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_BoolOp(self, node, type_):
         for value in node.values:
             self.visit(value)
-
-    def visit_Bytes(self, node, type_):
-        node._metadata["type"] = type_
 
     def visit_Call(self, node, type_):
         call_type = get_exact_type_from_node(node.func)
@@ -204,14 +198,8 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_Dict(self, node, type_):
         node._metadata["type"] = type_
 
-    def visit_Hex(self, node, type_):
-        node._metadata["type"] = type_
-
     def visit_Index(self, node, type_):
         self.visit(node.value, type_)
-
-    def visit_Int(self, node, type_):
-        node._metadata["type"] = type_
 
     def visit_List(self, node, type_):
         if type_ is None:


### PR DESCRIPTION
### What I did

Fix #3258.

### How I did it

Remove `visit_Hex`, which was overriding `visit_Constant`. This caused the propagated type to be ignored and overriden with the `None` value.

On an unrelated but similar reasoning, I also removed `visit_Int` and `visit_Bytes`.

### How to verify it

See tests.

### Commit message

```
fix: allow accessing members of constant address
```

### Description for the changelog

Allow accessing members of constant address

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/k22Gg13ahDc/maxresdefault.jpg)
