### PR TITLE
fix: check usage of `address.code` and `msg.data` in `AugAssign` nodes

### DIFF
--- a/tests/parser/syntax/test_address_code.py
+++ b/tests/parser/syntax/test_address_code.py
@@ -78,7 +78,7 @@ def code_slice(x: address) -> uint256:
         ),
         (
             """
-a: HashMap[Bytes[30], uint256]
+a: HashMap[Bytes[4], uint256]
 
 @external
 def foo(x: address):

--- a/tests/parser/syntax/test_address_code.py
+++ b/tests/parser/syntax/test_address_code.py
@@ -77,6 +77,17 @@ def code_slice(x: address) -> uint256:
             "(address).code is only allowed inside of a slice function with a constant length",
         ),
         (
+            """
+a: HashMap[Bytes[30], uint256]
+
+@external
+def foo(x: address):
+    self.a[x.code] += 1
+""",
+            StructureException,
+            "(address).code is only allowed inside of a slice function with a constant length",
+        ),
+        (
             # `len` not supported
             """
 @external

--- a/tests/parser/syntax/test_msg_data.py
+++ b/tests/parser/syntax/test_msg_data.py
@@ -132,6 +132,16 @@ def foo() -> uint256:
     ),
     (
         """
+a: HashMap[Bytes[10], uint256]
+
+@external
+def foo():
+    self.a[msg.data] += 1
+    """,
+        StructureException,
+    ),
+    (
+        """
 @external
 def foo(bar: uint256) -> bytes32:
     ret_val: bytes32 = slice(msg.data, 4, 32)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -268,6 +268,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         lhs_info.validate_modification(node, self.func.mutability)
 
         self.expr_visitor.visit(node.value)
+        self.expr_visitor.visit(node.target)
 
     def visit_Raise(self, node):
         if node.exc:


### PR DESCRIPTION
### What I did

Check usage of `address.code` and `msg.data` in `AugAssign` nodes.

This contract throws during IR generation but it should fail at typechecking:
```
a: HashMap[Bytes[10], uint256]

@external
def foo(a: uint256):
    self.a[msg.data] += 1
```

### How I did it

Visit the `target` attribute of `AugAssign` nodes in `_LocalExpressionVisitor`

### How to verify it

See new tests

### Commit message

```
fix: check usage of `address.code` and `msg.data` in `AugAssign` nodes
```

### Description for the changelog

Check usage of `address.code` and `msg.data` in `AugAssign` nodes

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT6Lr5--rnunGwAjSslrFCxdqghMfsw3EihgD0bQZWRiNKgr3xeCy9FdKYZnQKX-QZ8YT8&usqp=CAU)
