### PR TITLE
fix: length of empty byte arrays and dynamic arrays

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -918,9 +918,9 @@ Utilities
         def foo():
             x: uint256[2][5] = empty(uint256[2][5])
 
-.. py:function:: len(b: Union[Bytes, String]) -> uint256
+.. py:function:: len(b: Union[Bytes, String, DynArray[_Type, _Integer]]) -> uint256
 
-    Return the length of a given ``Bytes`` or ``String``.
+    Return the length of a given ``Bytes``, ``String`` or ``DynArray[_Type, _Integer]``.
 
     .. code-block:: python
 

--- a/tests/parser/functions/test_length.py
+++ b/tests/parser/functions/test_length.py
@@ -1,4 +1,4 @@
-import pytest 
+import pytest
 
 
 def test_test_length(get_contract_with_gas_estimation):

--- a/tests/parser/functions/test_length.py
+++ b/tests/parser/functions/test_length.py
@@ -1,3 +1,6 @@
+import pytest 
+
+
 def test_test_length(get_contract_with_gas_estimation):
     test_length = """
 y: Bytes[10]
@@ -12,3 +15,31 @@ def foo(inp: Bytes[10]) -> uint256:
     c = get_contract_with_gas_estimation(test_length)
     assert c.foo(b"badminton") == 954, c.foo(b"badminton")
     print("Passed length test")
+
+
+zero_length_cases = [
+    """
+@external
+def boo() -> uint256:
+    e: uint256 = len(empty(DynArray[uint256, 50]))
+    return e
+    """,
+    """
+@external
+def boo() -> uint256:
+    e: uint256 = len(empty(Bytes[50]))
+    return e
+    """,
+    """
+@external
+def boo() -> uint256:
+    e: uint256 = len(empty(String[50]))
+    return e
+    """,
+]
+
+
+@pytest.mark.parametrize("code", zero_length_cases)
+def test_zero_length(get_contract_with_gas_estimation, code):
+    c = get_contract_with_gas_estimation(code)
+    assert c.boo() == 0

--- a/tests/parser/functions/test_length.py
+++ b/tests/parser/functions/test_length.py
@@ -17,29 +17,14 @@ def foo(inp: Bytes[10]) -> uint256:
     print("Passed length test")
 
 
-zero_length_cases = [
-    """
+@pytest.mark.parametrize("typ", ["DynArray[uint256, 50]", "Bytes[50]", "String[50]"])
+def test_zero_length(get_contract_with_gas_estimation, typ):
+    code = f"""
 @external
 def boo() -> uint256:
-    e: uint256 = len(empty(DynArray[uint256, 50]))
+    e: uint256 = len(empty({typ}))
     return e
-    """,
     """
-@external
-def boo() -> uint256:
-    e: uint256 = len(empty(Bytes[50]))
-    return e
-    """,
-    """
-@external
-def boo() -> uint256:
-    e: uint256 = len(empty(String[50]))
-    return e
-    """,
-]
 
-
-@pytest.mark.parametrize("code", zero_length_cases)
-def test_zero_length(get_contract_with_gas_estimation, code):
     c = get_contract_with_gas_estimation(code)
     assert c.boo() == 0

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -304,7 +304,8 @@ def copy_bytes(dst, src, length, length_bound):
 def get_bytearray_length(arg):
     typ = UINT256_T
 
-    # TODO add "~empty" case to mirror get_dyn_array_count
+    if arg.value == "~empty":
+        return IRnode.from_list(0, typ=typ)
 
     return IRnode.from_list(LOAD(arg), typ=typ)
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -304,6 +304,8 @@ def copy_bytes(dst, src, length, length_bound):
 def get_bytearray_length(arg):
     typ = UINT256_T
 
+    # TODO: it would be nice to merge the implementations of get_bytearray_length and 
+    # get_dynarray_count
     if arg.value == "~empty":
         return IRnode.from_list(0, typ=typ)
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -304,7 +304,7 @@ def copy_bytes(dst, src, length, length_bound):
 def get_bytearray_length(arg):
     typ = UINT256_T
 
-    # TODO: it would be nice to merge the implementations of get_bytearray_length and 
+    # TODO: it would be nice to merge the implementations of get_bytearray_length and
     # get_dynarray_count
     if arg.value == "~empty":
         return IRnode.from_list(0, typ=typ)


### PR DESCRIPTION
### What I did

Fix #3275.

Also adds `DynArray` to `len()` in docs for builtins.

### How I did it

Add `~empty` case.

### How to verify it

See tests

### Commit message

```
fix: length of empty byte arrays and dynamic arrays
```

### Description for the changelog

Fix length of empty byte arrays and dynamic arrays

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s3.amazonaws.com/mongabay-images/12/DSC_0595.reticulatedgiraffe.boy.568.jpg)
