### PR TITLE
chore: make FuncIRInfo generation private

### DIFF
--- a/vyper/codegen/function_definitions/__init__.py
+++ b/vyper/codegen/function_definitions/__init__.py
@@ -1,1 +1,1 @@
-from .common import FuncIRInfo, generate_ir_for_function  # noqa
+from .common import generate_ir_for_function  # noqa

--- a/vyper/codegen/function_definitions/common.py
+++ b/vyper/codegen/function_definitions/common.py
@@ -28,7 +28,7 @@ class FrameInfo:
 
 
 @dataclass
-class FuncIRInfo:
+class _FuncIRInfo:
     func_t: ContractFunctionT
     gas_estimate: Optional[int] = None
     frame_info: Optional[FrameInfo] = None
@@ -77,6 +77,9 @@ def generate_ir_for_function(
         - Function body
     """
     func_t = code._metadata["type"]
+
+    # generate _FuncIRInfo
+    func_t._ir_info = _FuncIRInfo(func_t)
 
     # Validate return statements.
     check_single_exit(code)

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 from vyper import ast as vy_ast
 from vyper.codegen.core import shr
-from vyper.codegen.function_definitions import FuncIRInfo, generate_ir_for_function
+from vyper.codegen.function_definitions import generate_ir_for_function
 from vyper.codegen.global_context import GlobalContext
 from vyper.codegen.ir_node import IRnode
 from vyper.exceptions import CompilerPanic
@@ -135,11 +135,6 @@ def generate_ir_for_module(global_ctx: GlobalContext) -> tuple[IRnode, IRnode]:
     function_defs = _topsort(global_ctx.functions)
 
     init_function: Optional[vy_ast.FunctionDef] = None
-
-    # generate all FuncIRInfos
-    for f in function_defs:
-        func_t = f._metadata["type"]
-        func_t._ir_info = FuncIRInfo(func_t)
 
     runtime_functions = [f for f in function_defs if not _is_constructor(f)]
     init_function = next((f for f in function_defs if _is_constructor(f)), None)


### PR DESCRIPTION
this moves generation of func_t._ir_info to be closer to where it is used (and where FuncIRInfo is defined!). since FuncIRInfo is no longer imported anywhere, it can be changed to a private member of the function_definitions/common.py module.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
