### PR TITLE
fix: add getters for public constants and immutables to `self` namespace

### DIFF
--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -210,6 +210,26 @@ interface MyInterface:
 
 kickers: HashMap[address, MyInterface]
     """,
+    """
+interface ITestInterface:
+    def foo() -> uint256: view
+
+implements: ITestInterface
+
+foo: public(constant(uint256)) = 1
+    """,
+    """
+interface ITestInterface:
+    def foo() -> uint256: view
+
+implements: ITestInterface
+
+foo: public(immutable(uint256))
+
+@external
+def __init__(x: uint256):
+    foo = x
+    """,
 ]
 
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -209,14 +209,16 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
         node._metadata["type"] = type_
 
         def _finalize():
-            if not node.is_public:
+            if (node.is_constant or node.is_immutable) and not node.is_public:
                 return
 
             try:
                 self.namespace["self"].typ.add_member(name, var_info)
                 node.target._metadata["type"] = type_
             except NamespaceCollision:
-                raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
+                raise NamespaceCollision(
+                    f"Value '{name}' has already been declared", node
+                ) from None
             except VyperException as exc:
                 raise exc.with_annotation(node) from None
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -209,6 +209,9 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
         node._metadata["type"] = type_
 
         def _finalize():
+            # add the variable name to `self` namespace if the variable is either
+            # 1. a public constant or immutable; or
+            # 2. a storage variable, whether private or public
             if (node.is_constant or node.is_immutable) and not node.is_public:
                 return
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -164,36 +164,10 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
         if name is None:
             raise VariableDeclarationException("Invalid module-level assignment", node)
 
-        data_loc = (
-            DataLocation.CODE
-            if node.is_immutable
-            else DataLocation.UNSET
-            if node.is_constant
-            else DataLocation.STORAGE
-        )
-
-        type_ = type_from_annotation(node.annotation)
-        var_info = VarInfo(
-            type_,
-            decl_node=node,
-            location=data_loc,
-            is_constant=node.is_constant,
-            is_public=node.is_public,
-            is_immutable=node.is_immutable,
-        )
-
         if node.is_public:
             # generate function type and add to metadata
             # we need this when building the public getter
             node._metadata["func_type"] = ContractFunctionT.getter_from_VariableDecl(node)
-
-            try:
-                self.namespace["self"].typ.add_member(name, var_info)
-                node.target._metadata["type"] = type_
-            except NamespaceCollision:
-                raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
-            except VyperException as exc:
-                raise exc.with_annotation(node) from None
 
         if node.is_immutable:
             # mutability is checked automatically preventing assignment
@@ -214,6 +188,23 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 )
                 raise SyntaxException(message, node.node_source_code, node.lineno, node.col_offset)
 
+        data_loc = (
+            DataLocation.CODE
+            if node.is_immutable
+            else DataLocation.UNSET
+            if node.is_constant
+            else DataLocation.STORAGE
+        )
+
+        type_ = type_from_annotation(node.annotation)
+        var_info = VarInfo(
+            type_,
+            decl_node=node,
+            location=data_loc,
+            is_constant=node.is_constant,
+            is_public=node.is_public,
+            is_immutable=node.is_immutable,
+        )
         node.target._metadata["varinfo"] = var_info  # TODO maybe put this in the global namespace
         node._metadata["type"] = type_
 
@@ -229,9 +220,10 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             except VyperException as exc:
                 raise exc.with_annotation(node) from None
 
-            return
+            if not node.is_public:
+                return
 
-        if node.value:
+        if node.value and not node.is_constant:
             var_type = "Immutable" if node.is_immutable else "Storage"
             raise VariableDeclarationException(
                 f"{var_type} variables cannot have an initial value", node.value
@@ -248,11 +240,21 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             except VyperException as exc:
                 raise exc.with_annotation(node) from None
 
-            return
+            if not node.is_public:
+                return
+
+        if not node.is_constant and not node.is_immutable:
+            try:
+                self.namespace.validate_assignment(name)
+            except NamespaceCollision as exc:
+                raise exc.with_annotation(node) from None
 
         try:
-            self.namespace.validate_assignment(name)
-        except NamespaceCollision as exc:
+            self.namespace["self"].typ.add_member(name, var_info)
+            node.target._metadata["type"] = type_
+        except NamespaceCollision:
+            raise NamespaceCollision(f"Value '{name}' has already been declared", node) from None
+        except VyperException as exc:
             raise exc.with_annotation(node) from None
 
     def visit_EnumDef(self, node):

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -253,11 +253,10 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
 
             return _finalize()
 
-        if not node.is_constant and not node.is_immutable:
-            try:
-                self.namespace.validate_assignment(name)
-            except NamespaceCollision as exc:
-                raise exc.with_annotation(node) from None
+        try:
+            self.namespace.validate_assignment(name)
+        except NamespaceCollision as exc:
+            raise exc.with_annotation(node) from None
 
         return _finalize()
 


### PR DESCRIPTION
### What I did

Fix #3329.

Getters for public constants and immutables were not added to the `self` namespace, causing validation of implementing an interface to fail.

### How I did it

Add the getters to namespace

### How to verify it

See tests

### Commit message

```
fix: add getters for public constants and immutables to `self` namespace
```

### Description for the changelog

Add getters for public constants and immutables to `self` namespace

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTsr0lEqIvEMpveLwl7MNS9CVBzFK_IdV1_xw&usqp=CAU)
