### PR TITLE
fix: propagate tuple members' immutability to tuple's expression

### DIFF
--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -90,12 +90,10 @@ def test(a: bytes32) -> (bytes32, uint256, int128):
     ),
     (
         """
-A: immutable(uint256)
 B: immutable(uint256)
 
 @external
-def __init__(a: uint256, b: uint256):
-    A = a
+def __init__(b: uint256):
     B = b
 
 @internal

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -90,6 +90,26 @@ def test(a: bytes32) -> (bytes32, uint256, int128):
     ),
     (
         """
+A: immutable(uint256)
+B: immutable(uint256)
+
+@external
+def __init__(a: uint256, b: uint256):
+    A = a
+    B = b
+
+@internal
+def foo() -> (uint256, uint256):
+    return (1, 2)
+
+@external
+def bar():
+    A, B = self.foo()
+    """,
+        ImmutableViolation,
+    ),
+    (
+        """
 x: public(uint256)
 
 @internal

--- a/tests/parser/syntax/test_tuple_assign.py
+++ b/tests/parser/syntax/test_tuple_assign.py
@@ -104,7 +104,8 @@ def foo() -> (uint256, uint256):
 
 @external
 def bar():
-    A, B = self.foo()
+    a: uint256 = 1
+    a, B = self.foo()
     """,
         ImmutableViolation,
     ),

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -91,8 +91,9 @@ class _ExprAnalyser:
             types = [self.get_expr_info(n) for n in node.elements]
             location = sorted((i.location for i in types), key=lambda k: k.value)[-1]
             is_constant = any((getattr(i, "is_constant", False) for i in types))
+            is_immutable = any((getattr(i, "is_immutable", False) for i in types))
 
-            return ExprInfo(t, location=location, is_constant=is_constant)
+            return ExprInfo(t, location=location, is_constant=is_constant, is_immutable=is_immutable)
 
         # If it's a Subscript, propagate the subscriptable varinfo
         if isinstance(node, vy_ast.Subscript):

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -93,7 +93,9 @@ class _ExprAnalyser:
             is_constant = any((getattr(i, "is_constant", False) for i in types))
             is_immutable = any((getattr(i, "is_immutable", False) for i in types))
 
-            return ExprInfo(t, location=location, is_constant=is_constant, is_immutable=is_immutable)
+            return ExprInfo(
+                t, location=location, is_constant=is_constant, is_immutable=is_immutable
+            )
 
         # If it's a Subscript, propagate the subscriptable varinfo
         if isinstance(node, vy_ast.Subscript):


### PR DESCRIPTION
### What I did

The following contract that tries to re-assign values to immutable variables in a tuple fails at IR generation when it should fail at typechecking:
```
A: immutable(uint256)
B: immutable(uint256)

@external
def __init__(a: uint256, b: uint256):
    A = a
    B = b

@internal
def foo() -> (uint256, uint256):
    return (1, 2)

@external
def bar():
    A, B = self.foo()
```

### How I did it

Propagate the `is_immutable` attribute of a tuple's members to the tuple's `ExprInfo`.

### How to verify it

See new test.

### Commit message

```
fix: propagate tuple members' immutability to tuple's expression
```

### Description for the changelog

Propagate tuple members' immutability to tuple's expression

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQE8rNUTrIHFEoZDi_DQVP3vM1R2-EFxn_dEg&usqp=CAU)
