### PR TITLE
fix: typechecking of folded builtins

### DIFF
--- a/tests/parser/syntax/test_addmulmod.py
+++ b/tests/parser/syntax/test_addmulmod.py
@@ -1,0 +1,27 @@
+import pytest
+
+from vyper.exceptions import InvalidType
+
+fail_list = [
+    (  # bad AST nodes given as arguments
+        """
+@external
+def foo() -> uint256:
+    return uint256_addmod(1.1, 1.2, 3.0)
+    """,
+        InvalidType,
+    ),
+    (  # bad AST nodes given as arguments
+        """
+@external
+def foo() -> uint256:
+    return uint256_mulmod(1.1, 1.2, 3.0)
+    """,
+        InvalidType,
+    ),
+]
+
+
+@pytest.mark.parametrize("code,exc", fail_list)
+def test_add_mod_fail(assert_compile_failed, get_contract, code, exc):
+    assert_compile_failed(lambda: get_contract(code), exc)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1370,7 +1370,7 @@ class BitwiseAnd(BuiltinFunction):
 
         validate_call_args(node, 2)
         for arg in node.args:
-            if not isinstance(arg, vy_ast.Num):
+            if not isinstance(arg, vy_ast.Int):
                 raise UnfoldableNode
             if arg.value < 0 or arg.value >= 2**256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
@@ -1396,7 +1396,7 @@ class BitwiseOr(BuiltinFunction):
 
         validate_call_args(node, 2)
         for arg in node.args:
-            if not isinstance(arg, vy_ast.Num):
+            if not isinstance(arg, vy_ast.Int):
                 raise UnfoldableNode
             if arg.value < 0 or arg.value >= 2**256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
@@ -1422,7 +1422,7 @@ class BitwiseXor(BuiltinFunction):
 
         validate_call_args(node, 2)
         for arg in node.args:
-            if not isinstance(arg, vy_ast.Num):
+            if not isinstance(arg, vy_ast.Int):
                 raise UnfoldableNode
             if arg.value < 0 or arg.value >= 2**256:
                 raise InvalidLiteral("Value out of range for uint256", arg)
@@ -1447,7 +1447,7 @@ class BitwiseNot(BuiltinFunction):
             self.__class__._warned = True
 
         validate_call_args(node, 1)
-        if not isinstance(node.args[0], vy_ast.Num):
+        if not isinstance(node.args[0], vy_ast.Int):
             raise UnfoldableNode
 
         value = node.args[0].value
@@ -1474,7 +1474,7 @@ class Shift(BuiltinFunction):
             self.__class__._warned = True
 
         validate_call_args(node, 2)
-        if [i for i in node.args if not isinstance(i, vy_ast.Num)]:
+        if [i for i in node.args if not isinstance(i, vy_ast.Int)]:
             raise UnfoldableNode
         value, shift = [i.value for i in node.args]
         if value < 0 or value >= 2**256:
@@ -1522,10 +1522,10 @@ class _AddMulMod(BuiltinFunction):
 
     def evaluate(self, node):
         validate_call_args(node, 3)
-        if isinstance(node.args[2], vy_ast.Num) and node.args[2].value == 0:
+        if isinstance(node.args[2], vy_ast.Int) and node.args[2].value == 0:
             raise ZeroDivisionException("Modulo by 0", node.args[2])
         for arg in node.args:
-            if not isinstance(arg, vy_ast.Num):
+            if not isinstance(arg, vy_ast.Int):
                 raise UnfoldableNode
             if arg.value < 0 or arg.value >= 2**256:
                 raise InvalidLiteral("Value out of range for uint256", arg)


### PR DESCRIPTION
### What I did

Fix #3486

### How I did it

The `eval` functions of the builtins having integer arguments now expect `Int` instead of `Num`.

### How to verify it

The following contract now fails to compile with `InvalidType` instead of a `CompilerPanic`.

```Vyper
@external
def foo():
    ds:uint256 = uint256_addmod(1.1,2.2,2)
```
### Commit message

    fix: typechecking of folded builtins.

### Description for the changelog

Prevent decimals from being passed as parameters to builtins expecting integers.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s.yimg.com/ny/api/res/1.2/UiU_RIdJhf6cvsd7dqUmKA--/YXBwaWQ9aGlnaGxhbmRlcjt3PTY0MDtoPTQyNw--/https://media.zenfs.com/en/pethelpful_915/c7fb322d2c8220f9896af2d0f53bf25f)
