### PR TITLE
fix: enforce namespace collisions between globals

### DIFF
--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -88,6 +88,30 @@ VAL: constant(uint256) = 1
     """,
         NamespaceCollision,
     ),
+    # global with same type and name
+    (
+        """
+VAL: immutable(uint256)
+VAL: uint256
+
+@external
+def __init__():
+    VAL = 1
+    """,
+        NamespaceCollision,
+    ),
+    # global with same type and name, different order
+    (
+        """
+VAL: uint256
+VAL: immutable(uint256)
+
+@external
+def __init__():
+    VAL = 1
+    """,
+        NamespaceCollision,
+    ),
     # signature variable with same name
     (
         """

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -72,6 +72,14 @@ VAL: uint256
     """,
         NamespaceCollision,
     ),
+    # global with same type and name, different order
+    (
+        """
+VAL: uint256
+VAL: constant(uint256) = 1
+    """,
+        NamespaceCollision,
+    ),
     # signature variable with same name
     (
         """

--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -72,6 +72,14 @@ VAL: uint256
     """,
         NamespaceCollision,
     ),
+    # global with same type and name
+    (
+        """
+VAL: constant(uint256) = 1
+VAL: uint256
+    """,
+        NamespaceCollision,
+    ),
     # global with same type and name, different order
     (
         """

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -225,6 +225,17 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             except VyperException as exc:
                 raise exc.with_annotation(node) from None
 
+        def _validate_self_namespace():
+            # block globals if storage variable already exists
+            try:
+                if name in self.namespace["self"].typ.members:
+                    raise NamespaceCollision(
+                        f"Value '{name}' has already been declared", node
+                    ) from None
+                self.namespace[name] = var_info
+            except VyperException as exc:
+                raise exc.with_annotation(node) from None
+
         if node.is_constant:
             if not node.value:
                 raise VariableDeclarationException("Constant must be declared with a value", node)
@@ -232,10 +243,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 raise StateAccessViolation("Value must be a literal", node.value)
 
             validate_expected_type(node.value, type_)
-            try:
-                self.namespace[name] = var_info
-            except VyperException as exc:
-                raise exc.with_annotation(node) from None
+            _validate_self_namespace()
 
             return _finalize()
 
@@ -246,16 +254,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             )
 
         if node.is_immutable:
-            try:
-                # block immutable if storage variable already exists
-                if name in self.namespace["self"].typ.members:
-                    raise NamespaceCollision(
-                        f"Value '{name}' has already been declared", node
-                    ) from None
-                self.namespace[name] = var_info
-            except VyperException as exc:
-                raise exc.with_annotation(node) from None
-
+            _validate_self_namespace()
             return _finalize()
 
         try:


### PR DESCRIPTION
### What I did

The first contract compiles, but the second raises a namespace collision. The behaviour should be consistent, similar to immutables where both would fail compilation.
```
a: constant(uint256) = 1
a: uint256
```
```
a: uint256
a: constant(uint256) = 1
```

### How I did it

Check constants with `self` namespace.

### How to verify it

See new tests.

### Commit message

```
fix: enforce namespace collisions between globals

collisions between constants, immutables and storage variables were
dependent on declaration order; this commit fixes that.
```

### Description for the changelog

Prevent namespace collision for constants regardless of order

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTWMHwCOQDMSfPXJd6Esxda8t5cHw_EOwjqVI-L_BqGoA&s)
