### PR TITLE
chore: fix data location of constants

### DIFF
--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -190,7 +190,13 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 )
                 raise SyntaxException(message, node.node_source_code, node.lineno, node.col_offset)
 
-        data_loc = DataLocation.CODE if node.is_immutable else DataLocation.STORAGE
+        data_loc = (
+            DataLocation.CODE
+            if node.is_immutable
+            else DataLocation.UNSET
+            if node.is_constant
+            else DataLocation.STORAGE
+        )
 
         type_ = type_from_annotation(node.annotation)
         var_info = VarInfo(


### PR DESCRIPTION
### What I did

Set the `DataLocation` of constants to `UNSET` instead of `STORAGE`

### How I did it

Add a branch for constants

### How to verify it

Tests pass.

### Commit message

```
chore: fix data location of constant declarations
```

### Description for the changelog

Fix data location of constant declarations

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://thisnzlife.co.nz/wp-content/uploads/2019/05/iStock-492881830.jpg)
