### PR TITLE
Optimize "if + goto" + minor function dispatcher optmizations

### DIFF
--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -150,7 +150,7 @@ def _add_postambles(asm_ops):
 
     global _revert_label
 
-    _revert_string = [_revert_label, "JUMPDEST", *PUSH(0), "DUP1", "REVERT"]
+    _revert_string = [_revert_label, "JUMPDEST", *PUSH(0), *PUSH(0), "REVERT"]
 
     if _revert_label in asm_ops:
         # shared failure block
@@ -932,6 +932,50 @@ def _stack_peephole_opts(assembly):
     return changed
 
 
+def _is_sym(asm):
+    return isinstance(asm, str) and asm.startswith('_sym_')
+
+
+def _merge_staggered_jumps(assembly):
+    '''
+    <cond>
+    <join_dest>
+    jumpi
+        <alt_dest>
+        jump
+    join_dest:
+
+    =>
+
+    <cond>
+    iszero
+    <alt_dest>
+    jumpi
+    '''
+    pattern_size = 6
+    changed = False
+    i = 0
+    while i < len(assembly) - pattern_size + 1:
+        target_dest, jumpi, alt_dest, jump, land_dest, jt = assembly[i:i + pattern_size]
+        if _is_sym(target_dest)\
+                and _is_sym(alt_dest)\
+                and target_dest == land_dest\
+                and jumpi == 'JUMPI'\
+                and jump == 'JUMP'\
+                and jt == 'JUMPDEST':
+            assembly[i + 0] = 'ISZERO'
+            assembly[i + 1] = alt_dest
+            assembly[i + 2] = 'JUMPI'
+            del assembly[i + 5]
+            del assembly[i + 4]
+            del assembly[i + 3]
+            changed = True
+
+        i += 1
+
+    return changed
+
+
 # optimize assembly, in place
 def _optimize_assembly(assembly):
     for x in assembly:
@@ -947,6 +991,7 @@ def _optimize_assembly(assembly):
         changed |= _prune_inefficient_jumps(assembly)
         changed |= _prune_unused_jumpdests(assembly)
         changed |= _stack_peephole_opts(assembly)
+        changed |= _merge_staggered_jumps(assembly)
 
         if not changed:
             return


### PR DESCRIPTION
### What I did

- **If + goto:** Add the optimization pattern `... <join> JUMPI <alt> JUMP <join>: JUMPDEST` => `... ISZERO <alt> JUMPI` the unoptimized version would typically be found in the function dispatcher. The optimization reduces the gas use for the `<alt>` branch by 11 gas (-1x JUMP, -1x PUSH), for other branch costs are reduced by 4 gas if the ISZERO is optimized out (-1x ISZERO, -1x JUMDPEST) otherwise the cost is increased by 2 (+1x ISZERO, -1x JUMDPEST)
- **Revert when no fallback:** Improved the IR-gen for when there's no fallback function: the first calldatasize will reuse the global revert dest and the end of the function dispatcher chain will step to the revert without needing a JUMPDEST.

### How I did it

- Added `_merge_staggered_jumps` to `_optimize_assembly`
- Replace `[if, <cond>, goto fallback]` with `[assert, !<cond>]` in IR gen
- Do not generate fallback label if there's no fallback function, instead place simple revert

### How to verify it

Run the tests?

### Commit message

`feat: Optimize redundant jumpi + jump and simplify function dispatcher`

### Description for the changelog

- Optimizes certain branch constellations
- Reduces code size of function dispatcher when there's no fallback function

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/21957732/d6d2f512-1495-4ca2-88f2-da4f55f1d4f7)
