### PR TITLE
Fix `max_outsize` type in `raw_call` docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -220,7 +220,7 @@ Vyper has three built-ins for contract creation; all three contract creation bui
 
     * ``to``: Destination address to call to
     * ``data``: Data to send to the destination address
-    * ``max_outsize``: Maximum length of the bytes array returned from the call. If the returned call data exceeds this length, only this number of bytes is returned.
+    * ``max_outsize``: Maximum length of the bytes array returned from the call. If the returned call data exceeds this length, only this number of bytes is returned. (Optional, default ``0``)
     * ``gas``: The amount of gas to attach to the call. If not set, all remaining gas is forwarded.
     * ``value``: The wei value to send to the address (Optional, default ``0``)
     * ``is_delegate_call``: If ``True``, the call will be sent as ``DELEGATECALL`` (Optional, default ``False``)

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -214,7 +214,7 @@ Vyper has three built-ins for contract creation; all three contract creation bui
             # `blueprint` is a blueprint contract with some known preamble b"abcd..."
             return create_from_blueprint(blueprint, code_offset=<preamble length>)
 
-.. py:function:: raw_call(to: address, data: Bytes, max_outsize: int = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False, is_static_call: bool = False, revert_on_failure: bool = True) -> Bytes[max_outsize]
+.. py:function:: raw_call(to: address, data: Bytes, max_outsize: uint256 = 0, gas: uint256 = gasLeft, value: uint256 = 0, is_delegate_call: bool = False, is_static_call: bool = False, revert_on_failure: bool = True) -> Bytes[max_outsize]
 
     Call to the specified Ethereum address.
 


### PR DESCRIPTION
### What I did

As title. I also added a note on the default value of `max_outsize`.

### How I did it

N/A.

### How to verify it

`max_outsize` cannot be negative.

### Commit message

`Fix max_outsize type in raw_call docs`

### Description for the changelog

Fix `max_outsize` type in `raw_call` docs.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/234091395-37d81db2-cbde-4708-a03d-aaefc46fa114.png)
