### PR TITLE
chore(ci): fix binary names in release asset upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
               -X POST \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
               -H "Content-Type: application/octet-stream" \
-              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME}" \
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=${BIN_NAME/+/%2B}" \
               --data-binary "@${BIN_NAME}"
           done
 


### PR DESCRIPTION
rename binary during asset upload to properly escape the filename for the github API call.

(Github API states:
> GitHub renames asset filenames that have special characters,
non-alphanumeric characters, and leading or trailing periods. The "List release assets" endpoint lists the renamed filenames. For more information and help, contact GitHub Support.
)

### What I did

### How I did it

### How to verify it
https://github.com/charles-cooper/vyper/releases/tag/v0.3.10rc5
https://github.com/charles-cooper/vyper/actions/runs/6114530221/job/16596363225

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
