### PR TITLE
fix: order of evaluation for some builtins

### DIFF
--- a/tests/parser/functions/test_addmod.py
+++ b/tests/parser/functions/test_addmod.py
@@ -55,3 +55,35 @@ def c() -> uint256:
     c = get_contract_with_gas_estimation(code)
 
     assert c.foo() == 2
+
+
+def test_uint256_addmod_evaluation_order(get_contract_with_gas_estimation):
+    code = """
+a: uint256
+
+@external
+def foo1() -> uint256:
+    self.a = 0
+    return uint256_addmod(self.a, 1, self.bar())
+
+@external
+def foo2() -> uint256:
+    self.a = 0
+    return uint256_addmod(self.a, self.bar(), 3)
+
+@external
+def foo3() -> uint256:
+    self.a = 0
+    return uint256_addmod(1, self.a, self.bar())
+
+@internal
+def bar() -> uint256:
+    self.a = 1
+    return 2
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.foo1() == 1
+    assert c.foo2() == 2
+    assert c.foo3() == 1

--- a/tests/parser/functions/test_ec.py
+++ b/tests/parser/functions/test_ec.py
@@ -76,6 +76,26 @@ def foo(a: Foo) -> uint256[2]:
     assert_side_effects_invoked(c1, lambda: c2.foo(c1.address, transact={}))
 
 
+def test_ecadd_evaluation_order(get_contract_with_gas_estimation):
+    code = """
+x: uint256[2]
+
+@internal
+def bar() -> uint256[2]:
+    self.x = ecadd([1, 2], [1, 2])
+    return [1, 2]
+
+@external
+def foo() -> bool:
+    self.x = [1, 2]
+    a: uint256[2] = ecadd([1, 2], [1, 2])
+    b: uint256[2] = ecadd(self.x, self.bar())
+    return a[0] == b[0] and a[1] == b[1]
+    """
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() is True
+
+
 def test_ecmul(get_contract_with_gas_estimation):
     ecmuller = """
 x3: uint256[2]
@@ -136,3 +156,23 @@ def foo(a: Foo) -> uint256[2]:
     assert c2.foo(c1.address) == G1_times_three
 
     assert_side_effects_invoked(c1, lambda: c2.foo(c1.address, transact={}))
+
+
+def test_ecmul_evaluation_order(get_contract_with_gas_estimation):
+    code = """
+x: uint256[2]
+
+@internal
+def bar() -> uint256:
+    self.x = ecmul([1, 2], 3)
+    return 3
+
+@external
+def foo() -> bool:
+    self.x = [1, 2]
+    a: uint256[2] = ecmul([1, 2], 3)
+    b: uint256[2] = ecmul(self.x, self.bar())
+    return a[0] == b[0] and a[1] == b[1]
+    """
+    c = get_contract_with_gas_estimation(code)
+    assert c.foo() is True

--- a/tests/parser/functions/test_mulmod.py
+++ b/tests/parser/functions/test_mulmod.py
@@ -73,3 +73,35 @@ def c() -> uint256:
     c = get_contract_with_gas_estimation(code)
 
     assert c.foo() == 600
+
+
+def test_uint256_mulmod_evaluation_order(get_contract_with_gas_estimation):
+    code = """
+a: uint256
+
+@external
+def foo1() -> uint256:
+    self.a = 1
+    return uint256_mulmod(self.a, 2, self.bar())
+
+@external
+def foo2() -> uint256:
+    self.a = 1
+    return uint256_mulmod(self.bar(), self.a, 2)
+
+@external
+def foo3() -> uint256:
+    self.a = 1
+    return uint256_mulmod(2, self.a, self.bar())
+
+@internal
+def bar() -> uint256:
+    self.a = 7
+    return 5
+    """
+
+    c = get_contract_with_gas_estimation(code)
+
+    assert c.foo1() == 2
+    assert c.foo2() == 1
+    assert c.foo3() == 2

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -814,7 +814,7 @@ class ECAdd(BuiltinFunction):
                 typ=SArrayT(UINT256_T, 2),
                 location=MEMORY,
             )
-            return b2.resolve(b1.resolve(o))
+            return b1.resolve(b2.resolve(o))
 
 
 class ECMul(BuiltinFunction):
@@ -844,7 +844,7 @@ class ECMul(BuiltinFunction):
                 typ=SArrayT(UINT256_T, 2),
                 location=MEMORY,
             )
-            return b2.resolve(b1.resolve(o))
+            return b1.resolve(b2.resolve(o))
 
 
 def _generic_element_getter(op):
@@ -1525,13 +1525,14 @@ class _AddMulMod(BuiltinFunction):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        c = args[2]
-
-        with c.cache_when_complex("c") as (b1, c):
-            ret = IRnode.from_list(
-                ["seq", ["assert", c], [self._opcode, args[0], args[1], c]], typ=UINT256_T
-            )
-            return b1.resolve(ret)
+        x, y, z = args
+        with x.cache_when_complex("x") as (b1, x):
+            with y.cache_when_complex("y") as (b2, y):
+                with z.cache_when_complex("z") as (b3, z):
+                    ret = IRnode.from_list(
+                        ["seq", ["assert", z], [self._opcode, x, y, z]], typ=UINT256_T
+                    )
+                    return b1.resolve(b2.resolve(b3.resolve(ret)))
 
 
 class AddMod(_AddMulMod):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -826,7 +826,7 @@ class ECMul(BuiltinFunction):
         dst1 = IRnode.from_list(buf + 64, typ=UINT256_T, location=MEMORY)
         ret.append(make_setter(dst1, args[1]))
 
-        ret.append(["assert", ["staticcall", ["gas"], 7, buf, 128, buf, 64]])
+        ret.append(["assert", ["staticcall", ["gas"], 7, buf, 96, buf, 64]])
         ret.append(buf)
 
         return IRnode.from_list(ret, typ=SArrayT(UINT256_T, 2), location=MEMORY)


### PR DESCRIPTION
ecadd, ecmul, addmod, mulmod

in the case that the arguments have side effects, they could be evaluated out of order

chainsec june 2023 review 5.1

patch for https://github.com/vyperlang/vyper/security/advisories/GHSA-4hg4-9mf5-wxxq

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
