### PR TITLE
chore: set `raw_revert` terminus as terminus

### DIFF
--- a/tests/parser/syntax/test_unbalanced_return.py
+++ b/tests/parser/syntax/test_unbalanced_return.py
@@ -64,6 +64,36 @@ def valid_address(sender: address) -> bool:
     """,
         StructureException,
     ),
+    (
+        """
+@internal
+def foo() -> bool:
+    raw_revert(b"vyper")
+    return True
+    """,
+        StructureException,
+    ),
+    (
+        """
+@internal
+def foo() -> bool:
+    raw_revert(b"vyper")
+    x: uint256 = 3
+    """,
+        StructureException,
+    ),
+    (
+        """
+@internal
+def foo(x: uint256) -> bool:
+    if x == 2:
+        raw_revert(b"vyper")
+        a: uint256 = 3
+    else:
+        return False
+    """,
+        StructureException,
+    ),
 ]
 
 
@@ -125,6 +155,14 @@ def test() -> int128:
         x = keccak256(x)
         return 1
     return 1
+    """,
+    """
+@external
+def foo() -> int128:
+    if True:
+        return 123
+    else:
+        raw_revert(b"vyper")
     """,
 ]
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1255,6 +1255,8 @@ class BlockHash(BuiltinFunction):
 class RawRevert(BuiltinFunction):
     _id = "raw_revert"
     _inputs = [("data", BytesT.any())]
+    _return_type = None
+    _is_terminus = True
 
     def fetch_call_return(self, node):
         return None

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -917,7 +917,10 @@ def eval_seq(ir_node):
 
 # TODO move return checks to vyper/semantics/validation
 def is_return_from_function(node):
-    if isinstance(node, vy_ast.Expr) and node.get("value.func.id") == "selfdestruct":
+    if isinstance(node, vy_ast.Expr) and node.get("value.func.id") in (
+        "raw_revert",
+        "selfdestruct",
+    ):
         return True
     if isinstance(node, (vy_ast.Return, vy_ast.Raise)):
         return True


### PR DESCRIPTION
### What I did

Set `raw_revert` terminus as a terminal statement, similar to `selfdestruct`.

For example, this contract should not compile because the last statement can never be reached.
```
@external
def foo(a: Bytes[100]) -> uint256:
    raw_revert(a)
    b: uint256 = 76
```

### How I did it

For `RawRevert`, set `_is_terminus = True` and `_return_type = None`.

### How to verify it

See new tests.

### Commit message

```
chore: set `raw_revert` builtin as terminus
```

### Description for the changelog

Set `raw_revert` builtin as terminus.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/1837/29973743688_065a8ffd85_b.jpg)
