### PR TITLE
chore: improve error message for invalid references to public constants and immutables

### DIFF
--- a/tests/parser/exceptions/test_invalid_reference.py
+++ b/tests/parser/exceptions/test_invalid_reference.py
@@ -37,6 +37,24 @@ def foo():
 def foo():
     int128 = 5
     """,
+    """
+a: public(constant(uint256)) = 1
+
+@external
+def foo():
+    b: uint256 = self.a
+    """,
+    """
+a: public(immutable(uint256))
+
+@external
+def __init__():
+    a = 123
+
+@external
+def foo():
+    b: uint256 = self.a
+    """,
 ]
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -186,14 +186,14 @@ class _ExprAnalyser:
         name = node.attr
         try:
             s = t.get_member(name, node)
+            if isinstance(s, VyperType):
+                # ex. foo.bar(). bar() is a ContractFunctionT
+                return [s]
             if is_self_reference and (s.is_constant or s.is_immutable):
                 raise InvalidReference(
                     f"'{name}' is not a storage variable, it should not be prepended with self",
                     node,
                 )
-            if isinstance(s, VyperType):
-                # ex. foo.bar(). bar() is a ContractFunctionT
-                return [s]
             # general case. s is a VarInfo, e.g. self.foo
             return [s.typ]
         except UnknownAttribute:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -180,24 +180,25 @@ class _ExprAnalyser:
         raise StructureException("Cannot determine type of this object", node)
 
     def types_from_Attribute(self, node):
+        is_self_reference = node.get("value.id") == "self"
         # variable attribute, e.g. `foo.bar`
         t = self.get_exact_type_from_node(node.value, include_type_exprs=True)
         name = node.attr
         try:
             s = t.get_member(name, node)
+            if is_self_reference and (s.is_constant or s.is_immutable):
+                raise InvalidReference(
+                    f"'{name}' is not a storage variable, it should not be prepended with self",
+                    node,
+                )
             if isinstance(s, VyperType):
                 # ex. foo.bar(). bar() is a ContractFunctionT
                 return [s]
             # general case. s is a VarInfo, e.g. self.foo
             return [s.typ]
         except UnknownAttribute:
-            if node.get("value.id") != "self":
+            if not is_self_reference:
                 raise
-            if name in self.namespace:
-                raise InvalidReference(
-                    f"'{name}' is not a storage variable, it should not be prepended with self",
-                    node,
-                ) from None
 
             suggestions_str = get_levenshtein_error_suggestions(name, t.members, 0.4)
             raise UndeclaredDefinition(


### PR DESCRIPTION
### What I did

Fix #3518 

### How I did it

Move the statement catching the exception from the `except` branch to the `try` branch.

### How to verify it

See tests.

### Commit message

```
chore: improve error message for invalid references to public constants and immutables
```

### Description for the changelog

Improve error message for invalid references to public constants and immutables

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRlgWltruI6AxRj8dRelsG_XnvxHc2n9aJEiw&usqp=CAU)
