### PR TITLE
fix: improve type check for subscript folding

### DIFF
--- a/tests/parser/syntax/test_constants.py
+++ b/tests/parser/syntax/test_constants.py
@@ -10,6 +10,7 @@ from vyper.exceptions import (
     StateAccessViolation,
     StructureException,
     SyntaxException,
+    TypeMismatch,
     VariableDeclarationException,
 )
 
@@ -130,6 +131,22 @@ def hello() :
     x.a =  2
     """,
         ImmutableViolation,
+    ),
+    (
+        """
+@external
+def foo():
+    a: uint256 = [1.0, 1][1]
+    """,
+        TypeMismatch,
+    ),
+    (
+        """
+@external
+def foo():
+    a: uint256 = [max_value(decimal), max_value(uint256)][1]
+    """,
+        TypeMismatch,
     ),
 ]
 

--- a/vyper/ast/folding.py
+++ b/vyper/ast/folding.py
@@ -39,8 +39,8 @@ def fold(vyper_module: vy_ast.Module) -> None:
         changed_nodes = 0
         changed_nodes += replace_user_defined_constants(vyper_module)
         changed_nodes += replace_literal_ops(vyper_module)
-        changed_nodes += replace_subscripts(vyper_module)
         changed_nodes += replace_builtin_functions(vyper_module)
+        changed_nodes += replace_subscripts(vyper_module)
 
 
 def replace_literal_ops(vyper_module: vy_ast.Module) -> int:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1269,6 +1269,8 @@ class Subscript(ExprNode):
             raise UnfoldableNode("Subscript object is not a literal list")
         elements = self.value.elements
         if len(set([type(i) for i in elements])) > 1:
+            if all(isinstance(i, Constant) for i in elements):
+                raise TypeMismatch("List contains multiple literal types", self.value)
             raise UnfoldableNode("List contains multiple node types")
         idx = self.slice.get("value.value")
         if not isinstance(idx, int) or idx < 0 or idx >= len(elements):


### PR DESCRIPTION
### What I did

This contract compiles when it should not
```
@external
def foo():
    a: uint256 = [max_value(decimal), max_value(uint256)][1]
```

### How I did it

Check for different node types if all elements in a list are literals, and move subscript folding to the end.

Note that this still would not catch lists with literals of the same node types but different types e.g. `x: uint256 = [-1, 1][1]`, which probably requires folding to come after the semantics pass.

### How to verify it

See tests.

### Commit message

```
fix: improve type check for subscript folding
```

### Description for the changelog

Improve type check for subscript folding

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://modernfarmer.com/wp-content/uploads/2015/09/sleepy-alpaca-1200x845.jpg)
