### PR TITLE
feat: add optimization mode to vyper compiler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
     strategy:
       matrix:
         python-version: [["3.10", "310"], ["3.11", "311"]]
-        # run in default (optimized) and --no-optimize mode
-        flag: ["core", "no-opt"]
+        # run in default (optimized, gas) and --no-optimize mode
+        flag: ["core", "no-opt", "codesize"]
 
     name: py${{ matrix.python-version[1] }}-${{ matrix.flag }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         python-version: [["3.10", "310"], ["3.11", "311"]]
-        # run in default (optimized, gas) and --no-optimize mode
+        # run in modes: --optimize [gas, none, codesize]
         flag: ["core", "no-opt", "codesize"]
 
     name: py${{ matrix.python-version[1] }}-${{ matrix.flag }}

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -213,9 +213,10 @@ The following example describes the expected input format of ``vyper-json``. Com
         // Optional
         "settings": {
             "evmVersion": "shanghai",  // EVM version to compile for. Can be istanbul, berlin, paris, shanghai (default) or cancun (experimental!).
-            // optional, whether or not optimizations are turned on
-            // defaults to true
-            "optimize": true,
+            // optional, optimization mode
+            // defaults to "gas". can be one of "gas", "codesize", "none",
+            // false  and true (the last two are for backwards compatibility).
+            "optimize": "gas",
             // optional, whether or not the bytecode should include Vyper's signature
             // defaults to true
             "bytecodeMetadata": true,

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -122,7 +122,7 @@ Setting the Target EVM Version
 When you compile your contract code, you can specify the target Ethereum Virtual Machine version to compile for, to access or avoid particular features. You can specify the version either with a source code pragma or as a compiler option. It is recommended to use the compiler option when you want flexibility (for instance, ease of deploying across different chains), and the source code pragma when you want bytecode reproducibility (for instance, when verifying code on a block explorer).
 
 .. note::
-   If the evm version specified by the compiler options conflicts with the source code pragma, an exception will be raised.
+   If the evm version specified by the compiler options conflicts with the source code pragma, an exception will be raised and compilation will not continue.
 
 For instance, the adding the following pragma to a contract indicates that it should be compiled for the "shanghai" fork of the EVM.
 
@@ -134,7 +134,7 @@ For instance, the adding the following pragma to a contract indicates that it sh
 
     Compiling for the wrong EVM version can result in wrong, strange, or failing behavior. Please ensure, especially if running a private chain, that you use matching EVM versions.
 
-When compiling via ``vyper``, you can specify the EVM version option using the ``--evm-version`` flag:
+When compiling via the ``vyper`` CLI, you can specify the EVM version option using the ``--evm-version`` flag:
 
 ::
 

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -99,6 +99,11 @@ See :ref:`searching_for_imports` for more information on Vyper's import system.
 Online Compilers
 ================
 
+Try VyperLang!
+-----------------
+
+`Try VyperLang! <https://try.vyperlang.org>`_ is a JupterHub instance hosted by the Vyper team as a sandbox for developing and testing contracts in Vyper. It requires github for login, and supports deployment via the browser.
+
 Remix IDE
 ---------
 
@@ -109,22 +114,33 @@ Remix IDE
    While the Vyper version of the Remix IDE compiler is updated on a regular basis, it might be a bit behind the latest version found in the master branch of the repository. Make sure the byte code matches the output from your local compiler.
 
 
+.. _evm-version:
+
 Setting the Target EVM Version
 ==============================
 
-When you compile your contract code, you can specify the Ethereum Virtual Machine version to compile for, to avoid particular features or behaviours.
+When you compile your contract code, you can specify the target Ethereum Virtual Machine version to compile for, to access or avoid particular features. You can specify the version either with a source code pragma or as a compiler option. It is recommended to use the compiler option when you want flexibility (for instance, ease of deploying across different chains), and the source code pragma when you want bytecode reproducibility (for instance, when verifying code on a block explorer).
+
+.. note::
+   If the evm version specified by the compiler options conflicts with the source code pragma, an exception will be raised.
+
+For instance, the adding the following pragma to a contract indicates that it should be compiled for the "shanghai" fork of the EVM.
+
+.. code-block:: python
+
+   #pragma evm-version shanghai
 
 .. warning::
 
     Compiling for the wrong EVM version can result in wrong, strange and failing behaviour. Please ensure, especially if running a private chain, that you use matching EVM versions.
 
-When compiling via ``vyper``, include the ``--evm-version`` flag:
+When compiling via ``vyper``, you can specify the EVM version option using the ``--evm-version`` flag:
 
 ::
 
     $ vyper --evm-version [VERSION]
 
-When using the JSON interface, include the ``"evmVersion"`` key within the ``"settings"`` field:
+When using the JSON interface, you can include the ``"evmVersion"`` key within the ``"settings"`` field:
 
 .. code-block:: javascript
 

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -132,7 +132,7 @@ For instance, the adding the following pragma to a contract indicates that it sh
 
 .. warning::
 
-    Compiling for the wrong EVM version can result in wrong, strange and failing behaviour. Please ensure, especially if running a private chain, that you use matching EVM versions.
+    Compiling for the wrong EVM version can result in wrong, strange, or failing behavior. Please ensure, especially if running a private chain, that you use matching EVM versions.
 
 When compiling via ``vyper``, you can specify the EVM version option using the ``--evm-version`` flag:
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -12,7 +12,7 @@ This section provides a quick overview of the types of data present within a con
 Pragmas
 ==============
 
-Vyper supports several directives to control compiler modes and help with build reproducibility
+Vyper supports several source code directives to control compiler modes and help with build reproducibility.
 
 Version Pragma
 --------------
@@ -37,7 +37,7 @@ In the above examples, the contract will only compile with Vyper versions ``0.3.
 Optimization Mode
 -----------------
 
-The optimization mode can be one of "none", "codesize", or "gas" (default). For instance, the following contract will be compiled in a way which tries to minimize codesize:
+The optimization mode can be one of ``"none"``, ``"codesize"``, or ``"gas"`` (default). For instance, the following contract will be compiled in a way which tries to minimize codesize:
 
 .. code-block:: python
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -9,16 +9,47 @@ This section provides a quick overview of the types of data present within a con
 
 .. _structure-versions:
 
-Version Pragma
+Pragmas
 ==============
 
-Vyper supports a version pragma to ensure that a contract is only compiled by the intended compiler version, or range of versions. Version strings use `NPM <https://docs.npmjs.com/about-semantic-versioning>`_ style syntax.
+Vyper supports several directives to control compiler modes and help with build reproducibility
+
+Version Pragma
+--------------
+
+The version pragma ensures that a contract is only compiled by the intended compiler version, or range of versions. Version strings use `NPM <https://docs.npmjs.com/about-semantic-versioning>`_ style syntax.
+
+As of 0.3.10, the recommended way to specify the version pragma is as follows:
 
 .. code-block:: python
 
-    # @version ^0.2.0
+    #pragma version ^0.3.0
 
-In the above example, the contract only compiles with Vyper versions ``0.2.x``.
+The following declaration is equivalent, and, prior to 0.3.10, was the only supported method to specify the compiler version:
+
+.. code-block:: python
+
+    # @version ^0.3.0
+
+
+In the above examples, the contract will only compile with Vyper versions ``0.3.x``.
+
+Optimization Mode
+-----------------
+
+The optimization mode can be one of "none", "codesize", or "gas" (default). For instance, the following contract will be compiled in a way which tries to minimize codesize:
+
+.. code-block:: python
+
+   #pragma optimize codesize
+
+The optimization mode can also be set as a compiler option. If the compiler option conflicts with the source code pragma, an exception will be raised and compilation will not continue.
+
+EVM Version
+-----------------
+
+The EVM version can be set with the ``evm-version`` pragma, which is documented in :ref:`evm-version`.
+
 
 .. _structure-state-variables:
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "flake8-bugbear==20.1.4",
         "flake8-use-fstring==1.1",
         "isort==5.9.3",
-        "mypy==0.910",
+        "mypy==0.940",
     ],
     "docs": ["recommonmark", "sphinx>=6.0,<7.0", "sphinx_rtd_theme>=1.2,<1.3"],
     "dev": ["ipython", "pre-commit", "pyinstaller", "twine"],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "flake8-bugbear==20.1.4",
         "flake8-use-fstring==1.1",
         "isort==5.9.3",
-        "mypy==0.940",
+        "mypy==0.982",
     ],
     "docs": ["recommonmark", "sphinx>=6.0,<7.0", "sphinx_rtd_theme>=1.2,<1.3"],
     "dev": ["ipython", "pre-commit", "pyinstaller", "twine"],

--- a/tests/ast/test_pre_parser.py
+++ b/tests/ast/test_pre_parser.py
@@ -51,14 +51,14 @@ invalid_versions = [
 @pytest.mark.parametrize("file_version", valid_versions)
 def test_valid_version_pragma(file_version, mock_version):
     mock_version(COMPILER_VERSION)
-    validate_version_pragma(f" @version {file_version}", (SRC_LINE))
+    validate_version_pragma(f"{file_version}", (SRC_LINE))
 
 
 @pytest.mark.parametrize("file_version", invalid_versions)
 def test_invalid_version_pragma(file_version, mock_version):
     mock_version(COMPILER_VERSION)
     with pytest.raises(VersionException):
-        validate_version_pragma(f" @version {file_version}", (SRC_LINE))
+        validate_version_pragma(f"{file_version}", (SRC_LINE))
 
 
 prerelease_valid_versions = [
@@ -98,11 +98,11 @@ prerelease_invalid_versions = [
 @pytest.mark.parametrize("file_version", prerelease_valid_versions)
 def test_prerelease_valid_version_pragma(file_version, mock_version):
     mock_version(PRERELEASE_COMPILER_VERSION)
-    validate_version_pragma(f" @version {file_version}", (SRC_LINE))
+    validate_version_pragma(file_version, (SRC_LINE))
 
 
 @pytest.mark.parametrize("file_version", prerelease_invalid_versions)
 def test_prerelease_invalid_version_pragma(file_version, mock_version):
     mock_version(PRERELEASE_COMPILER_VERSION)
     with pytest.raises(VersionException):
-        validate_version_pragma(f" @version {file_version}", (SRC_LINE))
+        validate_version_pragma(file_version, (SRC_LINE))

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -111,13 +111,13 @@ def w3(tester):
     return w3
 
 
-def _get_contract(w3, source_code, no_optimize, *args, **kwargs):
+def _get_contract(w3, source_code, optimize, *args, **kwargs):
     out = compiler.compile_code(
         source_code,
         # test that metadata gets generated
         ["abi", "bytecode", "metadata"],
         interface_codes=kwargs.pop("interface_codes", None),
-        no_optimize=no_optimize,
+        optimize=optimize,
         evm_version=kwargs.pop("evm_version", None),
         show_gas_estimates=True,  # Enable gas estimates for testing
     )
@@ -135,12 +135,12 @@ def _get_contract(w3, source_code, no_optimize, *args, **kwargs):
     return w3.eth.contract(address, abi=abi, bytecode=bytecode, ContractFactoryClass=VyperContract)
 
 
-def _deploy_blueprint_for(w3, source_code, no_optimize, initcode_prefix=b"", **kwargs):
+def _deploy_blueprint_for(w3, source_code, optimize, initcode_prefix=b"", **kwargs):
     out = compiler.compile_code(
         source_code,
         ["abi", "bytecode"],
         interface_codes=kwargs.pop("interface_codes", None),
-        no_optimize=no_optimize,
+        optimize=optimize,
         evm_version=kwargs.pop("evm_version", None),
         show_gas_estimates=True,  # Enable gas estimates for testing
     )
@@ -173,17 +173,17 @@ def _deploy_blueprint_for(w3, source_code, no_optimize, initcode_prefix=b"", **k
 
 
 @pytest.fixture(scope="module")
-def deploy_blueprint_for(w3, no_optimize):
+def deploy_blueprint_for(w3, optimize):
     def deploy_blueprint_for(source_code, *args, **kwargs):
-        return _deploy_blueprint_for(w3, source_code, no_optimize, *args, **kwargs)
+        return _deploy_blueprint_for(w3, source_code, optimize, *args, **kwargs)
 
     return deploy_blueprint_for
 
 
 @pytest.fixture(scope="module")
-def get_contract(w3, no_optimize):
+def get_contract(w3, optimize):
     def get_contract(source_code, *args, **kwargs):
-        return _get_contract(w3, source_code, no_optimize, *args, **kwargs)
+        return _get_contract(w3, source_code, optimize, *args, **kwargs)
 
     return get_contract
 

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -12,6 +12,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 
 from vyper import compiler
 from vyper.ast.grammar import parse_vyper_source
+from vyper.compiler.settings import Settings
 
 
 class VyperMethod:
@@ -112,13 +113,15 @@ def w3(tester):
 
 
 def _get_contract(w3, source_code, optimize, *args, **kwargs):
+    settings = Settings()
+    settings.evm_version = kwargs.pop("evm_version", None)
+    settings.optimize = optimize
     out = compiler.compile_code(
         source_code,
         # test that metadata gets generated
         ["abi", "bytecode", "metadata"],
+        settings=settings,
         interface_codes=kwargs.pop("interface_codes", None),
-        optimize=optimize,
-        evm_version=kwargs.pop("evm_version", None),
         show_gas_estimates=True,  # Enable gas estimates for testing
     )
     parse_vyper_source(source_code)  # Test grammar.
@@ -136,12 +139,14 @@ def _get_contract(w3, source_code, optimize, *args, **kwargs):
 
 
 def _deploy_blueprint_for(w3, source_code, optimize, initcode_prefix=b"", **kwargs):
+    settings = Settings()
+    settings.evm_version = kwargs.pop("evm_version", None)
+    settings.optimize = optimize
     out = compiler.compile_code(
         source_code,
         ["abi", "bytecode"],
         interface_codes=kwargs.pop("interface_codes", None),
-        optimize=optimize,
-        evm_version=kwargs.pop("evm_version", None),
+        settings=settings,
         show_gas_estimates=True,  # Enable gas estimates for testing
     )
     parse_vyper_source(source_code)  # Test grammar.

--- a/tests/cli/vyper_json/test_get_settings.py
+++ b/tests/cli/vyper_json/test_get_settings.py
@@ -3,7 +3,6 @@
 import pytest
 
 from vyper.cli.vyper_json import get_evm_version
-from vyper.evm.opcodes import DEFAULT_EVM_VERSION
 from vyper.exceptions import JSONError
 
 
@@ -31,7 +30,3 @@ def test_early_evm(evm_version):
 @pytest.mark.parametrize("evm_version", ["istanbul", "berlin", "paris", "shanghai", "cancun"])
 def test_valid_evm(evm_version):
     assert evm_version == get_evm_version({"settings": {"evmVersion": evm_version}})
-
-
-def test_default_evm():
-    assert get_evm_version({}) == DEFAULT_EVM_VERSION

--- a/tests/compiler/asm/test_asm_optimizer.py
+++ b/tests/compiler/asm/test_asm_optimizer.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper.compiler.phases import CompilerData
+from vyper.compiler.settings import OptimizationLevel
 
 codes = [
     """
@@ -72,7 +73,7 @@ def __init__():
 
 @pytest.mark.parametrize("code", codes)
 def test_dead_code_eliminator(code):
-    c = CompilerData(code, no_optimize=True)
+    c = CompilerData(code, optimize=OptimizationLevel.NONE)
     initcode_asm = [i for i in c.assembly if not isinstance(i, list)]
     runtime_asm = c.assembly_runtime
 
@@ -87,7 +88,7 @@ def test_dead_code_eliminator(code):
     for s in (ctor_only_label, runtime_only_label):
         assert s + "_runtime" in runtime_asm
 
-    c = CompilerData(code, no_optimize=False)
+    c = CompilerData(code, optimize=OptimizationLevel.GAS)
     initcode_asm = [i for i in c.assembly if not isinstance(i, list)]
     runtime_asm = c.assembly_runtime
 

--- a/tests/compiler/asm/test_asm_optimizer.py
+++ b/tests/compiler/asm/test_asm_optimizer.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper.compiler.phases import CompilerData
-from vyper.compiler.settings import OptimizationLevel
+from vyper.compiler.settings import OptimizationLevel, Settings
 
 codes = [
     """
@@ -73,7 +73,7 @@ def __init__():
 
 @pytest.mark.parametrize("code", codes)
 def test_dead_code_eliminator(code):
-    c = CompilerData(code, optimize=OptimizationLevel.NONE)
+    c = CompilerData(code, settings=Settings(optimize=OptimizationLevel.NONE))
     initcode_asm = [i for i in c.assembly if not isinstance(i, list)]
     runtime_asm = c.assembly_runtime
 
@@ -88,7 +88,7 @@ def test_dead_code_eliminator(code):
     for s in (ctor_only_label, runtime_only_label):
         assert s + "_runtime" in runtime_asm
 
-    c = CompilerData(code, optimize=OptimizationLevel.GAS)
+    c = CompilerData(code, settings=Settings(optimize=OptimizationLevel.GAS))
     initcode_asm = [i for i in c.assembly if not isinstance(i, list)]
     runtime_asm = c.assembly_runtime
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 
 from vyper import compiler
 from vyper.codegen.ir_node import IRnode
+from vyper.compiler.esttings import OptimizationLevel
 from vyper.ir import compile_ir, optimizer
 
 from .base_conftest import VyperContract, _get_contract, zero_gas_price_strategy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 
 from vyper import compiler
 from vyper.codegen.ir_node import IRnode
-from vyper.compiler.esttings import OptimizationLevel
+from vyper.compiler.settings import OptimizationLevel
 from vyper.ir import compile_ir, optimizer
 
 from .base_conftest import VyperContract, _get_contract, zero_gas_price_strategy
@@ -37,14 +37,12 @@ def set_evm_verbose_logging():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--no-optimize", action="store_true", help="disable asm and IR optimizations")
+    parser.addoption("--optimize", choices=["codesize", "gas", "none"], default="gas", help="disable asm and IR optimizations")
 
 
 @pytest.fixture(scope="module")
 def optimize(pytestconfig):
     flag = pytestconfig.getoption("optimize")
-    if not flag:
-        return OptimizationLevel.GAS
     return OptimizationLevel.from_string(flag)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def pytest_addoption(parser):
         "--optimize",
         choices=["codesize", "gas", "none"],
         default="gas",
-        help="disable asm and IR optimizations",
+        help="change optimization mode",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,12 @@ def set_evm_verbose_logging():
 
 
 def pytest_addoption(parser):
-    parser.addoption("--optimize", choices=["codesize", "gas", "none"], default="gas", help="disable asm and IR optimizations")
+    parser.addoption(
+        "--optimize",
+        choices=["codesize", "gas", "none"],
+        default="gas",
+        help="disable asm and IR optimizations",
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,8 +40,11 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module")
-def no_optimize(pytestconfig):
-    return pytestconfig.getoption("no_optimize")
+def optimize(pytestconfig):
+    flag = pytestconfig.getoption("optimize")
+    if not flag:
+        return OptimizationLevel.GAS
+    return OptimizationLevel.from_string(flag)
 
 
 @pytest.fixture
@@ -58,13 +61,13 @@ def bytes_helper():
 
 
 @pytest.fixture
-def get_contract_from_ir(w3, no_optimize):
+def get_contract_from_ir(w3, optimize):
     def ir_compiler(ir, *args, **kwargs):
         ir = IRnode.from_list(ir)
-        if not no_optimize:
+        if optimize != OptimizationLevel.NONE:
             ir = optimizer.optimize(ir)
         bytecode, _ = compile_ir.assembly_to_evm(
-            compile_ir.compile_to_assembly(ir, no_optimize=no_optimize)
+            compile_ir.compile_to_assembly(ir, optimize=optimize)
         )
         abi = kwargs.get("abi") or []
         c = w3.eth.contract(abi=abi, bytecode=bytecode)
@@ -80,7 +83,7 @@ def get_contract_from_ir(w3, no_optimize):
 
 
 @pytest.fixture(scope="module")
-def get_contract_module(no_optimize):
+def get_contract_module(optimize):
     """
     This fixture is used for Hypothesis tests to ensure that
     the same contract is called over multiple runs of the test.
@@ -93,7 +96,7 @@ def get_contract_module(no_optimize):
     w3.eth.set_gas_price_strategy(zero_gas_price_strategy)
 
     def get_contract_module(source_code, *args, **kwargs):
-        return _get_contract(w3, source_code, no_optimize, *args, **kwargs)
+        return _get_contract(w3, source_code, optimize, *args, **kwargs)
 
     return get_contract_module
 
@@ -138,9 +141,9 @@ def set_decorator_to_contract_function(w3, tester, contract, source_code, func):
 
 
 @pytest.fixture
-def get_contract_with_gas_estimation(tester, w3, no_optimize):
+def get_contract_with_gas_estimation(tester, w3, optimize):
     def get_contract_with_gas_estimation(source_code, *args, **kwargs):
-        contract = _get_contract(w3, source_code, no_optimize, *args, **kwargs)
+        contract = _get_contract(w3, source_code, optimize, *args, **kwargs)
         for abi_ in contract._classic_contract.functions.abi:
             if abi_["type"] == "function":
                 set_decorator_to_contract_function(w3, tester, contract, source_code, abi_["name"])
@@ -150,9 +153,9 @@ def get_contract_with_gas_estimation(tester, w3, no_optimize):
 
 
 @pytest.fixture
-def get_contract_with_gas_estimation_for_constants(w3, no_optimize):
+def get_contract_with_gas_estimation_for_constants(w3, optimize):
     def get_contract_with_gas_estimation_for_constants(source_code, *args, **kwargs):
-        return _get_contract(w3, source_code, no_optimize, *args, **kwargs)
+        return _get_contract(w3, source_code, optimize, *args, **kwargs)
 
     return get_contract_with_gas_estimation_for_constants
 

--- a/tests/examples/factory/test_factory.py
+++ b/tests/examples/factory/test_factory.py
@@ -2,6 +2,7 @@ import pytest
 from eth_utils import keccak
 
 import vyper
+from vyper.compiler.settings import Settings
 
 
 @pytest.fixture
@@ -35,7 +36,7 @@ def factory(get_contract, optimize):
         code = f.read()
 
     exchange_interface = vyper.compile_code(
-        code, output_formats=["bytecode_runtime"], optimize=optimize
+        code, output_formats=["bytecode_runtime"], settings=Settings(optimize=optimize)
     )
     exchange_deployed_bytecode = exchange_interface["bytecode_runtime"]
 

--- a/tests/examples/factory/test_factory.py
+++ b/tests/examples/factory/test_factory.py
@@ -30,12 +30,12 @@ def create_exchange(w3, get_contract):
 
 
 @pytest.fixture
-def factory(get_contract, no_optimize):
+def factory(get_contract, optimize):
     with open("examples/factory/Exchange.vy") as f:
         code = f.read()
 
     exchange_interface = vyper.compile_code(
-        code, output_formats=["bytecode_runtime"], no_optimize=no_optimize
+        code, output_formats=["bytecode_runtime"], optimize=optimize
     )
     exchange_deployed_bytecode = exchange_interface["bytecode_runtime"]
 

--- a/tests/grammar/test_grammar.py
+++ b/tests/grammar/test_grammar.py
@@ -106,7 +106,6 @@ def has_no_docstrings(c):
 @hypothesis.settings(deadline=400, max_examples=500, suppress_health_check=(HealthCheck.too_slow,))
 def test_grammar_bruteforce(code):
     if utf8_encodable(code):
-
         _, _, reformatted_code = pre_parse(code + "\n")
         tree = parse_to_ast(reformatted_code)
         assert isinstance(tree, Module)

--- a/tests/grammar/test_grammar.py
+++ b/tests/grammar/test_grammar.py
@@ -106,5 +106,7 @@ def has_no_docstrings(c):
 @hypothesis.settings(deadline=400, max_examples=500, suppress_health_check=(HealthCheck.too_slow,))
 def test_grammar_bruteforce(code):
     if utf8_encodable(code):
-        tree = parse_to_ast(pre_parse(code + "\n")[1])
+
+        _, _, reformatted_code = pre_parse(code + "\n")
+        tree = parse_to_ast(reformatted_code)
         assert isinstance(tree, Module)

--- a/tests/parser/features/test_immutable.py
+++ b/tests/parser/features/test_immutable.py
@@ -1,5 +1,7 @@
 import pytest
 
+from vyper.compiler.settings import OptimizationLevel
+
 
 @pytest.mark.parametrize(
     "typ,value",
@@ -269,7 +271,7 @@ def __init__(to_copy: address):
 # GH issue 3101, take 2
 def test_immutables_initialized2(get_contract, get_contract_from_ir):
     dummy_contract = get_contract_from_ir(
-        ["deploy", 0, ["seq"] + ["invalid"] * 600, 0], no_optimize=True
+        ["deploy", 0, ["seq"] + ["invalid"] * 600, 0], optimize=OptimizationLevel.NONE
     )
 
     # rekt because immutables section extends past allocated memory

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -1,7 +1,6 @@
 import pytest
 
 from vyper.compiler import compile_code
-from vyper.evm.opcodes import EVM_VERSIONS
 from vyper.exceptions import InvalidLiteral, InvalidOperation, TypeMismatch
 from vyper.utils import unsigned_to_signed
 
@@ -32,16 +31,14 @@ def _shr(x: uint256, y: uint256) -> uint256:
     """
 
 
-@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-def test_bitwise_opcodes(evm_version):
-    opcodes = compile_code(code, ["opcodes"], evm_version=evm_version)["opcodes"]
+def test_bitwise_opcodes():
+    opcodes = compile_code(code, ["opcodes"])["opcodes"]
     assert "SHL" in opcodes
     assert "SHR" in opcodes
 
 
-@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-def test_test_bitwise(get_contract_with_gas_estimation, evm_version):
-    c = get_contract_with_gas_estimation(code, evm_version=evm_version)
+def test_test_bitwise(get_contract_with_gas_estimation):
+    c = get_contract_with_gas_estimation(code)
     x = 126416208461208640982146408124
     y = 7128468721412412459
     assert c._bitwise_and(x, y) == (x & y)
@@ -55,8 +52,7 @@ def test_test_bitwise(get_contract_with_gas_estimation, evm_version):
             assert c._shl(t, s) == (t << s) % (2**256)
 
 
-@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS.keys()))
-def test_signed_shift(get_contract_with_gas_estimation, evm_version):
+def test_signed_shift(get_contract_with_gas_estimation):
     code = """
 @external
 def _sar(x: int256, y: uint256) -> int256:
@@ -66,7 +62,7 @@ def _sar(x: int256, y: uint256) -> int256:
 def _shl(x: int256, y: uint256) -> int256:
     return x << y
     """
-    c = get_contract_with_gas_estimation(code, evm_version=evm_version)
+    c = get_contract_with_gas_estimation(code)
     x = 126416208461208640982146408124
     y = 7128468721412412459
     cases = [x, y, -x, -y]
@@ -97,8 +93,7 @@ def baz(a: uint256, b: uint256, c: uint256) -> (uint256, uint256):
     assert tuple(c.baz(1, 6, 14)) == (1 + 8 | ~6 & 14 * 2, (1 + 8 | ~6) & 14 * 2) == (25, 24)
 
 
-@pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-def test_literals(get_contract, evm_version):
+def test_literals(get_contract):
     code = """
 @external
 def _shr(x: uint256) -> uint256:
@@ -109,7 +104,7 @@ def _shl(x: uint256) -> uint256:
     return x << 3
     """
 
-    c = get_contract(code, evm_version=evm_version)
+    c = get_contract(code)
     assert c._shr(80) == 10
     assert c._shl(80) == 640
 

--- a/tests/parser/functions/test_create_functions.py
+++ b/tests/parser/functions/test_create_functions.py
@@ -5,6 +5,7 @@ from hexbytes import HexBytes
 
 import vyper.ir.compile_ir as compile_ir
 from vyper.codegen.ir_node import IRnode
+from vyper.compiler.settings import OptimizationLevel
 from vyper.utils import EIP_170_LIMIT, checksum_encode, keccak256
 
 
@@ -232,7 +233,9 @@ def test(code_ofst: uint256) -> address:
     # zeroes (so no matter which offset, create_from_blueprint will
     # return empty code)
     ir = IRnode.from_list(["deploy", 0, ["seq"] + ["stop"] * initcode_len, 0])
-    bytecode, _ = compile_ir.assembly_to_evm(compile_ir.compile_to_assembly(ir, no_optimize=True))
+    bytecode, _ = compile_ir.assembly_to_evm(
+        compile_ir.compile_to_assembly(ir, optimize=OptimizationLevel.NONE)
+    )
     # manually deploy the bytecode
     c = w3.eth.contract(abi=[], bytecode=bytecode)
     deploy_transaction = c.constructor()

--- a/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
+++ b/tests/parser/parser_utils/test_annotate_and_optimize_ast.py
@@ -29,7 +29,7 @@ def foo() -> int128:
 
 
 def get_contract_info(source_code):
-    class_types, reformatted_code = pre_parse(source_code)
+    _, class_types, reformatted_code = pre_parse(source_code)
     py_ast = python_ast.parse(reformatted_code)
 
     annotate_python_ast(py_ast, reformatted_code, class_types)

--- a/tests/parser/syntax/test_address_code.py
+++ b/tests/parser/syntax/test_address_code.py
@@ -175,7 +175,7 @@ def code_runtime() -> Bytes[32]:
     return slice(self.code, 0, 32)
 """
     contract = get_contract(code)
-    settings=Settings(optimize=optimize)
+    settings = Settings(optimize=optimize)
     code_compiled = compiler.compile_code(
         code, output_formats=["bytecode", "bytecode_runtime"], settings=settings
     )

--- a/tests/parser/syntax/test_address_code.py
+++ b/tests/parser/syntax/test_address_code.py
@@ -161,7 +161,7 @@ def test_address_code_compile_success(code: str):
     compiler.compile_code(code)
 
 
-def test_address_code_self_success(get_contract, no_optimize: bool):
+def test_address_code_self_success(get_contract, optimize):
     code = """
 code_deployment: public(Bytes[32])
 
@@ -175,7 +175,7 @@ def code_runtime() -> Bytes[32]:
 """
     contract = get_contract(code)
     code_compiled = compiler.compile_code(
-        code, output_formats=["bytecode", "bytecode_runtime"], no_optimize=no_optimize
+        code, output_formats=["bytecode", "bytecode_runtime"], optimize=optimize
     )
     assert contract.code_deployment() == bytes.fromhex(code_compiled["bytecode"][2:])[:32]
     assert contract.code_runtime() == bytes.fromhex(code_compiled["bytecode_runtime"][2:])[:32]

--- a/tests/parser/syntax/test_address_code.py
+++ b/tests/parser/syntax/test_address_code.py
@@ -5,6 +5,7 @@ from eth_tester.exceptions import TransactionFailed
 from web3 import Web3
 
 from vyper import compiler
+from vyper.compiler.settings import Settings
 from vyper.exceptions import NamespaceCollision, StructureException, VyperException
 
 # For reproducibility, use precompiled data of `hello: public(uint256)` using vyper 0.3.1
@@ -174,8 +175,9 @@ def code_runtime() -> Bytes[32]:
     return slice(self.code, 0, 32)
 """
     contract = get_contract(code)
+    settings=Settings(optimize=optimize)
     code_compiled = compiler.compile_code(
-        code, output_formats=["bytecode", "bytecode_runtime"], optimize=optimize
+        code, output_formats=["bytecode", "bytecode_runtime"], settings=settings
     )
     assert contract.code_deployment() == bytes.fromhex(code_compiled["bytecode"][2:])[:32]
     assert contract.code_runtime() == bytes.fromhex(code_compiled["bytecode_runtime"][2:])[:32]

--- a/tests/parser/syntax/test_chainid.py
+++ b/tests/parser/syntax/test_chainid.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper import compiler
+from vyper.compiler.settings import Settings
 from vyper.evm.opcodes import EVM_VERSIONS
 from vyper.exceptions import InvalidType, TypeMismatch
 
@@ -12,8 +13,9 @@ def test_evm_version(evm_version):
 def foo():
     a: uint256 = chain.id
     """
+    settings = Settings(evm_version=evm_version)
 
-    assert compiler.compile_code(code, evm_version=evm_version) is not None
+    assert compiler.compile_code(code, settings=settings) is not None
 
 
 fail_list = [

--- a/tests/parser/syntax/test_codehash.py
+++ b/tests/parser/syntax/test_codehash.py
@@ -6,7 +6,7 @@ from vyper.utils import keccak256
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
-def test_get_extcodehash(get_contract, evm_version, no_optimize):
+def test_get_extcodehash(get_contract, evm_version, optimize):
     code = """
 a: address
 
@@ -31,9 +31,7 @@ def foo3() -> bytes32:
 def foo4() -> bytes32:
     return self.a.codehash
     """
-    compiled = compile_code(
-        code, ["bytecode_runtime"], evm_version=evm_version, no_optimize=no_optimize
-    )
+    compiled = compile_code(code, ["bytecode_runtime"], evm_version=evm_version, optimize=optimize)
     bytecode = bytes.fromhex(compiled["bytecode_runtime"][2:])
     hash_ = keccak256(bytecode)
 

--- a/tests/parser/syntax/test_codehash.py
+++ b/tests/parser/syntax/test_codehash.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper.compiler import compile_code
+from vyper.compiler.settings import Settings
 from vyper.evm.opcodes import EVM_VERSIONS
 from vyper.utils import keccak256
 
@@ -31,7 +32,8 @@ def foo3() -> bytes32:
 def foo4() -> bytes32:
     return self.a.codehash
     """
-    compiled = compile_code(code, ["bytecode_runtime"], evm_version=evm_version, optimize=optimize)
+    settings = Settings(evm_version=evm_version, optimize=optimize)
+    compiled = compile_code(code, ["bytecode_runtime"], settings)
     bytecode = bytes.fromhex(compiled["bytecode_runtime"][2:])
     hash_ = keccak256(bytecode)
 

--- a/tests/parser/syntax/test_codehash.py
+++ b/tests/parser/syntax/test_codehash.py
@@ -33,7 +33,7 @@ def foo4() -> bytes32:
     return self.a.codehash
     """
     settings = Settings(evm_version=evm_version, optimize=optimize)
-    compiled = compile_code(code, ["bytecode_runtime"], settings)
+    compiled = compile_code(code, ["bytecode_runtime"], settings=settings)
     bytecode = bytes.fromhex(compiled["bytecode_runtime"][2:])
     hash_ = keccak256(bytecode)
 

--- a/tests/parser/syntax/test_self_balance.py
+++ b/tests/parser/syntax/test_self_balance.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper import compiler
+from vyper.compiler.settings import Settings
 from vyper.evm.opcodes import EVM_VERSIONS
 
 
@@ -18,7 +19,8 @@ def get_balance() -> uint256:
 def __default__():
     pass
     """
-    opcodes = compiler.compile_code(code, ["opcodes"], evm_version=evm_version)["opcodes"]
+    settings = Settings(evm_version=evm_version)
+    opcodes = compiler.compile_code(code, ["opcodes"], settings=settings)["opcodes"]
     if EVM_VERSIONS[evm_version] >= EVM_VERSIONS["istanbul"]:
         assert "SELFBALANCE" in opcodes
     else:

--- a/tests/parser/types/test_dynamic_array.py
+++ b/tests/parser/types/test_dynamic_array.py
@@ -2,6 +2,7 @@ import itertools
 
 import pytest
 
+from vyper.compiler.settings import OptimizationLevel
 from vyper.exceptions import (
     ArgumentException,
     ArrayIndexException,
@@ -1543,7 +1544,7 @@ def bar(x: int128) -> DynArray[int128, 3]:
     assert c.bar(7) == [7, 14]
 
 
-def test_nested_struct_of_lists(get_contract, assert_compile_failed, no_optimize):
+def test_nested_struct_of_lists(get_contract, assert_compile_failed, optimize):
     code = """
 struct nestedFoo:
     a1: DynArray[DynArray[DynArray[uint256, 2], 2], 2]
@@ -1585,7 +1586,7 @@ def bar2() -> uint256:
         newFoo.b1[0][1][0].a1[0][0][0]
     """
 
-    if no_optimize:
+    if optimize == OptimizationLevel.NONE:
         # fails at assembly stage with too many stack variables
         assert_compile_failed(lambda: get_contract(code), Exception)
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ usedevelop = True
 commands =
     core: pytest -m "not fuzzing" --showlocals {posargs:tests/}
     no-opt: pytest -m "not fuzzing" --showlocals --no-optimize {posargs:tests/}
+    codesize: pytest -m "not fuzzing" --showlocals --optimize codesize {posargs:tests/}
 basepython =
     py310: python3.10
     py311: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 usedevelop = True
 commands =
     core: pytest -m "not fuzzing" --showlocals {posargs:tests/}
-    no-opt: pytest -m "not fuzzing" --showlocals --no-optimize {posargs:tests/}
+    no-opt: pytest -m "not fuzzing" --showlocals --optimize none {posargs:tests/}
     codesize: pytest -m "not fuzzing" --showlocals --optimize codesize {posargs:tests/}
 basepython =
     py310: python3.10

--- a/vyper/ast/__init__.py
+++ b/vyper/ast/__init__.py
@@ -6,7 +6,7 @@ import sys
 from . import nodes, validation
 from .natspec import parse_natspec
 from .nodes import compare_nodes
-from .utils import ast_to_dict, parse_to_ast
+from .utils import ast_to_dict, parse_to_ast, parse_to_ast_with_settings
 
 # adds vyper.ast.nodes classes into the local namespace
 for name, obj in (

--- a/vyper/ast/nodes.pyi
+++ b/vyper/ast/nodes.pyi
@@ -3,7 +3,8 @@ from typing import Any, Optional, Sequence, Type, Union
 
 from .natspec import parse_natspec as parse_natspec
 from .utils import ast_to_dict as ast_to_dict
-from .utils import parse_to_ast as parse_to_ast, parse_to_ast_with_settings as parse_to_ast_with_settings
+from .utils import parse_to_ast as parse_to_ast
+from .utils import parse_to_ast_with_settings as parse_to_ast_with_settings
 
 NODE_BASE_ATTRIBUTES: Any
 NODE_SRC_ATTRIBUTES: Any

--- a/vyper/ast/nodes.pyi
+++ b/vyper/ast/nodes.pyi
@@ -3,7 +3,7 @@ from typing import Any, Optional, Sequence, Type, Union
 
 from .natspec import parse_natspec as parse_natspec
 from .utils import ast_to_dict as ast_to_dict
-from .utils import parse_to_ast as parse_to_ast
+from .utils import parse_to_ast as parse_to_ast, parse_to_ast_with_settings as parse_to_ast_with_settings
 
 NODE_BASE_ATTRIBUTES: Any
 NODE_SRC_ATTRIBUTES: Any

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -112,7 +112,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, str]:
 
             if typ == COMMENT:
                 contents = string[1:].strip()
-                if contents.startswith("@version "):
+                if contents.startswith("@version"):
                     if settings.compiler_version is not None:
                         raise StructureException("compiler version specified twice!", start)
                     compiler_version = contents.removeprefix("@version ").strip()

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -1,7 +1,6 @@
 import io
 import re
 from tokenize import COMMENT, NAME, OP, TokenError, TokenInfo, tokenize, untokenize
-from typing import Tuple
 
 from semantic_version import NpmSpec, Version
 
@@ -68,7 +67,7 @@ VYPER_CLASS_TYPES = {"enum", "event", "interface", "struct"}
 VYPER_EXPRESSION_TYPES = {"log"}
 
 
-def pre_parse(code: str) -> Tuple[ModificationOffsets, str]:
+def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, str]:
     """
     Re-formats a vyper source string into a python source string and performs
     some validation.  More specifically,

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -5,7 +5,12 @@ from typing import Tuple
 
 from semantic_version import NpmSpec, Version
 
-from vyper.exceptions import SyntaxException, VersionException
+from vyper.compiler.settings import OptimizationLevel, Settings
+
+# seems a bit early to be importing this but we want it to validate the
+# evm-version pragma
+from vyper.evm.opcodes import EVM_VERSIONS
+from vyper.exceptions import StructureException, SyntaxException, VersionException
 from vyper.typing import ModificationOffsets, ParserPosition
 
 VERSION_ALPHA_RE = re.compile(r"(?<=\d)a(?=\d)")  # 0.1.0a17
@@ -33,10 +38,7 @@ def validate_version_pragma(version_str: str, start: ParserPosition) -> None:
     # NOTE: should be `x.y.z.*`
     installed_version = ".".join(__version__.split(".")[:3])
 
-    version_arr = version_str.split("@version")
-
-    raw_file_version = version_arr[1].strip()
-    strict_file_version = _convert_version_str(raw_file_version)
+    strict_file_version = _convert_version_str(version_str)
     strict_compiler_version = Version(_convert_version_str(installed_version))
 
     if len(strict_file_version) == 0:
@@ -46,14 +48,14 @@ def validate_version_pragma(version_str: str, start: ParserPosition) -> None:
         npm_spec = NpmSpec(strict_file_version)
     except ValueError:
         raise VersionException(
-            f'Version specification "{raw_file_version}" is not a valid NPM semantic '
+            f'Version specification "{version_str}" is not a valid NPM semantic '
             f"version specification",
             start,
         )
 
     if not npm_spec.match(strict_compiler_version):
         raise VersionException(
-            f'Version specification "{raw_file_version}" is not compatible '
+            f'Version specification "{version_str}" is not compatible '
             f'with compiler version "{installed_version}"',
             start,
         )
@@ -93,6 +95,7 @@ def pre_parse(code: str) -> Tuple[ModificationOffsets, str]:
     """
     result = []
     modification_offsets: ModificationOffsets = {}
+    settings = Settings()
 
     try:
         code_bytes = code.encode("utf-8")
@@ -108,8 +111,39 @@ def pre_parse(code: str) -> Tuple[ModificationOffsets, str]:
             end = token.end
             line = token.line
 
-            if typ == COMMENT and "@version" in string:
-                validate_version_pragma(string[1:], start)
+            if typ == COMMENT:
+                contents = string[1:].strip()
+                if contents.startswith("@version "):
+                    if settings.compiler_version is not None:
+                        raise StructureException("compiler version specified twice!", start)
+                    compiler_version = contents.removeprefix("@version ").strip()
+                    validate_version_pragma(compiler_version, start)
+                    settings.compiler_version = compiler_version
+
+                if string.startswith("#pragma "):
+                    pragma = string.removeprefix("#pragma").strip()
+                    if pragma.startswith("version "):
+                        if settings.compiler_version is not None:
+                            raise StructureException("pragma version specified twice!", start)
+                        compiler_version = pragma.removeprefix("version ".strip())
+                        validate_version_pragma(compiler_version, start)
+                        settings.compiler_version = compiler_version
+
+                    if pragma.startswith("optimize "):
+                        if settings.optimize is not None:
+                            raise StructureException("pragma optimize specified twice!", start)
+                        try:
+                            mode = pragma.removeprefix("optimize").strip()
+                            settings.optimize = OptimizationLevel.from_string(mode)
+                        except ValueError:
+                            raise StructureException(f"Invalid optimization mode `{mode}`", start)
+                    if pragma.startswith("evm-version "):
+                        if settings.evm_version is not None:
+                            raise StructureException("pragma evm-version specified twice!", start)
+                        evm_version = pragma.removeprefix("evm-version").strip()
+                        if evm_version not in EVM_VERSIONS:
+                            raise StructureException("Invalid evm version: `{evm_version}`", start)
+                        settings.evm_version = evm_version
 
             if typ == NAME and string in ("class", "yield"):
                 raise SyntaxException(
@@ -130,4 +164,4 @@ def pre_parse(code: str) -> Tuple[ModificationOffsets, str]:
     except TokenError as e:
         raise SyntaxException(e.args[0], code, e.args[1][0], e.args[1][1]) from e
 
-    return modification_offsets, untokenize(result).decode("utf-8")
+    return settings, modification_offsets, untokenize(result).decode("utf-8")

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Union
 from vyper.ast import nodes as vy_ast
 from vyper.ast.annotation import annotate_python_ast
 from vyper.ast.pre_parser import pre_parse
+from vyper.compiler.settings import Settings
 from vyper.exceptions import CompilerPanic, ParserException, SyntaxException
 
 
@@ -12,7 +13,7 @@ def parse_to_ast(
     source_id: int = 0,
     contract_name: Optional[str] = None,
     add_fn_node: Optional[str] = None,
-) -> vy_ast.Module:
+) -> tuple[Settings, vy_ast.Module]:
     """
     Parses a Vyper source string and generates basic Vyper AST nodes.
 
@@ -34,7 +35,7 @@ def parse_to_ast(
     """
     if "\x00" in source_code:
         raise ParserException("No null bytes (\\x00) allowed in the source code.")
-    class_types, reformatted_code = pre_parse(source_code)
+    settings, class_types, reformatted_code = pre_parse(source_code)
     try:
         py_ast = python_ast.parse(reformatted_code)
     except SyntaxError as e:
@@ -51,7 +52,7 @@ def parse_to_ast(
     annotate_python_ast(py_ast, source_code, class_types, source_id, contract_name)
 
     # Convert to Vyper AST.
-    return vy_ast.get_node(py_ast)  # type: ignore
+    return settings, vy_ast.get_node(py_ast)
 
 
 def ast_to_dict(ast_struct: Union[vy_ast.VyperNode, List]) -> Union[Dict, List]:

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -52,7 +52,9 @@ def parse_to_ast(
     annotate_python_ast(py_ast, source_code, class_types, source_id, contract_name)
 
     # Convert to Vyper AST.
-    return settings, vy_ast.get_node(py_ast)
+    module = vy_ast.get_node(py_ast)
+    assert isinstance(module, vy_ast.Module)  # mypy hint
+    return settings, module
 
 
 def ast_to_dict(ast_struct: Union[vy_ast.VyperNode, List]) -> Union[Dict, List]:

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -1,5 +1,5 @@
 import ast as python_ast
-from typing import Dict, List, Optional, Union, Any
+from typing import Any, Dict, List, Optional, Union
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.annotation import annotate_python_ast

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -1,5 +1,5 @@
 import ast as python_ast
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.annotation import annotate_python_ast
@@ -8,7 +8,11 @@ from vyper.compiler.settings import Settings
 from vyper.exceptions import CompilerPanic, ParserException, SyntaxException
 
 
-def parse_to_ast(
+def parse_to_ast(*args: Any, **kwargs: Any) -> vy_ast.Module:
+    return parse_to_ast_with_settings(*args, **kwargs)[1]
+
+
+def parse_to_ast_with_settings(
     source_code: str,
     source_id: int = 0,
     contract_name: Optional[str] = None,

--- a/vyper/cli/utils.py
+++ b/vyper/cli/utils.py
@@ -27,7 +27,7 @@ def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
 
 
 def extract_file_interface_imports(code: SourceCode) -> InterfaceImports:
-    _pragmas, ast_tree = vy_ast.parse_to_ast(code)
+    ast_tree = vy_ast.parse_to_ast(code)
 
     imports_dict: InterfaceImports = {}
     for node in ast_tree.get_children((vy_ast.Import, vy_ast.ImportFrom)):

--- a/vyper/cli/utils.py
+++ b/vyper/cli/utils.py
@@ -27,7 +27,7 @@ def get_interface_file_path(base_paths: Sequence, import_path: str) -> Path:
 
 
 def extract_file_interface_imports(code: SourceCode) -> InterfaceImports:
-    ast_tree = vy_ast.parse_to_ast(code)
+    _pragmas, ast_tree = vy_ast.parse_to_ast(code)
 
     imports_dict: InterfaceImports = {}
     for node in ast_tree.get_children((vy_ast.Import, vy_ast.ImportFrom)):

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, Set, TypeVar
+from typing import Dict, Iterable, Iterator, Optional, Set, TypeVar
 
 import vyper
 import vyper.codegen.ir_node as ir_node
@@ -266,8 +266,8 @@ def compile_files(
     output_formats: OutputFormats,
     root_folder: str = ".",
     show_gas_estimates: bool = False,
-    settings: Settings = None,
-    storage_layout: Iterable[str] = None,
+    settings: Optional[Settings] = None,
+    storage_layout: Optional[Iterable[str]] = None,
     no_bytecode_metadata: bool = False,
 ) -> OrderedDict:
     root_path = Path(root_folder).resolve()

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -155,7 +155,9 @@ def _parse_args(argv):
     if args.no_optimize and args.optimize:
         raise ValueError("Cannot use `--no-optimize` and `--optimize` at the same time!")
 
-    optimize = OptimizationLevel.NONE if args.no_optimize else OptimizationLevel.from_string(args.optimize)
+    optimize = (
+        OptimizationLevel.NONE if args.no_optimize else OptimizationLevel.from_string(args.optimize)
+    )
 
     compiled = compile_files(
         args.input_files,

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -155,9 +155,10 @@ def _parse_args(argv):
     if args.no_optimize and args.optimize:
         raise ValueError("Cannot use `--no-optimize` and `--optimize` at the same time!")
 
-    optimize = (
-        OptimizationLevel.NONE if args.no_optimize else OptimizationLevel.from_string(args.optimize)
-    )
+    if args.no_optimize or not args.optimize:
+        optimize = OptimizationLevel.NONE
+    else:
+        optimize = OptimizationLevel.from_string(args.optimize)
 
     compiled = compile_files(
         args.input_files,

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -11,7 +11,7 @@ import vyper
 import vyper.codegen.ir_node as ir_node
 from vyper.cli import vyper_json
 from vyper.cli.utils import extract_file_interface_imports, get_interface_file_path
-from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel
+from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel, Settings
 from vyper.evm.opcodes import DEFAULT_EVM_VERSION, EVM_VERSIONS
 from vyper.typing import ContractCodes, ContractPath, OutputFormats
 
@@ -102,7 +102,6 @@ def _parse_args(argv):
         help=f"Select desired EVM version (default {DEFAULT_EVM_VERSION}). "
         "note: cancun support is EXPERIMENTAL",
         choices=list(EVM_VERSIONS),
-        default=DEFAULT_EVM_VERSION,
         dest="evm_version",
     )
     parser.add_argument("--no-optimize", help="Do not optimize", action="store_true")
@@ -155,18 +154,25 @@ def _parse_args(argv):
     if args.no_optimize and args.optimize:
         raise ValueError("Cannot use `--no-optimize` and `--optimize` at the same time!")
 
-    if args.no_optimize or not args.optimize:
-        optimize = OptimizationLevel.NONE
-    else:
-        optimize = OptimizationLevel.from_string(args.optimize)
+    settings = Settings()
+
+    if args.no_optimize:
+        settings.optimize = OptimizationLevel.NONE
+    elif args.optimize is not None:
+        settings.optimize = OptimizationLevel.from_string(args.optimize)
+
+    if args.evm_version:
+        settings.evm_version = args.evm_version
+
+    if args.verbose:
+        print(f"using `{settings}`", file=sys.stderr)
 
     compiled = compile_files(
         args.input_files,
         output_formats,
         args.root_folder,
         args.show_gas_estimates,
-        args.evm_version,
-        optimize,
+        settings,
         args.storage_layout,
         args.no_bytecode_metadata,
     )
@@ -260,8 +266,7 @@ def compile_files(
     output_formats: OutputFormats,
     root_folder: str = ".",
     show_gas_estimates: bool = False,
-    evm_version: str = DEFAULT_EVM_VERSION,
-    optimize: OptimizationLevel = OptimizationLevel.GAS,
+    settings: Settings = None,
     storage_layout: Iterable[str] = None,
     no_bytecode_metadata: bool = False,
 ) -> OrderedDict:
@@ -303,8 +308,7 @@ def compile_files(
         final_formats,
         exc_handler=exc_handler,
         interface_codes=get_interface_codes(root_path, contract_sources),
-        evm_version=evm_version,
-        optimize=optimize,
+        settings=settings,
         storage_layouts=storage_layouts,
         show_gas_estimates=show_gas_estimates,
         no_bytecode_metadata=no_bytecode_metadata,

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -11,7 +11,7 @@ import vyper
 import vyper.codegen.ir_node as ir_node
 from vyper.cli import vyper_json
 from vyper.cli.utils import extract_file_interface_imports, get_interface_file_path
-from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT
+from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel
 from vyper.evm.opcodes import DEFAULT_EVM_VERSION, EVM_VERSIONS
 from vyper.typing import ContractCodes, ContractPath, OutputFormats
 
@@ -37,8 +37,6 @@ opcodes_runtime    - List of runtime opcodes as a string
 ir                 - Intermediate representation in list format
 ir_json            - Intermediate representation in JSON format
 hex-ir             - Output IR and assembly constants in hex instead of decimal
-no-optimize        - Do not optimize (don't use this for production code)
-no-bytecode-metadata - Do not add metadata to bytecode
 """
 
 combined_json_outputs = [
@@ -108,6 +106,7 @@ def _parse_args(argv):
         dest="evm_version",
     )
     parser.add_argument("--no-optimize", help="Do not optimize", action="store_true")
+    parser.add_argument("--optimize", help="Optimization flag", choices=["gas", "codesize"])
     parser.add_argument(
         "--no-bytecode-metadata", help="Do not add metadata to bytecode", action="store_true"
     )
@@ -153,13 +152,18 @@ def _parse_args(argv):
 
     output_formats = tuple(uniq(args.format.split(",")))
 
+    if args.no_optimize and args.optimize:
+        raise ValueError("Cannot use `--no-optimize` and `--optimize` at the same time!")
+
+    optimize = OptimizationLevel.NONE if args.no_optimize else OptimizationLevel.from_string(args.optimize)
+
     compiled = compile_files(
         args.input_files,
         output_formats,
         args.root_folder,
         args.show_gas_estimates,
         args.evm_version,
-        args.no_optimize,
+        optimize,
         args.storage_layout,
         args.no_bytecode_metadata,
     )
@@ -254,7 +258,7 @@ def compile_files(
     root_folder: str = ".",
     show_gas_estimates: bool = False,
     evm_version: str = DEFAULT_EVM_VERSION,
-    no_optimize: bool = False,
+    optimize: OptimizationLevel = OptimizationLevel.GAS,
     storage_layout: Iterable[str] = None,
     no_bytecode_metadata: bool = False,
 ) -> OrderedDict:
@@ -297,7 +301,7 @@ def compile_files(
         exc_handler=exc_handler,
         interface_codes=get_interface_codes(root_path, contract_sources),
         evm_version=evm_version,
-        no_optimize=no_optimize,
+        optimize=optimize,
         storage_layouts=storage_layouts,
         show_gas_estimates=show_gas_estimates,
         no_bytecode_metadata=no_bytecode_metadata,

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -366,7 +366,9 @@ def compile_from_input_dict(
     optimize = input_dict["settings"].get("optimize", "gas")
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility
-        warnings.warn("optimize: <bool> is deprecated! please use one of 'gas', 'codesize', 'none'.")
+        warnings.warn(
+            "optimize: <bool> is deprecated! please use one of 'gas', 'codesize', 'none'."
+        )
         optimize = OptimizationLevel.GAS if optimize else OptimizationLevel.NONE
     else:
         optimize = OptimizationLevel.from_string(optimize)

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -372,7 +372,7 @@ def compile_from_input_dict(
         warnings.warn(
             "optimize: <bool> is deprecated! please use one of 'gas', 'codesize', 'none'."
         )
-        optimize = OptimizationLevel.GAS if optimize else OptimizationLevel.NONE
+        optimize = OptimizationLevel.default() if optimize else OptimizationLevel.NONE
     elif isinstance(optimize, str):
         optimize = OptimizationLevel.from_string(optimize)
     else:

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -361,7 +361,6 @@ def compile_from_input_dict(
         raise JSONError(f"Invalid language '{input_dict['language']}' - Only Vyper is supported.")
 
     evm_version = get_evm_version(input_dict)
-    input_dict["settings"].get()
 
     optimize = input_dict["settings"].get("optimize", "gas")
     if isinstance(optimize, bool):

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -5,7 +5,7 @@ import json
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, Hashable, List, Tuple, Union
+from typing import Any, Callable, Dict, Hashable, List, Optional, Tuple, Union
 
 import vyper
 from vyper.cli.utils import extract_file_interface_imports, get_interface_file_path
@@ -145,7 +145,7 @@ def _standardize_path(path_str: str) -> str:
     return path.as_posix()
 
 
-def get_evm_version(input_dict: Dict) -> str:
+def get_evm_version(input_dict: Dict) -> Optional[str]:
     if "settings" not in input_dict:
         return None
 
@@ -361,7 +361,7 @@ def compile_from_input_dict(
     if input_dict["language"] != "Vyper":
         raise JSONError(f"Invalid language '{input_dict['language']}' - Only Vyper is supported.")
 
-    evm_version = input_dict.get("evm_version")
+    evm_version = get_evm_version(input_dict)
 
     optimize = input_dict["settings"].get("optimize")
     if isinstance(optimize, bool):

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -151,6 +151,9 @@ def get_evm_version(input_dict: Dict) -> Optional[str]:
 
     # TODO: move this validation somewhere it can be reused more easily
     evm_version = input_dict["settings"].get("evmVersion")
+    if evm_version is None:
+        return None
+
     if evm_version in (
         "homestead",
         "tangerineWhistle",

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -2,12 +2,13 @@ from functools import cached_property
 from typing import Optional
 
 from vyper import ast as vy_ast
+from vyper.compiler.settings import OptimizationLevel
 
 
 # Datatype to store all global context information.
 # TODO: rename me to ModuleT
 class GlobalContext:
-    def __init__(self, module: Optional[vy_ast.Module] = None):
+    def __init__(self, module: Optional[vy_ast.Module] = None, optimize = OptimizationLevel.GAS):
         self._module = module
 
     @cached_property

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -2,13 +2,12 @@ from functools import cached_property
 from typing import Optional
 
 from vyper import ast as vy_ast
-from vyper.compiler.settings import OptimizationLevel
 
 
 # Datatype to store all global context information.
 # TODO: rename me to ModuleT
 class GlobalContext:
-    def __init__(self, module: Optional[vy_ast.Module] = None, optimize=OptimizationLevel.GAS):
+    def __init__(self, module: Optional[vy_ast.Module] = None):
         self._module = module
 
     @cached_property

--- a/vyper/codegen/global_context.py
+++ b/vyper/codegen/global_context.py
@@ -8,7 +8,7 @@ from vyper.compiler.settings import OptimizationLevel
 # Datatype to store all global context information.
 # TODO: rename me to ModuleT
 class GlobalContext:
-    def __init__(self, module: Optional[vy_ast.Module] = None, optimize = OptimizationLevel.GAS):
+    def __init__(self, module: Optional[vy_ast.Module] = None, optimize=OptimizationLevel.GAS):
         self._module = module
 
     @cached_property

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -54,7 +54,7 @@ def compile_codes(
     interface_codes: Union[InterfaceDict, InterfaceImports, None] = None,
     initial_id: int = 0,
     settings: Settings = None,
-    storage_layouts: Dict[ContractPath, StorageLayout] = None,
+    storage_layouts: Optional[dict[ContractPath, Optional[StorageLayout]]] = None,
     show_gas_estimates: bool = False,
     no_bytecode_metadata: bool = False,
 ) -> OrderedDict:
@@ -95,8 +95,7 @@ def compile_codes(
     Dict
         Compiler output as `{'contract name': {'output key': "output data"}}`
     """
-
-    settings = settings or None
+    settings = settings or Settings()
 
     if output_formats is None:
         output_formats = ("bytecode",)
@@ -156,7 +155,7 @@ def compile_code(
     output_formats: Optional[OutputFormats] = None,
     interface_codes: Optional[InterfaceImports] = None,
     settings: Settings = None,
-    storage_layout_override: StorageLayout = None,
+    storage_layout_override: Optional[StorageLayout] = None,
     show_gas_estimates: bool = False,
 ) -> dict:
     """

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -171,8 +171,8 @@ def compile_code(
     evm_version: str, optional
         The target EVM ruleset to compile for. If not given, defaults to the latest
         implemented ruleset.
-    optimize: OptimizationLevel, optional
-        Set optimization mode. Defaults to OptimizationLevel.GAS
+    settings: Settings, optional
+        Compiler settings.
     show_gas_estimates: bool, optional
         Show gas estimates for abi and ir output modes
     interface_codes: Dict, optional

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -53,7 +53,7 @@ def compile_codes(
     exc_handler: Union[Callable, None] = None,
     interface_codes: Union[InterfaceDict, InterfaceImports, None] = None,
     initial_id: int = 0,
-    no_optimize: bool = False,
+    optimize: OptimizationLevel = OptimizationLevel.GAS,
     storage_layouts: Dict[ContractPath, StorageLayout] = None,
     show_gas_estimates: bool = False,
     no_bytecode_metadata: bool = False,
@@ -76,8 +76,8 @@ def compile_codes(
     evm_version: str, optional
         The target EVM ruleset to compile for. If not given, defaults to the latest
         implemented ruleset.
-    no_optimize: bool, optional
-        Turn off optimizations. Defaults to False
+    optimize: OptimizerLevel, optional
+        Set optimization mode. Defaults to OptimizationLevel.GAS
     show_gas_estimates: bool, optional
         Show gas estimates for abi and ir output modes
     interface_codes: Dict, optional
@@ -126,7 +126,7 @@ def compile_codes(
             contract_name,
             interfaces,
             source_id,
-            no_optimize,
+            optimize,
             storage_layout_override,
             show_gas_estimates,
             no_bytecode_metadata,
@@ -154,7 +154,7 @@ def compile_code(
     output_formats: Optional[OutputFormats] = None,
     interface_codes: Optional[InterfaceImports] = None,
     evm_version: str = DEFAULT_EVM_VERSION,
-    no_optimize: bool = False,
+    optimize: OptimizerLevel = OptimizerLevel.GAS,
     storage_layout_override: StorageLayout = None,
     show_gas_estimates: bool = False,
 ) -> dict:
@@ -171,8 +171,8 @@ def compile_code(
     evm_version: str, optional
         The target EVM ruleset to compile for. If not given, defaults to the latest
         implemented ruleset.
-    no_optimize: bool, optional
-        Turn off optimizations. Defaults to False
+    optimize: OptimizerLevel, optional
+        Set optimization mode. Defaults to OptimizationLevel.GAS
     show_gas_estimates: bool, optional
         Show gas estimates for abi and ir output modes
     interface_codes: Dict, optional
@@ -195,7 +195,7 @@ def compile_code(
         output_formats,
         interface_codes=interface_codes,
         evm_version=evm_version,
-        no_optimize=no_optimize,
+        optimize=optimize,
         storage_layouts=storage_layouts,
         show_gas_estimates=show_gas_estimates,
     )[UNKNOWN_CONTRACT_NAME]

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -5,7 +5,7 @@ import vyper.ast as vy_ast  # break an import cycle
 import vyper.codegen.core as codegen
 import vyper.compiler.output as output
 from vyper.compiler.phases import CompilerData
-from vyper.compiler.settings import OptimizerLevel
+from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import DEFAULT_EVM_VERSION, evm_wrapper
 from vyper.typing import (
     ContractCodes,
@@ -54,7 +54,7 @@ def compile_codes(
     exc_handler: Union[Callable, None] = None,
     interface_codes: Union[InterfaceDict, InterfaceImports, None] = None,
     initial_id: int = 0,
-    optimize: OptimizerLevel = OptimizerLevel.GAS,
+    optimize: OptimizationLevel = OptimizationLevel.GAS,
     storage_layouts: Dict[ContractPath, StorageLayout] = None,
     show_gas_estimates: bool = False,
     no_bytecode_metadata: bool = False,
@@ -77,7 +77,7 @@ def compile_codes(
     evm_version: str, optional
         The target EVM ruleset to compile for. If not given, defaults to the latest
         implemented ruleset.
-    optimize: OptimizerLevel, optional
+    optimize: OptimizationLevel, optional
         Set optimization mode. Defaults to OptimizationLevel.GAS
     show_gas_estimates: bool, optional
         Show gas estimates for abi and ir output modes
@@ -155,7 +155,7 @@ def compile_code(
     output_formats: Optional[OutputFormats] = None,
     interface_codes: Optional[InterfaceImports] = None,
     evm_version: str = DEFAULT_EVM_VERSION,
-    optimize: OptimizerLevel = OptimizerLevel.GAS,
+    optimize: OptimizationLevel = OptimizationLevel.GAS,
     storage_layout_override: StorageLayout = None,
     show_gas_estimates: bool = False,
 ) -> dict:
@@ -172,7 +172,7 @@ def compile_code(
     evm_version: str, optional
         The target EVM ruleset to compile for. If not given, defaults to the latest
         implemented ruleset.
-    optimize: OptimizerLevel, optional
+    optimize: OptimizationLevel, optional
         Set optimization mode. Defaults to OptimizationLevel.GAS
     show_gas_estimates: bool, optional
         Show gas estimates for abi and ir output modes

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -5,6 +5,7 @@ import vyper.ast as vy_ast  # break an import cycle
 import vyper.codegen.core as codegen
 import vyper.compiler.output as output
 from vyper.compiler.phases import CompilerData
+from vyper.compiler.settings import OptimizerLevel
 from vyper.evm.opcodes import DEFAULT_EVM_VERSION, evm_wrapper
 from vyper.typing import (
     ContractCodes,
@@ -53,7 +54,7 @@ def compile_codes(
     exc_handler: Union[Callable, None] = None,
     interface_codes: Union[InterfaceDict, InterfaceImports, None] = None,
     initial_id: int = 0,
-    optimize: OptimizationLevel = OptimizationLevel.GAS,
+    optimize: OptimizerLevel = OptimizerLevel.GAS,
     storage_layouts: Dict[ContractPath, StorageLayout] = None,
     show_gas_estimates: bool = False,
     no_bytecode_metadata: bool = False,

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -7,6 +7,7 @@ from vyper import ast as vy_ast
 from vyper.codegen import module
 from vyper.codegen.global_context import GlobalContext
 from vyper.codegen.ir_node import IRnode
+from vyper.compiler.settings import OptimizationLevel
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics import set_data_positions, validate_semantics
 from vyper.semantics.types.function import ContractFunctionT
@@ -260,7 +261,9 @@ def generate_ir_nodes(global_ctx: GlobalContext, optimize: bool) -> tuple[IRnode
     return ir_nodes, ir_runtime
 
 
-def generate_assembly(ir_nodes: IRnode, optimize: OptimizationLevel = OptimizationLevel.GAS) -> list:
+def generate_assembly(
+    ir_nodes: IRnode, optimize: OptimizationLevel = OptimizationLevel.GAS
+) -> list:
     """
     Generate assembly instructions from IR.
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -225,7 +225,7 @@ def generate_ast(
     vy_ast.Module
         Top-level Vyper AST node
     """
-    return vy_ast.parse_to_ast(source_code, source_id, contract_name)
+    return vy_ast.parse_to_ast_with_settings(source_code, source_id, contract_name)
 
 
 def generate_unfolded_ast(

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -8,11 +8,11 @@ from vyper.codegen import module
 from vyper.codegen.global_context import GlobalContext
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.exceptions import StructureException
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics import set_data_positions, validate_semantics
 from vyper.semantics.types.function import ContractFunctionT
 from vyper.typing import InterfaceImports, StorageLayout
-from vyper.exceptions import StructureException
 
 
 class CompilerData:

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -309,7 +309,7 @@ def generate_assembly(ir_nodes: IRnode, optimize: Optional[OptimizationLevel] = 
     list
         List of assembly instructions.
     """
-    optimize = optimize or OptimizationLevel.GAS
+    optimize = optimize or OptimizationLevel.default()
     assembly = compile_ir.compile_to_assembly(ir_nodes, optimize=optimize)
 
     if _find_nested_opcode(assembly, "DEBUG"):

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -298,9 +298,7 @@ def generate_ir_nodes(global_ctx: GlobalContext, optimize: bool) -> tuple[IRnode
     return ir_nodes, ir_runtime
 
 
-def generate_assembly(
-    ir_nodes: IRnode, optimize: OptimizationLevel = OptimizationLevel.GAS
-) -> list:
+def generate_assembly(ir_nodes: IRnode, optimize: Optional[OptimizationLevel] = None) -> list:
     """
     Generate assembly instructions from IR.
 
@@ -314,6 +312,7 @@ def generate_assembly(
     list
         List of assembly instructions.
     """
+    optimize = optimize or OptimizationLevel.GAS
     assembly = compile_ir.compile_to_assembly(ir_nodes, optimize=optimize)
 
     if _find_nested_opcode(assembly, "DEBUG"):

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -12,6 +12,7 @@ from vyper.ir import compile_ir, optimizer
 from vyper.semantics import set_data_positions, validate_semantics
 from vyper.semantics.types.function import ContractFunctionT
 from vyper.typing import InterfaceImports, StorageLayout
+from vyper.exceptions import StructureException
 
 
 class CompilerData:
@@ -96,22 +97,18 @@ class CompilerData:
                 self.settings.evm_version is not None
                 and self.settings.evm_version != settings.evm_version
             ):
-                # TODO: consider raising an exception
-                warnings.warn(
+                raise StructureException(
                     f"compiler settings indicate evm version {self.settings.evm_version}, "
-                    f"but source pragma indicates {settings.evm_version}.\n"
-                    f"using `evm version: {self.settings.evm_version}`!"
+                    f"but source pragma indicates {settings.evm_version}."
                 )
 
             self.settings.evm_version = settings.evm_version
 
         if settings.optimize is not None:
             if self.settings.optimize is not None and self.settings.optimize != settings.optimize:
-                # TODO: consider raising an exception
-                warnings.warn(
+                raise StructureException(
                     f"compiler options indicate optimization mode {self.settings.optimize}, "
-                    f"but source pragma indicates {settings.optimize}.\n"
-                    f"using `optimize: {self.settings.optimize}`!"
+                    f"but source pragma indicates {settings.optimize}."
                 )
             self.settings.optimize = settings.optimize
 

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -1,6 +1,6 @@
 import os
-from typing import Optional
 from enum import Enum
+from typing import Optional
 
 VYPER_COLOR_OUTPUT = os.environ.get("VYPER_COLOR_OUTPUT", "0") == "1"
 VYPER_ERROR_CONTEXT_LINES = int(os.environ.get("VYPER_ERROR_CONTEXT_LINES", "1"))
@@ -13,6 +13,7 @@ if _tb_limit_str is not None:
     VYPER_TRACEBACK_LIMIT = int(_tb_limit_str)
 else:
     VYPER_TRACEBACK_LIMIT = None
+
 
 class OptimizationLevel(Enum):
     NONE = 0
@@ -30,6 +31,6 @@ class OptimizationLevel(Enum):
                 return cls.CODESIZE
         raise ValueError(f"unrecognized optimization level: {val}")
 
-    #@classmethod
-    #def default(cls):
+    # @classmethod
+    # def default(cls):
     #    return cls.GAS

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
@@ -16,9 +17,9 @@ else:
 
 
 class OptimizationLevel(Enum):
-    NONE = 0
-    GAS = 1
-    CODESIZE = 2
+    NONE = 1
+    GAS = 2
+    CODESIZE = 3
 
     @classmethod
     def from_string(cls, val):
@@ -31,6 +32,13 @@ class OptimizationLevel(Enum):
                 return cls.CODESIZE
         raise ValueError(f"unrecognized optimization level: {val}")
 
-    # @classmethod
-    # def default(cls):
-    #    return cls.GAS
+    @classmethod
+    def default(cls):
+        return cls.GAS
+
+
+@dataclass
+class Settings:
+    compiler_version: Optional[str] = None
+    optimize: Optional[OptimizationLevel] = None
+    evm_version: Optional[str] = None

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+from enum import Enum
 
 VYPER_COLOR_OUTPUT = os.environ.get("VYPER_COLOR_OUTPUT", "0") == "1"
 VYPER_ERROR_CONTEXT_LINES = int(os.environ.get("VYPER_ERROR_CONTEXT_LINES", "1"))
@@ -12,3 +13,23 @@ if _tb_limit_str is not None:
     VYPER_TRACEBACK_LIMIT = int(_tb_limit_str)
 else:
     VYPER_TRACEBACK_LIMIT = None
+
+class OptimizationLevel(Enum):
+    NONE = 0
+    GAS = 1
+    CODESIZE = 2
+
+    @classmethod
+    def from_string(cls, val):
+        match val:
+            case "none":
+                return cls.NONE
+            case "gas":
+                return cls.GAS
+            case "codesize":
+                return cls.CODESIZE
+        raise ValueError(f"unrecognized optimization level: {val}")
+
+    #@classmethod
+    #def default(cls):
+    #    return cls.GAS

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import Dict, Optional
 
 from vyper.exceptions import CompilerPanic
@@ -206,17 +207,16 @@ PSEUDO_OPCODES: OpcodeMap = {
 IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 
-def evm_wrapper(fn, *args, **kwargs):
-    def _wrapper(*args, **kwargs):
-        global active_evm_version
-        evm_version = kwargs.pop("evm_version", None) or DEFAULT_EVM_VERSION
-        active_evm_version = EVM_VERSIONS[evm_version]
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            active_evm_version = EVM_VERSIONS[DEFAULT_EVM_VERSION]
-
-    return _wrapper
+@contextlib.contextmanager
+def anchor_evm_version(evm_version: str = None):
+    global active_evm_version
+    anchor = active_evm_version
+    evm_version = evm_version or DEFAULT_EVM_VERSION
+    active_evm_version = EVM_VERSIONS[evm_version]
+    try:
+        yield
+    finally:
+        active_evm_version = anchor
 
 
 def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -1,5 +1,5 @@
 import contextlib
-from typing import Dict, Optional
+from typing import Dict, Generator, Optional
 
 from vyper.exceptions import CompilerPanic
 from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRulesetValue, OpcodeValue
@@ -208,7 +208,7 @@ IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 
 @contextlib.contextmanager
-def anchor_evm_version(evm_version: str = None):
+def anchor_evm_version(evm_version: Optional[str] = None) -> Generator:
     global active_evm_version
     anchor = active_evm_version
     evm_version = evm_version or DEFAULT_EVM_VERSION

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -201,7 +201,7 @@ def apply_line_numbers(func):
 
 
 @apply_line_numbers
-def compile_to_assembly(code, no_optimize=False):
+def compile_to_assembly(code, optimize=OptimizationLevel.GAS):
     global _revert_label
     _revert_label = mksymbol("revert")
 
@@ -212,7 +212,7 @@ def compile_to_assembly(code, no_optimize=False):
     res = _compile_to_assembly(code)
 
     _add_postambles(res)
-    if not no_optimize:
+    if optimize != OptimizationLevel.NONE:
         _optimize_assembly(res)
     return res
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -3,6 +3,7 @@ import functools
 import math
 
 from vyper.codegen.ir_node import IRnode
+from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import get_opcodes, version_check
 from vyper.exceptions import CodegenPanic, CompilerPanic
 from vyper.utils import MemoryPositions

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -337,7 +337,7 @@ def _add_import(
         raise UndeclaredDefinition(f"Unknown interface: {name}. {suggestions_str}", node)
 
     if interface_codes[name]["type"] == "vyper":
-        interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)
+        _, interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)
         type_ = InterfaceT.from_ast(interface_ast)
     elif interface_codes[name]["type"] == "json":
         type_ = InterfaceT.from_json_abi(name, interface_codes[name]["code"])  # type: ignore

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -337,7 +337,7 @@ def _add_import(
         raise UndeclaredDefinition(f"Unknown interface: {name}. {suggestions_str}", node)
 
     if interface_codes[name]["type"] == "vyper":
-        _, interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)
+        interface_ast = vy_ast.parse_to_ast(interface_codes[name]["code"], contract_name=name)
         type_ = InterfaceT.from_ast(interface_ast)
     elif interface_codes[name]["type"] == "json":
         type_ = InterfaceT.from_json_abi(name, interface_codes[name]["code"])  # type: ignore


### PR DESCRIPTION
this commit adds the `--optimize` flag to the vyper cli, which can take the values of `"codesize"` and `"gas"`, and as an option in vyper json. it is to be used separately from the `--no-optimize` flag. this commit does not actually change any codegen, just adds the flag, threads it through the codebase so it is available once we want to start differentiating between the two modes, and sets up the test harness to test both modes.

### What I did

### How I did it

### How to verify it

### Commit message

```
this commit adds the `--optimize` flag to the vyper cli, and as an
option in vyper json. it is to be used separately from the
`--no-optimize` flag. this commit does not actually change codegen,
just adds the flag and threads it through the codebase so it is
available once we want to start differentiating between the two modes,
and sets up the test harness to test both modes.

it also makes the `optimize` and `evm-version` available as source code
pragmas, and adds an additional syntax for specifying the compiler
version (`#pragma version X.Y.Z`). if the CLI / JSON options conflict
with the source code pragmas, an exception is raised.

this commit also:
* bumps mypy - it was needed to bump to 0.940 to handle match/case, and
  discovered we could bump all the way to 0.98* without breaking
  anything
* removes evm_version from bitwise op tests - it was probably important
  when we supported pre-constantinople targets, which we don't anymore
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
