### PR TITLE
chore: rm redundant var declaration

### DIFF
--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -1,8 +1,7 @@
 # a contract.vy -- all functions and constructor
 
-from typing import Any, List, Optional
+from typing import Any, List
 
-from vyper import ast as vy_ast
 from vyper.codegen.core import shr
 from vyper.codegen.function_definitions import generate_ir_for_function
 from vyper.codegen.global_context import GlobalContext

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -141,8 +141,6 @@ def generate_ir_for_module(global_ctx: GlobalContext) -> tuple[IRnode, IRnode]:
     # order functions so that each function comes after all of its callees
     function_defs = _topsort(global_ctx.functions)
 
-    init_function: Optional[vy_ast.FunctionDef] = None
-
     runtime_functions = [f for f in function_defs if not _is_constructor(f)]
     init_function = next((f for f in function_defs if _is_constructor(f)), None)
 


### PR DESCRIPTION
### What I did

remove an unneeded declared var

### How I did it

### How to verify it

### Commit message

```
it was apparently there as a type hint but it is no longer needed
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
