### PR TITLE
chore: fix up ghcr tags

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -45,17 +45,21 @@ jobs:
           pip install .
           echo "VYPER_VERSION=$(PYTHONPATH=. python vyper/cli/vyper_compile.py --version)" >> "$GITHUB_ENV"
 
+      - name: generate tag suffix
+        if: ${{ github.event_name != 'release' }}
+        run: echo "VERSION_SUFFIX=-dev" >> "$GITHUB_ENV"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=true
           tags: |
-            type=ref,event=branch
             type=ref,event=tag
-            type=raw,value=${{ env.VYPER_VERSION }}
+            type=raw,value=${{ env.VYPER_VERSION }}${{ env.VERSION_SUFFIX }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
-            type=raw,value=${{ env.VYPER_VERSION }}${{ env.VERSION_SUFFIX }}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/master' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=ref,event=tag,priority=400
+            type=raw,value=${{ env.VYPER_VERSION }}${{ env.VERSION_SUFFIX }},priority=200
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/master' }},priority=600
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }},priority=1000
 
 
       - name: Login to ghcr.io

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag,priority=400
-            type=raw,value=${{ env.VYPER_VERSION }}${{ env.VERSION_SUFFIX }},priority=200
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/master' }},priority=600
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }},priority=1000
+            type=ref,event=tag
+            type=raw,value=${{ env.VYPER_VERSION }}${{ env.VERSION_SUFFIX }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
 
       - name: Login to ghcr.io


### PR DESCRIPTION
use `latest` for latest release, `dev` for continuous, and tag dev builds with `-dev`. also remove the 'master' tag since that's redundant with `dev`.

### How to verify it

see example packages on https://github.com/charles-cooper/vyper/pkgs/container/vyper/ -
a "dev" build:
![Screenshot from 2023-05-20 13-00-04](https://github.com/vyperlang/vyper/assets/3867501/ad0ab512-c955-480d-a06d-271f7b9d5d8d)
a release build:
![Screenshot from 2023-05-20 13-00-21](https://github.com/vyperlang/vyper/assets/3867501/ce126a10-ad27-4d8e-a950-ea51d775fceb)



### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
