### PR TITLE
fix: improve error message for conflicting methods IDs

### DIFF
--- a/tests/signatures/test_method_id_conflicts.py
+++ b/tests/signatures/test_method_id_conflicts.py
@@ -67,6 +67,13 @@ def gfah(): pass
 @view
 def eexo(): pass
     """,
+    """
+# check collision with ID = 0x00000000
+wycpnbqcyf:public(uint256)
+
+@external
+def randallsRevenge_ilxaotc(): pass
+    """,
 ]
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -24,7 +24,7 @@ from vyper.semantics.types.base import TYPE_T, VyperType
 from vyper.semantics.types.bytestrings import BytesT, StringT
 from vyper.semantics.types.primitives import AddressT, BoolT, BytesM_T, IntegerT
 from vyper.semantics.types.subscriptable import DArrayT, SArrayT, TupleT
-from vyper.utils import checksum_encode
+from vyper.utils import checksum_encode, int_to_fourbytes
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -593,8 +593,9 @@ def validate_unique_method_ids(functions: List) -> None:
     seen = set()
     for method_id in method_ids:
         if method_id in seen:
-            collision_str = ", ".join(i.name for i in functions if method_id in i.method_ids)
-            raise StructureException(f"Methods have conflicting IDs: {collision_str}")
+            collision_str = ", ".join(x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == method_id)
+            collision_hex = int_to_fourbytes(method_id).hex()
+            raise StructureException(f"Methods produce colliding method ID `0x{collision_hex}`: {collision_str}")
         seen.add(method_id)
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -593,9 +593,13 @@ def validate_unique_method_ids(functions: List) -> None:
     seen = set()
     for method_id in method_ids:
         if method_id in seen:
-            collision_str = ", ".join(x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == method_id)
+            collision_str = ", ".join(
+                x for i in functions for x in i.method_ids.keys() if i.method_ids[x] == method_id
+            )
             collision_hex = int_to_fourbytes(method_id).hex()
-            raise StructureException(f"Methods produce colliding method ID `0x{collision_hex}`: {collision_str}")
+            raise StructureException(
+                f"Methods produce colliding method ID `0x{collision_hex}`: {collision_str}"
+            )
         seen.add(method_id)
 
 


### PR DESCRIPTION
### What I did

Fix again #3133 as it has been reverted by #2974.
Additionally, added a test for collisions of functions having `0x00000000` as ID.

### How I did it

Similarly to #3134, modified `validate_unique_method_ids` so that it outputs both the signature of each function having a collision together with the collision id itself.

### How to verify it

Trying to compile the following contract will now output the signature of the functions having a collision and the collision id:

```Vyper
@external
def OwnerTransferV7b711143(a : uint256) : 
    pass
@external
def withdraw(a : uint256):
    pass
```

- Before: `Methods have conflicting IDs: `
- Now: `Methods produce colliding method ID '0x2e1a7d4d': OwnerTransferV7b711143(uint256), withdraw(uint256)`

### Commit message

fix: improve error message for conflicting methods IDs

### Description for the changelog

Improve error message for conflicting methods IDs

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://render.fineartamerica.com/images/rendered/default/flat/blanket/images/artworkimages/medium/3/cute-abandoned-baby-squirrel-looking-at-camera-nilanka-sampath.jpg?&targetx=-235&targety=0&imagewidth=1422&imageheight=800&modelwidth=952&modelheight=800&backgroundcolor=EDD09D&orientation=1&producttype=blanket-coral-50-60)
