### PR TITLE
fix: codegen for hashmaps with string keys

### DIFF
--- a/tests/parser/features/test_string_map_keys.py
+++ b/tests/parser/features/test_string_map_keys.py
@@ -9,4 +9,17 @@ def test() -> bool:
     return self.f[b]  # should return False
     """
     c = get_contract(code)
+    c.test()
+    assert c.test() is False
+
+
+def test_string_map_keys_literals(get_contract):
+    code = """
+f:HashMap[String[1], bool]
+@external
+def test() -> bool:
+    self.f["a"] = True
+    return self.f["b"]  # should return False
+    """
+    c = get_contract(code)
     assert c.test() is False

--- a/tests/parser/features/test_string_map_keys.py
+++ b/tests/parser/features/test_string_map_keys.py
@@ -1,0 +1,12 @@
+def test_string_map_keys(get_contract):
+    code = """
+f:HashMap[String[1], bool]
+@external
+def test() -> bool:
+    a:String[1] = "a"
+    b:String[1] = "b"
+    self.f[a] = True
+    return self.f[b]  # should return False
+    """
+    c = get_contract(code)
+    assert c.test() is False

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -611,7 +611,7 @@ class Keccak256(BuiltinFunction):
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         assert len(args) == 1
-        return keccak256_helper(expr, args[0], context)
+        return keccak256_helper(args[0], context)
 
 
 def _make_sha256_call(inp_start, inp_len, out_start, out_len):

--- a/vyper/codegen/events.py
+++ b/vyper/codegen/events.py
@@ -15,7 +15,7 @@ def _encode_log_topics(expr, event_id, arg_nodes, context):
             value = unwrap_location(arg)
 
         elif isinstance(arg.typ, _BytestringT):
-            value = keccak256_helper(expr, arg, context=context)
+            value = keccak256_helper(arg, context=context)
         else:
             # TODO block at higher level
             raise TypeMismatch("Event indexes may only be value types", expr)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -39,7 +39,6 @@ from vyper.semantics.types import (
     BoolT,
     BytesT,
     DArrayT,
-    _BytestringT,
     DecimalT,
     EnumT,
     HashMapT,

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -339,7 +339,7 @@ class Expr:
         if isinstance(sub.typ, HashMapT):
             # TODO sanity check we are in a self.my_map[i] situation
             index = Expr(self.expr.slice.value, self.context).ir_node
-            if isinstance(sub.typ, _BytestringT):
+            if isinstance(index.typ, _BytestringT):
                 # we have to hash the key to get a storage location
                 index = keccak256_helper(index, self.context)
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -39,6 +39,7 @@ from vyper.semantics.types import (
     BoolT,
     BytesT,
     DArrayT,
+    _BytestringT,
     DecimalT,
     EnumT,
     HashMapT,
@@ -339,7 +340,7 @@ class Expr:
         if isinstance(sub.typ, HashMapT):
             # TODO sanity check we are in a self.my_map[i] situation
             index = Expr.parse_value_expr(self.expr.slice.value, self.context)
-            if isinstance(index.typ, BytesT):
+            if isinstance(index.typ, _BytestringT):
                 # we have to hash the key to get a storage location
                 assert len(index.args) == 1
                 index = keccak256_helper(self.expr.slice.value, index.args[0], self.context)

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -338,11 +338,10 @@ class Expr:
 
         if isinstance(sub.typ, HashMapT):
             # TODO sanity check we are in a self.my_map[i] situation
-            index = Expr.parse_value_expr(self.expr.slice.value, self.context)
-            if isinstance(index.typ, _BytestringT):
+            index = Expr(self.expr.slice.value, self.context).ir_node
+            if isinstance(sub.typ, _BytestringT):
                 # we have to hash the key to get a storage location
-                assert len(index.args) == 1
-                index = keccak256_helper(self.expr.slice.value, index.args[0], self.context)
+                index = keccak256_helper(index, self.context)
 
         elif is_array_like(sub.typ):
             index = Expr.parse_value_expr(self.expr.slice.value, self.context)
@@ -528,8 +527,8 @@ class Expr:
             left = Expr(self.expr.left, self.context).ir_node
             right = Expr(self.expr.right, self.context).ir_node
 
-            left_keccak = keccak256_helper(self.expr, left, self.context)
-            right_keccak = keccak256_helper(self.expr, right, self.context)
+            left_keccak = keccak256_helper(left, self.context)
+            right_keccak = keccak256_helper(right, self.context)
 
             if op not in ("eq", "ne"):
                 return  # raises

--- a/vyper/codegen/keccak256_helper.py
+++ b/vyper/codegen/keccak256_helper.py
@@ -8,7 +8,7 @@ from vyper.semantics.types.shortcuts import BYTES32_T
 from vyper.utils import SHA3_BASE, SHA3_PER_WORD, MemoryPositions, bytes_to_int, keccak256
 
 
-def _check_byteslike(typ, _expr):
+def _check_byteslike(typ):
     if not isinstance(typ, _BytestringT) and typ != BYTES32_T:
         # NOTE this may be checked at a higher level, but just be safe
         raise CompilerPanic("keccak256 only accepts bytes-like objects")
@@ -18,8 +18,8 @@ def _gas_bound(num_words):
     return SHA3_BASE + num_words * SHA3_PER_WORD
 
 
-def keccak256_helper(expr, to_hash, context):
-    _check_byteslike(to_hash.typ, expr)
+def keccak256_helper(to_hash, context):
+    _check_byteslike(to_hash.typ)
 
     # Can hash literals
     # TODO this is dead code.


### PR DESCRIPTION
### What I did
fix #3291 

### How I did it

### How to verify it
see test

### Commit message
```
fix: codegen for hashmaps with `String[...]` keys.
```


### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
