### PR TITLE
fix: type annotation of Subscript nodes

### DIFF
--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -31,7 +31,7 @@ class VyperMethod:
                 if x.get("name") == self._function.function_identifier
             ].pop()
             # To make tests faster just supply some high gas value.
-            modifier_dict.update({"gas": fn_abi.get("gas", 0) + 50000})
+            modifier_dict.update({"gas": fn_abi.get("gas", 0) + 500000})
         elif len(kwargs) == 1:
             modifier, modifier_dict = kwargs.popitem()
             if modifier not in self.ALLOWED_MODIFIERS:

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -759,7 +759,7 @@ def foo(xs: uint256[257], i: uint8) -> uint256:
         assert c.foo(xs, ix) == xs[ix + 1]
 
     # safemath should fail for uint8: 255 + 1.
-    assert_tx_failed(lambda: c.foo(255))
+    assert_tx_failed(lambda: c.foo(xs, 255))
 
 
 @pytest.mark.parametrize(

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -745,6 +745,23 @@ def ix(i: uint256) -> address:
     assert_tx_failed(lambda: c.ix(len(some_good_address) + 1))
 
 
+def test_list_index_complex_expr(get_contract, assert_tx_failed):
+    # test subscripts where the index is not a literal
+    code = """
+@external
+def foo(xs: uint256[257], i: uint8) -> uint256:
+    return xs[i + 1]
+    """
+    c = get_contract(code)
+    xs = [i + 1 for i in range(257)]
+
+    for ix in range(255):
+        assert c.foo(xs, ix) == xs[ix + 1]
+
+    # safemath should fail for uint8: 255 + 1.
+    assert_tx_failed(lambda: c.foo(255))
+
+
 @pytest.mark.parametrize(
     "type,value",
     [

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -75,11 +75,11 @@ class Expr:
 
         fn = getattr(self, f"parse_{type(node).__name__}", None)
         if fn is None:
-            raise TypeCheckFailure(f"Invalid statement node: {type(node).__name__}")
+            raise TypeCheckFailure(f"Invalid statement node: {type(node).__name__}", node)
 
         self.ir_node = fn()
         if self.ir_node is None:
-            raise TypeCheckFailure(f"{type(node).__name__} node did not produce IR. {self.expr}")
+            raise TypeCheckFailure(f"{type(node).__name__} node did not produce IR.", node)
 
         self.ir_node.annotation = self.expr.get("node_source_code")
         self.ir_node.source_pos = getpos(self.expr)
@@ -365,7 +365,8 @@ class Expr:
         if not isinstance(self.expr.op, (vy_ast.LShift, vy_ast.RShift)):
             # Sanity check - ensure that we aren't dealing with different types
             # This should be unreachable due to the type check pass
-            assert left.typ == right.typ, str(VyperException(f"unreachable, {left.typ} != {right.typ}", self.expr))
+            if left.typ != right.typ:
+                raise TypeCheckFailure(f"unreachable, {left.typ} != {right.typ}", self.expr)
 
         assert is_numeric_type(left.typ) or is_enum_type(left.typ)
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -365,7 +365,7 @@ class Expr:
         if not isinstance(self.expr.op, (vy_ast.LShift, vy_ast.RShift)):
             # Sanity check - ensure that we aren't dealing with different types
             # This should be unreachable due to the type check pass
-            assert left.typ == right.typ, f"unreachable, {left.typ} != {right.typ}"
+            assert left.typ == right.typ, str(VyperException(f"unreachable, {left.typ} != {right.typ}", self.expr))
 
         assert is_numeric_type(left.typ) or is_enum_type(left.typ)
 

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -22,7 +22,7 @@ class ExceptionList(list):
             raise VyperException("\n\n".join(err_msg))
 
 
-class VyperException(Exception):
+class _VyperException(Exception):
     """
     Base Vyper exception class.
 
@@ -123,6 +123,10 @@ class VyperException(Exception):
 
         annotation_msg = "\n".join(annotation_list)
         return f"{self.message}\n{annotation_msg}"
+
+
+class VyperException(_VyperException):
+    pass
 
 
 class SyntaxException(VyperException):
@@ -285,7 +289,7 @@ class StaticAssertionException(VyperException):
     """An assertion is proven to fail at compile-time."""
 
 
-class VyperInternalException(Exception):
+class VyperInternalException(_VyperException):
     """
     Base Vyper internal exception class.
 
@@ -295,9 +299,6 @@ class VyperInternalException(Exception):
     Internal exceptions are raised as a means of telling the user that the
     compiler has panicked, and that filing a bug report would be appropriate.
     """
-
-    def __init__(self, message=""):
-        self.message = message
 
     def __str__(self):
         return (

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -22,7 +22,7 @@ class ExceptionList(list):
             raise VyperException("\n\n".join(err_msg))
 
 
-class _VyperException(Exception):
+class _BaseVyperException(Exception):
     """
     Base Vyper exception class.
 
@@ -125,7 +125,7 @@ class _VyperException(Exception):
         return f"{self.message}\n{annotation_msg}"
 
 
-class VyperException(_VyperException):
+class VyperException(_BaseVyperException):
     pass
 
 
@@ -289,7 +289,7 @@ class StaticAssertionException(VyperException):
     """An assertion is proven to fail at compile-time."""
 
 
-class VyperInternalException(_VyperException):
+class VyperInternalException(_BaseVyperException):
     """
     Base Vyper internal exception class.
 

--- a/vyper/semantics/analysis/annotation.py
+++ b/vyper/semantics/analysis/annotation.py
@@ -238,7 +238,12 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
         else:
             base_type = get_exact_type_from_node(node.value)
 
-        self.visit(node.slice, base_type.key_type)
+        # get the correct type for the index, it might
+        # not be base_type.key_type
+        index_types = get_possible_types_from_node(node.slice.value)
+        index_type = index_types.pop()
+
+        self.visit(node.slice, index_type)
         self.visit(node.value, base_type)
 
     def visit_Tuple(self, node, type_):


### PR DESCRIPTION
### What I did
codes like the following would panic during codegen:
```vyper
@external
def foo() -> uint256:
    arr: uint256[9] = empty(uint256[9])
    i: uint8 = 3
    return arr[i + 1]  # <-- panics with uint8 != uint256
```

### How I did it

### How to verify it

### Commit message

```
the index type was being incorrectly annotated in the frontend in the
case where the index type was not uint256. this would lead to a panic
during codegen. an example which would lead to this bug is:

\```vyper
@external
def foo(xs: uint256[5], ix: uint8):
    return xs[ix + 1]  # <-- panics with uint8 != uint256
\```

this commit also improves the `VyperInternalException` class so it can
include a node for prettier traceback
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
