### PR TITLE
add compile-time evaluation of `slice()`

### DIFF
--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -432,3 +432,44 @@ def test_slice_bytes32_calldata_extended(get_contract, code, result):
         c.bar(3, "0x0001020304050607080910111213141516171819202122232425262728293031", 5).hex()
         == result
     )
+
+
+code_comptime = [
+    (
+        """
+@external
+@view
+def baz() -> Bytes[16]:
+    return slice(0x1234567891234567891234567891234567891234567891234567891234567891, 0, 16)
+        """,
+        "12345678912345678912345678912345",
+    ),
+    (
+        """
+@external
+@view
+def baz() -> String[5]:
+    return slice("why hello! how are you?", 4, 5)
+        """,
+        "hello",
+    ),
+    (
+        """
+@external
+@view
+def baz() -> Bytes[6]:
+    return slice(b'gm sir, how are you ?', 0, 6)
+        """,
+        "gm sir".encode("utf-8").hex(),
+    ),
+]
+
+
+@pytest.mark.parametrize("code,result", code_comptime)
+def test_comptime(get_contract, code, result):
+    c = get_contract(code)
+    ret = c.baz()
+    if hasattr(ret, "hex"):
+        assert ret.hex() == result
+    else:
+        assert ret == result

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -483,13 +483,15 @@ def baz() -> Bytes[6]:
 def baz(val: Bytes[100]) -> Bytes[6]:
     return slice(val, 0, 6)
         """,
-        b'gm sir, how are you ?',
+        b"gm sir, how are you ?",
         "gm sir".encode("utf-8").hex(),
     ),
 ]
 
 
-@pytest.mark.parametrize("name,compcode,runcode,arg,result", code_compruntime, ids=[el[0] for el in code_compruntime])
+@pytest.mark.parametrize(
+    "name,compcode,runcode,arg,result", code_compruntime, ids=[el[0] for el in code_compruntime]
+)
 def test_comptime_runtime(get_contract, name, compcode, runcode, arg, result):
     c1 = get_contract(compcode)
     c2 = get_contract(runcode)

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -434,72 +434,42 @@ def test_slice_bytes32_calldata_extended(get_contract, code, result):
     )
 
 
-code_compruntime = [
+code_comptime = [
     (
-        "bytes32",
         """
 @external
 @view
 def baz() -> Bytes[16]:
     return slice(0x1234567891234567891234567891234567891234567891234567891234567891, 0, 16)
         """,
-        """
-@external
-@view
-def baz(val: bytes32) -> Bytes[16]:
-    return slice(val, 0, 16)
-        """,
-        "0x1234567891234567891234567891234567891234567891234567891234567891",
         "12345678912345678912345678912345",
     ),
     (
-        "string",
         """
 @external
 @view
 def baz() -> String[5]:
     return slice("why hello! how are you?", 4, 5)
         """,
-        """
-@external
-@view
-def baz(val: String[100]) -> String[5]:
-    return slice(val, 4, 5)
-        """,
-        "why hello! how are you?",
         "hello",
     ),
     (
-        "bytes",
         """
 @external
 @view
 def baz() -> Bytes[6]:
     return slice(b'gm sir, how are you ?', 0, 6)
         """,
-        """
-@external
-@view
-def baz(val: Bytes[100]) -> Bytes[6]:
-    return slice(val, 0, 6)
-        """,
-        b"gm sir, how are you ?",
         "gm sir".encode("utf-8").hex(),
     ),
 ]
 
 
-@pytest.mark.parametrize(
-    "name,compcode,runcode,arg,result", code_compruntime, ids=[el[0] for el in code_compruntime]
-)
-def test_comptime_runtime(get_contract, name, compcode, runcode, arg, result):
-    c1 = get_contract(compcode)
-    c2 = get_contract(runcode)
-    ret1 = c1.baz()
-    ret2 = c2.baz(arg)
-    if hasattr(ret1, "hex"):
-        assert ret1.hex() == result
-        assert ret2.hex() == result
+@pytest.mark.parametrize("code,result", code_comptime)
+def test_comptime(get_contract, code, result):
+    c = get_contract(code)
+    ret = c.baz()
+    if hasattr(ret, "hex"):
+        assert ret.hex() == result
     else:
-        assert ret1 == result
-        assert ret2 == result
+        assert ret == result

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -479,11 +479,13 @@ def test_comptime(get_contract, code, result):
 
 error_slice = [
     "slice(0x00, 0, 1)",
+    "slice(b'\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10', 10, 1)",
+    "slice(b'', 0, 1)",
     'slice("why hello! how are you?", 32, 1)',
     'slice("why hello! how are you?", -1, 1)',
     'slice("why hello! how are you?", 4, 0)',
     'slice("why hello! how are you?", 0, 33)',
-    'slice("why hello! how are you?", 16, 17)',
+    'slice("why hello! how are you?", 16, 10)',
 ]
 
 

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -471,7 +471,7 @@ def baz() -> Bytes[6]:
 def test_comptime(get_contract, code, result):
     c = get_contract(code)
     ret = c.baz()
-    if hasattr(ret, "hex"):
+    if isinstance(ret, bytes):
         assert ret.hex() == result
     else:
         assert ret == result

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -434,42 +434,70 @@ def test_slice_bytes32_calldata_extended(get_contract, code, result):
     )
 
 
-code_comptime = [
+code_compruntime = [
     (
+        "bytes32",
         """
 @external
 @view
 def baz() -> Bytes[16]:
     return slice(0x1234567891234567891234567891234567891234567891234567891234567891, 0, 16)
         """,
+        """
+@external
+@view
+def baz(val: bytes32) -> Bytes[16]:
+    return slice(val, 0, 16)
+        """,
+        "0x1234567891234567891234567891234567891234567891234567891234567891",
         "12345678912345678912345678912345",
     ),
     (
+        "string",
         """
 @external
 @view
 def baz() -> String[5]:
     return slice("why hello! how are you?", 4, 5)
         """,
+        """
+@external
+@view
+def baz(val: String[100]) -> String[5]:
+    return slice(val, 4, 5)
+        """,
+        "why hello! how are you?",
         "hello",
     ),
     (
+        "bytes",
         """
 @external
 @view
 def baz() -> Bytes[6]:
     return slice(b'gm sir, how are you ?', 0, 6)
         """,
+        """
+@external
+@view
+def baz(val: Bytes[100]) -> Bytes[6]:
+    return slice(val, 0, 6)
+        """,
+        b'gm sir, how are you ?',
         "gm sir".encode("utf-8").hex(),
     ),
 ]
 
 
-@pytest.mark.parametrize("code,result", code_comptime)
-def test_comptime(get_contract, code, result):
-    c = get_contract(code)
-    ret = c.baz()
-    if hasattr(ret, "hex"):
-        assert ret.hex() == result
+@pytest.mark.parametrize("name,compcode,runcode,arg,result", code_compruntime, ids=[el[0] for el in code_compruntime])
+def test_comptime_runtime(get_contract, name, compcode, runcode, arg, result):
+    c1 = get_contract(compcode)
+    c2 = get_contract(runcode)
+    ret1 = c1.baz()
+    ret2 = c2.baz(arg)
+    if hasattr(ret1, "hex"):
+        assert ret1.hex() == result
+        assert ret2.hex() == result
     else:
-        assert ret == result
+        assert ret1 == result
+        assert ret2 == result

--- a/tests/functional/builtins/folding/test_slice.py
+++ b/tests/functional/builtins/folding/test_slice.py
@@ -9,10 +9,6 @@ from vyper.builtins import functions as vy_fn
 from vyper.exceptions import ArgumentException
 
 
-def normalize_bytes(data):
-    return bytes(int.from_bytes(data, "big"))
-
-
 @pytest.mark.fuzzing
 @settings(max_examples=50)
 @given(
@@ -39,7 +35,7 @@ def foo(a: bytes32) -> Bytes[{le}]:
 
     s *= 2
     le *= 2
-    assert normalize_bytes(contract.foo(a)) == new_node.value == bytes.fromhex(a[2:][s : (s + le)])
+    assert contract.foo(a) == new_node.value == bytes.fromhex(a[2:][s : (s + le)])
 
 
 @pytest.mark.fuzzing

--- a/tests/functional/builtins/folding/test_slice.py
+++ b/tests/functional/builtins/folding/test_slice.py
@@ -17,7 +17,7 @@ from vyper.exceptions import ArgumentException
     length=st.integers(min_value=1, max_value=32),
 )
 def test_slice_bytes32(get_contract, bytes_in, start, length):
-    as_hex = "0x" + str.join("", ["00" for _ in range(32 - len(bytes_in))]) + bytes_in.hex()
+    as_hex = "0x" + str(bytes_in.hex()).zfill(64)
     length = min(32 - start, length)
 
     source = f"""

--- a/tests/functional/builtins/folding/test_slice.py
+++ b/tests/functional/builtins/folding/test_slice.py
@@ -1,0 +1,63 @@
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from vyper import ast as vy_ast
+from vyper.builtins import functions as vy_fn
+from vyper.exceptions import ArgumentException
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50)
+@given(
+    a=st.integers(min_value=0, max_value=2**256 - 1),
+    s=st.integers(min_value=0, max_value=31),
+    le=st.integers(min_value=1, max_value=32),
+)
+def test_slice_bytes32(get_contract, a, s, le):
+    a = hex(a)
+    while len(a) < 66:
+        a = f"0x0{a[2:]}"
+    le = min(32, 32 - s, le)
+
+    source = f"""
+@external
+def foo(a: bytes32) -> Bytes[{le}]:
+    return slice(a, {s}, {le})
+    """
+    contract = get_contract(source)
+
+    vyper_ast = vy_ast.parse_to_ast(f"slice({a}, {s}, {le})")
+    old_node = vyper_ast.body[0].value
+    new_node = vy_fn.DISPATCH_TABLE["slice"].evaluate(old_node)
+
+    s *= 2
+    le *= 2
+    assert (
+        int.from_bytes(contract.foo(a), "big")
+        == int.from_bytes(new_node.value, "big")
+        == int(a[2:][s : (s + le)], 16)
+    )
+
+
+@pytest.mark.fuzzing
+@settings(max_examples=50)
+@given(
+    a=st.integers(min_value=0, max_value=2**256 - 1),
+    s=st.integers(min_value=0, max_value=31),
+    le=st.integers(min_value=1, max_value=32),
+)
+def test_slice_bytesnot32(a, s, le):
+    a = hex(a)
+    if len(a) == 3:
+        a = f"0x0{a[2:]}"
+    elif len(a) == 66:
+        a = a[:-2]
+    elif len(a) % 2 == 1:
+        a = a[:-1]
+    le = min(32, 32 - s, le)
+
+    vyper_ast = vy_ast.parse_to_ast(f"slice({a}, {s}, {le})")
+    old_node = vyper_ast.body[0].value
+    with pytest.raises(ArgumentException):
+        vy_fn.DISPATCH_TABLE["slice"].evaluate(old_node)

--- a/tests/functional/builtins/folding/test_slice.py
+++ b/tests/functional/builtins/folding/test_slice.py
@@ -33,7 +33,11 @@ def foo(bytes_in: bytes32) -> Bytes[{length}]:
 
     start *= 2
     length *= 2
-    assert contract.foo(as_hex) == new_node.value == bytes.fromhex(as_hex[2:][start : (start + length)])
+    assert (
+        contract.foo(as_hex)
+        == new_node.value
+        == bytes.fromhex(as_hex[2:][start : (start + length)])
+    )
 
 
 @pytest.mark.fuzzing

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -294,6 +294,25 @@ class Slice(BuiltinFunction):
     ]
     _return_type = None
 
+    def evaluate(self, node):
+        (lit, st, le) = node.args[:3]
+        (st_val, le_val) = (st.value, le.value)
+        if isinstance(lit, vy_ast.Bytes):
+            sublit = lit.value[st_val : (st_val + le_val)]
+            return vy_ast.Bytes.from_node(node, value=sublit)
+        elif isinstance(lit, vy_ast.Str):
+            sublit = lit.value[st_val : (st_val + le_val)]
+            return vy_ast.Str.from_node(node, value=sublit)
+        elif isinstance(lit, vy_ast.Hex):
+            length = len(lit.value) // 2 - 1
+            if length != 32:
+                # TODO unreachable?
+                raise UnfoldableNode
+            sublit = lit.value[st_val : (2 + st_val + (le_val * 2))]
+            return vy_ast.Bytes.from_node(node, value=sublit)
+        else:
+            raise UnfoldableNode
+
     def fetch_call_return(self, node):
         arg_type, _, _ = self.infer_arg_types(node)
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -328,7 +328,7 @@ class Slice(BuiltinFunction):
             raise ArgumentException("Slice is out of bounds", start_node)
 
         end = start + length
-        res = bytes_value[start : end]
+        res = bytes_value[start:end]
         if isinstance(bytestring, vy_ast.Bytes):
             return vy_ast.Bytes.from_node(node, value=res)
         if isinstance(bytestring, vy_ast.Str):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -310,8 +310,6 @@ class Slice(BuiltinFunction):
             if st_val + le_val > 32:
                 raise ArgumentException("Slice is out of bounds", st)
             if isinstance(lit, vy_ast.Bytes):
-                st_val *= 2
-                le_val *= 2
                 sublit = lit.value[st_val : (st_val + le_val)]
                 return vy_ast.Bytes.from_node(node, value=sublit)
             elif isinstance(lit, vy_ast.Str):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -307,7 +307,7 @@ class Slice(BuiltinFunction):
                 raise ArgumentException("Start cannot take that value", st)
             if not 1 <= le_val <= 32:
                 raise ArgumentException("Length cannot take that value", le)
-            if st_val + le_val > 32:
+            if st_val + le_val > len(lit.value):
                 raise ArgumentException("Slice is out of bounds", st)
             if isinstance(lit, vy_ast.Bytes):
                 sublit = lit.value[st_val : (st_val + le_val)]

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -296,41 +296,41 @@ class Slice(BuiltinFunction):
 
     def evaluate(self, node):
         validate_call_args(node, 3)
-        (lit, st, le) = node.args[:3]
+        literal_value, start, length = node.args
         if (
-            isinstance(lit, (vy_ast.Bytes, vy_ast.Str, vy_ast.Hex))
-            and isinstance(st, vy_ast.Int)
-            and isinstance(le, vy_ast.Int)
+            isinstance(literal_value, (vy_ast.Bytes, vy_ast.Str, vy_ast.Hex))
+            and isinstance(start, vy_ast.Int)
+            and isinstance(length, vy_ast.Int)
         ):
-            (st_val, le_val) = (st.value, le.value)
+            (st_val, le_val) = (start.value, length.value)
 
             if st_val < 0:
-                raise ArgumentException("Start cannot be negative", st)
+                raise ArgumentException("Start cannot be negative", start)
             elif le_val <= 0:
-                raise ArgumentException("Length cannot be negative", le)
+                raise ArgumentException("Length cannot be negative", length)
 
-            if isinstance(lit, vy_ast.Hex):
+            if isinstance(literal_value, vy_ast.Hex):
                 if st_val >= 32:
-                    raise ArgumentException("Start cannot take that value", st)
+                    raise ArgumentException("Start cannot take that value", start)
                 if le_val > 32:
-                    raise ArgumentException("Length cannot take that value", le)
-                length = len(lit.value) // 2 - 1
+                    raise ArgumentException("Length cannot take that value", length)
+                length = len(literal_value.value) // 2 - 1
                 if length != 32:
-                    raise ArgumentException("Length can only be of 32", lit)
+                    raise ArgumentException("Length can only be of 32", literal_value)
                 st_val *= 2
                 le_val *= 2
 
-            if st_val + le_val > len(lit.value):
-                raise ArgumentException("Slice is out of bounds", st)
+            if st_val + le_val > len(literal_value.value):
+                raise ArgumentException("Slice is out of bounds", start)
 
-            if isinstance(lit, vy_ast.Bytes):
-                sublit = lit.value[st_val : (st_val + le_val)]
+            if isinstance(literal_value, vy_ast.Bytes):
+                sublit = literal_value.value[st_val : (st_val + le_val)]
                 return vy_ast.Bytes.from_node(node, value=sublit)
-            elif isinstance(lit, vy_ast.Str):
-                sublit = lit.value[st_val : (st_val + le_val)]
+            elif isinstance(literal_value, vy_ast.Str):
+                sublit = literal_value.value[st_val : (st_val + le_val)]
                 return vy_ast.Str.from_node(node, value=sublit)
-            elif isinstance(lit, vy_ast.Hex):
-                sublit = lit.value[2:][st_val : (st_val + le_val)]
+            elif isinstance(literal_value, vy_ast.Hex):
+                sublit = literal_value.value[2:][st_val : (st_val + le_val)]
                 return vy_ast.Bytes.from_node(node, value=f"0x{sublit}")
         raise UnfoldableNode
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -302,35 +302,35 @@ class Slice(BuiltinFunction):
             and isinstance(start, vy_ast.Int)
             and isinstance(length, vy_ast.Int)
         ):
-            (st_val, le_val) = (start.value, length.value)
+            (start_val, length_val) = (start.value, length.value)
 
-            if st_val < 0:
+            if start_val < 0:
                 raise ArgumentException("Start cannot be negative", start)
-            elif le_val <= 0:
+            elif length_val <= 0:
                 raise ArgumentException("Length cannot be negative", length)
 
             if isinstance(literal_value, vy_ast.Hex):
-                if st_val >= 32:
+                if start_val >= 32:
                     raise ArgumentException("Start cannot take that value", start)
-                if le_val > 32:
+                if length_val > 32:
                     raise ArgumentException("Length cannot take that value", length)
                 length = len(literal_value.value) // 2 - 1
                 if length != 32:
                     raise ArgumentException("Length can only be of 32", literal_value)
-                st_val *= 2
-                le_val *= 2
+                start_val *= 2
+                length_val *= 2
 
-            if st_val + le_val > len(literal_value.value):
+            if start_val + length_val > len(literal_value.value):
                 raise ArgumentException("Slice is out of bounds", start)
 
             if isinstance(literal_value, vy_ast.Bytes):
-                sublit = literal_value.value[st_val : (st_val + le_val)]
+                sublit = literal_value.value[start_val : (start_val + length_val)]
                 return vy_ast.Bytes.from_node(node, value=sublit)
             elif isinstance(literal_value, vy_ast.Str):
-                sublit = literal_value.value[st_val : (st_val + le_val)]
+                sublit = literal_value.value[start_val : (start_val + length_val)]
                 return vy_ast.Str.from_node(node, value=sublit)
             elif isinstance(literal_value, vy_ast.Hex):
-                sublit = literal_value.value[2:][st_val : (st_val + le_val)]
+                sublit = literal_value.value[2:][start_val : (start_val + length_val)]
                 return vy_ast.Bytes.from_node(node, value=f"0x{sublit}")
         raise UnfoldableNode
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -296,20 +296,25 @@ class Slice(BuiltinFunction):
 
     def evaluate(self, node):
         (lit, st, le) = node.args[:3]
-        (st_val, le_val) = (st.value, le.value)
-        if isinstance(lit, vy_ast.Bytes):
-            sublit = lit.value[st_val : (st_val + le_val)]
-            return vy_ast.Bytes.from_node(node, value=sublit)
-        elif isinstance(lit, vy_ast.Str):
-            sublit = lit.value[st_val : (st_val + le_val)]
-            return vy_ast.Str.from_node(node, value=sublit)
-        elif isinstance(lit, vy_ast.Hex):
-            length = len(lit.value) // 2 - 1
-            if length != 32:
-                # TODO unreachable?
-                raise UnfoldableNode
-            sublit = lit.value[st_val : (2 + st_val + (le_val * 2))]
-            return vy_ast.Bytes.from_node(node, value=sublit)
+        if (
+            isinstance(lit, (vy_ast.Bytes, vy_ast.Str, vy_ast.Hex))
+            and isinstance(st, vy_ast.Int)
+            and isinstance(le, vy_ast.Int)
+        ):
+            (st_val, le_val) = (st.value, le.value)
+            if isinstance(lit, vy_ast.Bytes):
+                sublit = lit.value[st_val : (st_val + le_val)]
+                return vy_ast.Bytes.from_node(node, value=sublit)
+            elif isinstance(lit, vy_ast.Str):
+                sublit = lit.value[st_val : (st_val + le_val)]
+                return vy_ast.Str.from_node(node, value=sublit)
+            else:
+                length = len(lit.value) // 2 - 1
+                if length != 32:
+                    # TODO unreachable?
+                    raise UnfoldableNode
+                sublit = lit.value[st_val : (2 + st_val + (le_val * 2))]
+                return vy_ast.Bytes.from_node(node, value=sublit)
         else:
             raise UnfoldableNode
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -318,7 +318,6 @@ class Slice(BuiltinFunction):
             else:
                 length = len(lit.value) // 2 - 1
                 if length != 32:
-                    # raise UnfoldableNode
                     raise ArgumentException("Length can only be of 32", lit)
                 st_val *= 2
                 le_val *= 2


### PR DESCRIPTION
### What I did

Adding compile-time evaluation support for `slice`.

### How I did it

Fill in the blanks in the `evaluate` function of the `Slice` class builtin

### How to verify it

Wrote some unit tests that compare the compile time and runtime evaluation of the function for equivalent inputs and made sure that the output were the same.

### Commit message

Add compile-time support for the `slice` built-in

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/5sf7mxdnb6l41.jpg)
