### PR TITLE
fix: issue with finding installed packages in editable mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     license="Apache License 2.0",
     keywords="ethereum evm smart contract language",
     include_package_data=True,
-    packages=find_packages(exclude=("tests", "docs")),
+    packages=find_packages(include="vyper",),
     python_requires=">=3.10,<4",
     py_modules=["vyper"],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 import subprocess
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 extras_require = {
     "test": [
@@ -88,7 +88,7 @@ setup(
     license="Apache License 2.0",
     keywords="ethereum evm smart contract language",
     include_package_data=True,
-    packages=find_packages(include="vyper",),
+    packages=["vyper"],
     python_requires=">=3.10,<4",
     py_modules=["vyper"],
     install_requires=[


### PR DESCRIPTION
### What I did

fixes: #3509 

### How I did it

fix how packages are found
exclude kwarg was not working as expected i dont think, that seems to be for file globs within the found packages

### How to verify it

uninstall
reininstall in editable mode
go somewhere else (cd)
```sh
python -c "import tests; print(tests.__path__)"
```
^ should not output anything about vyper


### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
