### PR TITLE
chore: polish some codegen issues

### DIFF
--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -38,11 +38,6 @@ class NullAttractor(int):
     __mul__ = __add__
 
 
-def push_label_to_stack(labelname: str) -> str:
-    #  items prefixed with `_sym_` are ignored until asm phase
-    return "_sym_" + labelname
-
-
 class Encoding(Enum):
     # vyper encoding, default for memory variables
     VYPER = auto()

--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -21,7 +21,7 @@ Stmt = Any  # mypy kludge
 def make_return_stmt(ir_val: IRnode, stmt: Any, context: Context) -> Optional[IRnode]:
     func_t = context.func_t
 
-    jump_to_exit = ["exit_to", f"_sym_{func_t._ir_info.exit_sequence_label}"]
+    jump_to_exit = ["exit_to", func_t._ir_info.exit_sequence_label]
 
     if context.return_type is None:
         if stmt.value is not None:
@@ -43,7 +43,8 @@ def make_return_stmt(ir_val: IRnode, stmt: Any, context: Context) -> Optional[IR
         return IRnode.from_list(["seq", fill_return_buffer, cleanup_loops, jump_to_exit])
 
     if context.return_type is None:
-        jump_to_exit += ["return_pc"]
+        if context.is_internal:
+            jump_to_exit += ["return_pc"]
         return finalize(["seq"])
 
     if context.is_internal:

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -1,5 +1,5 @@
 from vyper.codegen.core import _freshname, eval_once_check, make_setter
-from vyper.codegen.ir_node import IRnode, push_label_to_stack
+from vyper.codegen.ir_node import IRnode
 from vyper.evm.address_space import MEMORY
 from vyper.exceptions import StateAccessViolation
 from vyper.semantics.types.subscriptable import TupleT
@@ -104,7 +104,7 @@ def ir_for_self_call(stmt_expr, context):
     if return_buffer is not None:
         goto_op += [return_buffer]
     # pass return label to subroutine
-    goto_op += [push_label_to_stack(return_label)]
+    goto_op += ["symbol", return_label]
 
     call_sequence = ["seq"]
     call_sequence.append(eval_once_check(_freshname(stmt_expr.node_source_code)))

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -104,7 +104,7 @@ def ir_for_self_call(stmt_expr, context):
     if return_buffer is not None:
         goto_op += [return_buffer]
     # pass return label to subroutine
-    goto_op += ["symbol", return_label]
+    goto_op.append(["symbol", return_label])
 
     call_sequence = ["seq"]
     call_sequence.append(eval_once_check(_freshname(stmt_expr.node_source_code)))

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -667,8 +667,8 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
         o.extend(["_sym_" + str(code.args[0]), "JUMP"])
         return o
     # push a literal symbol
-    elif isinstance(code.value, str) and is_symbol(code.value):
-        return [code.value]
+    elif code.value == "symbol":
+        return ["_sym_" + str(code.args[0])]
     # set a symbol as a location.
     elif code.value == "label":
         label_name = code.args[0].value

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -118,14 +118,14 @@ def _rewrite_return_sequences(ir_node, label_params=None):
             args[0].value = "pass"
         else:
             # handle jump to cleanup
-            assert is_symbol(args[0].value)
             ir_node.value = "seq"
 
             _t = ["seq"]
             if "return_buffer" in label_params:
                 _t.append(["pop", "pass"])
 
-            dest = args[0].value[5:]  # `_sym_foo` -> `foo`
+            dest = args[0].value
+            # works for both internal and external exit_to
             more_args = ["pass" if t.value == "return_pc" else t for t in args[1:]]
             _t.append(["goto", dest] + more_args)
             ir_node.args = IRnode.from_list(_t, source_pos=ir_node.source_pos).args


### PR DESCRIPTION
fix some issues with well-formedness of generated IR (which were getting hidden by the `rewrite_return_sequences` routine). this shouldn't affect correctness of current vyper programs, but may help programs which consume vyper IR directly.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
