### PR TITLE
chore: change pass to seq

### DIFF
--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -79,7 +79,7 @@ def _unpack_returndata(buf, fn_type, call_kwargs, contract_address, context, exp
     return_t = fn_type.return_type
 
     if return_t is None:
-        return ["pass"], 0, 0
+        return ["seq"], 0, 0
 
     wrapped_return_t = calculate_type_for_external_return(return_t)
 

--- a/vyper/codegen/function_definitions/utils.py
+++ b/vyper/codegen/function_definitions/utils.py
@@ -4,7 +4,7 @@ from vyper.semantics.types.function import StateMutability
 
 def get_nonreentrant_lock(func_type):
     if not func_type.nonreentrant:
-        return ["pass"], ["pass"]
+        return ["seq"], ["seq"]
 
     nkey = func_type.reentrancy_key_position.position
 

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -71,7 +71,7 @@ def make_return_stmt(ir_val: IRnode, stmt: Any, context: Context) -> Optional[IR
         if can_skip_encode:
             assert ir_val.typ.memory_bytes_required == maxlen  # type: ignore
             jump_to_exit += [ir_val, maxlen]  # type: ignore
-            return finalize(["pass"])
+            return finalize(["seq"])
 
         ir_val = wrap_value_for_external_return(ir_val)
 
@@ -86,4 +86,4 @@ def make_return_stmt(ir_val: IRnode, stmt: Any, context: Context) -> Optional[IR
         # append ofst and len to exit_to the cleanup subroutine
         jump_to_exit += [return_buffer_ofst, return_len]  # type: ignore
 
-        return finalize(["pass"])
+        return finalize(["seq"])

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -93,7 +93,7 @@ def ir_for_self_call(stmt_expr, context):
 
     call_sequence = ["seq"]
     call_sequence.append(eval_once_check(_freshname(stmt_expr.node_source_code)))
-    call_sequence.extend([copy_args, goto_op, ["label", return_label, ["var_list"], "pass"]])
+    call_sequence.extend([copy_args, goto_op, ["label", return_label, ["var_list"], "seq"]])
     if return_buffer is not None:
         # push return buffer location to stack
         call_sequence += [return_buffer]

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -50,7 +50,7 @@ class Stmt:
         return Stmt(self.stmt.value, self.context).ir_node
 
     def parse_Pass(self):
-        return IRnode.from_list("pass")
+        return IRnode.from_list("seq")
 
     def parse_Name(self):
         if self.stmt.id == "vdb":
@@ -420,5 +420,5 @@ def parse_body(code, context, ensure_terminated=False):
         ir_node.append(parse_stmt(vy_ast.Return(value=None), context))
 
     # force zerovalent, even last statement
-    ir_node.append("pass")  # CMC 2022-01-16 is this necessary?
+    ir_node.append("seq")  # CMC 2022-01-16 is this necessary?
     return IRnode.from_list(ir_node)


### PR DESCRIPTION
some downstream tooling has issues parsing `pass`, so we just change all pass to seq

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
