### PR TITLE
fix: block memory allocation overflow

### DIFF
--- a/vyper/codegen/memory_allocator.py
+++ b/vyper/codegen/memory_allocator.py
@@ -46,6 +46,8 @@ class MemoryAllocator:
 
     next_mem: int
 
+    _ALLOCATION_LIMIT: int = 2**64
+
     def __init__(self, start_position: int = MemoryPositions.RESERVED_MEMORY):
         """
         Initializer.
@@ -111,10 +113,11 @@ class MemoryAllocator:
         self.next_mem += size
         self.size_of_mem = max(self.size_of_mem, self.next_mem)
 
-        if self.size_of_mem >= 2**64:
+        if self.size_of_mem >= self._ALLOCATION_LIMIT:
             # this should not be caught
             raise MemoryAllocationException(
-                "Tried to allocate {self.size_of_mem} bytes! (limit is 2**32 bytes)"
+                f"Tried to allocate {self.size_of_mem} bytes! "
+                f"(limit is 2**64 bytes)"
             )
 
         return before_value

--- a/vyper/codegen/memory_allocator.py
+++ b/vyper/codegen/memory_allocator.py
@@ -117,7 +117,7 @@ class MemoryAllocator:
             # this should not be caught
             raise MemoryAllocationException(
                 f"Tried to allocate {self.size_of_mem} bytes! "
-                f"(limit is 2**64 bytes)"
+                f"(limit is {self._ALLOCATION_LIMIT} (2**64) bytes)"
             )
 
         return before_value

--- a/vyper/codegen/memory_allocator.py
+++ b/vyper/codegen/memory_allocator.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from vyper.exceptions import CompilerPanic
+from vyper.exceptions import CompilerPanic, MemoryAllocationException
 from vyper.utils import MemoryPositions
 
 
@@ -110,6 +110,13 @@ class MemoryAllocator:
         before_value = self.next_mem
         self.next_mem += size
         self.size_of_mem = max(self.size_of_mem, self.next_mem)
+
+        if self.size_of_mem >= 2**64:
+            # this should not be caught
+            raise MemoryAllocationException(
+                "Tried to allocate {self.size_of_mem} bytes! (limit is 2**32 bytes)"
+            )
+
         return before_value
 
     def deallocate_memory(self, pos: int, size: int) -> None:

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -269,6 +269,10 @@ class StorageLayoutException(VyperException):
     """Invalid slot for the storage layout overrides"""
 
 
+class MemoryAllocationException(VyperException):
+    """Tried to allocate too much memory"""
+
+
 class JSONError(Exception):
 
     """Invalid compiler input JSON."""


### PR DESCRIPTION
### What I did

fix https://github.com/vyperlang/vyper/issues/3637

### How I did it

this fixes potential overflow bugs in pointer calculation by blocking memory allocation above a certain size. the size limit is set at `2**64`, which is the size of addressable memory on physical machines.

practically, for EVM use cases, we could limit at a much smaller number (like `2**24`), but we want to allow for "exotic" targets which may allow much more addressable memory.

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
