### PR TITLE
ci: deploy to ghcr on push

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: name/app
+          images: charles-cooper/vyper
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,0 +1,41 @@
+name: Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ''
+  push:
+    tags:
+      - '*'
+    branches:
+      - master
+
+jobs:
+  deploy-ghcr:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+            # need to fetch unshallow so that setuptools_scm can infer the version
+            fetch-depth: 0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: name/app
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,4 +1,4 @@
-name: Artifacts
+name: Deploy docker image to ghcr.io
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,4 +1,4 @@
-name: Deploy docker image to ghcr.io
+name: Deploy docker image
 
 on:
   workflow_dispatch:
@@ -13,6 +13,12 @@ on:
 
 jobs:
   deploy-ghcr:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -49,6 +49,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=edge
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ env.VYPER_VERSION }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref
+            type=ref,event=branch
             type=edge
             type=raw,value=${{ env.VYPER_VERSION }}
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=sha-,format=short
+            type=sha,prefix=commit-,format=short
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -47,8 +47,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=edge
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ env.VYPER_VERSION }}
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -30,13 +30,24 @@ jobs:
             # need to fetch unshallow so that setuptools_scm can infer the version
             fetch-depth: 0
 
+      - uses: actions/setup-python@v4
+        name: Install python
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Generate vyper/version.py
+        run: |
+          pip install .
+          echo "VYPER_VERSION=$(PYTHONPATH=. python vyper/cli/vyper_compile.py --version)" >> "$GITHUB_ENV"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=commit-,format=short
+            type=custom,value=${{ env.VYPER_VERSION }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=ref
             type=edge
             type=raw,value=${{ env.VYPER_VERSION }}
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,4 +1,10 @@
-name: Deploy docker image on pushes to master and release
+name: Deploy docker image to ghcr
+
+# Deploy docker image to ghcr on pushes to master and all releases/tags.
+# Note releases to docker hub are managed separately in another process
+# (github sends webhooks to docker hub which triggers the build there).
+# This workflow is an alternative form of retention for docker images
+# which also allows us to tag and retain every single commit to master.
 
 on:
   push:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -62,5 +62,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - master
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   deploy-ghcr:
 
@@ -30,14 +34,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: charles-cooper/vyper
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix=sha-,format=short
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -31,6 +31,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: charles-cooper/vyper
+          tags: |
+            type=sha,prefix=sha-,format=short
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=edge
             type=raw,value=${{ env.VYPER_VERSION }}
 
       - name: Login to ghcr.io

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=custom,value=${{ env.VYPER_VERSION }}
+            type=raw,value=${{ env.VYPER_VERSION }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,15 +1,13 @@
-name: Deploy docker image
+name: Deploy docker image on pushes to master and release
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        default: ''
   push:
     tags:
       - '*'
     branches:
       - master
+  release:
+    types: [released]
 
 env:
   REGISTRY: ghcr.io
@@ -46,8 +44,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
             type=raw,value=${{ env.VYPER_VERSION }}
 
       - name: Login to ghcr.io


### PR DESCRIPTION
### What I did
publish and tag docker images continuously to ghcr.io. i wanted to add custom tagging (so we can retain every commit) in docker hub, but i didn't really like the fact that for docker hub, in order to have custom tags, you need to set up a regular user and log in via that user. the authentication is much cleaner in github actions for ghcr.

(note docker hub pulls are still staying the same, this is just an alternative form of retention going forward).

can preview test builds here: https://github.com/charles-cooper/vyper/pkgs/container/vyper

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
