### PR TITLE
fix: code generation for `<MyInterface>.address`

### DIFF
--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -321,6 +321,23 @@ def test():
     assert erc20.balanceOf(sender) == 1000
 
 
+def test_address_member(w3, get_contract):
+    code = f"""
+interface Foo:
+    def foo(): payable
+
+f: Foo
+
+@external
+def test(addr: address):
+    self.f = Foo(addr)
+    assert self.f.address == addr
+    """
+    c = get_contract(code)
+    for address in w3.eth.accounts:
+        c.test(address)
+
+
 # test data returned from external interface gets clamped
 @pytest.mark.parametrize("typ", ("int128", "uint8"))
 def test_external_interface_int_clampers(get_contract, assert_tx_failed, typ):

--- a/tests/parser/functions/test_interfaces.py
+++ b/tests/parser/functions/test_interfaces.py
@@ -322,7 +322,7 @@ def test():
 
 
 def test_address_member(w3, get_contract):
-    code = f"""
+    code = """
 interface Foo:
     def foo(): payable
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -320,6 +320,9 @@ class Expr:
             sub = Expr(self.expr.value, self.context).ir_node
             # contract type
             if isinstance(sub.typ, InterfaceT):
+                # MyInterface.address
+                assert self.expr.attr == "address"
+                sub.typ = typ
                 return sub
             if isinstance(sub.typ, StructT) and self.expr.attr in sub.typ.member_types:
                 return get_element_ptr(sub, self.expr.attr)


### PR DESCRIPTION
code like <MyInterface>.address would result being tagged with the wrong type during codegen - InterfaceT instead of AddressT.

this was a regression introduced in 3abe588e0, and for some reason there were no existing tests for <MyInterface>.address codegen. this fixes the type tagging during codegen and adds a test to prevent this regression in the future.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
