### PR TITLE
chore: remove dead code in `_get_module_definitions`

### DIFF
--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -425,21 +425,6 @@ def _get_module_definitions(base_node: vy_ast.Module) -> Tuple[Dict, Dict]:
     for node in base_node.get_children(vy_ast.FunctionDef):
         if "external" in [i.id for i in node.decorator_list if isinstance(i, vy_ast.Name)]:
             func = ContractFunctionT.from_FunctionDef(node)
-            if node.name in functions:
-                # compare the input arguments of the new function and the previous one
-                # if one function extends the inputs, this is a valid function name overload
-                existing_args = list(functions[node.name].arguments)
-                new_args = list(func.arguments)
-                for a, b in zip(existing_args, new_args):
-                    if not isinstance(a, type(b)):
-                        raise NamespaceCollision(
-                            f"Interface contains multiple functions named '{node.name}' "
-                            "with incompatible input types",
-                            base_node,
-                        )
-                if len(new_args) <= len(existing_args):
-                    # only keep the `ContractFunctionT` with the longest set of input args
-                    continue
             functions[node.name] = func
     for node in base_node.get_children(vy_ast.VariableDecl, {"is_public": True}):
         name = node.target.id


### PR DESCRIPTION
### What I did

Removed dead code in `_get_module_definitions`. Since Vyper does not allow overloaded functions, this is never reachable. 

Q: Was this meant for interfaces? Even the error message refers to interface.

### How I did it

Select and delete.

### How to verify it

Tests still pass.

### Commit message

```
chore: remove dead code in `_get_module_definitions`
```

### Description for the changelog

Remove dead code in `_get_module_definitions`

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1272006108/photo/alpaca.jpg?s=612x612&w=0&k=20&c=v1L7fpOo6Jz80L0gDaTtdS_GKrNjQ7XJ3-Rg5pDHZYU=)
