### PR TITLE
fix: call graph stability

### DIFF
--- a/tests/parser/test_call_graph_stability.py
+++ b/tests/parser/test_call_graph_stability.py
@@ -1,0 +1,54 @@
+from hypothesis import given, settings
+from hypothesis.strategies import text , lists
+import random
+import string
+import pytest
+from vyper.compiler.phases import CompilerData
+import vyper.ast as vy_ast
+
+# random names for functions
+@settings(max_examples=20, deadline=1000)
+@given(lists(text(alphabet=string.ascii_lowercase, min_size=1), unique=True,min_size=1, max_size=10))
+@pytest.mark.fuzzing
+def test_call_graph_stability_fuzz(func_names):
+    def generate_func_def(func_name, i):
+        return f"""
+@internal
+def {func_name}() -> uint256:
+    return {i}
+        """
+    func_defs = "\n".join(generate_func_def(s, i) for i, s in enumerate(func_names))
+
+ 
+    for i in range(10):
+        fs = func_names.copy()
+        random.shuffle(fs)
+
+        self_calls = "\n".join(f"  self.{f}()" for f in func_names)
+        code = f"""
+{func_defs}
+
+@external
+def foo():
+{self_calls}
+        """
+        t = CompilerData(code)
+
+        # check the .called_functions data structure on foo() directly
+        foo = t.vyper_module_folded.get_children(vy_ast.FunctionDef, filters={"name": "foo"})[0]
+        foo_t = foo._metadata["type"]
+        assert [f.name for f in foo_t.called_functions] == func_names
+
+        # now for sanity, ensure the order that the function definitions appear
+        # in the IR is the same as the order of the calls
+        sigs = t.function_signatures
+        del sigs["foo"]
+        ir = t.ir_runtime
+        ir_funcs = []
+        # search for function labels
+        for d in ir.args:  # currently: (seq ... (seq (label foo ...)) ...)
+            if d.value == "seq" and d.args[0].value == "label":
+                r = d.args[0].args[0].value
+                if isinstance(r, str) and r.startswith("internal"):
+                    ir_funcs.append(r)
+        assert ir_funcs == [f.internal_function_label for f in sigs.values()]

--- a/tests/parser/test_call_graph_stability.py
+++ b/tests/parser/test_call_graph_stability.py
@@ -10,7 +10,7 @@ from vyper.compiler.phases import CompilerData
 
 
 # random names for functions
-@settings(max_examples=20, deadline=1000)
+@settings(max_examples=20, deadline=None)
 @given(
     lists(text(alphabet=string.ascii_lowercase, min_size=1), unique=True, min_size=1, max_size=10)
 )

--- a/tests/parser/test_call_graph_stability.py
+++ b/tests/parser/test_call_graph_stability.py
@@ -17,8 +17,10 @@ from vyper.compiler.phases import CompilerData
 @pytest.mark.fuzzing
 def test_call_graph_stability_fuzz(func_names):
     def generate_func_def(func_name, i):
+        mutability = random.choice(["@pure", "@view", "@nonpayable", "@payable"])
         return f"""
 @internal
+{mutability}
 def {func_name}() -> uint256:
     return {i}
         """

--- a/tests/parser/test_call_graph_stability.py
+++ b/tests/parser/test_call_graph_stability.py
@@ -1,14 +1,19 @@
-from hypothesis import given, settings
-from hypothesis.strategies import text , lists
 import random
 import string
+
 import pytest
-from vyper.compiler.phases import CompilerData
+from hypothesis import given, settings
+from hypothesis.strategies import lists, text
+
 import vyper.ast as vy_ast
+from vyper.compiler.phases import CompilerData
+
 
 # random names for functions
 @settings(max_examples=20, deadline=1000)
-@given(lists(text(alphabet=string.ascii_lowercase, min_size=1), unique=True,min_size=1, max_size=10))
+@given(
+    lists(text(alphabet=string.ascii_lowercase, min_size=1), unique=True, min_size=1, max_size=10)
+)
 @pytest.mark.fuzzing
 def test_call_graph_stability_fuzz(func_names):
     def generate_func_def(func_name, i):
@@ -17,10 +22,10 @@ def test_call_graph_stability_fuzz(func_names):
 def {func_name}() -> uint256:
     return {i}
         """
+
     func_defs = "\n".join(generate_func_def(s, i) for i, s in enumerate(func_names))
 
- 
-    for i in range(10):
+    for _ in range(10):
         fs = func_names.copy()
         random.shuffle(fs)
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -1,11 +1,9 @@
 import re
 import warnings
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set, Tuple
-
+from typing import Any, Dict, List, Optional, Tuple
 
 from vyper import ast as vy_ast
-from vyper.utils import OrderedSet
 from vyper.ast.validation import validate_call_args
 from vyper.exceptions import (
     ArgumentException,
@@ -30,7 +28,7 @@ from vyper.semantics.types.primitives import BoolT
 from vyper.semantics.types.shortcuts import UINT256_T
 from vyper.semantics.types.subscriptable import TupleT
 from vyper.semantics.types.utils import type_from_abi, type_from_annotation
-from vyper.utils import keccak256
+from vyper.utils import OrderedSet, keccak256
 
 
 class ContractFunctionT(VyperType):

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -3,7 +3,9 @@ import warnings
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+
 from vyper import ast as vy_ast
+from vyper.utils import OrderedSet
 from vyper.ast.validation import validate_call_args
 from vyper.exceptions import (
     ArgumentException,
@@ -89,7 +91,7 @@ class ContractFunctionT(VyperType):
         self.nonreentrant = nonreentrant
 
         # a list of internal functions this function calls
-        self.called_functions: Set["ContractFunctionT"] = set()
+        self.called_functions = OrderedSet()
 
         # special kwargs that are allowed in call site
         self.call_site_kwargs = {

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -11,6 +11,11 @@ from typing import List, Union
 from vyper.exceptions import DecimalOverrideException, InvalidLiteral
 
 
+class OrderedSet(dict):
+    def add(self, item):
+        self[item] = None
+
+
 class DecimalContextOverride(decimal.Context):
     def __setattr__(self, name, value):
         if name == "prec":

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -12,6 +12,14 @@ from vyper.exceptions import DecimalOverrideException, InvalidLiteral
 
 
 class OrderedSet(dict):
+    """
+    a minimal "ordered set" class. this is needed in some places
+    because, while dict guarantees you can recover insertion order
+    vanilla sets do not.
+    no attempt is made to fully implement the set API, will add
+    functionality as needed.
+    """
+
     def add(self, item):
         self[item] = None
 


### PR DESCRIPTION
the use of `set` (which does not guarantee order of its elements) instead of `dict` (which guarantees insertion order) led to instability across runs of the compiler between different versions of python. this commit patches the problem by using a derivation of `dict` to track the call graph instead of `set`.

### What I did

fix #3369 

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
