### PR TITLE
chore: fix fuzzer test case

### DIFF
--- a/tests/builtins/folding/test_bitwise.py
+++ b/tests/builtins/folding/test_bitwise.py
@@ -3,7 +3,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from vyper import ast as vy_ast
-from vyper.exceptions import OverflowException
+from vyper.exceptions import InvalidType, OverflowException
 from vyper.semantics.analysis.utils import validate_expected_type
 from vyper.semantics.types.shortcuts import INT256_T, UINT256_T
 from vyper.utils import unsigned_to_signed
@@ -83,7 +83,8 @@ def foo(a: int256, b: uint256) -> int256:
         validate_expected_type(new_node, INT256_T)  # force bounds check
     # compile time behavior does not match runtime behavior.
     # compile-time will throw on OOB, runtime will wrap.
-    except OverflowException:  # here: check the wrapped value matches runtime
+    except (InvalidType, OverflowException):
+        # check the wrapped value matches runtime
         assert op == "<<"
         assert contract.foo(a, b) == unsigned_to_signed((a << b) % (2**256), 256)
     else:


### PR DESCRIPTION
for cases where `a << b` is an int256 between `max_value(int256)` and `max_value(uint256)`, the typechecker will fail with TypeMismatch instead of OverflowException. this fixes the test to catch the case. note that the code was correctly failing to compile, just the test was not catching both exception types.

(this test case was found in https://github.com/vyperlang/vyper/actions/runs/4886254516/jobs/8721370863?pr=3370):

```
E           vyper.exceptions.InvalidType: <unprintable InvalidType object>

vyper/semantics/analysis/utils.py:578: InvalidType
---------------------------------- Hypothesis ----------------------------------
Falsifying example: test_bitwise_shift_signed(
    get_contract=<function tests.base_conftest.get_contract.<locals>.get_contract>,
    a=16,
    b=251,
    op='<<',
)
```

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
