### PR TITLE
fix: allow `self` as struct field

### DIFF
--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -202,7 +202,12 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             # Add references to `self` as standalone address
             self_references = fn_node.get_descendants(vy_ast.Name, {"id": "self"})
             standalone_self = [
-                n for n in self_references if not isinstance(n.get_ancestor(), vy_ast.Attribute)
+                n
+                for n in self_references
+                if (parent := n.get_ancestor())  # store the parent node and evaluates to True
+                and not isinstance(parent, vy_ast.Attribute)  # filter out self.MEMBER
+                # filter out `self` as struct field
+                and not (isinstance(parent, vy_ast.Dict) and n not in parent.values)
             ]
             node_list.extend(standalone_self)  # type: ignore
 


### PR DESCRIPTION
### What I did

Fix #3520.

### How I did it

Filter out standalone `self` references used as struct fields when checking for state access violation.

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://res.klook.com/images/fl_lossy.progressive,q_65/c_fill,w_1200,h_630/w_80,x_15,y_15,g_south_west,l_Klook_water_br_trans_yhcmh3/activities/phccpv57uwsl66s4puzt/Pingtung%20Kenting%20Deer%20Island%20Capybara%20Ecological%20Park%20Ticket.jpg)
