### PR TITLE
Add deprecation warning for `selfdestruct` usage

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -299,6 +299,10 @@ Vyper has three built-ins for contract creation; all three contract creation bui
 
         This method deletes the contract from the blockchain. All non-ether assets associated with this contract are "burned" and the contract is no longer accessible.
 
+    .. note::
+
+        This function has been deprecated from version 0.3.8 onwards. The underlying opcode will eventually undergo breaking changes, and its use is not recommended.
+
     .. code-block:: python
 
         @external

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1238,6 +1238,7 @@ class SelfDestruct(BuiltinFunction):
     _inputs = [("to", AddressT())]
     _return_type = None
     _is_terminus = True
+    _warned = False
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1243,9 +1243,7 @@ class SelfDestruct(BuiltinFunction):
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         if not self._warned:
-            vyper_warn(
-                "`selfdestruct` is deprecated! The underlying opcode will eventually undergo breaking changes, and its use is not recommended."
-            )
+            vyper_warn("`selfdestruct` is deprecated! The opcode is no longer recommended for use.")
             self._warned = True
 
         context.check_is_not_constant("selfdestruct", expr)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1241,6 +1241,12 @@ class SelfDestruct(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
+        if not self._warned:
+            vyper_warn(
+                "`selfdestruct` is deprecated! The underlying opcode will eventually undergo breaking changes, and its use is not recommended."
+            )
+            self._warned = True
+
         context.check_is_not_constant("selfdestruct", expr)
         return IRnode.from_list(
             ["seq", eval_once_check(_freshname("selfdestruct")), ["selfdestruct", args[0]]]


### PR DESCRIPTION
### What I did

Fixes #3277.

### How I did it

Add the following warning if `selfdestruct` is used:

```bash
`selfdestruct` is deprecated! The opcode is no longer recommended for use.
```

I also updated the docs.

### How to verify it

Run the following function:

```vyper
@external
def foo():
    selfdestruct(msg.sender)
```

#### Compilation Output

```bash
Warning: `selfdestruct` is deprecated! The opcode is no longer recommended for use.
0x61003961000f6000396100396000f360003560e01c346100285763c2985578811861002157600436106100285733ff005b5060006000fd5b600080fda1657679706572830001000a
```

### Commit message

`Add deprecation warning for selfdestruct usage`

### Description for the changelog

Add deprecation warning for `selfdestruct` usage.

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25297591/235133065-bdefbd31-92dc-494f-9acc-9c0b17fc0bcd.png)