### PR TITLE
fix: `ecrecover()` edge case

### DIFF
--- a/tests/parser/functions/test_ecrecover.py
+++ b/tests/parser/functions/test_ecrecover.py
@@ -58,3 +58,29 @@ def test_ecrecover(hash: bytes32, v: uint8, r: uint256) -> address:
     r = 0
     # note web3.py decoding of 0x000..00 address is None.
     assert c.test_ecrecover(hash_, v, r) is None
+
+# slightly more subtle example: get_v() stomps memory location 0,
+# so this tests that the output buffer stays clean during ecrecover()
+# builtin execution.
+def test_invalid_signature2(get_contract):
+    code = """
+
+owner: immutable(address)
+
+@external
+def __init__():
+    owner = 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
+
+@internal
+def get_v() -> uint256:
+    assert owner == owner # force a dload to write at index 0 of memory
+    return 21
+
+@payable
+@external
+def test_ecrecover() -> bool:
+    assert ecrecover(empty(bytes32), self.get_v(), 0, 0) == empty(address)
+    return True
+    """
+    c = get_contract(code)
+    assert c.test_ecrecover() is True

--- a/tests/parser/functions/test_ecrecover.py
+++ b/tests/parser/functions/test_ecrecover.py
@@ -59,6 +59,7 @@ def test_ecrecover(hash: bytes32, v: uint8, r: uint256) -> address:
     # note web3.py decoding of 0x000..00 address is None.
     assert c.test_ecrecover(hash_, v, r) is None
 
+
 # slightly more subtle example: get_v() stomps memory location 0,
 # so this tests that the output buffer stays clean during ecrecover()
 # builtin execution.

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -765,7 +765,7 @@ class ECRecover(BuiltinFunction):
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         input_buf = context.new_internal_variable(get_type_for_exact_size(128))
-        output_buf = MemoryPositions.FREE_VAR_SPACE
+        output_buf = context.new_internal_variable(get_type_for_exact_size(32))
         return IRnode.from_list(
             [
                 "seq",


### PR DESCRIPTION
### What I did
fix an edge case that was not coverd by 019a37ab98ff53f04fecfadf602b6cd5ac748f7f

### How I did it

### How to verify it

### Commit message

```
this commit fixes an edge case in `ecrecover()` that was not covered by
019a37ab98ff5. in the case that one of the arguments to ecrecover writes
to memory location 0, and the signature is invalid, `ecrecover()` could
return the data written by the argument. this commit fixes the issue by
allocating fresh memory for the output buffer (which won't be written to
by evaluating any of the arguments unless the memory allocator is
broken).
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
