### PR TITLE
fix: guard against mutating code in non-mutable functions

### DIFF
--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -76,16 +76,111 @@ def foo():
     for i in range(x):
         pass""",
         """
-f:int128
+from vyper.interfaces import ERC20
+
+token: ERC20
 
 @external
-def a (x:int128):
-    self.f = 100
-
 @view
+def topup(amount: uint256):
+    assert self.token.transferFrom(msg.sender, self, amount)
+        """,
+        """
+from vyper.interfaces import ERC20
+
+token: ERC20
+
 @external
-def b():
-    self.a(10)""",
+@view
+def topup(amount: uint256):
+    x: bool = self.token.transferFrom(msg.sender, self, amount)
+        """,
+        """
+from vyper.interfaces import ERC20
+
+token: ERC20
+
+@external
+@view
+def topup(amount: uint256):
+    x: bool = False
+    x = self.token.transferFrom(msg.sender, self, amount)
+        """,
+        """
+from vyper.interfaces import ERC20
+
+token: ERC20
+
+@external
+@view
+def topup(amount: uint256) -> bool:
+    return self.token.transferFrom(msg.sender, self, amount)
+        """,
+        """
+a: DynArray[uint256, 3]
+
+@external
+@view
+def foo():
+    assert self.a.pop() > 123, "vyper"
+        """,
+        """
+a: DynArray[uint256, 3]
+
+@external
+@view
+def foo():
+    x: uint256 = self.a.pop()
+        """,
+        """
+a: DynArray[uint256, 3]
+
+@external
+@view
+def foo():
+    x: uint256 = 0
+    x = self.a.pop()
+        """,
+        """
+a: DynArray[uint256, 3]
+
+@external
+@view
+def foo() -> uint256:
+    return self.a.pop()
+        """,
+        """
+@external
+@view
+def foo(x: address):
+    assert convert(
+        raw_call(
+            x,
+            b'',
+            max_outsize=32,
+            revert_on_failure=False
+        ), uint256
+    ) > 123, "vyper"
+        """,
+        """
+@external
+@view
+def foo(a: address):
+    x: address = create_minimal_proxy_to(a)
+        """,
+        """
+@external
+@view
+def foo(a: address):
+    x: address = empty(address)
+    x = create_copy_of(a)
+        """,
+        """
+@external
+@view
+def foo(a: address) -> address:
+    return create_from_blueprint(a)
+        """,
     ],
 )
 def test_statefulness_violations(bad_code):

--- a/tests/parser/features/decorators/test_view.py
+++ b/tests/parser/features/decorators/test_view.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vyper.exceptions import FunctionDeclarationException
 
 
@@ -28,3 +30,25 @@ def foo() -> num:
     assert_compile_failed(
         lambda: get_contract_with_gas_estimation_for_constants(code), FunctionDeclarationException
     )
+
+
+good_code = [
+    """
+@external
+@view
+def foo(x: address):
+    assert convert(
+        raw_call(
+            x,
+            b'',
+            max_outsize=32,
+            is_static_call=True,
+        ), uint256
+    ) > 123, "vyper"
+    """
+]
+
+
+@pytest.mark.parametrize("code", good_code)
+def test_view_call_compiles(get_contract, code):
+    get_contract(code)

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -881,7 +881,7 @@ def set_lucky(arg1: address, arg2: int128):
     print("Successfully executed an external contract call state change")
 
 
-def test_constant_external_contract_call_cannot_change_state(
+def test_constant_external_contract_call_cannot_change_state1(
     assert_compile_failed, get_contract_with_gas_estimation
 ):
     c = """
@@ -892,6 +892,23 @@ interface Foo:
 @view
 def set_lucky_expr(arg1: address, arg2: int128):
     Foo(arg1).set_lucky(arg2)
+    """
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(c), StateAccessViolation)
+
+    print("Successfully blocked an external contract call from a constant function")
+
+
+def test_constant_external_contract_call_cannot_change_state2(
+    assert_compile_failed, get_contract_with_gas_estimation
+):
+    c = """
+interface Foo:
+    def set_lucky(_lucky: int128) -> int128: nonpayable
+
+@external
+@view
+def set_lucky_stmt(arg1: address, arg2: int128) -> int128:
+    return Foo(arg1).set_lucky(arg2)
     """
     assert_compile_failed(lambda: get_contract_with_gas_estimation(c), StateAccessViolation)
 

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -892,11 +892,6 @@ interface Foo:
 @view
 def set_lucky_expr(arg1: address, arg2: int128):
     Foo(arg1).set_lucky(arg2)
-
-@external
-@view
-def set_lucky_stmt(arg1: address, arg2: int128) -> int128:
-    return Foo(arg1).set_lucky(arg2)
     """
     assert_compile_failed(lambda: get_contract_with_gas_estimation(c), StateAccessViolation)
 

--- a/vyper/builtins/_signatures.py
+++ b/vyper/builtins/_signatures.py
@@ -6,6 +6,7 @@ from vyper.ast.validation import validate_call_args
 from vyper.codegen.expr import Expr
 from vyper.codegen.ir_node import IRnode
 from vyper.exceptions import CompilerPanic, TypeMismatch
+from vyper.semantics.analysis.base import StateMutability
 from vyper.semantics.analysis.utils import get_exact_type_from_node, validate_expected_type
 from vyper.semantics.types import TYPE_T, KwargSettings, VyperType
 from vyper.semantics.types.utils import type_from_annotation
@@ -77,6 +78,7 @@ def process_inputs(wrapped_fn):
 class BuiltinFunction:
     _has_varargs = False
     _kwargs: Dict[str, KwargSettings] = {}
+    mutability = StateMutability.PURE
 
     # helper function to deal with TYPE_DEFINITIONs
     def _validate_single(self, arg, expected_type):

--- a/vyper/semantics/analysis/annotation.py
+++ b/vyper/semantics/analysis/annotation.py
@@ -184,8 +184,8 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
             for arg, arg_type in zip(node.args, call_type.arg_types):
                 self.visit(arg, arg_type)
         else:
+            # note that mutability for`raw_call` is handled in its `build_IR` function
             mutable_builtins = (
-                "raw_call",
                 "create_minimal_proxy_to",
                 "create_copy_of",
                 "create_from_blueprint",

--- a/vyper/semantics/analysis/annotation.py
+++ b/vyper/semantics/analysis/annotation.py
@@ -187,7 +187,8 @@ class ExpressionAnnotationVisitor(_AnnotationVisitorBase):
             for arg, arg_type in zip(node.args, call_type.arg_types):
                 self.visit(arg, arg_type)
         else:
-            _check_mutability(call_type)
+            if hasattr(call_type, "mutability"):
+                _check_mutability(call_type)
 
             # builtin functions
             arg_types = call_type.infer_arg_types(node)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -518,29 +518,6 @@ class FunctionNodeVisitor(VyperNodeVisitorBase):
         if is_type_t(fn_type, StructT):
             raise StructureException("Struct creation without assignment is disallowed", node)
 
-        if isinstance(fn_type, ContractFunctionT):
-            if (
-                fn_type.mutability > StateMutability.VIEW
-                and self.func.mutability <= StateMutability.VIEW
-            ):
-                raise StateAccessViolation(
-                    f"Cannot call a mutating function from a {self.func.mutability.value} function",
-                    node,
-                )
-
-            if (
-                self.func.mutability == StateMutability.PURE
-                and fn_type.mutability != StateMutability.PURE
-            ):
-                raise StateAccessViolation(
-                    "Cannot call non-pure function from a pure function", node
-                )
-
-        if isinstance(fn_type, MemberFunctionT) and fn_type.is_modifying:
-            # it's a dotted function call like dynarray.pop()
-            expr_info = get_expr_info(node.value.func.value)
-            expr_info.validate_modification(node, self.func.mutability)
-
         # NOTE: fetch_call_return validates call args.
         return_value = fn_type.fetch_call_return(node.value)
         if (


### PR DESCRIPTION
### What I did

Fix #3554.

### How I did it

Move the checks from `visit_Expr` to `visit_Call`. This causes semantic analysis to leak into `annotation.py`, but it should be fixed later on by #3456 when annotation and validation are combined into a single pass.

### How to verify it

See tests.

### Commit message

```
fix: guard against mutating code in non-mutable functions
```

### Description for the changelog

Guard against mutating code in non-mutable functions

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://t3.ftcdn.net/jpg/01/93/88/84/360_F_193888418_eszf9ZfO20j6724Hz2Nkh2y63XwTmeCG.jpg)
