### PR TITLE
Add note on security advisory for `ecrecover` in docs

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -379,7 +379,11 @@ Cryptography
     * ``s``: second 32 bytes of signature
     * ``v``: final 1 byte of signature
 
-    Returns the associated address, or ``0`` on error.
+    Returns the associated address, or ``empty(address)`` on error.
+
+    .. note::
+
+         We strongly recommend using Vyper versions ``>=0.3.10`` if ``ecrecover`` is employed due to the security advisory `GHSA-f5x6-7qgp-jhf3 <https://github.com/vyperlang/vyper/security/advisories/GHSA-f5x6-7qgp-jhf3>`_.
 
     .. code-block:: python
 

--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -383,7 +383,7 @@ Cryptography
 
     .. note::
 
-         We strongly recommend using Vyper versions ``>=0.3.10`` if ``ecrecover`` is employed due to the security advisory `GHSA-f5x6-7qgp-jhf3 <https://github.com/vyperlang/vyper/security/advisories/GHSA-f5x6-7qgp-jhf3>`_.
+         Prior to Vyper ``0.3.10``, the ``ecrecover`` function could return an undefined (possibly nonzero) value for invalid inputs to ``ecrecover``. For more information, please see `GHSA-f5x6-7qgp-jhf3 <https://github.com/vyperlang/vyper/security/advisories/GHSA-f5x6-7qgp-jhf3>`_.
 
     .. code-block:: python
 


### PR DESCRIPTION
### What I did

I added a note on the recent security advisory for `ecrecover` in the docs. I also replaced `0` with `empty(address)` in case of error.

### How I did it

Added a `note` section in the `ecrecover` docs.

### How to verify it

Reference: https://github.com/vyperlang/vyper/security/advisories/GHSA-f5x6-7qgp-jhf3

### Commit message

```
Add note on security advisory for `ecrecover` in docs
```

### Description for the changelog

Add note on security advisory for `ecrecover` in docs.

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/19fdc067-7527-40cc-b2f9-769612cbf71f)
