### PR TITLE
fix: block `empty` for mappings

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -910,7 +910,7 @@ Utilities
 
     Return a value which is the default (zero-ed) value of its type. Useful for initializing new memory variables.
 
-    * ``typename``: Name of the type
+    * ``typename``: Name of the type, except ``HashMap[_KeyType, _ValueType]``
 
     .. code-block:: python
 

--- a/tests/parser/functions/test_empty.py
+++ b/tests/parser/functions/test_empty.py
@@ -691,3 +691,17 @@ def foo():
     assert log.args.arg3 == 314159
     assert log.args.arg4 == b"help" * 11
     assert log.args.arg5 == [0, 0, 0]
+
+
+@pytest.mark.parametrize(
+    "contract",
+    [
+        """
+@external
+def test():
+    a: uint256 = empty(HashMap[uint256, uint256])[0]
+    """
+    ],
+)
+def test_invalid_types(contract, get_contract, assert_compile_failed):
+    assert_compile_failed(lambda: get_contract(contract), TypeMismatch)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -66,6 +66,7 @@ from vyper.semantics.types import (
     BytesT,
     DArrayT,
     DecimalT,
+    HashMapT,
     IntegerT,
     KwargSettings,
     SArrayT,
@@ -2255,6 +2256,12 @@ class ISqrt(BuiltinFunction):
 class Empty(TypenameFoldedFunction):
 
     _id = "empty"
+
+    def fetch_call_return(self, node):
+        type_ = self.infer_arg_types(node)[0].typedef
+        if isinstance(type_, HashMapT):
+            raise TypeMismatch("Cannot use empty on HashMap", node)
+        return type_
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):


### PR DESCRIPTION
### What I did

Fix #3301.

### How I did it

Check for `HashMapT` in the `empty` builtin.

### How to verify it

See test.

### Commit message

```
fix: block `empty` for mappings
```

### Description for the changelog

Block `empty` builtin for mappings.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://bloximages.newyork1.vip.townnews.com/lancasterfarming.com/content/tncms/assets/v3/editorial/7/01/701d6b4c-e69f-56bd-a60c-8264a32d47c7/56c6534657ecd.image.jpg)
