### PR TITLE
fix: kwargs passed to `validate_call_args`

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -488,8 +488,8 @@ class ContractFunctionT(VyperType):
         if node.get("func.value.id") == "self" and self.visibility == FunctionVisibility.EXTERNAL:
             raise CallViolation("Cannot call external functions via 'self'", node)
 
+        kwarg_keys = []
         # for external calls, include gas and value as optional kwargs
-        kwarg_keys = [arg.name for arg in self.keyword_args]
         if not self.is_internal:
             kwarg_keys += list(self.call_site_kwargs.keys())
         validate_call_args(node, (self.n_positional_args, self.n_total_args), kwarg_keys)


### PR DESCRIPTION
`validate_call_args` takes kwargs, the list of valid keywords as an argument and makes sure that when a call is made, the given keywords are valid according to the passed kwargs. however, vyper does not allow kwargs when calling internal functions, so we should actually pass no kwargs to `validate_call_args`.

note that this PR does not actually introduce observed changes in compiler behavior, as the later check in `fetch_call_return` correctly validates there are no call site kwargs for internal functions.

chainsec june 2023 review 5.7

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
