### PR TITLE
chore: refactor redundant branch for handling tuple return types

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -315,13 +315,8 @@ class ContractFunctionT(VyperType):
             raise FunctionDeclarationException(
                 "Constructor may not have a return type", node.returns
             )
-        elif isinstance(node.returns, (vy_ast.Name, vy_ast.Subscript)):
+        elif isinstance(node.returns, (vy_ast.Name, vy_ast.Subscript, vy_ast.Tuple)):
             return_type = type_from_annotation(node.returns)
-        elif isinstance(node.returns, vy_ast.Tuple):
-            tuple_types: Tuple = ()
-            for n in node.returns.elements:
-                tuple_types += (type_from_annotation(n),)
-            return_type = TupleT(tuple_types)
         else:
             raise InvalidType("Function return value must be a type name or tuple", node.returns)
 


### PR DESCRIPTION
### What I did

The branch to handle function return types of tuple type is redundant, and can be collapsed into a single branch that calls `type_from_annotation(node.returns)`.

### How I did it

Delete code

### How to verify it

Tests still pass

### Commit message

```
chore: refactor redundant branch for handling tuple return types
```

### Description for the changelog

Refactor redundant branch for handling tuple return types

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/14/4a/29/144a29094aef5082bbeb30c24b540007.jpg)
