### PR TITLE
docs: fix typo in release-notes.rst

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -774,7 +774,7 @@ The following VIPs were implemented for Beta 13:
 
 - Add ``vyper-json`` compilation mode (VIP `#1520 <https://github.com/vyperlang/vyper/issues/1520>`_)
 - Environment variables and constants can now be used as default parameters (VIP `#1525 <https://github.com/vyperlang/vyper/issues/1525>`_)
-- Require unitialized memory be set on creation (VIP `#1493 <https://github.com/vyperlang/vyper/issues/1493>`_)
+- Require uninitialized memory be set on creation (VIP `#1493 <https://github.com/vyperlang/vyper/issues/1493>`_)
 
 Some of the bug and stability fixes:
 


### PR DESCRIPTION


### What I did
Fixed typo.
### How I did it
unitialized -> uninitialized
### How to verify it

### Commit message



### Description for the changelog

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/22633385/c5c533d4-6fe5-43d5-af3a-b2f711fb0b59)
