### PR TITLE
fix: type check abi_decode arguments

### DIFF
--- a/tests/parser/syntax/test_abi_decode.py
+++ b/tests/parser/syntax/test_abi_decode.py
@@ -1,0 +1,45 @@
+import pytest
+
+from vyper import compiler
+from vyper.exceptions import InvalidType, TypeMismatch
+
+fail_list = [
+    (
+        """
+@external
+def foo(j: uint256) -> bool:
+    s: bool = _abi_decode(j, bool, unwrap_tuple= False)
+    return s
+    """,
+        TypeMismatch,
+    ),
+    (
+        """
+@external
+def bar(j: String[32]) -> bool:
+    s: bool = _abi_decode(j, bool, unwrap_tuple= False)
+    return s
+    """,
+        TypeMismatch,
+    ),
+]
+
+
+@pytest.mark.parametrize("bad_code,exc", fail_list)
+def test_abi_encode_fail(bad_code, exc):
+    with pytest.raises(exc):
+        compiler.compile_code(bad_code)
+
+
+valid_list = [
+    """
+@external
+def foo(x: Bytes[32]) -> uint256:
+    return _abi_decode(x, uint256)
+    """,
+]
+
+
+@pytest.mark.parametrize("good_code", valid_list)
+def test_abi_encode_success(good_code):
+    assert compiler.compile_code(good_code) is not None

--- a/tests/parser/syntax/test_abi_decode.py
+++ b/tests/parser/syntax/test_abi_decode.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -36,7 +36,7 @@ valid_list = [
 @external
 def foo(x: Bytes[32]) -> uint256:
     return _abi_decode(x, uint256)
-    """,
+    """
 ]
 
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2494,6 +2494,8 @@ class ABIDecode(BuiltinFunction):
         return output_type.typedef
 
     def infer_arg_types(self, node):
+        self._validate_arg_types(node)
+
         validate_call_args(node, 2, ["unwrap_tuple"])
 
         data_type = get_exact_type_from_node(node.args[0])


### PR DESCRIPTION
currently, the following code will trigger a compiler panic:
```vyper
@external
def foo(j: uint256) -> bool:
    s: bool = _abi_decode(j, bool, unwrap_tuple= False)
    return s
```

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
