### PR TITLE
fix: typechecking for user-defined types

### DIFF
--- a/tests/parser/syntax/test_enum.py
+++ b/tests/parser/syntax/test_enum.py
@@ -110,6 +110,20 @@ def foo() -> Roles:
     """,
         UnknownAttribute,
     ),
+    (
+        """
+enum A:
+    a
+enum B:
+    a
+    b
+
+@internal
+def foo():
+    a: A = B.b
+    """,
+        TypeMismatch,
+    ),
 ]
 
 

--- a/tests/parser/syntax/test_interfaces.py
+++ b/tests/parser/syntax/test_interfaces.py
@@ -106,6 +106,19 @@ implements: Foo
     """,
         StructureException,
     ),
+    (
+        """
+from vyper.interfaces import ERC20
+
+interface A:
+    def f(): view
+
+@internal
+def foo():
+    a: ERC20 = A(empty(address))
+    """,
+        TypeMismatch,
+    ),
 ]
 
 

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -32,6 +32,10 @@ class _UserType(VyperType):
     def __eq__(self, other):
         return self is other
 
+    # TODO: revisit this once user types can be imported via modules
+    def compare_type(self, other):
+        return super().compare_type(other) and self._id == other._id
+
     def __hash__(self):
         return hash(id(self))
 
@@ -536,10 +540,6 @@ class StructT(_UserType):
 
     def __repr__(self):
         return f"{self._id} declaration object"
-
-    # TODO check me
-    def compare_type(self, other):
-        return super().compare_type(other) and self._id == other._id
 
     @property
     def size_in_bytes(self):


### PR DESCRIPTION
### What I did
typechecking for user-defined types was busted as of 046ea166. fix the typechecker rules and add a test

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
