### PR TITLE
chore: fix dead parameter usages

### DIFF
--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -662,9 +662,7 @@ class Expr:
             elif isinstance(self.expr._metadata["type"], StructT):
                 args = self.expr.args
                 if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
-                    return Expr.struct_literals(
-                        args[0], self.context, self.expr._metadata["type"]
-                    )
+                    return Expr.struct_literals(args[0], self.context, self.expr._metadata["type"])
 
             # Interface assignment. Bar(<address>).
             elif isinstance(self.expr._metadata["type"], InterfaceT):

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -663,7 +663,7 @@ class Expr:
                 args = self.expr.args
                 if len(args) == 1 and isinstance(args[0], vy_ast.Dict):
                     return Expr.struct_literals(
-                        args[0], function_name, self.context, self.expr._metadata["type"]
+                        args[0], self.context, self.expr._metadata["type"]
                     )
 
             # Interface assignment. Bar(<address>).
@@ -733,7 +733,7 @@ class Expr:
         return IRnode.from_list(["if", test, body, orelse], typ=typ, location=location)
 
     @staticmethod
-    def struct_literals(expr, name, context, typ):
+    def struct_literals(expr, context, typ):
         member_subs = {}
         member_typs = {}
         for key, value in zip(expr.keys, expr.values):

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -313,11 +313,11 @@ class InterfaceT(_UserType):
 
         def _is_function_implemented(fn_name, fn_type):
             vyper_self = namespace["self"].typ
-            if name not in vyper_self.members:
+            if fn_name not in vyper_self.members:
                 return False
-            s = vyper_self.members[name]
+            s = vyper_self.members[fn_name]
             if isinstance(s, ContractFunctionT):
-                to_compare = vyper_self.members[name]
+                to_compare = vyper_self.members[fn_name]
             # this is kludgy, rework order of passes in ModuleNodeVisitor
             elif isinstance(s, VarInfo) and s.is_public:
                 to_compare = s.decl_node._metadata["func_type"]


### PR DESCRIPTION
`_is_function_implemented` did not use its parameter `fn_name`, it used the captured `name` variable, which happened to be the same as `fn_name`.

chainsec june 2023 review 6.2

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
