### PR TITLE
chore: remove duplicate check for a function call into itself

### DIFF
--- a/tests/functional/semantics/analysis/test_cyclic_function_calls.py
+++ b/tests/functional/semantics/analysis/test_cyclic_function_calls.py
@@ -6,6 +6,18 @@ from vyper.semantics.analysis import validate_semantics
 from vyper.semantics.analysis.module import ModuleAnalyzer
 
 
+def test_self_function_call(namespace):
+    code = """
+@internal
+def foo():
+    self.foo()
+    """
+    vyper_module = parse_to_ast(code)
+    with namespace.enter_scope():
+        with pytest.raises(CallViolation):
+            ModuleAnalyzer(vyper_module, {}, namespace)
+
+
 def test_cyclic_function_call(namespace):
     code = """
 @internal

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -116,11 +116,6 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             # anything that is not a function call will get semantically checked later
             calls_to_self = calls_to_self.intersection(function_names)
             self_members[node.name].internal_calls = calls_to_self
-            if node.name in self_members[node.name].internal_calls:
-                self_node = node.get_descendants(
-                    vy_ast.Attribute, {"value.id": "self", "attr": node.name}
-                )[0]
-                raise CallViolation(f"Function '{node.name}' calls into itself", self_node)
 
         for fn_name in sorted(function_names):
             if fn_name not in self_members:


### PR DESCRIPTION
### What I did

A function that calls itself is already caught in `_find_cyclic_call`. This PR removes a duplicate check.

### How I did it

Delete code.

### How to verify it

See added test.

### Commit message

```
chore: remove duplicate check for a function call into itself
```

### Description for the changelog

Remove duplicate check for a function call into itself

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://c4.wallpaperflare.com/wallpaper/238/857/132/5bd26133a5d56-wallpaper-preview.jpg)
