### PR TITLE
chore: serialize ir_runtime output for vyper-serve

### DIFF
--- a/vyper/cli/vyper_serve.py
+++ b/vyper/cli/vyper_serve.py
@@ -97,6 +97,7 @@ class VyperRequestHandler(BaseHTTPRequestHandler):
                 evm_version=data.get("evm_version", DEFAULT_EVM_VERSION),
             )[""]
             out_dict["ir"] = str(out_dict["ir"])
+            out_dict["ir_runtime"] = str(out_dict["ir_runtime"])
         except VyperException as e:
             return (
                 {"status": "failed", "message": str(e), "column": e.col_offset, "line": e.lineno},


### PR DESCRIPTION
### What I did

Fix #3075.

### How I did it

Cast `ir_runtime` to `str`.

### How to verify it

1. Run `vyper-serve` in a console.
2. Run `curl -X POST localhost:8000/compile -H "Content-Type: application/json" -d '{"code": "\n\n# @version ^0.3.7\n\n@external\ndef foo():\n    pass\n"}'` in another console. The compiled code should be printed in console.

### Commit message

```
chore: serialize ir_runtime output for vyper-serve
```

### Description for the changelog

Serialize ir_runtime output for vyper-serve

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/106377037/photo/baby-donkey.jpg?s=612x612&w=0&k=20&c=TRxSvtSD9_zna4IG5T7pqfJckQHxua8r2rZk5yx7pBA=)
