### PR TITLE
chore: remove dead code in IR generation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,10 @@ def set_evm_verbose_logging():
     logger.setLevel("DEBUG2")
 
 
+# Useful options to comment out whilst working:
+# set_evm_verbose_logging()
+
+
 def pytest_addoption(parser):
     parser.addoption("--no-optimize", action="store_true", help="disable asm and IR optimizations")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,13 +28,6 @@ def set_evm_verbose_logging():
     logger.setLevel("DEBUG2")
 
 
-# Useful options to comment out whilst working:
-# set_evm_verbose_logging()
-#
-# from vdb import vdb
-# vdb.set_evm_opcode_debugger()
-
-
 def pytest_addoption(parser):
     parser.addoption("--no-optimize", action="store_true", help="disable asm and IR optimizations")
 

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -120,11 +120,7 @@ class FunctionSignature:
     # Get a signature from a function definition
     @classmethod
     def from_definition(
-        cls,
-        func_ast,  # vy_ast.FunctionDef
-        global_ctx,
-        interface_def=False,
-        is_from_json=False,
+        cls, func_ast, global_ctx, interface_def=False, is_from_json=False  # vy_ast.FunctionDef
     ):
         name = func_ast.name
 

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -124,7 +124,6 @@ class FunctionSignature:
         func_ast,  # vy_ast.FunctionDef
         global_ctx,
         interface_def=False,
-        constant_override=False,  # CMC 20210907 what does this do?
         is_from_json=False,
     ):
         name = func_ast.name
@@ -151,12 +150,6 @@ class FunctionSignature:
                 is_internal = False
             elif isinstance(dec, vy_ast.Call) and dec.func.id == "nonreentrant":
                 nonreentrant_key = dec.args[0].s
-
-        if constant_override:
-            # In case this override is abused, match previous behavior
-            if mutability == "payable":
-                raise StructureException(f"Function {name} cannot be both constant and payable.")
-            mutability = "view"
 
         # Determine the return type and whether or not it's constant. Expects something
         # of the form:

--- a/vyper/ast/signatures/function_signature.py
+++ b/vyper/ast/signatures/function_signature.py
@@ -3,7 +3,7 @@ from functools import cached_property
 from typing import Dict, Optional, Tuple
 
 from vyper import ast as vy_ast
-from vyper.exceptions import CompilerPanic, StructureException
+from vyper.exceptions import CompilerPanic
 from vyper.semantics.types import VyperType
 from vyper.utils import MemoryPositions, mkalphanum
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -52,12 +52,6 @@ class Stmt:
     def parse_Pass(self):
         return IRnode.from_list("pass")
 
-    def parse_Name(self):
-        if self.stmt.id == "vdb":
-            return IRnode("debugger")
-        else:
-            raise StructureException(f"Unsupported statement type: {type(self.stmt)}", self.stmt)
-
     def parse_AnnAssign(self):
         ltyp = self.context.parse_type(self.stmt.annotation)
         varname = self.stmt.target.id

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -23,7 +23,7 @@ from vyper.codegen.core import (
 from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
 from vyper.evm.address_space import MEMORY, STORAGE
-from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure
+from vyper.exceptions import CompilerPanic, TypeCheckFailure
 from vyper.semantics.types import DArrayT, MemberFunctionT
 from vyper.semantics.types.shortcuts import INT256_T, UINT256_T
 

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -207,7 +207,6 @@ PSEUDO_OPCODES: OpcodeMap = {
     "CEIL32": (None, 1, 1, 20),
     "SET": (None, 2, 0, 20),
     "NE": (None, 2, 1, 6),
-    "DEBUGGER": (None, 0, 0, 0),
     "ILOAD": (None, 1, 1, 6),
     "ISTORE": (None, 2, 0, 6),
     "DLOAD": (None, 1, 1, 9),

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -727,9 +727,6 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
         raise CodegenPanic("exit_to not implemented yet!")
 
     # inject debug opcode.
-    elif code.value == "debugger":
-        return mkdebug(pc_debugger=False, source_pos=code.source_pos)
-    # inject debug opcode.
     elif code.value == "pc_debugger":
         return mkdebug(pc_debugger=True, source_pos=code.source_pos)
     else:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -281,7 +281,6 @@ VALID_IR_MACROS = {
     "dloadbytes",
     "ceil32",
     "continue",
-    "debugger",
     "ge",
     "if",
     "select",


### PR DESCRIPTION
### What I did

Remove dead code in IR generation
- `constant_override` kwarg in `FunctionSignature.from_definition` of vyper/ast/signatures/function_signature.py is never set to True, and therefore the `if` branch is never hit.
- `parse_Name` in `vyper/codegen/stmt.py` is never reachable because a statement can no longer be a standalone Name node. This was the original form of the equivalent function a while [back](https://github.com/vyperlang/vyper/blob/17bfed46411e2bc9aa47c88a784f068a59a09d9d/vyper/parser/stmt.py). Also removed code related to a single statement Name node being "vdb", which "vdb" [file](https://github.com/vyperlang/vyper/blob/115a051d711845b4403181fb50c5bcaa1888e278/vyper/vdb.py) no longer exists in the repo.

### How I did it

Delete code.

### How to verify it

Nothing.

### Commit message

```
chore: remove dead code in IR generation
```

### Description for the changelog

Remove dead code in IR generation.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.newmindmedia.com/TellUs/image/?file=FC11063C45DF7497B3E7420785207412F8583E43.jpg)
