### PR TITLE
fix: metadata output interaction with natspec

### DIFF
--- a/examples/tokens/ERC1155ownable.vy
+++ b/examples/tokens/ERC1155ownable.vy
@@ -214,7 +214,6 @@ def mint(receiver: address, id: uint256, amount:uint256):
     @param receiver the account that will receive the minted token
     @param id the ID of the token
     @param amount of tokens for this ID
-    @param data the data associated with this mint. Usually stays empty
     """
     assert not self.paused, "The contract has been paused"
     assert self.owner == msg.sender, "Only the contract owner can mint"
@@ -232,7 +231,6 @@ def mintBatch(receiver: address, ids: DynArray[uint256, BATCH_SIZE], amounts: Dy
     @param receiver the account that will receive the minted token
     @param ids array of ids for the tokens
     @param amounts amounts of tokens for each ID in the ids array
-    @param data the data associated with this mint. Usually stays empty
     """
     assert not self.paused, "The contract has been paused"
     assert self.owner == msg.sender, "Only the contract owner can mint"

--- a/tests/base_conftest.py
+++ b/tests/base_conftest.py
@@ -118,8 +118,8 @@ def _get_contract(w3, source_code, optimize, *args, override_opt_level=None, **k
     settings.optimize = override_opt_level or optimize
     out = compiler.compile_code(
         source_code,
-        # test that metadata gets generated
-        ["abi", "bytecode", "metadata"],
+        # test that metadata and natspecs get generated
+        ["abi", "bytecode", "metadata", "userdoc", "devdoc"],
         settings=settings,
         interface_codes=kwargs.pop("interface_codes", None),
         show_gas_estimates=True,  # Enable gas estimates for testing

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -107,7 +107,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
     sigs = compiler_data.function_signatures
 
     def _var_rec_dict(variable_record):
-        ret = vars(variable_record)
+        ret = vars(variable_record).copy()
         ret["typ"] = str(ret["typ"])
         if ret["data_offset"] is None:
             del ret["data_offset"]
@@ -133,7 +133,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
             args = ret[attr]
             ret[attr] = {arg.name: str(arg.typ) for arg in args}
 
-        ret["frame_info"] = vars(func_t._ir_info.frame_info)
+        ret["frame_info"] = vars(func_t._ir_info.frame_info).copy()
         del ret["frame_info"]["frame_vars"]  # frame_var.pos might be IR, cannot serialize
 
         keep_keys = {

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -117,7 +117,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
         return ret
 
     def _to_dict(func_t):
-        ret = vars(func_t)
+        ret = vars(func_t).copy()
         ret["return_type"] = str(ret["return_type"])
         ret["_ir_identifier"] = func_t._ir_info.ir_identifier
 


### PR DESCRIPTION
enabling the `-f metadata` output has an interaction with other outputs because the metadata output format mutates some internal data structures in-place. this is because `vars()` returns a reference to the object's `__dict__` as opposed to a copy of it. the behavior can be seen by trying to call the compiler with `-f metadata,devdoc,userdoc`.

this commit fixes the issue by constructing a copy of the object during metadata output formatting. it also modifies the test suite to include more output formats, to test the interactions between these different output formats. in doing so, it was also found that some examples have invalid natspec, which has also been fixed.

the issue was revealed in (but not introduced by) #3622, because that causes the relevant interaction to happen when constructing vyper-json `'*'` output.

### What I did

### How I did it

### How to verify it

### Commit message

```
enabling the `-f metadata` output has an interaction with other outputs
because the metadata output format mutates some internal data structures
in-place. this is because `vars()` returns a reference to the object's
`__dict__` as opposed to a copy of it. the behavior can be seen by
trying to call the compiler with `-f metadata,devdoc,userdoc`. this
issue was revealed in (but not introduced by) 2bdbd846b0, because that
commit caused metadata and userdoc to be bundled together by default.

this commit fixes the issue by constructing a copy of the object during
metadata output formatting. it also modifies the test suite to include
more output formats, to test the interactions between these different
output formats. in doing so, it was also found that some examples have
invalid natspec, which has also been fixed.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
