### PR TITLE
chore: remove redundant semantic check of sqrt body

### DIFF
--- a/vyper/builtins/_utils.py
+++ b/vyper/builtins/_utils.py
@@ -25,9 +25,7 @@ def generate_inline_function(code, variables, variables_2, memory_allocator):
         ast_code.body[0]._metadata["type"] = ContractFunctionT(
             "sqrt_builtin", {}, 0, 0, None, FunctionVisibility.INTERNAL, StateMutability.NONPAYABLE
         )
-        sv = FunctionNodeVisitor(ast_code, ast_code.body[0], namespace)
-        for n in ast_code.body[0].body:
-            sv.visit(n)
+        FunctionNodeVisitor(ast_code, ast_code.body[0], namespace)
 
     new_context = Context(
         vars_=variables, global_ctx=GlobalContext(), memory_allocator=memory_allocator

--- a/vyper/builtins/_utils.py
+++ b/vyper/builtins/_utils.py
@@ -25,6 +25,8 @@ def generate_inline_function(code, variables, variables_2, memory_allocator):
         ast_code.body[0]._metadata["type"] = ContractFunctionT(
             "sqrt_builtin", {}, 0, 0, None, FunctionVisibility.INTERNAL, StateMutability.NONPAYABLE
         )
+        # The FunctionNodeVisitor's constructor performs semantic checks
+        # annotate the AST as side effects.
         FunctionNodeVisitor(ast_code, ast_code.body[0], namespace)
 
     new_context = Context(


### PR DESCRIPTION
### What I did

Fix #3286 

### How I did it

Removed the redundant semantic check of the body of `sqrt` builtin

### How to verify it

See that the removed check is performed just before as part of the initialisation of the `FunctionNodeVisitor`.

### Commit message

    chore: remove redundant semantic check of sqrt body

### Description for the changelog

Remove redundant semantic check of sqrt body

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/45201/kitty-cat-kitten-pet-45201.jpeg?auto=compress&cs=tinysrgb&w=1600)
