### PR TITLE
fix: displaying of ``ArgumentException``

### DIFF
--- a/vyper/ast/validation.py
+++ b/vyper/ast/validation.py
@@ -48,7 +48,7 @@ def validate_call_args(
             arg_count = (arg_count[0], 2**64)
 
         if arg_count[0] == arg_count[1]:
-            arg_count == arg_count[0]
+            arg_count = arg_count[0]
 
     if isinstance(node.func, vy_ast.Attribute):
         msg = f" for call to '{node.func.attr}'"


### PR DESCRIPTION
### What I did

Fixed the displaying of ``ArgumentException``
### How I did it

The change is pretty self-explanatory.

### How to verify it

```Vyper
@internal
@view
def bar():
    pass

@external
def foo():
    self.bar(12)
```

Was failing to compile with:
``vyper.exceptions.ArgumentException: Invalid argument count for call to 'bar': expected 0 to 0, got 1``

And now fail to compile with:

``vyper.exceptions.ArgumentException: Invalid argument count for call to 'bar': expected 0, got 1``

### Commit message

  fix: displaying of ArgumentException

### Description for the changelog

fix displaying of ArgumentException

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/05/96/7b/05967ba7a49130269bf8c23a3b5e253c.jpg)
