### PR TITLE
docs: retire security@vyperlang.org

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,7 @@ https://github.com/vyperlang/vyper/security/advisories
 
 If you think you have found a security vulnerability with a project that has used Vyper,
 please report the vulnerability to the relevant project's security disclosure program prior
-to reporting to us. If one is not available, please email your vulnerability to security@vyperlang.org.
+to reporting to us. If one is not available, submit it at https://github.com/vyperlang/vyper/security/advisories.
 
 **Please Do Not Log An Issue** mentioning the vulnerability.
 


### PR DESCRIPTION
now that private vulnerability reporting is available on github, the security inbox is no longer required (or regularly monitored)

cf. https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
