### PR TITLE
feat: optimize dload/mstore sequences

### DIFF
--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -690,7 +690,10 @@ def _merge_load(argz, _LOAD, _COPY):
 
         # if we get this far, the current node is a different operation
         # it's time to apply the optimization if possible
-        if len(mstore_nodes) > 1:
+        # note: (mstore dst (dload src)) is ALWAYS better as straight
+        # dloadbytes to dst (because dload implicitly generates codecopy)
+        rewrite_threshold = 0 if _LOAD == "dload" else 1
+        if len(mstore_nodes) > rewrite_threshold:
             changed = True
             new_ir = IRnode.from_list(
                 [_COPY, initial_dst_offset, initial_src_offset, total_length],

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -474,6 +474,7 @@ def _optimize(node: IRnode, parent: Optional[IRnode]) -> Tuple[bool, IRnode]:
         changed |= _merge_memzero(argz)
         changed |= _merge_calldataload(argz)
         changed |= _merge_dload(argz)
+        changed |= _rewrite_mstore_dload(argz)
         changed |= _merge_mload(argz)
         changed |= _remove_empty_seqs(argz)
 
@@ -644,6 +645,18 @@ def _merge_calldataload(argz):
 
 def _merge_dload(argz):
     return _merge_load(argz, "dload", "dloadbytes")
+
+
+def _rewrite_mstore_dload(argz):
+    changed = False
+    for i, arg in enumerate(argz):
+        if arg.value == "mstore" and arg.args[1].value == "dload":
+            dst = arg.args[0]
+            src = arg.args[1].args[0]
+            len_ = 32
+            argz[i] = IRnode.from_list(["dloadbytes", dst, src, len_], source_pos=arg.source_pos)
+            changed = True
+    return changed
 
 
 def _merge_mload(argz):

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -690,10 +690,7 @@ def _merge_load(argz, _LOAD, _COPY):
 
         # if we get this far, the current node is a different operation
         # it's time to apply the optimization if possible
-        # note: (mstore dst (dload src)) is ALWAYS better as straight
-        # dloadbytes to dst (because dload implicitly generates codecopy)
-        rewrite_threshold = 0 if _LOAD == "dload" else 1
-        if len(mstore_nodes) > rewrite_threshold:
+        if len(mstore_nodes) > 1:
             changed = True
             new_ir = IRnode.from_list(
                 [_COPY, initial_dst_offset, initial_src_offset, total_length],

--- a/vyper/ir/optimizer.py
+++ b/vyper/ir/optimizer.py
@@ -473,6 +473,7 @@ def _optimize(node: IRnode, parent: Optional[IRnode]) -> Tuple[bool, IRnode]:
     if value == "seq":
         changed |= _merge_memzero(argz)
         changed |= _merge_calldataload(argz)
+        changed |= _merge_dload(argz)
         changed |= _merge_mload(argz)
         changed |= _remove_empty_seqs(argz)
 


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
merge_dload was defined in 5dc3ac7, but was not applied.

this commit also adds a rewrite rule for single dload/mstore patterns,
any `(mstore dst (dload src))` (which compiles to a `codecopy` followed
by an `mload` and `mstore`) is rewritten to a `dloadbytes` (which
compiles directly to a `codecopy`).

this rule saves 4 bytes / ~10 gas per rewrite. for instance, it shaves
25 bytes off `VaultV3.vy`, 50 bytes off `CurveTricryptoOptimizedWETH.vy`
and 75 bytes off `CurveStableSwapMetaNG.vy` (basically 0.1%-0.3%).
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
