### PR TITLE
chore: remove redundant sanity check

### DIFF
--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -83,8 +83,6 @@ class _ExprAnalyser:
                 return ExprInfo.from_varinfo(t)
 
             # it's something else, like my_struct.foo
-            # sanity check
-            assert t is info.typ.get_member(name, node)
             return info.copy_with_type(t)
 
         if isinstance(node, vy_ast.Tuple):


### PR DESCRIPTION
### What I did

Remove a redundant sanity check. It always passes because `t` was assigned with the same operation just three lines above and has not been mutated.

### How I did it

### How to verify it

### Commit message

```
chore: remove redundant sanity check
```

### Description for the changelog

Remove redundant sanity check

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRE9s2nsGjAlbW8VHXC7uBKoWVjUQvh2Ytvgg&usqp=CAU)
