### PR TITLE
chore: fix test for `slice`

### DIFF
--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -146,12 +146,11 @@ def do_slice(inp: Bytes[{length_bound}], start: uint256, length: uint256) -> Byt
     if (
         (start + length > data_length and literal_start and literal_length)
         or (literal_length and length > data_length)
-        or (location == "literal" and len(bytesdata) > length_bound)
         or (literal_start and start > data_length)
         or (literal_length and length < 1)
     ):
         assert_compile_failed(lambda: _get_contract(), (ArgumentException, TypeMismatch))
-    elif len(bytesdata) > data_length:
+    elif len(bytesdata) > data_length or (location == "literal" and len(bytesdata) > length_bound):
         # deploy fail
         assert_tx_failed(lambda: _get_contract())
     elif start + length > len(bytesdata):

--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -146,11 +146,12 @@ def do_slice(inp: Bytes[{length_bound}], start: uint256, length: uint256) -> Byt
     if (
         (start + length > data_length and literal_start and literal_length)
         or (literal_length and length > data_length)
+        or (location == "literal" and len(bytesdata) > length_bound)
         or (literal_start and start > data_length)
         or (literal_length and length < 1)
     ):
         assert_compile_failed(lambda: _get_contract(), (ArgumentException, TypeMismatch))
-    elif len(bytesdata) > data_length or (location == "literal" and len(bytesdata) > length_bound):
+    elif len(bytesdata) > data_length:
         # deploy fail
         assert_tx_failed(lambda: _get_contract())
     elif start + length > len(bytesdata):

--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -152,7 +152,11 @@ def do_slice(inp: Bytes[{length_bound}], start: uint256, length: uint256) -> Byt
     if (
         (start + length > data_length and literal_start and literal_length)
         or (literal_length and length > data_length)
-        or (location == "literal" and len(bytesdata) > length_bound and not literal_length)
+        or (
+            location == "literal"
+            and len(bytesdata) > length_bound
+            and ((literal_length and length > length_bound) or (not literal_length))
+        )
         or (literal_start and start > data_length)
         or (literal_length and length < 1)
     ):

--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -161,7 +161,7 @@ def do_slice(inp: Bytes[{length_bound}], start: uint256, length: uint256) -> Byt
         or (literal_length and length < 1)
     ):
         assert_compile_failed(lambda: _get_contract(), (ArgumentException, TypeMismatch))
-    elif location in "code" and len(bytesdata) > data_length:
+    elif location == "code" and len(bytesdata) > data_length:
         # deploy fail
         assert_tx_failed(lambda: _get_contract())
     elif start + length > len(bytesdata) or len(bytesdata) > length_bound:

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -333,8 +333,6 @@ class Slice(BuiltinFunction):
         # we know the length statically
         if length_literal is not None:
             return_type.set_length(length_literal)
-        else:
-            return_type.set_min_length(arg_type.length)
 
         return return_type
 
@@ -378,12 +376,8 @@ class Slice(BuiltinFunction):
                 buflen += 32
 
             # Get returntype string or bytes
-            assert isinstance(src.typ, _BytestringT) or is_bytes32
-            # TODO: try to get dst_typ from semantic analysis
-            if isinstance(src.typ, StringT):
-                dst_typ = StringT(dst_maxlen)
-            else:
-                dst_typ = BytesT(dst_maxlen)
+            dst_typ = expr._metadata.get("type")
+            assert isinstance(dst_typ, _BytestringT) or is_bytes32
 
             # allocate a buffer for the return value
             buf = context.new_internal_variable(BytesT(buflen))

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -377,7 +377,11 @@ class Slice(BuiltinFunction):
 
             # Get returntype string or bytes
             dst_typ = expr._metadata.get("type")
-            assert isinstance(dst_typ, _BytestringT) or is_bytes32
+            assert isinstance(dst_typ, _BytestringT)
+
+            # set the length of the return type if it was not defined in annotation
+            if dst_typ.length == 0:
+                dst_typ.set_length(dst_maxlen)
 
             # allocate a buffer for the return value
             buf = context.new_internal_variable(BytesT(buflen))

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -333,6 +333,8 @@ class Slice(BuiltinFunction):
         # we know the length statically
         if length_literal is not None:
             return_type.set_length(length_literal)
+        else:
+            return_type.set_min_length(arg_type.length)
 
         return return_type
 
@@ -376,8 +378,12 @@ class Slice(BuiltinFunction):
                 buflen += 32
 
             # Get returntype string or bytes
-            dst_typ = expr._metadata.get("type")
-            assert isinstance(dst_typ, _BytestringT) or is_bytes32
+            assert isinstance(src.typ, _BytestringT) or is_bytes32
+            # TODO: try to get dst_typ from semantic analysis
+            if isinstance(src.typ, StringT):
+                dst_typ = StringT(dst_maxlen)
+            else:
+                dst_typ = BytesT(dst_maxlen)
 
             # allocate a buffer for the return value
             buf = context.new_internal_variable(BytesT(buflen))

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -377,11 +377,7 @@ class Slice(BuiltinFunction):
 
             # Get returntype string or bytes
             dst_typ = expr._metadata.get("type")
-            assert isinstance(dst_typ, _BytestringT)
-
-            # set the length of the return type if it was not defined in annotation
-            if dst_typ.length == 0:
-                dst_typ.set_length(dst_maxlen)
+            assert isinstance(dst_typ, _BytestringT) or is_bytes32
 
             # allocate a buffer for the return value
             buf = context.new_internal_variable(BytesT(buflen))


### PR DESCRIPTION
### What I did

Fix failing fuzzing [test](https://github.com/vyperlang/vyper/actions/runs/6318947122/job/17158979469) for `slice`.

### How I did it

Make the test contract for each bytesdata location more specific.

### How to verify it

See tests.

### Commit message

```
chore: fix test for `slice``
```

### Description for the changelog

Fix test for `slice`.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/1200x/17/67/96/1767963b399a015b6b9727dc7abaff3f.jpg)
