### PR TITLE
chore: cache pip in setup-python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: "pip"
 
       - name: Generate Binary
         run: >-
@@ -61,6 +62,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: "pip"
 
       - name: Generate Binary
         run: >-

--- a/.github/workflows/era-tester.yml
+++ b/.github/workflows/era-tester.yml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version[0] }}
+        cache: "pip"
 
     - name: Get cache
       id: get-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: "3.11"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
+        cache: "pip"
 
     - name: Install Dependencies
       run: pip install .[lint]
@@ -46,6 +47,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+        cache: "pip"
 
       - name: Install Tox
         run: pip install tox
@@ -63,6 +65,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
+        cache: "pip"
 
     - name: Install Tox
       run: pip install tox
@@ -88,6 +91,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version[0] }}
+        cache: "pip"
 
     - name: Install Tox
       run: pip install tox
@@ -130,6 +134,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
+        cache: "pip"
 
     - name: Install Tox
       run: pip install tox
@@ -171,6 +176,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
+        cache: "pip"
 
     - name: Install Tox
       run: pip install tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-        cache: "pip"
+          cache: "pip"
 
       - name: Install Tox
         run: pip install tox


### PR DESCRIPTION
installing dependencies takes about 1min per job. pip caching should speed it up. note that in theory, this caches "correctly" in that it doesn't cache the dependency graph or install directories, just the wheels. so if upstream packages are updated, they should get reinstalled.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
