### PR TITLE
fix: remove hex-ir from format cli options list

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -43,7 +43,6 @@ ir                 - Intermediate representation in list format
 ir_json            - Intermediate representation in JSON format
 ir_runtime         - Intermediate representation of runtime bytecode in list format
 asm                - Output the EVM assembly of the deployable bytecode
-hex-ir             - Output IR and assembly constants in hex instead of decimal
 """
 
 combined_json_outputs = [


### PR DESCRIPTION
### What I did

Removed `hex-ir` from CLI help text. The option is available with the `--hex-ir` flag. A similar change was made to remove the duplicate `no-optimize` and `no-bytecode-metadata` cli format options [here](https://github.com/vyperlang/vyper/commit/593c9b86cfea23f624655d5847ef36ae00d7ccdc#diff-ca71900c54e006e760ac124b89b9790803bbac110c9ba51d9bbf5e5b08d76a0aL40).

### How I did it

### How to verify it

### Commit message

fix: remove hex-ir from format cli options

### Description for the changelog

Remove redundant hex-ir from format cli options list

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hedgecombers.com/wp-content/uploads/2009/06/hedgecombers1250.jpg)
