### PR TITLE
fix: add missing `asset` function to `ERC4626` built-in interface

### DIFF
--- a/vyper/builtins/interfaces/ERC4626.py
+++ b/vyper/builtins/interfaces/ERC4626.py
@@ -1,13 +1,13 @@
 interface_code = """
 # Events
 event Deposit:
-    depositor: indexed(address)
-    receiver: indexed(address)
+    sender: indexed(address)
+    owner: indexed(address)
     assets: uint256
     shares: uint256
 
 event Withdraw:
-    withdrawer: indexed(address)
+    sender: indexed(address)
     receiver: indexed(address)
     owner: indexed(address)
     assets: uint256
@@ -16,17 +16,22 @@ event Withdraw:
 # Functions
 @view
 @external
+def asset() -> address:
+    pass
+
+@view
+@external
 def totalAssets() -> uint256:
     pass
 
 @view
 @external
-def convertToAssets(shareAmount: uint256) -> uint256:
+def convertToShares(assetAmount: uint256) -> uint256:
     pass
 
 @view
 @external
-def convertToShares(assetAmount: uint256) -> uint256:
+def convertToAssets(shareAmount: uint256) -> uint256:
     pass
 
 @view


### PR DESCRIPTION
### What I did

I added the `asset` function to `ERC4626` built-in interface. I also used the official parameter names from the [EIP-4626](https://eips.ethereum.org/EIPS/eip-4626) event definitions, and also quickly reordered the function sequence according to the official EIP sequence.

### How I did it

Brain and eyes.

### How to verify it

You can review the interface here: https://eips.ethereum.org/EIPS/eip-4626.

### Commit message

`fix: add missing asset function to ERC4626 built-in interface`

### Description for the changelog

Add missing `asset` function to `ERC4626` built-in interface.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/220141419-a98c6799-ce5a-4908-a0d4-6e85702b9587.png)