### PR TITLE
add message to error map for repeat range check

### DIFF
--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -305,7 +305,9 @@ class Stmt:
         # NOTE: codegen for `repeat` inserts an assertion that rounds <= rounds_bound.
         # if we ever want to remove that, we need to manually add the assertion
         # where it makes sense.
-        ir_node = IRnode.from_list(["repeat", i, start, rounds, rounds_bound, loop_body])
+        ir_node = IRnode.from_list(
+            ["repeat", i, start, rounds, rounds_bound, loop_body], error_msg="range() bounds check"
+        )
         del self.context.forvars[varname]
 
         return ir_node


### PR DESCRIPTION
### What I did
since https://github.com/vyperlang/vyper/commit/d48438e10722db8fc9e74d8ed434745e3b0d31cf, loops can revert depending on user input. add it to the error map so it's easier to debug.

edit -- actually, since 3de1415ee77a9244eb04bdb695e249d3ec9ed868

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
