### PR TITLE
optimize external call check

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -77,10 +77,15 @@ def get_type_for_exact_size(n_bytes):
 
 # propagate revert message when calls to external contracts fail
 def check_external_call(call_ir):
+    if _opt_codesize():
+        ret = ["jumpi", ["symbol", "propagate_revert_data"], ["iszero", call_ir]]
+        return IRnode.from_list(ret, error_msg="external call failed")
+
     copy_revertdata = ["returndatacopy", 0, 0, "returndatasize"]
     revert = IRnode.from_list(["revert", 0, "returndatasize"], error_msg="external call failed")
 
     propagate_revert_ir = ["seq", copy_revertdata, revert]
+
     return ["if", ["iszero", call_ir], propagate_revert_ir]
 
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -157,6 +157,12 @@ def _add_postambles(asm_ops):
         # shared failure block
         to_append.extend(_revert_string)
 
+    _revertdata_label = "_sym_propagate_revert_data"
+    _revertdata_string = [_revertdata_label, "JUMPDEST", "RETURNDATASIZE", *PUSH(0), *PUSH(0), "RETURNDATACOPY", "RETURNDATASIZE", "REVERT"]
+    if _revertdata_label in asm_ops:
+        # shared failure block
+        to_append.extend(_revertdata_string)
+
     if len(to_append) > 0:
         # for some reason there might not be a STOP at the end of asm_ops.
         # (generally vyper programs will have it but raw IR might not).


### PR DESCRIPTION
when optimizing for codesize, pay 2 gas to save 7 bytes per external call.

### What I did
out-line external calls when optimizing for codesize. leaving as draft for now because the implementation is not too clean (in that it touches both IR generation and assembly).

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
