### PR TITLE
feat: optimize dynarray and bytearray copies

### DIFF
--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -2,7 +2,7 @@ import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
 
-from vyper.exceptions import ArgumentException
+from vyper.exceptions import ArgumentException, TypeMismatch
 
 _fun_bytes32_bounds = [(0, 32), (3, 29), (27, 5), (0, 5), (5, 3), (30, 2)]
 
@@ -143,7 +143,7 @@ def do_slice(inp: Bytes[{length_bound}], start: uint256, length: uint256) -> Byt
         or (literal_start and start > data_length)
         or (literal_length and length < 1)
     ):
-        assert_compile_failed(lambda: _get_contract(), ArgumentException)
+        assert_compile_failed(lambda: _get_contract(), (ArgumentException, TypeMismatch))
     elif len(bytesdata) > data_length:
         # deploy fail
         assert_tx_failed(lambda: _get_contract())

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -222,7 +222,7 @@ def _dynarray_make_setter(dst, src):
 
             else:
                 element_size = src.typ.value_type.memory_bytes_required
-                # number of elements * size of element in bytes
+                # number of elements * size of element in bytes + length word
                 n_bytes = add_ofst(_mul(count, element_size), 32)
                 max_bytes = 32 + src.typ.count * element_size
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -213,19 +213,17 @@ def _dynarray_make_setter(dst, src):
                 loop_body.annotation = f"{dst}[i] = {src}[i]"
 
                 ret.append(["repeat", i, 0, count, src.typ.count, loop_body])
+                # write the length word after data is copied
+                ret.append(STORE(dst, count))
 
             else:
                 element_size = src.typ.value_type.memory_bytes_required
                 # number of elements * size of element in bytes
-                n_bytes = _mul(count, element_size)
-                max_bytes = src.typ.count * element_size
+                n_bytes = add_ofst(_mul(count, element_size), 32)
+                max_bytes = 32 + src.typ.count * element_size
 
-                src_ = dynarray_data_ptr(src)
-                dst_ = dynarray_data_ptr(dst)
-                ret.append(copy_bytes(dst_, src_, n_bytes, max_bytes))
+                ret.append(copy_bytes(dst, src, n_bytes, max_bytes))
 
-            # write the length word after data is copied
-            ret.append(STORE(dst, count))
 
             return b1.resolve(b2.resolve(ret))
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -121,11 +121,12 @@ def make_byte_array_copier(dst, src):
         if src.typ.maxlen <= 32 and (has_storage or batch_uses_identity):
             # it's cheaper to run two load/stores instead of copy_bytes
             len_ = get_bytearray_length(src)
-            dst_data = bytes_data_ptr(dst)
-            src_data = LOAD(bytes_data_ptr(src))
             ret = ["seq"]
             ret.append(STORE(dst, len_))
-            ret.append(STORE(dst_data, src_data))
+
+            dst_data_ptr = bytes_data_ptr(dst)
+            src_data_ptr = bytes_data_ptr(src)
+            ret.append(STORE(dst_data_ptr, LOAD(src_data_ptr)))
             return b1.resolve(ret)
 
         len_ = add_ofst(get_bytearray_length(src), 32)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -126,13 +126,13 @@ def make_byte_array_copier(dst, src):
             len_ = get_bytearray_length(src)
             ret.append(STORE(dst, len_))
 
-            # store the 1 word of data
+            # store the single data word.
             dst_data_ptr = bytes_data_ptr(dst)
             src_data_ptr = bytes_data_ptr(src)
             ret.append(STORE(dst_data_ptr, LOAD(src_data_ptr)))
             return b1.resolve(ret)
 
-        # batch copy the length word + data using copy_bytes.
+        # batch copy the bytearray (including length word) using copy_bytes
         len_ = add_ofst(get_bytearray_length(src), 32)
         max_bytes = src.typ.maxlen + 32
         ret = copy_bytes(dst, src, len_, max_bytes)
@@ -230,7 +230,7 @@ def _dynarray_make_setter(dst, src):
                 n_bytes = add_ofst(_mul(count, element_size), 32)
                 max_bytes = 32 + src.typ.count * element_size
 
-                # copy the entire dynarray, including length word
+                # batch copy the entire dynarray, including length word
                 ret.append(copy_bytes(dst, src, n_bytes, max_bytes))
 
             return b1.resolve(b2.resolve(ret))


### PR DESCRIPTION
### What I did
include the length word in the batch copy instead of issuing a separate store instruction.

brings CurveStableSwapMetaNG.vy down by 315 bytes (~1.5%) and VaultV3.vy by 45 bytes (0.25%) in both `--optimize codesize` and `--optimize gas` modes.

### How I did it

### How to verify it

### Commit message

```
include the length word in the batch copy instead of issuing a separate
store instruction.

brings CurveStableSwapMetaNG.vy down by 315 bytes (~1.5%) and VaultV3.vy
by 45 bytes (0.25%) in both `--optimize codesize` and `--optimize gas`
modes.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
