### PR TITLE
fix: calculate `active_evm_version` from `DEFAULT_EVM_VERSION`

### DIFF
--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 from vyper.exceptions import CompilerPanic
 from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRulesetValue, OpcodeValue
 
-active_evm_version: int = 4
+active_evm_version: int = 5
 
 # EVM version rules work as follows:
 # 1. Fork rules go from oldest (lowest value) to newest (highest value).

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -3,8 +3,6 @@ from typing import Dict, Optional
 from vyper.exceptions import CompilerPanic
 from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRulesetValue, OpcodeValue
 
-active_evm_version: int = 5
-
 # EVM version rules work as follows:
 # 1. Fork rules go from oldest (lowest value) to newest (highest value).
 # 2. Fork versions aren't actually tied to anything. They are not a part of our
@@ -17,7 +15,7 @@ active_evm_version: int = 5
 # 6. Yes, this will probably have to be rethought if there's ever conflicting support
 #    between multiple chains for a specific feature. Let's hope not.
 # 7. We support at a maximum 3 hard forks (for any given chain).
-EVM_VERSIONS: Dict[str, int] = {
+EVM_VERSIONS: dict[str, int] = {
     # ETH Forks
     "byzantium": 0,
     "constantinople": 1,
@@ -31,6 +29,7 @@ EVM_VERSIONS: Dict[str, int] = {
     "agharta": 1,
 }
 DEFAULT_EVM_VERSION: str = "shanghai"
+active_evm_version: int = EVM_VERSIONS[DEFAULT_EVM_VERSION]
 
 
 # opcode as hex value


### PR DESCRIPTION
per 1ac8362df0c, the DEFAULT_EVM_VERSION is updated to shanghai. however, entry points into the compiler which don't use the `@evm_wrapper` wrapper might continue using paris. this commit fixes the issue by calculating `active_evm_version` from `DEFAULT_EVM_VERSION` so that only one value needs to be updated going forward.

### What I did

### How I did it

### How to verify it

### Commit message

```
per 1ac8362df0c, the `DEFAULT_EVM_VERSION` is updated to shanghai, while
`active_evm_version` still points to paris. so entry points into the
compiler which don't use the @evm_wrapper wrapper might continue using
paris. this commit fixes the issue by calculating active_evm_version
from `DEFAULT_EVM_VERSION` so that only one value needs to be updated
going forward.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
