### PR TITLE
chore: add sanity check in parse_BinOp

### DIFF
--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -368,13 +368,18 @@ class Expr:
         left = Expr.parse_value_expr(self.expr.left, self.context)
         right = Expr.parse_value_expr(self.expr.right, self.context)
 
-        if not isinstance(self.expr.op, (vy_ast.LShift, vy_ast.RShift)):
+        is_shift_op = isinstance(self.expr.op, (vy_ast.LShift, vy_ast.RShift))
+
+        if is_shift_op:
+            assert is_numeric_type(left.typ)
+            assert is_numeric_type(right.typ)
+        else:
             # Sanity check - ensure that we aren't dealing with different types
             # This should be unreachable due to the type check pass
             if left.typ != right.typ:
                 raise TypeCheckFailure(f"unreachable, {left.typ} != {right.typ}", self.expr)
+            assert is_numeric_type(left.typ) or is_enum_type(left.typ)
 
-        assert is_numeric_type(left.typ) or is_enum_type(left.typ)
 
         out_typ = left.typ
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -380,7 +380,6 @@ class Expr:
                 raise TypeCheckFailure(f"unreachable, {left.typ} != {right.typ}", self.expr)
             assert is_numeric_type(left.typ) or is_enum_type(left.typ)
 
-
         out_typ = left.typ
 
         if isinstance(self.expr.op, vy_ast.BitAnd):


### PR DESCRIPTION
add sanity check in parse_BinOp, we can be stricter in the case where it's a shift binop.

chainsec june review 5.4

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
