### PR TITLE
fix: edit link to style guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ### Commit message
 
-Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../blob/master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)
+Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)
 
 ### Description for the changelog
 


### PR DESCRIPTION
### What I did

Fix the PR template link to style guide

### How I did it

### How to verify it

### Commit message

Fix broken link to style guide in github PR template

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lukaskeapproth.files.wordpress.com/2012/01/cuteredpandaphoto-2.jpg)
