### PR TITLE
fix: guard against `posonlyargs` in function arguments

### DIFF
--- a/tests/parser/exceptions/test_syntax_exception.py
+++ b/tests/parser/exceptions/test_syntax_exception.py
@@ -1,7 +1,5 @@
 import pytest
-from pytest import raises
 
-from vyper import compiler
 from vyper.exceptions import SyntaxException
 
 fail_list = [
@@ -79,10 +77,18 @@ a: internal(uint256)
 def foo():
     x: uint256 = +1  # test UAdd ast blocked
     """,
+    """
+@internal
+def f(a:uint256,/):  # test posonlyargs blocked
+    return
+
+@external
+def g():
+    self.f()
+    """,
 ]
 
 
 @pytest.mark.parametrize("bad_code", fail_list)
-def test_syntax_exception(bad_code):
-    with raises(SyntaxException):
-        compiler.compile_code(bad_code)
+def test_syntax_exception(assert_compile_failed, get_contract, bad_code):
+    assert_compile_failed(lambda: get_contract(bad_code), SyntaxException)

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -684,7 +684,7 @@ class DocStr(VyperNode):
 
 class arguments(VyperNode):
     __slots__ = ("args", "defaults", "default")
-    _only_empty_fields = ("vararg", "kwonlyargs", "kwarg", "kw_defaults")
+    _only_empty_fields = ("posonlyargs", "vararg", "kwonlyargs", "kwarg", "kw_defaults")
 
 
 class arg(VyperNode):


### PR DESCRIPTION
### What I did

`posonlyargs` are allowed in Python but not in Vyper. This contract compiles when it should not:
```
@internal
def f(a:uint256,/):
    return

@external
def g():
    self.f()
```

### How I did it

Require `posonlyargs` to be empty.

### How to verify it

See new test.

### Commit message

```
fix: guard against `posonlyargs` in function arguments

`posonlyargs` are allowed in Python but not in Vyper.
```

### Description for the changelog

Guard against `posonlyargs` in function arguments

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.images.express.co.uk/img/dynamic/1/590x/alpaca-390586.jpg)
