### PR TITLE
allow multiple assignment to immutables

### DIFF
--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -241,11 +241,6 @@ class ExprInfo:
         if self.is_immutable:
             if node.get_ancestor(vy_ast.FunctionDef).get("name") != "__init__":
                 raise ImmutableViolation("Immutable value cannot be written to", node)
-            # TODO: we probably want to remove this restriction.
-            if self.var_info._modification_count:  # type: ignore
-                raise ImmutableViolation(
-                    "Immutable value cannot be modified after assignment", node
-                )
             self.var_info._modification_count += 1  # type: ignore
 
         if isinstance(node, vy_ast.AugAssign):


### PR DESCRIPTION
### What I did
cf. #3278 and https://github.com/vyperlang/vyper/issues/3162, relaxing the restriction might be less confusing. also reference types (like dynamic arrays) can be modified in the constructor. creating this as draft until the language change is discussed further

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
