### PR TITLE
chore: remove vyper signature from runtime

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -218,9 +218,7 @@ def _build_asm(asm_list):
 
 def build_source_map_output(compiler_data: CompilerData) -> OrderedDict:
     _, line_number_map = compile_ir.assembly_to_evm(
-        compiler_data.assembly_runtime,
-        insert_vyper_signature=True,
-        disable_bytecode_metadata=compiler_data.no_bytecode_metadata,
+        compiler_data.assembly_runtime, insert_vyper_signature=False
     )
     # Sort line_number_map
     out = OrderedDict()

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -150,15 +150,12 @@ class CompilerData:
 
     @cached_property
     def bytecode(self) -> bytes:
-        return generate_bytecode(
-            self.assembly, is_runtime=False, no_bytecode_metadata=self.no_bytecode_metadata
-        )
+        insert_vyper_signature = not self.no_bytecode_metadata
+        return generate_bytecode(self.assembly, insert_vyper_signature=insert_vyper_signature)
 
     @cached_property
     def bytecode_runtime(self) -> bytes:
-        return generate_bytecode(
-            self.assembly_runtime, is_runtime=True, no_bytecode_metadata=self.no_bytecode_metadata
-        )
+        return generate_bytecode(self.assembly_runtime, insert_vyper_signature=False)
 
     @cached_property
     def blueprint_bytecode(self) -> bytes:
@@ -295,9 +292,7 @@ def _find_nested_opcode(assembly, key):
         return any(_find_nested_opcode(x, key) for x in sublists)
 
 
-def generate_bytecode(
-    assembly: list, is_runtime: bool = False, no_bytecode_metadata: bool = False
-) -> bytes:
+def generate_bytecode(assembly: list, insert_vyper_signature: bool) -> bytes:
     """
     Generate bytecode from assembly instructions.
 
@@ -311,6 +306,4 @@ def generate_bytecode(
     bytes
         Final compiled bytecode.
     """
-    return compile_ir.assembly_to_evm(
-        assembly, insert_vyper_signature=is_runtime, disable_bytecode_metadata=no_bytecode_metadata
-    )[0]
+    return compile_ir.assembly_to_evm(assembly, insert_vyper_signature=insert_vyper_signature)[0]

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -968,9 +968,7 @@ def adjust_pc_maps(pc_maps, ofst):
     return ret
 
 
-def assembly_to_evm(
-    assembly, pc_ofst=0, insert_vyper_signature=False, disable_bytecode_metadata=False
-):
+def assembly_to_evm(assembly, pc_ofst=0, insert_vyper_signature=False):
     """
     Assembles assembly into EVM
 
@@ -994,7 +992,7 @@ def assembly_to_evm(
     runtime_code, runtime_code_start, runtime_code_end = None, None, None
 
     bytecode_suffix = b""
-    if (not disable_bytecode_metadata) and insert_vyper_signature:
+    if insert_vyper_signature:
         # CBOR encoded: {"vyper": [major,minor,patch]}
         bytecode_suffix += b"\xa1\x65vyper\x83" + bytes(list(version_tuple))
         bytecode_suffix += len(bytecode_suffix).to_bytes(2, "big")
@@ -1011,11 +1009,7 @@ def assembly_to_evm(
     for i, item in enumerate(assembly):
         if isinstance(item, list):
             assert runtime_code is None, "Multiple subcodes"
-            runtime_code, runtime_map = assembly_to_evm(
-                item,
-                insert_vyper_signature=True,
-                disable_bytecode_metadata=disable_bytecode_metadata,
-            )
+            runtime_code, runtime_map = assembly_to_evm(item)
 
             assert item[0].startswith("_DEPLOY_MEM_OFST_")
             assert ctor_mem_size is None


### PR DESCRIPTION
it's going at the end of initcode instead, which is cheaper but still possible to pick up the vyper version by looking at the create tx.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
