### PR TITLE
fix: assignment when rhs is complex type and references lhs

### DIFF
--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -258,7 +258,7 @@ def foo():
 
 
 def test_assign_rhs_lhs_overlap(get_contract):
-    # issue #2418
+    # GH issue 2418
     code = """
 @external
 def bug(xs: uint256[2]) -> uint256[2]:
@@ -273,7 +273,7 @@ def bug(xs: uint256[2]) -> uint256[2]:
 
 
 def test_assign_rhs_lhs_partial_overlap(get_contract):
-    # issue #2418, generalize when lhs is not only dependency of rhs.
+    # GH issue 2418, generalize when lhs is not only dependency of rhs.
     code = """
 @external
 def bug(xs: uint256[2]) -> uint256[2]:

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -285,3 +285,33 @@ def bug(xs: uint256[2]) -> uint256[2]:
     c = get_contract(code)
 
     assert c.bug([1, 2]) == [2, 1]
+
+
+def test_assign_rhs_lhs_overlap_dynarray(get_contract):
+    # GH issue 2418, generalize to dynarrays
+    code = """
+@external
+def bug(xs: DynArray[uint256, 2]) -> DynArray[uint256, 2]:
+    ys: DynArray[uint256, 2] = xs
+    ys = [ys[1], ys[0]]
+    return ys
+    """
+    c = get_contract(code)
+    assert c.bug([1, 2]) == [2, 1]
+
+
+def test_assign_rhs_lhs_overlap_struct(get_contract):
+    # GH issue 2418, generalize to structs
+    code = """
+struct Point:
+    x: uint256
+    y: uint256
+
+@external
+def bug(p: Point) -> Point:
+    t: Point = p
+    t = Point({x: t.y, y: t.x})
+    return t
+    """
+    c = get_contract(code)
+    assert c.bug((1, 2)) == (2, 1)

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -255,3 +255,33 @@ def foo():
     ret : bool = self.bar()
 """
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), InvalidType)
+
+
+def test_assign_rhs_lhs_overlap(get_contract):
+    # issue #2418
+    code = """
+@external
+def bug(xs: uint256[2]) -> uint256[2]:
+    # Initial value
+    ys: uint256[2] = xs
+    ys = [ys[1], ys[0]]
+    return ys
+    """
+    c = get_contract(code)
+
+    assert c.bug([1, 2]) == [2, 1]
+
+
+def test_assign_rhs_lhs_partial_overlap(get_contract):
+    # issue #2418, generalize when lhs is not only dependency of rhs.
+    code = """
+@external
+def bug(xs: uint256[2]) -> uint256[2]:
+    # Initial value
+    ys: uint256[2] = xs
+    ys = [xs[1], ys[0]]
+    return ys
+    """
+    c = get_contract(code)
+
+    assert c.bug([1, 2]) == [2, 1]

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -30,6 +30,9 @@ class VariableRecord:
     is_immutable: bool = False
     data_offset: Optional[int] = None
 
+    def __hash__(self):
+        return hash(id(self))
+
     def __post_init__(self):
         if self.blockscopes is None:
             self.blockscopes = []

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -166,7 +166,7 @@ class Expr:
             return IRnode.from_list(["address"], typ=AddressT())
         elif self.expr.id in self.context.vars:
             var = self.context.vars[self.expr.id]
-            return IRnode.from_list(
+            ret = IRnode.from_list(
                 var.pos,
                 typ=var.typ,
                 location=var.location,  # either 'memory' or 'calldata' storage is handled above.
@@ -174,6 +174,8 @@ class Expr:
                 annotation=self.expr.id,
                 mutable=var.mutable,
             )
+            ret._referenced_variables = {var}
+            return ret
 
         # TODO: use self.expr._expr_info
         elif self.expr.id in self.context.globals:
@@ -189,9 +191,11 @@ class Expr:
                 mutable = False
                 location = DATA
 
-            return IRnode.from_list(
+            ret = IRnode.from_list(
                 ofst, typ=varinfo.typ, location=location, annotation=self.expr.id, mutable=mutable
             )
+            ret._referenced_variables = {varinfo}
+            return ret
 
     # x.y or x[5]
     def parse_Attribute(self):
@@ -255,12 +259,16 @@ class Expr:
         # self.x: global attribute
         elif isinstance(self.expr.value, vy_ast.Name) and self.expr.value.id == "self":
             varinfo = self.context.globals[self.expr.attr]
-            return IRnode.from_list(
+            ret = IRnode.from_list(
                 varinfo.position.position,
                 typ=varinfo.typ,
                 location=STORAGE,
                 annotation="self." + self.expr.attr,
             )
+            ret._referenced_variables = {varinfo}
+
+            return ret
+
         # Reserved keywords
         elif (
             isinstance(self.expr.value, vy_ast.Name) and self.expr.value.id in ENVIRONMENT_VARIABLES

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -398,6 +398,16 @@ class IRnode:
         return _WithBuilder(self, name, should_inline)
 
     @cached_property
+    def referenced_variables(self):
+        ret = set()
+        for arg in self.args:
+            ret |= arg.referenced_variables
+
+        ret |= getattr(self, "_referenced_variables", set())
+
+        return ret
+
+    @cached_property
     def contains_self_call(self):
         return getattr(self, "is_self_call", False) or any(x.contains_self_call for x in self.args)
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -1,5 +1,3 @@
-import warnings
-
 import vyper.codegen.events as events
 import vyper.utils as util
 from vyper import ast as vy_ast
@@ -26,7 +24,7 @@ from vyper.codegen.core import (
 from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
 from vyper.evm.address_space import MEMORY, STORAGE
-from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure, VyperException
+from vyper.exceptions import CompilerPanic, StructureException, TypeCheckFailure
 from vyper.semantics.types import DArrayT, MemberFunctionT
 from vyper.semantics.types.shortcuts import INT256_T, UINT256_T
 

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -145,7 +145,7 @@ class CodeOffset(DataPosition):
         return f"<CodeOffset: {self.offset}>"
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class VarInfo:
     """
     VarInfo are objects that represent the type of a variable,

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -145,7 +145,7 @@ class CodeOffset(DataPosition):
         return f"<CodeOffset: {self.offset}>"
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class VarInfo:
     """
     VarInfo are objects that represent the type of a variable,
@@ -164,6 +164,9 @@ class VarInfo:
     is_immutable: bool = False
     is_local_var: bool = False
     decl_node: Optional[vy_ast.VyperNode] = None
+
+    def __hash__(self):
+        return hash(id(self))
 
     def __post_init__(self):
         self._modification_count = 0


### PR DESCRIPTION
### What I did
fix #2418 

### How I did it
check that rhs and lhs do not overlap in parse_Assign. if they do, copy rhs to a temporary buffer, then copy to the lhs. this might not be the most efficient approach, but it is safe (and it's a relatively rare case to see in user code).

note that this doesn't touch `make_setter` directly because it would need access to the memory allocator (to allocate the temporary buffer). this would result in the fix not working in other cases where the arguments to `make_setter` overlap. i don't think there are any cases of those, but if there were, they would need to be fixed on a case by case basis.

### How to verify it
test cases fail on master (97ff017c5e8d1aa5b0bc) but pass on this branch.

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
