### PR TITLE
fix: `_abi_decode()` validation

### DIFF
--- a/tests/parser/functions/test_abi_decode.py
+++ b/tests/parser/functions/test_abi_decode.py
@@ -344,6 +344,35 @@ def abi_decode(x: Bytes[96]) -> (uint256, uint256):
     assert_tx_failed(lambda: c.abi_decode(input_))
 
 
+def test_clamper_nested_uint8(get_contract, assert_tx_failed):
+    # check that _abi_decode clamps on word-types even when it is in a nested expression
+    # decode -> validate uint8 -> revert if input >= 256 -> cast back to uint256
+    contract = """
+@external
+def abi_decode(x: uint256) -> uint256:
+    a: uint256 = convert(_abi_decode(slice(msg.data, 4, 32), (uint8)), uint256)
+    return a
+    """
+    c = get_contract(contract)
+    assert c.abi_decode(255) == 255
+    assert_tx_failed(lambda: c.abi_decode(256))
+
+
+def test_clamper_nested_bytes(get_contract, assert_tx_failed):
+    # check that _abi_decode clamps dynamic even when it is in a nested expression
+    # decode -> validate Bytes[20] -> revert if len(input) > 20 -> convert back to -> add 1
+    contract = """
+@external
+def abi_decode(x: Bytes[96]) -> Bytes[21]:
+    a: Bytes[21] = concat(b"a", _abi_decode(x, Bytes[20]))
+    return a
+    """
+    c = get_contract(contract)
+    assert c.abi_decode(abi.encode("(bytes)", (b"bc",))) == b"abc"
+    assert_tx_failed(lambda: c.abi_decode(abi.encode("(bytes)", (b"a" * 22,))))
+
+
+
 @pytest.mark.parametrize(
     "output_typ,input_",
     [

--- a/tests/parser/functions/test_abi_decode.py
+++ b/tests/parser/functions/test_abi_decode.py
@@ -372,7 +372,6 @@ def abi_decode(x: Bytes[96]) -> Bytes[21]:
     assert_tx_failed(lambda: c.abi_decode(abi.encode("(bytes)", (b"a" * 22,))))
 
 
-
 @pytest.mark.parametrize(
     "output_typ,input_",
     [

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -16,7 +16,6 @@ from vyper.codegen.core import (
     bytes_data_ptr,
     calculate_type_for_external_return,
     check_external_call,
-    needs_clamp,
     clamp,
     clamp2,
     clamp_basetype,
@@ -29,7 +28,6 @@ from vyper.codegen.core import (
     get_type_for_exact_size,
     ir_tuple_from_args,
     make_setter,
-    needs_external_call_wrap,
     promote_signed_int,
     sar,
     shl,
@@ -2540,10 +2538,8 @@ class ABIDecode(BuiltinFunction):
             )
             to_decode.encoding = Encoding.ABI
 
-            # optimization: skip make_setter when we don't need input validation
-            #if not needs_clamp(to_decode.typ, to_decode.encoding):
-            #    ret.append(to_decode)
-            #    return b1.resolve(IRnode.from_list(ret, typ=to_decode.typ, location=to_decode.location, encoding=to_decode.encoding))
+            # TODO optimization: skip make_setter when we don't need
+            # input validation
 
             output_buf = context.new_internal_variable(wrapped_typ)
             output = IRnode.from_list(output_buf, typ=wrapped_typ, location=MEMORY)


### PR DESCRIPTION
### What I did
tracking for https://github.com/vyperlang/vyper/security/advisories/GHSA-cx2q-hfxr-rj97

### How I did it

### How to verify it

### Commit message

```
    `_abi_decode()` does not validate input when it is nested in certain
    expressions. the following example gets correctly validated (bounds
    checked):

    ```vyper
        x: uint8 = _abi_decode(slice(msg.data, 4, 32), uint8)
    ```

    however, the following example is not bounds checked:

    ```vyper
    @external
    def abi_decode(x: uint256) -> uint256:
        a: uint256 = convert(
            _abi_decode(
                slice(msg.data, 4, 32),
                (uint8)
            ),
            uint256
        )
        return a  # abi_decode(256) returns: 256
    ```

    the issue is caused because the `ABIDecode()` builtin tags its output
    with `encoding=Encoding.ABI`, but this does not result in validation
    until that itself is passed to `make_setter` (which is called for
    instance when generating an assignment or return statement).

    the issue can be triggered by constructing an example where the output
    of `ABIDecode()` is not internally passed to `make_setter` or other
    input validating routine.

    this commit fixes the issue by calling `make_setter` in `ABIDecode()`
    before returning the output buffer, which causes validation to be
    performed. note that this causes a performance regression in the common
    (and majority of) cases where `make_setter` is immediately called on the
    result of `ABIDecode()` because a redundant memory copy ends up being
    generated (like in the aforementioned examples: in a plain assignment or
    return statement). however, fixing this performance regression is left
    to future work in the optimizer.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
