### PR TITLE
fix: range check for decimal values in evaluation of builtin functions

### DIFF
--- a/tests/builtins/folding/test_fold_as_wei_value.py
+++ b/tests/builtins/folding/test_fold_as_wei_value.py
@@ -4,12 +4,17 @@ from hypothesis import strategies as st
 
 from vyper import ast as vy_ast
 from vyper.builtins import functions as vy_fn
+from vyper.utils import SizeLimits
 
 denoms = [x for k in vy_fn.AsWeiValue.wei_denoms.keys() for x in k]
 
 
 st_decimals = st.decimals(
-    min_value=0, max_value=2 ** 32, allow_nan=False, allow_infinity=False, places=10
+    min_value=0,
+    max_value=SizeLimits.MAX_AST_DECIMAL,
+    allow_nan=False,
+    allow_infinity=False,
+    places=10,
 )
 
 

--- a/tests/builtins/folding/test_min_max.py
+++ b/tests/builtins/folding/test_min_max.py
@@ -4,9 +4,14 @@ from hypothesis import strategies as st
 
 from vyper import ast as vy_ast
 from vyper.builtins import functions as vy_fn
+from vyper.utils import SizeLimits
 
 st_decimals = st.decimals(
-    min_value=-(2 ** 32), max_value=2 ** 32, allow_nan=False, allow_infinity=False, places=10
+    min_value=SizeLimits.MIN_AST_DECIMAL,
+    max_value=SizeLimits.MAX_AST_DECIMAL,
+    allow_nan=False,
+    allow_infinity=False,
+    places=10,
 )
 st_int128 = st.integers(min_value=-(2 ** 127), max_value=2 ** 127 - 1)
 st_uint256 = st.integers(min_value=0, max_value=2 ** 256 - 1)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1026,7 +1026,7 @@ class AsWeiValue(BuiltinFunction):
 
         if isinstance(value, int) and value >= 2 ** 256:
             raise InvalidLiteral("Value out of range for uint256", node.args[0])
-        if isinstance(value, Decimal) and value >= 2 ** 127:
+        if isinstance(value, Decimal) and value > SizeLimits.MAX_AST_DECIMAL:
             raise InvalidLiteral("Value out of range for decimal", node.args[0])
 
         return vy_ast.Int.from_node(node, value=int(value * denom))
@@ -2012,7 +2012,8 @@ class _MinMax(BuiltinFunction):
 
         left, right = (i.value for i in node.args)
         if isinstance(left, Decimal) and (
-            min(left, right) < -(2 ** 127) or max(left, right) >= 2 ** 127
+            min(left, right) < SizeLimits.MIN_AST_DECIMAL
+            or max(left, right) > SizeLimits.MAX_AST_DECIMAL
         ):
             raise InvalidType("Decimal value is outside of allowable range", node)
         if isinstance(left, int) and (min(left, right) < 0 and max(left, right) >= 2 ** 127):


### PR DESCRIPTION
### What I did

Fix #3282 

### How I did it

- Changed `>= 2 ** 127` by ` > SizeLimits.MAX_AST_DECIMAL`
- Changed `< -(2 ** 127)` by ` < SizeLimits.MIN_AST_DECIMAL`

### How to verify it

See the modified tests that should have failed (depending on the generation of the input by the fuzzer) with the old code.

### Commit message

    fix: range check for decimal values in evaluation of builtin functions

### Description for the changelog

Fix the range check for decimal values in evaluation of builtin functions

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.lovethesepics.com/wp-content/uploads/2012/12/Emperor-Penguin-Chick-Snow-Hill-Island-Antarctica.jpg)
