### PR TITLE
fix: guard against state-modifying expressions in `range` expression

### DIFF
--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -119,7 +119,8 @@ def foo() -> int128:
 @external
 def bar():
     for i in range(self.foo(), self.foo() + 1):
-        pass""",
+        pass
+        """,
     ],
 )
 def test_immutability_violations(bad_code):

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -48,17 +48,6 @@ def foo() -> int128:
 def foo() -> int128:
     x: address = create_minimal_proxy_to(0x1234567890123456789012345678901234567890, value=9)
     return 5""",
-        # test constancy in range expressions
-        """
-glob: int128
-@internal
-def foo() -> int128:
-    self.glob += 1
-    return 5
-@external
-def bar():
-    for i in range(self.foo(), self.foo() + 1):
-        pass""",
         """
 glob: int128
 @internal
@@ -120,6 +109,17 @@ def foo(f: Foo) -> Foo:
     f.a[1] = [0, 1]
     return f
         """,
+        # test constancy in range expressions
+        """
+glob: int128
+@internal
+def foo() -> int128:
+    self.glob += 1
+    return 5
+@external
+def bar():
+    for i in range(self.foo(), self.foo() + 1):
+        pass""",
     ],
 )
 def test_immutability_violations(bad_code):

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -78,6 +78,42 @@ def test()-> (DynArray[uint256, 6], DynArray[uint256, 10]):
     return b, self.arr
     """,
         ImmutableViolation,
+    ),
+    (
+        """
+@external
+def bar(x:address):
+    for i in range(1 if raw_call(x, b'', revert_on_failure=False) else 2 , bound = 12):
+        pass
+        """,
+        ImmutableViolation,
+    ),
+    (
+        """
+@external
+def foo(a: address):
+    for i in range(1 if convert(create_minimal_proxy_to(a), uint256) > 2 else 2, bound=12):
+        pass
+        """,
+        ImmutableViolation,
+    ),
+    (
+        """
+@external
+def foo(a: address):
+    for i in range(1 if convert(create_copy_of(a), uint256) > 2 else 2, bound=12):
+        pass
+        """,
+        ImmutableViolation,
+    ),
+    (
+        """
+@external
+def foo(a: address):
+    for i in range(1 if convert(create_from_blueprint(a), uint256) > 2 else 2, bound=12):
+        pass
+        """,
+        ImmutableViolation,
     )
 ]
 

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -21,7 +21,7 @@ interface A:
 @external
 def bar(x:address):
     a: A = A(x)
-    for i in range(a.foo(), bound = 12):
+    for i in range(a.foo(), bound=12):
         pass
     """,
         ImmutableViolation,
@@ -34,7 +34,7 @@ interface A:
 @external
 def bar(x:address):
     a: A = A(x)
-    for i in range(max(a.foo(), 123), bound = 12):
+    for i in range(max(a.foo(), 123), bound=12):
         pass
     """,
         ImmutableViolation,
@@ -47,7 +47,7 @@ interface A:
 @external
 def bar(x:address):
     a: A = A(x)
-    for i in range(a.foo(), a.foo()+1):
+    for i in range(a.foo(), a.foo() + 1):
         pass
     """,
         ImmutableViolation,
@@ -110,7 +110,7 @@ interface A:
 @external
 def bar(x:address):
     a: A = A(x)
-    for i in range(a.foo(), bound = 12):
+    for i in range(a.foo(), bound=12):
         pass
     """,
     """
@@ -120,7 +120,7 @@ interface A:
 @external
 def bar(x:address):
     a: A = A(x)
-    for i in range(max(a.foo(), 123), bound = 12):
+    for i in range(max(a.foo(), 123), bound=12):
         pass
     """,
     """
@@ -130,7 +130,7 @@ interface A:
 @external
 def bar(x:address):
     a: A = A(x)
-    for i in range(a.foo(), a.foo()+1):
+    for i in range(a.foo(), a.foo() + 1):
         pass
     """,
     """

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -65,6 +65,20 @@ def bar(x:address):
     """,
         ImmutableViolation,
     ),
+    # Cannot call `pop()` in for range because it modifies state
+    (
+        """
+arr: DynArray[uint256, 10]
+@external
+def test()-> (DynArray[uint256, 6], DynArray[uint256, 10]):
+    b: DynArray[uint256, 6] = []
+    self.arr = [1,0]
+    for i in range(self.arr.pop(), self.arr.pop() + 2):
+        b.append(i)
+    return b, self.arr
+    """,
+        ImmutableViolation,
+    )
 ]
 
 

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -83,7 +83,13 @@ def test()-> (DynArray[uint256, 6], DynArray[uint256, 10]):
         """
 @external
 def bar(x:address):
-    for i in range(1 if raw_call(x, b'', revert_on_failure=False) else 2 , bound = 12):
+    for i in range(1 if raw_call(
+            x,
+            b'',
+            max_outsize=32,
+        ) == b"vyper" else 2,
+        bound=12
+    ):
         pass
         """,
         ImmutableViolation,
@@ -193,6 +199,19 @@ def bar(x:address):
     for i in range(min(a.foo(), 123), min(a.foo(), 123) + 1):
         pass
     """,
+    """
+@external
+def bar(x:address):
+    for i in range(1 if raw_call(
+            x,
+            b'',
+            max_outsize=32,
+            is_static_call=True
+        ) == b"vyper" else 2,
+        bound=12
+    ):
+        pass
+        """,
 ]
 
 

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -114,7 +114,7 @@ def foo(a: address):
         pass
         """,
         ImmutableViolation,
-    )
+    ),
 ]
 
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -424,6 +424,15 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             if assign:
                 raise ImmutableViolation("Cannot modify array during iteration", assign)
 
+        # Check for state-modifying functions in `iter`
+        iter_call_nodes = node.iter.get_descendants(vy_ast.Call)
+        for call_node in iter_call_nodes:
+            call_type = get_exact_type_from_node(call_node.func)
+            if isinstance(call_type, ContractFunctionT) and call_type.is_mutable:
+                raise ImmutableViolation(
+                    "Cannot call state-modifying functions for `range` expression", call_node
+                )
+
         # Check if `iter` is a storage variable. get_descendants` is used to check for
         # nested `self` (e.g. structs)
         iter_is_storage_var = (

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -424,7 +424,7 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
             if assign:
                 raise ImmutableViolation("Cannot modify array during iteration", assign)
 
-        # Check for state-modifying functions in `iter`
+        # Check for state-modifying function calls in `iter`
         iter_call_nodes = node.iter.get_descendants(vy_ast.Call)
         for call_node in iter_call_nodes:
             call_type = get_exact_type_from_node(call_node.func)


### PR DESCRIPTION
### What I did

Fix #3504, fix #3172, closes #3188.

### How I did it

Check for state modifying expressions in a range expression, and validate that no expression modifies state.

### How to verify it

See new tests.

### Commit message

```
fix: guard against state-modifying expressions in `range` expression
```

### Description for the changelog

Guard against state-modifying expressions in `range` expression

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/Jl5vto_khXcAAAAC/catscafe-snake.gif)
