### PR TITLE
Add snake name to the release

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -14,7 +14,7 @@ Release Notes
     for advisory links:
     :'<,'>s/\v(https:\/\/github.com\/vyperlang\/vyper\/security\/advisories\/)([-A-Za-z0-9]+)/(`\2 <\1\2>`_)/g
 
-v0.3.9
+v0.3.9 - Common Adder
 ******
 
 Date released: 2023-05-28

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -17,7 +17,7 @@ Release Notes
 v0.3.9 - Common Adder
 ******
 
-Date released: 2023-05-28
+Date released: 2023-05-29
 
 This is a patch release fix for v0.3.8. @bout3fiddy discovered a codesize regression for blueprint contracts in v0.3.8 which is fixed in this release. @bout3fiddy also discovered a runtime performance (gas) regression for default functions in v0.3.8 which is fixed in this release.
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -14,7 +14,7 @@ Release Notes
     for advisory links:
     :'<,'>s/\v(https:\/\/github.com\/vyperlang\/vyper\/security\/advisories\/)([-A-Za-z0-9]+)/(`\2 <\1\2>`_)/g
 
-v0.3.9 - Common Adder
+v0.3.9 ("Common Adder")
 ******
 
 Date released: 2023-05-29


### PR DESCRIPTION
### What I did

I added a snake name (Common Adder) the release notes for Vyper 0.3.9

### How I did it

Updated release notes

### How to verify it

Check the diff

### Commit message

Added snake name to release

### Description for the changelog

Added snake name for Vyper release, starting with Common Adder, which is first on the [Wikipedia snake name list](https://en.wikipedia.org/wiki/List_of_snakes_by_common_name), so that future releases can move down the list successively (or in the preference of the maintainers)

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/44706811/5ce46331-5946-4694-8b39-cca522d33b31)

