### PR TITLE
fix: pycryptodome on arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Generate Binary
         run: >-
-          pip install . &&
+          pip install --no-binary pycryptodome . &&
           pip install pyinstaller &&
           make freeze
 


### PR DESCRIPTION
### What I did
mac users were reporting bugs like:
```
OSError: Cannot load native module 'Crypto.Hash._keccak': Not found '_keccak.cpython-311-darwin.so', Cannot load '_keccak.abi3.so': Failed to load dynlib/dll '/<some directory>/Crypto/Util/../Hash/_keccak.abi3.so'. Most likely this dynlib/dll was not found when the application was frozen., Not found '_keccak.so'
```

### How I did it
rebuild pycryptodome during packaging

### How to verify it
build verified by @hedgar2017

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
