### PR TITLE
fix: pc maps for function selectors

### DIFF
--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -205,7 +205,7 @@ def generate_ir_for_external_function(code, func_t, context, skip_nonpayable_che
 
     # the ir which comprises the main body of the function,
     # besides any kwarg handling
-    func_common_ir = ["seq", body, exit]
+    func_common_ir = IRnode.from_list(["seq", body, exit], source_pos=getpos(code))
 
     if func_t.is_fallback or func_t.is_constructor:
         ret = ["seq"]
@@ -219,4 +219,4 @@ def generate_ir_for_external_function(code, func_t, context, skip_nonpayable_che
         # TODO rethink this / make it clearer
         ret[-1][-1].append(func_common_ir)
 
-    return IRnode.from_list(ret, source_pos=getpos(code))
+    return IRnode.from_list(ret)

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -451,7 +451,7 @@ class IRnode:
             return OKMAGENTA + val + ENDC
         return val
 
-    def repr(self) -> str:
+    def __repr__(self) -> str:
         if not len(self.args):
             if self.annotation:
                 return f"{self.repr_value} " + OKLIGHTBLUE + f"<{self.annotation}>" + ENDC
@@ -463,6 +463,8 @@ class IRnode:
         o = ""
         if self.annotation:
             o += f"/* {self.annotation} */ \n"
+        if self.source_pos:
+            o += f"/* POS {self.source_pos} */ "
         if self.repr_show_gas and self.gas:
             o += OKBLUE + "{" + ENDC + str(self.gas) + OKBLUE + "} " + ENDC  # add gas for info.
         o += "[" + self._colorise_keywords(self.repr_value)
@@ -477,7 +479,7 @@ class IRnode:
                 o += f"# Line {(arg_lineno)}\n  "
                 prev_lineno = arg_lineno
                 annotated = True
-            arg_repr = arg.repr()
+            arg_repr = repr(arg)
             if "\n" in arg_repr:
                 has_inner_newlines = True
             sub = arg_repr.replace("\n", "\n  ").strip(" ")
@@ -493,9 +495,6 @@ class IRnode:
             return output_on_one_line
         else:
             return output
-
-    def __repr__(self):
-        return self.repr()
 
     @classmethod
     def from_list(

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -463,8 +463,8 @@ class IRnode:
         o = ""
         if self.annotation:
             o += f"/* {self.annotation} */ \n"
-        if self.source_pos:
-            o += f"/* POS {self.source_pos} */ "
+        #if self.source_pos:
+        #    o += f"/* POS {self.source_pos} */ "
         if self.repr_show_gas and self.gas:
             o += OKBLUE + "{" + ENDC + str(self.gas) + OKBLUE + "} " + ENDC  # add gas for info.
         o += "[" + self._colorise_keywords(self.repr_value)

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -463,7 +463,7 @@ class IRnode:
         o = ""
         if self.annotation:
             o += f"/* {self.annotation} */ \n"
-        #if self.source_pos:
+        # if self.source_pos:
         #    o += f"/* POS {self.source_pos} */ "
         if self.repr_show_gas and self.gas:
             o += OKBLUE + "{" + ENDC + str(self.gas) + OKBLUE + "} " + ENDC  # add gas for info.

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -128,7 +128,7 @@ def _rewrite_return_sequences(ir_node, label_params=None):
             dest = args[0].value[5:]  # `_sym_foo` -> `foo`
             more_args = ["pass" if t.value == "return_pc" else t for t in args[1:]]
             _t.append(["goto", dest] + more_args)
-            ir_node.args = IRnode.from_list(_t, source_pos=ir_node.source_pos).args
+            ir_node.args = IRnode.from_list(_t).args
 
     if ir_node.value == "label":
         label_params = set(t.value for t in ir_node.args[1].args)


### PR DESCRIPTION
the existing pc annotator was annotating functions too early - when we do the check in the selector table rather than when the function is actually entered into. this moves the pc annotation to a few instructions later in the codegen so that tracers will not be confused as to where the function actually starts.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
