### PR TITLE
chore: only save cache on cache miss

### DIFF
--- a/.github/workflows/era-tester.yml
+++ b/.github/workflows/era-tester.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python-version[0] }}
 
     - name: Get cache
-      id: cache
+      id: get-cache
       uses: actions/cache@v3
       with:
         path: |
@@ -56,7 +56,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.ERA_HASH }}-${{ env.ERA_VYPER_HASH }}
 
     - name: Initialize repository and install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.get-cache.outputs.cache-hit != 'true'
       run: |
         git clone --depth 1 https://github.com/matter-labs/era-compiler-tester.git
         cd era-compiler-tester
@@ -70,7 +70,7 @@ jobs:
 
     - name: Save cache
       uses: actions/cache/save@v3
-      if: always()
+      if: steps.get-cache.outputs.cache-hit != 'true'
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION
in the era compiler tester workflow, we were always saving the cache, which wastes time if we had a cache hit (and could also lead to some strange race conditions)

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
