### PR TITLE
feat: let params of internal functions be mutable

### DIFF
--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -90,6 +90,33 @@ def bar(x: Foo) -> Foo:
     assert c.bar((123, [1, 2, 4], "vyper")) == (789, [4, 2, 1], "conda")
 
 
+def test_internal_assign_struct_member(get_contract_with_gas_estimation):
+    code = """
+enum Bar:
+    BAD
+    BAK
+    BAZ
+
+struct Foo:
+    a: uint256
+    b: DynArray[Bar, 3]
+    c: String[5]
+
+@internal
+def foo(x: Foo) -> Foo:
+    x.a = 789
+    x.b.pop()
+    return x
+
+@external
+def bar(x: Foo) -> Foo:
+    return self.foo(x)
+    """
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.bar((123, [1, 2, 4], "vyper")) == (789, [1, 2], "vyper")
+
+
 def test_internal_augassign(get_contract_with_gas_estimation):
     code = """
 @internal
@@ -121,33 +148,6 @@ def bar(x: {typ}) -> {typ}:
     c = get_contract_with_gas_estimation(code)
 
     assert c.bar([1, 2, 3]) == [1, 79, 3]
-
-
-def test_internal_augassign_struct(get_contract_with_gas_estimation):
-    code = """
-enum Bar:
-    BAD
-    BAK
-    BAZ
-
-struct Foo:
-    a: uint256
-    b: DynArray[Bar, 3]
-    c: String[5]
-
-@internal
-def foo(x: Foo) -> Foo:
-    x.a = 789
-    x.b.pop()
-    return x
-
-@external
-def bar(x: Foo) -> Foo:
-    return self.foo(x)
-    """
-    c = get_contract_with_gas_estimation(code)
-
-    assert c.bar((123, [1, 2, 4], "vyper")) == (789, [1, 2], "vyper")
 
 
 def test_invalid_external_assign(assert_compile_failed, get_contract_with_gas_estimation):

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -39,7 +39,39 @@ def augmod(x: int128, y: int128) -> int128:
     print("Passed aug-assignment test")
 
 
-def test_invalid_assign(assert_compile_failed, get_contract_with_gas_estimation):
+def test_internal_assign(get_contract_with_gas_estimation):
+    code = """
+@internal
+def foo(x: int128) -> int128:
+    x = 77
+    return x
+
+@external
+def bar(x: int128) -> int128:
+    return self.foo(x)
+    """
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.bar(123) == 77
+
+
+def test_internal_augassign(get_contract_with_gas_estimation):
+    code = """
+@internal
+def foo(x: int128) -> int128:
+    x += 77
+    return x
+
+@external
+def bar(x: int128) -> int128:
+    return self.foo(x)
+    """
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.bar(123) == 200
+
+
+def test_invalid_external_assign(assert_compile_failed, get_contract_with_gas_estimation):
     code = """
 @external
 def foo(x: int128):
@@ -48,7 +80,7 @@ def foo(x: int128):
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), ImmutableViolation)
 
 
-def test_invalid_augassign(assert_compile_failed, get_contract_with_gas_estimation):
+def test_invalid_external_augassign(assert_compile_failed, get_contract_with_gas_estimation):
     code = """
 @external
 def foo(x: int128):

--- a/vyper/codegen/function_definitions/internal_function.py
+++ b/vyper/codegen/function_definitions/internal_function.py
@@ -41,8 +41,8 @@ def generate_ir_for_internal_function(
 
     for arg in func_t.arguments:
         # allocate a variable for every arg, setting mutability
-        # to False to comply with vyper semantics, function arguments are immutable
-        context.new_variable(arg.name, arg.typ, is_mutable=False)
+        # to True to allow internal function arguments to be mutable
+        context.new_variable(arg.name, arg.typ, is_mutable=True)
 
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_t)
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -175,11 +175,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         self.expr_visitor = _LocalExpressionVisitor()
 
         # allow internal function params to be mutable
-        arg_location = DataLocation.MEMORY if self.func.is_internal else DataLocation.CALLDATA
-        arg_is_immutable = False if self.func.is_internal else True
+        location = DataLocation.MEMORY if self.func.is_internal else DataLocation.CALLDATA
+        is_immutable = False if self.func.is_internal else True
         for arg in self.func.arguments:
             namespace[arg.name] = VarInfo(
-                arg.typ, location=arg_location, is_immutable=arg_is_immutable
+                arg.typ, location=location, is_immutable=is_immutable
             )
 
         for node in fn_node.body:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -173,9 +173,13 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         self.func = fn_node._metadata["type"]
         self.annotation_visitor = StatementAnnotationVisitor(fn_node, namespace)
         self.expr_visitor = _LocalExpressionVisitor()
+
+        # allow internal function params to be mutable
+        arg_location = DataLocation.MEMORY if self.func.is_internal else DataLocation.CALLDATA
+        arg_is_immutable = False if self.func.is_internal else True
         for arg in self.func.arguments:
             namespace[arg.name] = VarInfo(
-                arg.typ, location=DataLocation.CALLDATA, is_immutable=True
+                arg.typ, location=arg_location, is_immutable=arg_is_immutable
             )
 
         for node in fn_node.body:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -175,12 +175,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         self.expr_visitor = _LocalExpressionVisitor()
 
         # allow internal function params to be mutable
-        location = DataLocation.MEMORY if self.func.is_internal else DataLocation.CALLDATA
-        is_immutable = False if self.func.is_internal else True
+        location, is_immutable = (
+            (DataLocation.MEMORY, False) if self.func.is_internal else (DataLocation.CALLDATA, True)
+        )
         for arg in self.func.arguments:
-            namespace[arg.name] = VarInfo(
-                arg.typ, location=location, is_immutable=is_immutable
-            )
+            namespace[arg.name] = VarInfo(arg.typ, location=location, is_immutable=is_immutable)
 
         for node in fn_node.body:
             self.visit(node)


### PR DESCRIPTION
### What I did

Fix #3449.

### How I did it

Update attributes in `VarInfo` and `VariableRecord`.

### How to verify it

See tests.

### Commit message

```
feat: let params of internal functions be mutable

This PR sets the data location of internal functions' params to
memory. Additionally, they are now mutable unlike an external
function's params.
```

### Description for the changelog

Let params of internal functions be mutable.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.mcsuk.org/images/RS34129_jelly2_scotland-lpr.width-765.jpg)
