### PR TITLE
chore: relax pragma parsing

### DIFF
--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -119,12 +119,12 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, str]:
                     validate_version_pragma(compiler_version, start)
                     settings.compiler_version = compiler_version
 
-                if string.startswith("#pragma "):
-                    pragma = string.removeprefix("#pragma").strip()
+                if contents.startswith("pragma "):
+                    pragma = contents.removeprefix("pragma ").strip()
                     if pragma.startswith("version "):
                         if settings.compiler_version is not None:
                             raise StructureException("pragma version specified twice!", start)
-                        compiler_version = pragma.removeprefix("version ".strip())
+                        compiler_version = pragma.removeprefix("version ").strip()
                         validate_version_pragma(compiler_version, start)
                         settings.compiler_version = compiler_version
 


### PR DESCRIPTION
allow `# pragma ...` in addition to `#pragma ...`

also fix a small bug in version parsing (it only affected the error message formatting, not the parsed version)

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
