### PR TITLE
fix: guard against decorators in interface

### DIFF
--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -84,7 +84,7 @@ interface A:
     def foo(): nonpayable
     """,
         StructureException,
-    )
+    ),
 ]
 
 

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -5,6 +5,7 @@ from vyper.exceptions import (
     ArgumentException,
     InvalidReference,
     InvalidType,
+    StructureException,
     SyntaxException,
     TypeMismatch,
     UnknownAttribute,
@@ -76,6 +77,14 @@ implements: ERC20 = 1
     """,
         SyntaxException,
     ),
+    (
+        """
+interface A:
+    @external
+    def foo(): nonpayable
+    """,
+        StructureException,
+    )
 ]
 
 

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -468,6 +468,8 @@ def _get_class_functions(base_node: vy_ast.InterfaceDef) -> Dict[str, ContractFu
             raise NamespaceCollision(
                 f"Interface contains multiple functions named '{node.name}'", node
             )
+        if len(node.decorator_list) > 0:
+            raise StructureException("Function definition in interface cannot be decorated", node.decorator_list[0])
         functions[node.name] = ContractFunctionT.from_FunctionDef(node, is_interface=True)
 
     return functions

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -469,7 +469,9 @@ def _get_class_functions(base_node: vy_ast.InterfaceDef) -> Dict[str, ContractFu
                 f"Interface contains multiple functions named '{node.name}'", node
             )
         if len(node.decorator_list) > 0:
-            raise StructureException("Function definition in interface cannot be decorated", node.decorator_list[0])
+            raise StructureException(
+                "Function definition in interface cannot be decorated", node.decorator_list[0]
+            )
         functions[node.name] = ContractFunctionT.from_FunctionDef(node, is_interface=True)
 
     return functions


### PR DESCRIPTION
### What I did

Fix #3248.

### How I did it

Check if decorator list is empty for `FunctionDef` node in an interface.

### How to verify it

See test

### Commit message

```
fix: guard against decorators in interface
```

### Description for the changelog

Guard against decorators in interface

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.shutterstock.com/image-photo/chinese-new-year-lion-dance-260nw-1615629028.jpg)
