### PR TITLE
chore: improve error message for undeclared enum member

### DIFF
--- a/tests/parser/syntax/test_enum.py
+++ b/tests/parser/syntax/test_enum.py
@@ -109,7 +109,7 @@ def foo() -> Roles:
     return Roles.GUEST
     """,
         UnknownAttribute,
-    )
+    ),
 ]
 
 

--- a/tests/parser/syntax/test_enum.py
+++ b/tests/parser/syntax/test_enum.py
@@ -7,6 +7,7 @@ from vyper.exceptions import (
     NamespaceCollision,
     StructureException,
     TypeMismatch,
+    UnknownAttribute,
 )
 
 fail_list = [
@@ -97,6 +98,18 @@ enum Numbers:
     """,
         EnumDeclarationException,
     ),
+    (
+        """
+enum Roles:
+    ADMIN
+    USER
+
+@external
+def foo() -> Roles:
+    return Roles.GUEST
+    """,
+        UnknownAttribute,
+    )
 ]
 
 

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -55,6 +55,9 @@ class EnumT(_UserType):
         # also conveniently checks well-formedness of the members namespace
         self._helper = VyperType(members)
 
+        # set the name for exception handling in `get_member`
+        self._helper._id = name
+
     def get_type_member(self, key: str, node: vy_ast.VyperNode) -> "VyperType":
         self._helper.get_member(key, node)
         return self


### PR DESCRIPTION
### What I did

Fix #3262 

### How I did it

Set `EnumT._helper._id` to the same name as the `EnumT`.

### How to verify it

See test.

### Commit message

```
chore: improve error message for undeclared enum member
```

### Description for the changelog

Improve error message for undeclared enum member

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://birdinflight.com/wp-content/uploads/2016/08/BRITAIN-PENGUIN-OFFBEAT.jpg)
