### PR TITLE
fix: generate separate function names depending on context

### DIFF
--- a/tests/compiler/asm/test_asm_optimizer.py
+++ b/tests/compiler/asm/test_asm_optimizer.py
@@ -31,8 +31,8 @@ def __init__():
 
     # all the labels should be in all the unoptimized asms
     for s in (foo_label, qux_label):
-        assert s in initcode_asm
-        assert s in runtime_asm
+        assert s + "_deploy" in initcode_asm
+        assert s + "_runtime" in runtime_asm
 
     c = CompilerData(code, no_optimize=False)
     initcode_asm = [i for i in c.assembly if not isinstance(i, list)]

--- a/tests/parser/test_call_graph_stability.py
+++ b/tests/parser/test_call_graph_stability.py
@@ -70,4 +70,6 @@ def foo():
                 r = d.args[0].args[0].value
                 if isinstance(r, str) and r.startswith("internal"):
                     ir_funcs.append(r)
-        assert ir_funcs == [f._ir_info.internal_function_label for f in sigs.values()]
+        assert ir_funcs == [
+            f._ir_info.internal_function_label(is_ctor_context=False) for f in sigs.values()
+        ]

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -57,10 +57,10 @@ class FuncIRInfo:
         assert not self.func_t.is_internal, "uh oh, should be external"
         return self.ir_identifier + "_common"
 
-    @property
-    def internal_function_label(self) -> str:
+    def internal_function_label(self, is_ctor_context: bool = False) -> str:
         assert self.func_t.is_internal, "uh oh, should be internal"
-        return self.ir_identifier
+        suffix = "_deploy" if is_ctor_context else "_runtime"
+        return self.ir_identifier + suffix
 
 
 def generate_ir_for_function(

--- a/vyper/codegen/function_definitions/internal_function.py
+++ b/vyper/codegen/function_definitions/internal_function.py
@@ -46,7 +46,7 @@ def generate_ir_for_internal_function(
 
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_t)
 
-    function_entry_label = func_t._ir_info.internal_function_label
+    function_entry_label = func_t._ir_info.internal_function_label(context.is_ctor_context)
     cleanup_label = func_t._ir_info.exit_sequence_label
 
     stack_args = ["var_list"]

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -62,7 +62,8 @@ def ir_for_self_call(stmt_expr, context):
         )
 
     # note: internal_function_label asserts `func_t.is_internal`.
-    return_label = _generate_label(f"{func_t._ir_info.internal_function_label}_call")
+    _label = func_t._ir_info.internal_function_label(context.is_ctor_context)
+    return_label = _generate_label(f"{_label}_call")
 
     # allocate space for the return buffer
     # TODO allocate in stmt and/or expr.py
@@ -98,7 +99,7 @@ def ir_for_self_call(stmt_expr, context):
     else:
         copy_args = make_setter(args_dst, args_as_tuple)
 
-    goto_op = ["goto", func_t._ir_info.internal_function_label]
+    goto_op = ["goto", func_t._ir_info.internal_function_label(context.is_ctor_context)]
     # pass return buffer to subroutine
     if return_buffer is not None:
         goto_op += [return_buffer]


### PR DESCRIPTION
### What I did
for backends which only have a single compilation context (i.e., they do not split initcode and runtime code like EVM), they need separate names for the two different codes generated per-function as of https://github.com/vyperlang/vyper/commit/c202c4e3ec884c6ddb28f738e45e8b9aa3d209b4. this is also hygienic - since the two functions actually have different codes as of c202c4e3ec88, give them different names.

### How I did it

### How to verify it

### Commit message
```
for backends (like zksync) which only have a single compilation context
(i.e., they do not split initcode and runtime code like EVM), they need
separate names for the two different codes generated per-function as of
c202c4e3ec8. this is also hygienic - since the two functions actually
have different codes as of c202c4e3ec8, give them different names.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
