### PR TITLE
ci: auto-upload release assets on release event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,6 @@ jobs:
               -X POST \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
               -H "Content-Type: application/octet-stream" \
-              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}"
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}" \
               --data-binary "@${BIN_NAME}"
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
             -H "Content-Type: application/octet-stream" \
             "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}" \
-            --data-binary "@${dist/BIN_NAME}"
+            --data-binary "@dist/${BIN_NAME}"
 
   windows-build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             -X POST \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
             -H "Content-Type: application/octet-stream" \
-            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release_id }}/assets?name=${BIN_NAME}" \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}" \
             --data-binary "@${dist/BIN_NAME}"
 
   windows-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
             -H "Content-Type: application/octet-stream" \
             "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release_id }}/assets?name=${BIN_NAME}" \
-            --data-binary "@${BIN_NAME}"
+            --data-binary "@${dist/BIN_NAME}"
 
   windows-build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build artifacts
+name: Build and release artifacts
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,6 @@ jobs:
           set -Eeuxo pipefail
           for BIN_NAME in $(ls)
           do
-            echo ${BIN_NAME}
             curl -L \
               --no-progress-meter \
               -X POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           path: artifacts/
 
       - name: Upload assets
-        # fun - artifacts are downloaded into "artifact"
+        # fun - artifacts are downloaded into "artifact/".
         working-directory: artifacts/artifact
         run: |
           set -Eeuxo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,11 @@ jobs:
       - name: Upload assets
         working-directory: artifacts/
         run: |
+          set -Eeuxo pipefail
+          ls -R
           for BIN_NAME in $(ls)
           do
+            echo ${BIN_NAME}
             curl -L \
               --no-progress-meter \
               -X POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,13 @@ jobs:
       - name: Publish release assets
         if: ${{ github.event_name == 'release' }}
         run: |
-          export BIN_NAME=$(ls dist/vyper.* | xargs basename)
+          export BIN_NAME=$(ls dist/vyper.* | xargs basename) && \
           curl -L \
             -X POST \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
             -H "Content-Type: application/octet-stream" \
-            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=$(BIN_NAME) \
-            --data-binary "@$(BIN_NAME)"
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release_id }}/assets?name=${BIN_NAME}" \
+            --data-binary "@${BIN_NAME}"
 
   windows-build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Artifacts
+name: Build artifacts
 
 on:
   workflow_dispatch:
@@ -10,6 +10,8 @@ on:
       - '*'
     branches:
       - master
+  release:
+    types: [released]
 
 defaults:
   run:
@@ -47,6 +49,17 @@ jobs:
         with:
           path: dist/vyper.*
 
+      - name: Publish release assets
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          export BIN_NAME=$(ls dist/vyper.* | xargs basename)
+          curl -L \
+            -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+            -H "Content-Type: application/octet-stream" \
+            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=$(BIN_NAME) \
+            --data-binary "@$(BIN_NAME)"
+
   windows-build:
     runs-on: windows-latest
 
@@ -74,3 +87,15 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: dist/vyper.*
+
+#      - name: Publish release assets
+#        if: ${{ github.event_name == 'release' }}
+#        --> something similar for windows here! <--
+#        run: |
+#          export BIN_NAME=$(ls dist/vyper.* | xargs basename)
+#          curl -L \
+#            -X POST \
+#            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+#            -H "Content-Type: application/octet-stream" \
+#            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=$(BIN_NAME) \
+#            --data-binary "@$(BIN_NAME)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,12 +89,13 @@ jobs:
       - name: Upload assets
         working-directory: artifacts/
         run: |
-          for bin_name in $(ls)
+          for BIN_NAME in $(ls)
           do
             curl -L \
+              --no-progress-meter \
               -X POST \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
               -H "Content-Type: application/octet-stream" \
-              https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=${bin_name} \
-              --data-binary "@${bin_name}"
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}"
+              --data-binary "@${BIN_NAME}"
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,10 +87,10 @@ jobs:
           path: artifacts/
 
       - name: Upload assets
-        working-directory: artifacts/
+        # fun - artifacts are downloaded into "artifact"
+        working-directory: artifacts/artifact
         run: |
           set -Eeuxo pipefail
-          ls -R
           for BIN_NAME in $(ls)
           do
             echo ${BIN_NAME}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
             # grab the commit passed in via `tag`, if any
             ref: ${{ github.event.inputs.tag }}
@@ -47,22 +47,11 @@ jobs:
         with:
           path: dist/vyper.*
 
-      - name: Publish release assets
-        if: ${{ github.event_name == 'release' }}
-        run: |
-          export BIN_NAME=$(ls dist/vyper.* | xargs basename) && \
-          curl -L \
-            -X POST \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-            -H "Content-Type: application/octet-stream" \
-            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}" \
-            --data-binary "@dist/${BIN_NAME}"
-
   windows-build:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
             # grab the commit passed in via `tag`, if any
             ref: ${{ github.event.inputs.tag }}
@@ -86,14 +75,26 @@ jobs:
         with:
           path: dist/vyper.*
 
-#      - name: Publish release assets
-#        if: ${{ github.event_name == 'release' }}
-#        --> something similar for windows here! <--
-#        run: |
-#          export BIN_NAME=$(ls dist/vyper.* | xargs basename)
-#          curl -L \
-#            -X POST \
-#            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-#            -H "Content-Type: application/octet-stream" \
-#            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=$(BIN_NAME) \
-#            --data-binary "@$(BIN_NAME)"
+  publish-release-assets:
+    needs: [windows-build, unix-build]
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          path: artifacts/
+
+      - name: Upload assets
+        working-directory: artifacts/
+        run: |
+          for bin_name in $(ls)
+          do
+            curl -L \
+              -X POST \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+              -H "Content-Type: application/octet-stream" \
+              https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=$(bin_name) \
+              --data-binary "@$(bin_name)"
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
       tag:
         default: ''
   push:
-    tags:
-      - '*'
     branches:
       - master
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,6 @@ jobs:
               -X POST \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
               -H "Content-Type: application/octet-stream" \
-              https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=$(bin_name) \
-              --data-binary "@$(bin_name)"
+              https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.payload.release.release_id }}/assets?name=${bin_name} \
+              --data-binary "@${bin_name}"
           done

--- a/.github/workflows/era-tester.yml
+++ b/.github/workflows/era-tester.yml
@@ -1,4 +1,4 @@
-name: era compiler tester
+name: Era compiler tester
 
 # run the matter labs compiler test to integrate their test cases
 # this is intended as a diagnostic / spot check to check that we

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -8,8 +8,6 @@ name: Deploy docker image to ghcr
 
 on:
   push:
-    tags:
-      - '*'
     branches:
       - master
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Publish
+name: Publish to PyPI
 
 on:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Run test suite
 
 on: [push, pull_request]
 


### PR DESCRIPTION
### What I did
as title. also removed the ghcr build on `tag` events (since it's redundant with the `release` and we end up with orphaned images, since two images get tagged with ex. v0.3.9)

### How I did it

### How to verify it
tested a release at https://github.com/charles-cooper/vyper/releases/tag/TEST_RELEASE (example ci run at https://github.com/charles-cooper/vyper/actions/runs/5117099747/jobs/9199915521)

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
