### PR TITLE
chore: add metadata to vyper-json

### DIFF
--- a/tests/cli/vyper_json/test_output_selection.py
+++ b/tests/cli/vyper_json/test_output_selection.py
@@ -52,3 +52,9 @@ def test_solc_style():
     input_json = {"settings": {"outputSelection": {"foo.vy": {"": ["abi"], "foo.vy": ["ir"]}}}}
     sources = {"foo.vy": ""}
     assert get_input_dict_output_formats(input_json, sources) == {"foo.vy": ["abi", "ir_dict"]}
+
+
+def test_metadata():
+    input_json = {"settings": {"outputSelection": {"*": ["metadata"]}}}
+    sources = {"foo.vy": ""}
+    assert get_input_dict_output_formats(input_json, sources) == {"foo.vy": ["metadata"]}

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -29,7 +29,7 @@ TRANSLATE_MAP = {
     "interface": "interface",
     "ir": "ir_dict",
     "ir_runtime": "ir_runtime_dict",
-    # "metadata": "metadata",  # don't include  in "*" output for now
+    "metadata": "metadata",
     "layout": "layout",
     "userdoc": "userdoc",
 }

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -104,7 +104,6 @@ def build_ir_runtime_dict_output(compiler_data: CompilerData) -> dict:
 
 
 def build_metadata_output(compiler_data: CompilerData) -> dict:
-    warnings.warn("metadata output format is unstable!")
     sigs = compiler_data.function_signatures
 
     def _var_rec_dict(variable_record):


### PR DESCRIPTION
### What I did

Fix #3619 

### How I did it

Add `metadata` output to `vyper-json`.

### How to verify it

### Commit message

chore: add metadata to vyper-json

### Description for the changelog

Add metadata output for vyper-json.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpapers.com/images/hd/cute-giraffe-hugs-a-tree-trunk-oqdfipeos9a825qk.jpg)
