### PR TITLE
fix: type inference for empty lists

### DIFF
--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -302,6 +302,12 @@ b: decimal[5]
 def foo():
     self.b[0] = 7.0
     """,
+    """
+@external
+def foo():
+    for i in [[], []]:
+        pass
+    """,
 ]
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -309,7 +309,11 @@ class _ExprAnalyser:
             # subtype can be anything
             types_list = types.PRIMITIVE_TYPES
             # 1 is minimum possible length for dynarray, assignable to anything
-            ret = [DArrayT(t, 1) for t in types_list.values()]
+            # for type classes like bytestrings, use a generic type acceptor
+            ret = [
+                DArrayT(t, 1) if isinstance(t, VyperType) else DArrayT(t.any(), 1)
+                for t in types_list.values()
+            ]
             return ret
         types_list = get_common_types(*node.elements)
 


### PR DESCRIPTION
### What I did

This contract should compile but throws:
```
@external
def foo():
    for i in [[], []]:
        pass
```
```
TypeError: _BytestringT.compare_type() missing 1 required positional argument: 'other'
```

### How I did it

The issue is that the possible types for an empty list include class objects (e.g. `BytesT`, `StringT`) in `types_from_List`. This causes `get_common_types` to throw the above error when we perform `self.value_type.compare_type(other.value_type)` in `DArrayT.compare_type()`.

### How to verify it

### Commit message

```
fix: allow iteration of list of empty lists
```

### Description for the changelog

Allow iteration of list of empty lists.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTxtGCbug_lA_jDaoPBe11ZmLKNob40cnBRQQ&usqp=CAU)
