### PR TITLE
chore(ci): fix macos universal2 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Generate Binary
         run: >-
-          pip install --no-binary pycryptodome . &&
+          pip install --no-binary pycryptodome --no-binary cbor2 . &&
           pip install pyinstaller &&
           make freeze
 


### PR DESCRIPTION
### What I did
fix macos universal2 build: https://github.com/vyperlang/vyper/actions/runs/6099031696/job/16550232924

this is a build regression introduced by the inclusion of the `cbor2` package in https://github.com/vyperlang/vyper/commit/96d20425fa2fbebb9e9aeb0402399c745eb80cfe.

### How I did it

### How to verify it
build tested here: https://github.com/charles-cooper/vyper/actions/runs/6099390346/job/16551425523

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
