### PR TITLE
chore: add `ir_runtime` option to cli help

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -41,6 +41,7 @@ opcodes            - List of opcodes as a string
 opcodes_runtime    - List of runtime opcodes as a string
 ir                 - Intermediate representation in list format
 ir_json            - Intermediate representation in JSON format
+ir_runtime         - Intermediate representation of runtime bytecode in list format
 asm                - Output the EVM assembly of the deployable bytecode
 hex-ir             - Output IR and assembly constants in hex instead of decimal
 """


### PR DESCRIPTION
### What I did

As title.

### Commit message

```bash
chore: add `ir_runtime` option to cli help
```

### Description for the changelog

chore: add `ir_runtime` option to cli help

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/fd37bb60-a329-47be-b5fc-b4258a2f8a5f)