### PR TITLE
chore: fix typo in test_ceil.py

### DIFF
--- a/tests/parser/functions/test_ceil.py
+++ b/tests/parser/functions/test_ceil.py
@@ -48,7 +48,7 @@ def fou() -> int256:
     assert c.fou() == 4
 
 
-# ceil(x) should yeild the smallest integer greater than or equal to x
+# ceil(x) should yield the smallest integer greater than or equal to x
 def test_ceil_negative(get_contract_with_gas_estimation):
     code = """
 x: decimal


### PR DESCRIPTION

### What I did

Fixed typo.
```
yeild -> yield
```

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/22633385/229678595-bbfb720e-f938-4d18-b7ee-38fa32369e43.png)


