### PR TITLE
fix: metadata output

### DIFF
--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -112,7 +112,8 @@ def w3(tester):
 def _get_contract(w3, source_code, no_optimize, *args, **kwargs):
     out = compiler.compile_code(
         source_code,
-        ["abi", "bytecode"],
+        # test that metadata gets generated
+        ["abi", "bytecode", "metadata"],
         interface_codes=kwargs.pop("interface_codes", None),
         no_optimize=no_optimize,
         evm_version=kwargs.pop("evm_version", None),

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -130,8 +130,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
             # e.g. {"x": vy_ast.Int(..)} -> {"x": 1}
             ret["default_values"][k] = ret["default_values"][k].node_source_code
         ret["frame_info"] = vars(ret["frame_info"])
-        for k in ret["frame_info"]["frame_vars"].keys():
-            ret["frame_info"]["frame_vars"][k] = _var_rec_dict(ret["frame_info"]["frame_vars"][k])
+        del ret["frame_info"]["frame_vars"]  # frame_var.pos might be IR, cannot serialize
         return ret
 
     return {"function_info": {name: _to_dict(sig) for (name, sig) in sigs.items()}}


### PR DESCRIPTION
### What I did
`-f metadata` output was not working for some functions. this fixes the issue and also checks that `metadata` output is successfully produced in the `get_contract` fixture to avoid this in the future.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
