### PR TITLE
fix: string to bool conversion

### DIFF
--- a/tests/parser/functions/test_convert.py
+++ b/tests/parser/functions/test_convert.py
@@ -22,7 +22,7 @@ from vyper.utils import (
 
 BASE_TYPES = set(IntegerT.all()) | set(BytesM_T.all()) | {DecimalT(), AddressT(), BoolT()}
 
-TEST_TYPES = BASE_TYPES | {BytesT(32)}
+TEST_TYPES = BASE_TYPES | {BytesT(32)} | {StringT(32)}
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
@@ -163,6 +163,17 @@ def _cases_for_Bytes(typ):
     # would not need this if we tested all Bytes[1]...Bytes[32] types.
     for i in range(32):
         ret.extend(_cases_for_bytes(BytesM_T(i + 1)))
+
+    ret.append(b"")
+    return uniq(ret)
+
+
+def _cases_for_String(typ):
+    ret = []
+    # would not need this if we tested all Bytes[1]...Bytes[32] types.
+    for i in range(32):
+        ret.extend([str(c, "utf-8") for c in _cases_for_bytes(BytesM_T(i + 1))])
+    ret.append("")
     return uniq(ret)
 
 
@@ -176,6 +187,8 @@ def interesting_cases_for_type(typ):
         return _cases_for_bytes(typ)
     if isinstance(typ, BytesT):
         return _cases_for_Bytes(typ)
+    if isinstance(typ, StringT):
+        return _cases_for_String(typ)
     if isinstance(typ, BoolT):
         return _cases_for_bool(typ)
     if isinstance(typ, AddressT):

--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -267,7 +267,7 @@ def _literal_decimal(expr, arg_typ, out_typ):
 def to_bool(expr, arg, out_typ):
     _check_bytes(expr, arg, out_typ, 32)  # should we restrict to Bytes[1]?
 
-    if isinstance(arg.typ, BytesT):
+    if isinstance(arg.typ, (BytesT, StringT)):
         # no clamp. checks for any nonzero bytes.
         arg = _bytes_to_num(arg, out_typ, signed=False)
 

--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -267,7 +267,7 @@ def _literal_decimal(expr, arg_typ, out_typ):
 def to_bool(expr, arg, out_typ):
     _check_bytes(expr, arg, out_typ, 32)  # should we restrict to Bytes[1]?
 
-    if isinstance(arg.typ, (BytesT, StringT)):
+    if isinstance(arg.typ, _BytestringT):
         # no clamp. checks for any nonzero bytes.
         arg = _bytes_to_num(arg, out_typ, signed=False)
 


### PR DESCRIPTION
### What I did

Conversion of string to bool should follow that of `BytesT` to compare non-zero bytes, but it currently compares pointer instead.

### How I did it

Add `StringT` to condition

### How to verify it

See tests

### Commit message

```
fix: string to bool conversion
```

### Description for the changelog

Fix string to bool conversion

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://d3ftabzjnxfdg6.cloudfront.net/app/uploads/2020/05/18-10-28_0002-sea-otter-BB-web-1024x512.jpg)
