### PR TITLE
fix: guard against kwargs for `range` expressions with two arguments

### DIFF
--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -12,7 +12,26 @@ def foo():
         pass
     """,
         StructureException,
-    )
+    ),
+    (
+        """
+@external
+def bar():
+    for i in range(1,2,bound=2):
+        pass
+    """,
+        StructureException,
+    ),
+    (
+        """
+@external
+def bar():
+    x:uint256 = 1
+    for i in range(x,x+1,bound=2):
+        pass
+    """,
+        StructureException,
+    ),
 ]
 
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -346,10 +346,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                 raise IteratorException(
                     "Cannot iterate over the result of a function call", node.iter
                 )
-            validate_call_args(node.iter, (1, 2), kwargs=["bound"])
+            range_ = node.iter
+            validate_call_args(range_, (1, 2), kwargs=["bound"])
 
-            args = node.iter.args
-            kwargs = {s.arg: s.value for s in node.iter.keywords or []}
+            args = range_.args
+            kwargs = {s.arg: s.value for s in range_.keywords or []}
             if len(args) == 1:
                 # range(CONSTANT)
                 n = args[0]
@@ -371,11 +372,11 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                     type_list = get_common_types(n, bound)
 
             else:
-                if kwargs:
+                if range_.keywords:
                     raise StructureException(
-                        """Keyword arguments are not supported for `range(N, M)` and
-                         `range(x, x + N)` expressions""",
-                        node.iter.keywords,
+                        "Keyword arguments are not supported for `range(N, M)` and"
+                        "`range(x, x + N)` expressions",
+                        range_.keywords[0],
                     )
 
                 validate_expected_type(args[0], IntegerT.any())

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -371,6 +371,13 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
                     type_list = get_common_types(n, bound)
 
             else:
+                if kwargs:
+                    raise StructureException(
+                        """Keyword arguments are not supported for `range(N, M)` and
+                         `range(x, x + N)` expressions""",
+                        node.iter.keywords,
+                    )
+
                 validate_expected_type(args[0], IntegerT.any())
                 type_list = get_common_types(*args)
                 if not isinstance(args[0], vy_ast.Constant):


### PR DESCRIPTION
### What I did

Fix #3550 

### How I did it

Check kwargs for range expressions with two arguments.

### How to verify it

See tests.

### Commit message

```
fix: guard against kwargs for `range` expressions with two arguments

Keyword arguments are not supported for `range(N, M)` and
`range(x, x + N)` expressions.
```

### Description for the changelog

Guard against kwargs for `range` expressions with two arguments

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.saymedia-content.com/.image/ar_1:1%2Cc_fill%2Ccs_srgb%2Cq_auto:eco%2Cw_1200/MTk3MTk4Njk1NDQyMTYzMDA3/llama-names.png)
