### PR TITLE
chore: add integrator test CI

### DIFF
--- a/.github/workflows/era-tester.yml
+++ b/.github/workflows/era-tester.yml
@@ -1,4 +1,11 @@
-name: Integrators
+name: era compiler tester
+
+# run the matter labs compiler test to integrate their test cases
+# this is intended as a diagnostic / spot check to check that we
+# haven't seriously broken the compiler. but, it is not intended as
+# a requirement for merging since we may make changes to our IR
+# which break the downstream backend (at which point, downstream needs
+# to update, which we do not want to be blocked on).
 
 on: [push, pull_request]
 

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
         cd era-compiler-tester
+        sed -i 's/ssh:\/\/git@/https:\/\//g' .gitmodules
         git submodule init
         git submodule update
         cd ..

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         sudo apt install cmake ninja-build clang-13 lld-13 parallel pkg-config
         cd era-compiler-tester
+        cargo install compiler-llvm-builder
         zkevm-llvm clone && zkevm-llvm build
         cargo build --release
         cd ..

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Initialize repository and submodules
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
+        cd era-compiler-tester
         sed -i 's/ssh:\/\/git@/https:\/\//g' .gitmodules
         git submodule init
         git submodule update

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -33,32 +33,24 @@ jobs:
     - name: Initialize repository and submodules
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
-        cd era-compiler-tester
         sed -i 's/ssh:\/\/git@/https:\/\//g' .gitmodules
         git submodule init
         git submodule update
-        cd ..
 
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         sudo apt install cmake ninja-build clang-13 lld-13 parallel pkg-config lld
-        cd era-compiler-tester
         cargo install compiler-llvm-builder
         zkevm-llvm clone && zkevm-llvm build
         cargo build --release
-        cd ..
 
     - name: Copy Vyper binary
       run: |
-        cd era-compiler-tester
         mkdir vyper-bin
         echo $(which vyper)
         cp $(which vyper) vyper-bin/vyper-0.3.8
-        cd ..
 
-    - name: Run tester with optimization for Vyper
+    - name: Run tester
       run: |
-        cd era-compiler-tester
         cargo run --release --bin compiler-tester -- -v --path='tests/vyper/' --mode='M*B* 0.3.8'
-        cd ..

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Install Vyper
       run: |
-        ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        pip install .
         mkdir era-compiler-tester/vyper-bin
         echo $(which vyper)
         cp $(which vyper) era-compiler-tester/vyper-bin/vyper-0.3.8

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Get latest commit hash
       run: |
         echo "ERA_HASH=$( curl -u "u:${{ github.token }}" https://api.github.com/repos/matter-labs/era-compiler-tester/git/ref/heads/main | jq .object.sha | tr -d '"' )" >> $GITHUB_ENV
+        echo "ERA_VYPER_HASH=$( curl -u "u:${{ github.token }}" https://api.github.com/repos/matter-labs/era-compiler-vyper/git/ref/heads/main | jq .object.sha | tr -d '"' )" >> $GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@v1
@@ -45,7 +46,7 @@ jobs:
           **/compiler_tester
           **/llvm
           **/era-compiler-tester
-        key: ${{ runner.os }}-${{ env.ERA_HASH }}
+        key: ${{ runner.os }}-${{ env.ERA_HASH }}-${{ env.ERA_VYPER_HASH }}
 
     - name: Initialize repository and install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
@@ -74,7 +75,7 @@ jobs:
           **/compiler_tester
           **/llvm
           **/era-compiler-tester
-        key: ${{ runner.os }}-${{ env.ERA_HASH }}
+        key: ${{ runner.os }}-${{ env.ERA_HASH }}-${{ env.ERA_VYPER_HASH }}
 
     - name: Install Vyper
       run: |

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -34,8 +34,8 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
         cd era-compiler-tester
-        git submodules init
-        git submodules update
+        git submodule init
+        git submodule update
         cd ..
 
     - name: Install dependencies

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
+    - name: Get latest commit hash
+      run: |
+        echo "ERA_HASH=$( curl -u "u:${{ github.token }}" https://api.github.com/repos/matter-labs/era-compiler-tester/git/ref/heads/main | jq .object.sha | tr -d '"' )" >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@v1
 
@@ -27,10 +31,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version[0] }}
 
-    - name: Install Vyper
-      run: pip install .
+    - name: Get cache
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          **/target
+          **/target-llvm
+          **/compiler_tester
+          **/llvm
+          **/era-compiler-tester
+        key: ${{ runner.os }}-${{ env.ERA_HASH }}
 
     - name: Initialize repository and install dependencies
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
         cd era-compiler-tester
@@ -42,8 +60,9 @@ jobs:
         zkevm-llvm clone && zkevm-llvm build
         cargo build --release
 
-    - name: Copy Vyper binary
+    - name: Install Vyper
       run: |
+        ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         mkdir era-compiler-tester/vyper-bin
         echo $(which vyper)
         cp $(which vyper) era-compiler-tester/vyper-bin/vyper-0.3.8

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python-version[0] }}
 
     - name: Install Vyper
-      run: make init
+      run: python setup.py install
 
     - name: Initialize repository and submodules
       run: |

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -30,17 +30,13 @@ jobs:
     - name: Install Vyper
       run: pip install .
 
-    - name: Initialize repository and submodules
+    - name: Initialize repository and install dependencies
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
         cd era-compiler-tester
         sed -i 's/ssh:\/\/git@/https:\/\//g' .gitmodules
         git submodule init
         git submodule update
-
-    - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
         sudo apt install cmake ninja-build clang-13 lld-13 parallel pkg-config lld
         cargo install compiler-llvm-builder
         zkevm-llvm clone && zkevm-llvm build
@@ -48,10 +44,11 @@ jobs:
 
     - name: Copy Vyper binary
       run: |
-        mkdir vyper-bin
+        mkdir era-compiler-tester/vyper-bin
         echo $(which vyper)
-        cp $(which vyper) vyper-bin/vyper-0.3.8
+        cp $(which vyper) era-compiler-tester/vyper-bin/vyper-0.3.8
 
     - name: Run tester
       run: |
+        cd era-compiler-tester
         cargo run --release --bin compiler-tester -- -v --path='tests/vyper/' --mode='M*B* 0.3.8'

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -48,7 +48,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.ERA_HASH }}
 
     - name: Initialize repository and install dependencies
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
         cd era-compiler-tester
@@ -59,6 +59,22 @@ jobs:
         cargo install compiler-llvm-builder
         zkevm-llvm clone && zkevm-llvm build
         cargo build --release
+
+    - name: Save cache
+      uses: actions/cache/save@v3
+      if: always()
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          **/target
+          **/target-llvm
+          **/compiler_tester
+          **/llvm
+          **/era-compiler-tester
+        key: ${{ runner.os }}-${{ env.ERA_HASH }}
 
     - name: Install Vyper
       run: |

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        apt install cmake ninja-build clang-13 lld-13 parallel pkg-config
+        sudo apt install cmake ninja-build clang-13 lld-13 parallel pkg-config
         cd era-compiler-tester
         zkevm-llvm clone && zkevm-llvm build
         cargo build --release

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -1,0 +1,62 @@
+name: Integrators
+
+on: [push, pull_request]
+
+concurrency:
+  # cancel older, in-progress jobs from the same PR, same workflow.
+  # use run_id if the job is triggered by a push to ensure
+  # push-triggered jobs to not get canceled.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  era-compiler-tester:
+    runs-on: ubuntu-latest
+  
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Rust setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly-2022-11-03
+
+    - name: Set up Python ${{ matrix.python-version[0] }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version[0] }}
+
+    - name: Install Vyper
+      run: make init
+
+    - name: Initialize repository and submodules
+      run: |
+        git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
+        cd era-compiler-tester
+        git submodules init
+        git submodules update
+        cd ..
+
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        apt install cmake ninja-build clang-13 lld-13 parallel pkg-config
+        cd era-compiler-tester
+        zkevm-llvm clone && zkevm-llvm build
+        cargo build --release
+        cd ..
+
+    - name: Copy Vyper binary
+      run: |
+        cd era-compiler-tester
+        mkdir vyper-bin
+        echo $(which vyper)
+        cp $(which vyper) vyper-bin/vyper-0.3.8
+        cd ..
+
+    - name: Run tester with optimization for Vyper
+      run: |
+        cd era-compiler-tester
+        cargo run --release --bin compiler-tester -- -v --path='tests/vyper/' --mode='M0B0'
+        cd ..

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python-version[0] }}
 
     - name: Install Vyper
-      run: python setup.py install
+      run: pip install .
 
     - name: Initialize repository and submodules
       run: |

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -60,5 +60,5 @@ jobs:
     - name: Run tester with optimization for Vyper
       run: |
         cd era-compiler-tester
-        cargo run --release --bin compiler-tester -- -v --path='tests/vyper/' --mode='M0B0'
+        cargo run --release --bin compiler-tester -- -v --path='tests/vyper/' --mode='M*B* 0.3.8'
         cd ..

--- a/.github/workflows/integrators.yml
+++ b/.github/workflows/integrators.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        sudo apt install cmake ninja-build clang-13 lld-13 parallel pkg-config
+        sudo apt install cmake ninja-build clang-13 lld-13 parallel pkg-config lld
         cd era-compiler-tester
         cargo install compiler-llvm-builder
         zkevm-llvm clone && zkevm-llvm build


### PR DESCRIPTION
### What I did

Add integrator CI to check for regressions.

### How I did it

### How to verify it

### Commit message

```
chore: add era compiler test suite to CI

this commit adds the era compiler test suite to the CI, as they have
good test cases and coverage of our compiler through IR codegen.

this is intended as a diagnostic tool to help catch compiler regressions
and notify us when a change breaks downstream. as explained in the
comments in the workflow file, it is not intended as a CI blocker since
an update in our code could break downstream, and we do not want to wait
on downstream as a blocker.
```

### Description for the changelog

Add integrators CI to check for regressions.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/7435/8730447232_522da44ec1_c.jpg)
