### PR TITLE
fix: wrong variable in type annotation of `IfExp`

### DIFF
--- a/tests/parser/syntax/test_ternary.py
+++ b/tests/parser/syntax/test_ternary.py
@@ -10,6 +10,11 @@ good_list = [
 def foo(a: uint256, b: uint256) -> uint256:
     return a if a > b else b
     """,
+    """
+@external
+def foo():
+    a: bool = (True if True else True) or True
+    """,
     # different locations:
     """
 b: uint256

--- a/vyper/semantics/analysis/annotation.py
+++ b/vyper/semantics/analysis/annotation.py
@@ -271,7 +271,7 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
     def visit_IfExp(self, node, type_):
         if type_ is None:
             ts = get_common_types(node.body, node.orelse)
-            if len(type_) == 1:
+            if len(ts) == 1:
                 type_ = ts.pop()
 
         node._metadata["type"] = type_


### PR DESCRIPTION
### What I did

Fixed incorrect variable reference. However, I haven't been able to find an example that triggers this bug.

### How I did it

### How to verify it

Tests still pass

### Commit message

```
fix: wrong variable in type annotation of `IfExp`
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.freepik.com/premium-photo/cute-capybara-farm-is-eating_361141-826.jpg?w=2000)
