### PR TITLE
chore: tighten bounds for setuptools_scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         "importlib-metadata",
         "wheel",
     ],
-    setup_requires=["pytest-runner", "setuptools_scm"],
+    setup_requires=["pytest-runner", "setuptools_scm>=7.1.0,<8.0.0"],
     tests_require=extras_require["test"],
     extras_require=extras_require,
     entry_points={

--- a/tests/ast/nodes/test_evaluate_binop_decimal.py
+++ b/tests/ast/nodes/test_evaluate_binop_decimal.py
@@ -13,7 +13,7 @@ st_decimals = st.decimals(
 
 
 @pytest.mark.fuzzing
-@settings(max_examples=50, deadline=1000)
+@settings(max_examples=50, deadline=None)
 @given(left=st_decimals, right=st_decimals)
 @example(left=Decimal("0.9999999999"), right=Decimal("0.0000000001"))
 @example(left=Decimal("0.0000000001"), right=Decimal("0.9999999999"))
@@ -52,7 +52,7 @@ def test_binop_pow():
 
 
 @pytest.mark.fuzzing
-@settings(max_examples=50, deadline=1000)
+@settings(max_examples=50, deadline=None)
 @given(
     values=st.lists(st_decimals, min_size=2, max_size=10),
     ops=st.lists(st.sampled_from("+-*/%"), min_size=11, max_size=11),


### PR DESCRIPTION
there is a regression in 8.0.0 which results in the following invalid code being generated for vyper/version.py:

```python
from __future__ import annotations
__version__ : str = version : str = '0.3.11'
__version_tuple__ : 'tuple[int | str, ...]' = \
  version_tuple : 'tuple[int | str, ...]' = (0, 3, 11)
```

this is a CI blocker.

### What I did
fix a linter error, for instance as seen here: https://github.com/vyperlang/vyper/actions/runs/6247580329/job/16960472804?pr=3603

### How I did it
pin setuptools_scm

### How to verify it
check that lint passes

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
