### PR TITLE
chore: improve exceptions for `implements` syntax

### DIFF
--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -85,6 +85,12 @@ interface A:
     """,
         StructureException,
     ),
+    (
+        """
+implements: self.x
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -91,6 +91,21 @@ implements: self.x
     """,
         StructureException,
     ),
+    (
+        """
+implements: 123
+    """,
+        StructureException,
+    ),
+    (
+        """
+struct Foo:
+    a: uint256
+
+implements: Foo
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -12,9 +12,9 @@ from vyper.exceptions import (
     InvalidLiteral,
     InvalidOperation,
     OverflowException,
+    StructureException,
     SyntaxException,
     TypeMismatch,
-    UnexpectedNodeType,
     UnfoldableNode,
     ZeroDivisionException,
 )
@@ -1402,7 +1402,7 @@ class ImplementsDecl(Stmt):
         super().__init__(*args, **kwargs)
 
         if not isinstance(self.annotation, Name):
-            raise UnexpectedNodeType("not an identifier", self.annotation)
+            raise StructureException("not an identifier", self.annotation)
 
 
 class If(Stmt):

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -155,10 +155,11 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             self_members[fn_name].recursive_calls = function_set
 
     def visit_ImplementsDecl(self, node):
-        interface_name = node.annotation.id
+        type_ = type_from_annotation(node.annotation)
+        if not isinstance(type_, InterfaceT):
+            raise StructureException("Invalid interface name", node.annotation)
 
-        other_iface = self.namespace[interface_name]
-        other_iface.validate_implements(node)
+        type_.validate_implements(node)
 
     def visit_VariableDecl(self, node):
         name = node.get("target.id")


### PR DESCRIPTION
### What I did

Fix #3297, fix #3298.

### How I did it

For 3297, change the exception from `UnexpectedNodeType` to `StructureException`.
For 3298, as suggested in issue.

### How to verify it

See tests

### Commit message

```
chore: improve exceptions for `implements` syntax
```

### Description for the changelog

Improve exceptions for `implements` syntax

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.treehugger.com/thmb/MRGd4B1iTdvc1LySe2rmnZuiWCs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__mnn__images__2017__01__alpaca-with-peacock-5822407ddf4f45339fd950ef0df97a77.jpg)
