### PR TITLE
fix: remove tuple node check in `validate_expected_type` for literal list

### DIFF
--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -496,8 +496,8 @@ def validate_expected_type(node, expected_type):
     if not isinstance(expected_type, tuple):
         expected_type = (expected_type,)
 
-    if isinstance(node, (vy_ast.List, vy_ast.Tuple)):
-        # special case - for literal arrays or tuples we individually validate each item
+    if isinstance(node, vy_ast.List):
+        # special case - for literal arrays we individually validate each item
         for expected in expected_type:
             if not isinstance(expected, (DArrayT, SArrayT)):
                 continue


### PR DESCRIPTION
### What I did

A literal list cannot be a `Tuple` node. Therefore, it is incorrect for the branch in `validate_expected_type` that is handling literal lists to include `Tuple` nodes.

### How I did it

Delete

### How to verify it

Tests still pass

### Commit message

```
fix: remove tuple node check in `validate_expected_type` for literal list

A literal list cannot be a `Tuple` node. Therefore, it is incorrect for the 
branch in `validate_expected_type` that is handling literal lists to include 
`Tuple` nodes.
```

### Description for the changelog

Remove tuple node check in `validate_expected_type` for literal list

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqTH0_jM6pDsVCyO1xm8aHWZzCdIqgYO_8icKX6cAX&s)
