### PR TITLE
chore: improve error message for unassigned structs

### DIFF
--- a/tests/parser/syntax/test_structs.py
+++ b/tests/parser/syntax/test_structs.py
@@ -435,6 +435,17 @@ struct B:
     """,
         NamespaceCollision,
     ),
+    (
+        """
+struct Foo:
+    a: uint256
+
+@external
+def foo():
+    Foo({a: 1})
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -40,6 +40,7 @@ from vyper.semantics.types import (
     IntegerT,
     SArrayT,
     StringT,
+    StructT,
     TupleT,
     is_type_t,
 )
@@ -483,6 +484,9 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         fn_type = get_exact_type_from_node(node.value.func)
         if is_type_t(fn_type, EventT):
             raise StructureException("To call an event you must use the `log` statement", node)
+
+        if is_type_t(fn_type, StructT):
+            raise StructureException("Struct creation without assignment is disallowed", node)
 
         if isinstance(fn_type, ContractFunctionT):
             if (


### PR DESCRIPTION
### What I did

Unassigned structs currently run into an error while raising an exception:
```
struct Foo:
    a: uint256

@external
def foo():
    Foo({a: 1})
```
```
AttributeError: 'TYPE_T' object has no attribute '_id'
```
This is due to `TYPE_T` not having an `_id` attribute: https://github.com/vyperlang/vyper/blob/8ebabc5ce277942ee470845e2d04df5f8a2e6ad6/vyper/semantics/analysis/local.py#L512-L520

Even if we remove `._id`, the error message is still not precise because it is a struct creation and not a function call:
```
vyper.exceptions.StructureException: Function 'type(Foo declaration object)' cannot be called without assigning the result
  contract "contracts/struct_assign.vy:8", function "foo", line 8:4 
       7 def foo():
  ---> 8     Foo({a: 1})
  -----------^
       9
```

### How I did it

Added a new branch to catch unassigned structs.

### How to verify it

See test.

### Commit message

```
chore: improve error message for unassigned structs
```

### Description for the changelog

Improve error message for unassigned structs

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.wixstatic.com/media/5697c0_ea2054f5f79c4b1eb137998ee2521a50~mv2.jpg/v1/fill/w_600,h_480,al_c,q_80,usm_0.66_1.00_0.01,enc_auto/5697c0_ea2054f5f79c4b1eb137998ee2521a50~mv2.jpg)
