### PR TITLE
fix: prevent return code after `if else` with exit statements in both branches

### DIFF
--- a/tests/parser/features/test_conditionals.py
+++ b/tests/parser/features/test_conditionals.py
@@ -7,7 +7,6 @@ def foo(i: bool) -> int128:
     else:
         assert 2 != 0
         return 7
-    return 11
     """
 
     c = get_contract_with_gas_estimation(conditional_return_code)

--- a/tests/parser/syntax/test_unbalanced_return.py
+++ b/tests/parser/syntax/test_unbalanced_return.py
@@ -64,6 +64,18 @@ def valid_address(sender: address) -> bool:
     """,
         StructureException,
     ),
+    (
+        """
+@internal
+def valid_address(sender: address) -> bool:
+    if sender == ZERO_ADDRESS:
+        return True
+    else:
+        return False
+    return True
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/tests/parser/syntax/test_unbalanced_return.py
+++ b/tests/parser/syntax/test_unbalanced_return.py
@@ -69,6 +69,7 @@ def valid_address(sender: address) -> bool:
 @internal
 def valid_address(sender: address) -> bool:
     if sender == ZERO_ADDRESS:
+        pass
         return True
     else:
         return False
@@ -122,21 +123,6 @@ def test() -> int128:
     else:
         assert msg.sender != msg.sender
         return 0
-    """,
-    """
-@external
-def test() -> int128:
-    x: bytes32 = EMPTY_BYTES32
-    if False:
-        if False:
-            return 0
-        else:
-            x = keccak256(x)
-            return 1
-    else:
-        x = keccak256(x)
-        return 1
-    return 1
     """,
 ]
 

--- a/tests/parser/syntax/test_unbalanced_return.py
+++ b/tests/parser/syntax/test_unbalanced_return.py
@@ -77,6 +77,22 @@ def valid_address(sender: address) -> bool:
     """,
         StructureException,
     ),
+    (
+        """
+@internal
+def valid_address(sender: address) -> bool:
+    if sender == ZERO_ADDRESS:
+        return True
+    elif sender != ZERO_ADDRESS:
+        pass
+        return False
+    else:
+        a: address = sender
+        return False
+    return True
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -927,10 +927,9 @@ def is_return_from_function(node):
     if isinstance(node, (vy_ast.Return, vy_ast.Raise)):
         return True
     if isinstance(node, vy_ast.If):
-        return_if_body = any(is_return_from_function(n) for n in node.body)
-        return_else_body = any(is_return_from_function(n) for n in node.orelse)
-        if return_if_body and return_else_body:
-            return True
+        body_returns = any(is_return_from_function(n) for n in node.body)
+        orelse_returns = any(is_return_from_function(n) for n in node.orelse)
+        return body_returns and orelse_returns
     return False
 
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -925,7 +925,10 @@ def is_return_from_function(node):
         return True
     if isinstance(node, vy_ast.If):
         return_if_body = is_return_from_function(node.body[0])
-        return_else_body = node.orelse and is_return_from_function(node.orelse[0])
+        if node.orelse and is_return_from_function(node.orelse[0]):
+            return_else_body = True
+        else:
+            return_else_body = False
         if return_if_body and return_else_body:
             return True
     return False

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -925,10 +925,7 @@ def is_return_from_function(node):
         return True
     if isinstance(node, vy_ast.If):
         return_if_body = is_return_from_function(node.body[0])
-        if node.orelse and is_return_from_function(node.orelse[0]):
-            return_else_body = True
-        else:
-            return_else_body = False
+        return_else_body = node.orelse and is_return_from_function(node.orelse[0])
         if return_if_body and return_else_body:
             return True
     return False

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -924,8 +924,8 @@ def is_return_from_function(node):
     if isinstance(node, (vy_ast.Return, vy_ast.Raise)):
         return True
     if isinstance(node, vy_ast.If):
-        return_if_body = is_return_from_function(node.body[0])
-        return_else_body = node.orelse and is_return_from_function(node.orelse[0])
+        return_if_body = any(is_return_from_function(n) for n in node.body)
+        return_else_body = any(is_return_from_function(n) for n in node.orelse)
         if return_if_body and return_else_body:
             return True
     return False

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -923,6 +923,11 @@ def is_return_from_function(node):
         return True
     if isinstance(node, (vy_ast.Return, vy_ast.Raise)):
         return True
+    if isinstance(node, vy_ast.If):
+        return_if_body = is_return_from_function(node.body[0])
+        return_else_body = node.orelse and is_return_from_function(node.orelse[0])
+        if return_if_body and return_else_body:
+            return True
     return False
 
 


### PR DESCRIPTION
### What I did

Fix #3265 

### How I did it

Added a checking for a `if else` AST node in `is_return_from_function`. If both branches have a `return` node, then we consider this `if else` node to be as same as the `return` node.

### How to verify it

`py.test  tests/parser/syntax/test_unbalanced_return.py`

### Commit message

fix: prevent return code after 'if else' with exit statements in both branches

### Description for the changelog

### Cute Animal Picture

![Elephant](https://i.redd.it/ehx2i71xllha1.jpg)
