### PR TITLE
chore: note `Context.in_assertion` is dead

### DIFF
--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -69,6 +69,7 @@ class Context:
         self.constancy = constancy
 
         # Whether body is currently in an assert statement
+        # XXX: dead, never set to True
         self.in_assertion = False
 
         # Whether we are currently parsing a range expression


### PR DESCRIPTION
the Context class has an `in_assertion` flag which, when set, indicates that the context should be constant according to is_constant() definition. however, this flag is never set during code generation, specifically, it is possible to have non-constant expression in an assert statement. For example, the following contract compiles:

```vyper
x: uint256

@internal
def bar() -> uint256:
    self.x = 1
    return self.x

@external
def foo():
    assert self.bar() == 1
```

chainsec june 2023 review 5.5

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
