### PR TITLE
fix: allow address members' names as struct fields

### DIFF
--- a/tests/parser/syntax/test_structs.py
+++ b/tests/parser/syntax/test_structs.py
@@ -575,6 +575,30 @@ struct C:
 def foo():
     bar: C = C({a: 1, b: block.timestamp})
     """,
+    """
+struct X:
+    balance: uint256
+    codesize: uint256
+    is_contract: bool
+    codehash: bytes32
+    code: Bytes[32]
+
+@external
+def foo():
+    x: X = X({
+        balance: 123,
+        codesize: 456,
+        is_contract: False,
+        codehash: empty(bytes32),
+        code: empty(Bytes[32])
+    })
+
+    a: uint256 = x.balance
+    b: uint256 = x.codesize
+    c: bool = x.is_contract
+    d: bytes32 = x.codehash
+    e: Bytes[32] = x.code
+    """,
 ]
 
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -321,17 +321,17 @@ class Expr:
                         "chain.id is unavailable prior to istanbul ruleset", self.expr
                     )
                 return IRnode.from_list(["chainid"], typ=UINT256_T)
+
         # Other variables
-        else:
-            sub = Expr(self.expr.value, self.context).ir_node
-            # contract type
-            if isinstance(sub.typ, InterfaceT):
-                # MyInterface.address
-                assert self.expr.attr == "address"
-                sub.typ = typ
-                return sub
-            if isinstance(sub.typ, StructT) and self.expr.attr in sub.typ.member_types:
-                return get_element_ptr(sub, self.expr.attr)
+        sub = Expr(self.expr.value, self.context).ir_node
+        # contract type
+        if isinstance(sub.typ, InterfaceT):
+            # MyInterface.address
+            assert self.expr.attr == "address"
+            sub.typ = typ
+            return sub
+        if isinstance(sub.typ, StructT) and self.expr.attr in sub.typ.member_types:
+            return get_element_ptr(sub, self.expr.attr)
 
     def parse_Subscript(self):
         sub = Expr(self.expr.value, self.context).ir_node


### PR DESCRIPTION
### What I did

Fix #3521.

### How I did it

Remove the `else` branch in `parse_Attribute` so that structs can be catched.

### How to verify it

See test.

### Commit message

```
fix: allow address members' names as struct fields
```

### Description for the changelog

Allow address members' names as struct fields.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.britannica.com/94/194294-138-B2CF7780/overview-capybara.jpg?w=800&h=450&c=crop)
