### PR TITLE
add abi_types unit tests

### DIFF
--- a/tests/abi_types/test_invalid_abi_types.py
+++ b/tests/abi_types/test_invalid_abi_types.py
@@ -11,20 +11,16 @@ from vyper.abi_types import (
 from vyper.exceptions import CompilerPanic
 
 cases_invalid_types = [
-    (ABI_GIntM, ((0, False), (7, False), (300, True), (300, False)), CompilerPanic),
-    (
-        ABI_FixedMxN,
-        ((0, 0, False), (8, 0, False), (256, 81, True), (300, 80, False)),
-        CompilerPanic,
-    ),
-    (ABI_BytesM, ((0,), (33,), (-10,)), CompilerPanic),
-    (ABI_Bytes, ((-1,), (-69,)), CompilerPanic),
-    (ABI_DynamicArray, ((ABI_GIntM(256, False), -1), (ABI_String(256), -10)), CompilerPanic),
+    (ABI_GIntM, ((0, False), (7, False), (300, True), (300, False))),
+    (ABI_FixedMxN, ((0, 0, False), (8, 0, False), (256, 81, True), (300, 80, False))),
+    (ABI_BytesM, ((0,), (33,), (-10,))),
+    (ABI_Bytes, ((-1,), (-69,))),
+    (ABI_DynamicArray, ((ABI_GIntM(256, False), -1), (ABI_String(256), -10))),
 ]
 
 
-@pytest.mark.parametrize("typ,params_variants,exc", cases_invalid_types)
-def test_invalid_abi_types(assert_compile_failed, typ, params_variants, exc):
+@pytest.mark.parametrize("typ,params_variants", cases_invalid_types)
+def test_invalid_abi_types(assert_compile_failed, typ, params_variants):
     # double parametrization cannot work because the 2nd dimension is variable
     for params in params_variants:
-        assert_compile_failed(lambda: typ(*params), exc)
+        assert_compile_failed(lambda: typ(*params), CompilerPanic)

--- a/tests/abi_types/test_invalid_abi_types.py
+++ b/tests/abi_types/test_invalid_abi_types.py
@@ -1,54 +1,25 @@
 import pytest
-from vyper.abi_types import ABI_Bytes, ABI_BytesM, ABI_DynamicArray, ABI_FixedMxN, ABI_GIntM, ABI_String
+
+from vyper.abi_types import (
+    ABI_Bytes,
+    ABI_BytesM,
+    ABI_DynamicArray,
+    ABI_FixedMxN,
+    ABI_GIntM,
+    ABI_String,
+)
 from vyper.exceptions import CompilerPanic
 
-
 cases_invalid_types = [
-    (
-        ABI_GIntM,
-        ( 
-            (0, False),
-            (7, False),
-            (300, True),
-            (300, False)
-        ),
-        CompilerPanic
-    ),
+    (ABI_GIntM, ((0, False), (7, False), (300, True), (300, False)), CompilerPanic),
     (
         ABI_FixedMxN,
-        (            
-            (0, 0, False),
-            (8, 0, False),
-            (256, 81, True),
-            (300, 80, False)
-        ),
-        CompilerPanic
+        ((0, 0, False), (8, 0, False), (256, 81, True), (300, 80, False)),
+        CompilerPanic,
     ),
-    (
-        ABI_BytesM,
-        (            
-            (0,),
-            (33,),
-            (-10,),
-        ),
-        CompilerPanic
-    ),
-    (
-        ABI_Bytes,
-        (            
-            (-1,),
-            (-69,),
-        ),
-        CompilerPanic
-    ),
-    (
-        ABI_DynamicArray,
-        (            
-            (ABI_GIntM(256, False), -1),
-            (ABI_String(256), -10),
-        ),
-        CompilerPanic
-    ),
+    (ABI_BytesM, ((0,), (33,), (-10,)), CompilerPanic),
+    (ABI_Bytes, ((-1,), (-69,)), CompilerPanic),
+    (ABI_DynamicArray, ((ABI_GIntM(256, False), -1), (ABI_String(256), -10)), CompilerPanic),
 ]
 
 

--- a/tests/abi_types/test_invalid_abi_types.py
+++ b/tests/abi_types/test_invalid_abi_types.py
@@ -1,0 +1,59 @@
+import pytest
+from vyper.abi_types import ABI_Bytes, ABI_BytesM, ABI_DynamicArray, ABI_FixedMxN, ABI_GIntM, ABI_String
+from vyper.exceptions import CompilerPanic
+
+
+cases_invalid_types = [
+    (
+        ABI_GIntM,
+        ( 
+            (0, False),
+            (7, False),
+            (300, True),
+            (300, False)
+        ),
+        CompilerPanic
+    ),
+    (
+        ABI_FixedMxN,
+        (            
+            (0, 0, False),
+            (8, 0, False),
+            (256, 81, True),
+            (300, 80, False)
+        ),
+        CompilerPanic
+    ),
+    (
+        ABI_BytesM,
+        (            
+            (0,),
+            (33,),
+            (-10,),
+        ),
+        CompilerPanic
+    ),
+    (
+        ABI_Bytes,
+        (            
+            (-1,),
+            (-69,),
+        ),
+        CompilerPanic
+    ),
+    (
+        ABI_DynamicArray,
+        (            
+            (ABI_GIntM(256, False), -1),
+            (ABI_String(256), -10),
+        ),
+        CompilerPanic
+    ),
+]
+
+
+@pytest.mark.parametrize("typ,params_variants,exc", cases_invalid_types)
+def test_invalid_abi_types(assert_compile_failed, typ, params_variants, exc):
+    # double parametrization cannot work because the 2nd dimension is variable
+    for params in params_variants:
+        assert_compile_failed(lambda: typ(*params), exc)

--- a/tests/abi_types/test_invalid_abi_types.py
+++ b/tests/abi_types/test_invalid_abi_types.py
@@ -8,7 +8,7 @@ from vyper.abi_types import (
     ABI_GIntM,
     ABI_String,
 )
-from vyper.exceptions import CompilerPanic
+from vyper.exceptions import InvalidABIType
 
 cases_invalid_types = [
     (ABI_GIntM, ((0, False), (7, False), (300, True), (300, False))),
@@ -23,4 +23,4 @@ cases_invalid_types = [
 def test_invalid_abi_types(assert_compile_failed, typ, params_variants):
     # double parametrization cannot work because the 2nd dimension is variable
     for params in params_variants:
-        assert_compile_failed(lambda: typ(*params), CompilerPanic)
+        assert_compile_failed(lambda: typ(*params), InvalidABIType)

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -1,4 +1,5 @@
 import pytest
+
 from vyper.exceptions import InvalidType, TypeMismatch
 
 

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -1,7 +1,5 @@
 import pytest
-from vyper.abi_types import ABI_Bytes, ABI_BytesM, ABI_DynamicArray, ABI_FixedMxN, ABI_GIntM, ABI_String
-
-from vyper.exceptions import CompilerPanic, InvalidType, TypeMismatch
+from vyper.exceptions import InvalidType, TypeMismatch
 
 
 def test_test_bytes(get_contract_with_gas_estimation, assert_tx_failed):
@@ -334,61 +332,3 @@ def assign():
 @pytest.mark.parametrize("code,exc", cases_invalid_assignments)
 def test_invalid_assignments(get_contract, assert_compile_failed, code, exc):
     assert_compile_failed(lambda: get_contract(code), exc)
-
-cases_invalid_types = [
-    (
-        ABI_GIntM,
-        [
-            (0, False),
-            (7, False),
-            (300, True),
-            (300, False)
-        ],
-        CompilerPanic
-    ),
-    (
-        ABI_FixedMxN,
-        [
-            (0, 0, False),
-            (8, 0, False),
-            (256, 81, True),
-            (300, 80, False)
-        ],
-        CompilerPanic
-    ),
-    (
-        ABI_BytesM,
-        [
-            (0,),
-            (33,),
-            (-10,),
-        ],
-        CompilerPanic
-    ),
-    (
-        ABI_Bytes,
-        [
-            (-1,),
-            (-69,),
-        ],
-        CompilerPanic
-    ),
-    (
-        ABI_DynamicArray,
-        [
-            (ABI_GIntM(256, False), -1),
-            (ABI_String(256), -10),
-        ],
-        CompilerPanic
-    ),
-]
-
-# double parametrization cannot work because the 2nd dimension is variable
-cases_invalid_types_flat = []
-for cases in cases_invalid_types:
-    for case in cases[1]:
-        cases_invalid_types_flat.append((cases[0], case, cases[2]))
-
-@pytest.mark.parametrize("typ,params,exc", cases_invalid_types_flat)
-def test_invalid_abi_types(assert_compile_failed, typ, params, exc):
-    assert_compile_failed(lambda: typ(*params), exc)

--- a/vyper/abi_types.py
+++ b/vyper/abi_types.py
@@ -1,4 +1,4 @@
-from vyper.exceptions import CompilerPanic
+from vyper.exceptions import InvalidABIType
 from vyper.utils import ceil32
 
 
@@ -69,7 +69,7 @@ class ABIType:
 class ABI_GIntM(ABIType):
     def __init__(self, m_bits, signed):
         if not (0 < m_bits <= 256 and 0 == m_bits % 8):
-            raise CompilerPanic("Invalid M provided for GIntM")
+            raise InvalidABIType("Invalid M provided for GIntM")
 
         self.m_bits = m_bits
         self.signed = signed
@@ -117,9 +117,9 @@ class ABI_Bool(ABI_GIntM):
 class ABI_FixedMxN(ABIType):
     def __init__(self, m_bits, n_places, signed):
         if not (0 < m_bits <= 256 and 0 == m_bits % 8):
-            raise CompilerPanic("Invalid M for FixedMxN")
+            raise InvalidABIType("Invalid M for FixedMxN")
         if not (0 < n_places and n_places <= 80):
-            raise CompilerPanic("Invalid N for FixedMxN")
+            raise InvalidABIType("Invalid N for FixedMxN")
 
         self.m_bits = m_bits
         self.n_places = n_places
@@ -142,7 +142,7 @@ class ABI_FixedMxN(ABIType):
 class ABI_BytesM(ABIType):
     def __init__(self, m_bytes):
         if not 0 < m_bytes <= 32:
-            raise CompilerPanic("Invalid M for BytesM")
+            raise InvalidABIType("Invalid M for BytesM")
 
         self.m_bytes = m_bytes
 
@@ -173,7 +173,7 @@ class ABI_Function(ABI_BytesM):
 class ABI_StaticArray(ABIType):
     def __init__(self, subtyp, m_elems):
         if not m_elems >= 0:
-            raise CompilerPanic("Invalid M")
+            raise InvalidABIType("Invalid M")
 
         self.subtyp = subtyp
         self.m_elems = m_elems
@@ -200,7 +200,7 @@ class ABI_StaticArray(ABIType):
 class ABI_Bytes(ABIType):
     def __init__(self, bytes_bound):
         if not bytes_bound >= 0:
-            raise CompilerPanic("Negative bytes_bound provided to ABI_Bytes")
+            raise InvalidABIType("Negative bytes_bound provided to ABI_Bytes")
 
         self.bytes_bound = bytes_bound
 
@@ -234,7 +234,7 @@ class ABI_String(ABI_Bytes):
 class ABI_DynamicArray(ABIType):
     def __init__(self, subtyp, elems_bound):
         if not elems_bound >= 0:
-            raise CompilerPanic("Negative bound provided to DynamicArray")
+            raise InvalidABIType("Negative bound provided to DynamicArray")
 
         self.subtyp = subtyp
         self.elems_bound = elems_bound

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -339,4 +339,4 @@ class TypeCheckFailure(VyperInternalException):
 
 
 class InvalidABIType(VyperInternalException):
-    """An internal routine constructed an invalid ABI type""
+    """An internal routine constructed an invalid ABI type"""

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -339,4 +339,4 @@ class TypeCheckFailure(VyperInternalException):
 
 
 class InvalidABIType(VyperInternalException):
-    """Unexpected ABI Type internals"""
+    """An internal routine constructed an invalid ABI type""

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -336,3 +336,7 @@ class UnfoldableNode(VyperInternalException):
 
 class TypeCheckFailure(VyperInternalException):
     """An issue was not caught during type checking that should have been."""
+
+
+class InvalidABIType(VyperInternalException):
+    """Unexpected ABI Type internals"""


### PR DESCRIPTION
### What I did

Filling some coverage holes regarding abi types that cannot be hit with integration testing because the type checker would have, well, caught it

### How I did it

Adding a parametrized unit test

### How to verify it

### Commit message

add abi types unit tests

### Description for the changelog

add abi types unit tests

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/vyperlang/vyper/assets/51274081/df0725d4-6b60-4a45-ae12-7ab1abafbed9)
