### PR TITLE
docs: add note on `pragma` parsing

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -17,7 +17,7 @@ Vyper supports several source code directives to control compiler modes and help
 Version Pragma
 --------------
 
-The version pragma ensures that a contract is only compiled by the intended compiler version, or range of versions. Version strings use `NPM <https://docs.npmjs.com/about-semantic-versioning>`_ style syntax. Starting from v0.4.0 and up, version strings will use `PEP440 version specifiers <https://peps.python.org/pep-0440/#version-specifiers>_`.
+The version pragma ensures that a contract is only compiled by the intended compiler version, or range of versions. Version strings use `NPM <https://docs.npmjs.com/about-semantic-versioning>`_ style syntax. Starting from v0.4.0 and up, version strings will use `PEP440 version specifiers <https://peps.python.org/pep-0440/#version-specifiers>`_.
 
 As of 0.3.10, the recommended way to specify the version pragma is as follows:
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -25,6 +25,10 @@ As of 0.3.10, the recommended way to specify the version pragma is as follows:
 
     #pragma version ^0.3.0
 
+.. note::
+
+    Both pragma directive versions ``#pragma`` and ``# pragma`` are supported.
+
 The following declaration is equivalent, and, prior to 0.3.10, was the only supported method to specify the compiler version:
 
 .. code-block:: python


### PR DESCRIPTION
### What I did

I add a note in the docs that both `pragma` directives `#pragma` and `# pragma` versions are supported. I deem this important as the previous version `# @version` also included a space. Furthermore, I fix a broken link for the _PEP440 version specifiers_.

### How I did it

N/A.

### How to verify it

N/A.

### Commit message

```console
docs: add note on pragma parsing
```

### Description for the changelog

docs: add note on `pragma` parsing

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/d1877514-aeab-4e35-9bf4-df3478379eb1)
