### PR TITLE
chore: remove redundant check for call node in function return type

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -317,7 +317,7 @@ class ContractFunctionT(VyperType):
             raise FunctionDeclarationException(
                 "Constructor may not have a return type", node.returns
             )
-        elif isinstance(node.returns, (vy_ast.Name, vy_ast.Call, vy_ast.Subscript)):
+        elif isinstance(node.returns, (vy_ast.Name, vy_ast.Subscript)):
             return_type = type_from_annotation(node.returns)
         elif isinstance(node.returns, vy_ast.Tuple):
             tuple_types: Tuple = ()


### PR DESCRIPTION
### What I did

Remove check for `Call` node in the return type of a function. No existing type is a `Call` node.

### How I did it

Delete code.

### How to verify it

Existing tests pass

### Commit message

```
chore: remove redundant check for call node in function return type
```

### Description for the changelog

Remove redundant check for call node in function return type

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT03m73HdCUDb3a50HzXiCH2-90GsZMtXN7VA&usqp=CAU)
