### PR TITLE
fix: source_map_full output in vyper-json

### DIFF
--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -429,7 +429,7 @@ def format_to_output_dict(compiler_data: Dict) -> Dict:
             if "source_map" in data:
                 evm["sourceMap"] = data["source_map"]["pc_pos_map_compressed"]
             if "source_map_full" in data:
-                evm["sourceMapFull"] = data["source_map"]
+                evm["sourceMapFull"] = data["source_map_full"]
 
     return output_dict
 


### PR DESCRIPTION
source_map_full output fails with a KeyError when user requests evm.sourceMapFull but not evm.sourceMap. this commit fixes

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
