### PR TITLE
feat: disallow invalid pragmas

### DIFF
--- a/tests/ast/test_pre_parser.py
+++ b/tests/ast/test_pre_parser.py
@@ -132,7 +132,7 @@ pragma_examples = [
     #pragma optimize codesize
     #pragma evm-version shanghai
     """,
-        Settings(evm_version="shanghai", optimize=OptimizationLevel.GAS),
+        Settings(evm_version="shanghai", optimize=OptimizationLevel.CODESIZE),
     ),
     (
         """
@@ -160,6 +160,7 @@ pragma_examples = [
 
 
 @pytest.mark.parametrize("code, expected_pragmas", pragma_examples)
-def parse_pragmas(code, expected_pragmas):
+def test_parse_pragmas(code, expected_pragmas, mock_version):
+    mock_version("0.3.10")
     pragmas, _, _ = pre_parse(code)
     assert pragmas == expected_pragmas

--- a/tests/ast/test_pre_parser.py
+++ b/tests/ast/test_pre_parser.py
@@ -1,8 +1,8 @@
 import pytest
 
 from vyper.ast.pre_parser import pre_parse, validate_version_pragma
-from vyper.compiler.settings import OptimizationLevel, Settings
 from vyper.compiler.phases import CompilerData
+from vyper.compiler.settings import OptimizationLevel, Settings
 from vyper.exceptions import VersionException
 
 SRC_LINE = (1, 0)  # Dummy source line

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -111,7 +111,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, str]:
                         validate_version_pragma(compiler_version, start)
                         settings.compiler_version = compiler_version
 
-                    if pragma.startswith("optimize "):
+                    elif pragma.startswith("optimize "):
                         if settings.optimize is not None:
                             raise StructureException("pragma optimize specified twice!", start)
                         try:
@@ -119,13 +119,16 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, str]:
                             settings.optimize = OptimizationLevel.from_string(mode)
                         except ValueError:
                             raise StructureException(f"Invalid optimization mode `{mode}`", start)
-                    if pragma.startswith("evm-version "):
+                    elif pragma.startswith("evm-version "):
                         if settings.evm_version is not None:
                             raise StructureException("pragma evm-version specified twice!", start)
                         evm_version = pragma.removeprefix("evm-version").strip()
                         if evm_version not in EVM_VERSIONS:
                             raise StructureException("Invalid evm version: `{evm_version}`", start)
                         settings.evm_version = evm_version
+
+                    else:
+                        raise StructureException(f"Unknown pragma `{pragma.split()[0]}`")
 
             if typ == NAME and string in ("class", "yield"):
                 raise SyntaxException(

--- a/vyper/compiler/README.md
+++ b/vyper/compiler/README.md
@@ -51,11 +51,9 @@ for specific implementation details.
 [`vyper.compiler.compile_codes`](__init__.py) is the main user-facing function for
 generating compiler output from Vyper source. The process is as follows:
 
-1. The `@evm_wrapper` decorator sets the target EVM version in
-[`opcodes.py`](../evm/opcodes.py).
-2. A [`CompilerData`](phases.py) object is created for each contract to be compiled.
+1. A [`CompilerData`](phases.py) object is created for each contract to be compiled.
 This object uses `@property` methods to trigger phases of the compiler as required.
-3. Functions in [`output.py`](output.py) generate the requested outputs from the
+2. Functions in [`output.py`](output.py) generate the requested outputs from the
 compiler data.
 
 ## Design

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -130,20 +130,18 @@ def compile_codes(
             show_gas_estimates,
             no_bytecode_metadata,
         )
-        _ = compiler_data._generate_ast
-        with anchor_evm_version(compiler_data.settings.evm_version):
-            for output_format in output_formats[contract_name]:
-                if output_format not in OUTPUT_FORMATS:
-                    raise ValueError(f"Unsupported format type {repr(output_format)}")
-                try:
-                    out.setdefault(contract_name, {})
-                    formatter = OUTPUT_FORMATS[output_format]
-                    out[contract_name][output_format] = formatter(compiler_data)
-                except Exception as exc:
-                    if exc_handler is not None:
-                        exc_handler(contract_name, exc)
-                    else:
-                        raise exc
+        for output_format in output_formats[contract_name]:
+            if output_format not in OUTPUT_FORMATS:
+                raise ValueError(f"Unsupported format type {repr(output_format)}")
+            try:
+                out.setdefault(contract_name, {})
+                formatter = OUTPUT_FORMATS[output_format]
+                out[contract_name][output_format] = formatter(compiler_data)
+            except Exception as exc:
+                if exc_handler is not None:
+                    exc_handler(contract_name, exc)
+                else:
+                    raise exc
 
     return out
 

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -130,18 +130,19 @@ def compile_codes(
             show_gas_estimates,
             no_bytecode_metadata,
         )
-        for output_format in output_formats[contract_name]:
-            if output_format not in OUTPUT_FORMATS:
-                raise ValueError(f"Unsupported format type {repr(output_format)}")
-            try:
-                out.setdefault(contract_name, {})
-                formatter = OUTPUT_FORMATS[output_format]
-                out[contract_name][output_format] = formatter(compiler_data)
-            except Exception as exc:
-                if exc_handler is not None:
-                    exc_handler(contract_name, exc)
-                else:
-                    raise exc
+        with anchor_evm_version(compiler_data.settings.evm_version):
+            for output_format in output_formats[contract_name]:
+                if output_format not in OUTPUT_FORMATS:
+                    raise ValueError(f"Unsupported format type {repr(output_format)}")
+                try:
+                    out.setdefault(contract_name, {})
+                    formatter = OUTPUT_FORMATS[output_format]
+                    out[contract_name][output_format] = formatter(compiler_data)
+                except Exception as exc:
+                    if exc_handler is not None:
+                        exc_handler(contract_name, exc)
+                    else:
+                        raise exc
 
     return out
 

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -120,17 +120,18 @@ def compile_codes(
         # make IR output the same between runs
         codegen.reset_names()
 
-        with anchor_evm_version(settings.evm_version):
-            compiler_data = CompilerData(
-                source_code,
-                contract_name,
-                interfaces,
-                source_id,
-                settings,
-                storage_layout_override,
-                show_gas_estimates,
-                no_bytecode_metadata,
-            )
+        compiler_data = CompilerData(
+            source_code,
+            contract_name,
+            interfaces,
+            source_id,
+            settings,
+            storage_layout_override,
+            show_gas_estimates,
+            no_bytecode_metadata,
+        )
+        _ = compiler_data._generate_ast
+        with anchor_evm_version(compiler_data.settings.evm_version):
             for output_format in output_formats[contract_name]:
                 if output_format not in OUTPUT_FORMATS:
                     raise ValueError(f"Unsupported format type {repr(output_format)}")

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -91,6 +91,7 @@ class CompilerData:
     @cached_property
     def _generate_ast(self):
         settings, ast = generate_ast(self.source_code, self.source_id, self.contract_name)
+
         # validate the compiler settings
         # XXX: this is a bit ugly, clean up later
         if settings.evm_version is not None:

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import warnings
 from functools import cached_property
 from typing import Optional, Tuple
@@ -9,11 +10,21 @@ from vyper.codegen.core import anchor_opt_level
 from vyper.codegen.global_context import GlobalContext
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.evm.opcodes import anchor_evm_version
 from vyper.exceptions import StructureException
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics import set_data_positions, validate_semantics
 from vyper.semantics.types.function import ContractFunctionT
 from vyper.typing import InterfaceImports, StorageLayout
+
+
+def _evm_wrapper(fn):
+    @functools.wraps(fn)
+    def inner(self, *args, **kwargs):
+        with anchor_evm_version(self.settings.evm_version):
+            return fn(self, *args, **kwargs)
+
+    return inner
 
 
 class CompilerData:
@@ -88,6 +99,8 @@ class CompilerData:
         self.no_bytecode_metadata = no_bytecode_metadata
         self.settings = settings or Settings()
 
+        _ = self._generate_ast  # force settings to be calculated
+
     @cached_property
     def _generate_ast(self):
         settings, ast = generate_ast(self.source_code, self.source_id, self.contract_name)
@@ -125,6 +138,7 @@ class CompilerData:
         return self._generate_ast
 
     @cached_property
+    @_evm_wrapper
     def vyper_module_unfolded(self) -> vy_ast.Module:
         # This phase is intended to generate an AST for tooling use, and is not
         # used in the compilation process.
@@ -132,41 +146,49 @@ class CompilerData:
         return generate_unfolded_ast(self.vyper_module, self.interface_codes)
 
     @cached_property
+    @_evm_wrapper
     def _folded_module(self):
         return generate_folded_ast(
             self.vyper_module, self.interface_codes, self.storage_layout_override
         )
 
     @property
+    @_evm_wrapper
     def vyper_module_folded(self) -> vy_ast.Module:
         module, storage_layout = self._folded_module
         return module
 
     @property
+    @_evm_wrapper
     def storage_layout(self) -> StorageLayout:
         module, storage_layout = self._folded_module
         return storage_layout
 
     @property
+    @_evm_wrapper
     def global_ctx(self) -> GlobalContext:
         return GlobalContext(self.vyper_module_folded)
 
     @cached_property
+    @_evm_wrapper
     def _ir_output(self):
         # fetch both deployment and runtime IR
         return generate_ir_nodes(self.global_ctx, self.settings.optimize)
 
     @property
+    @_evm_wrapper
     def ir_nodes(self) -> IRnode:
         ir, ir_runtime = self._ir_output
         return ir
 
     @property
+    @_evm_wrapper
     def ir_runtime(self) -> IRnode:
         ir, ir_runtime = self._ir_output
         return ir_runtime
 
     @property
+    @_evm_wrapper
     def function_signatures(self) -> dict[str, ContractFunctionT]:
         # some metadata gets calculated during codegen, so
         # ensure codegen is run:
@@ -176,23 +198,28 @@ class CompilerData:
         return {f.name: f._metadata["type"] for f in fs}
 
     @cached_property
+    @_evm_wrapper
     def assembly(self) -> list:
         return generate_assembly(self.ir_nodes, self.settings.optimize)
 
     @cached_property
+    @_evm_wrapper
     def assembly_runtime(self) -> list:
         return generate_assembly(self.ir_runtime, self.settings.optimize)
 
     @cached_property
+    @_evm_wrapper
     def bytecode(self) -> bytes:
         insert_compiler_metadata = not self.no_bytecode_metadata
         return generate_bytecode(self.assembly, insert_compiler_metadata=insert_compiler_metadata)
 
     @cached_property
+    @_evm_wrapper
     def bytecode_runtime(self) -> bytes:
         return generate_bytecode(self.assembly_runtime, insert_compiler_metadata=False)
 
     @cached_property
+    @_evm_wrapper
     def blueprint_bytecode(self) -> bytes:
         blueprint_preamble = b"\xFE\x71\x00"  # ERC5202 preamble
         blueprint_bytecode = blueprint_preamble + self.bytecode

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -120,6 +120,8 @@ class CompilerData:
         if self.settings.optimize is None:
             self.settings.optimize = OptimizationLevel.default()
 
+        # note self.settings.compiler_version is erased here as it is
+        # not used after pre-parsing
         return ast
 
     @cached_property


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
this commit prevents typos (ex. `# pragma evm-versionn ...`) from
getting unexpectedly ignored. it also fixes an issue with the
`evm_version` pragma getting properly propagated into `CompilerData`. it
also fixes a misnamed test function, and adds some unit tests to check
that `evm_version` gets properly propagated into `CompilerData`.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
