### PR TITLE
add comptime check for uint2str input

### DIFF
--- a/tests/functional/builtins/codegen/test_uint2str.py
+++ b/tests/functional/builtins/codegen/test_uint2str.py
@@ -37,3 +37,15 @@ def foo(x: uint{bits}) -> uint256:
     """
     c = get_contract(code)
     assert c.foo(2**bits - 1) == 0, bits
+
+
+def test_int_fails(get_contract):
+    code = """
+@external
+def test():
+    a: String[78] = uint2str(-1)
+    pass
+    """
+
+    with pytest.raises(ArithmeticError):
+        get_contract(code)

--- a/tests/functional/builtins/codegen/test_uint2str.py
+++ b/tests/functional/builtins/codegen/test_uint2str.py
@@ -2,6 +2,8 @@ import math
 
 import pytest
 
+from vyper.exceptions import InvalidType
+
 VALID_BITS = list(range(8, 257, 8))
 
 
@@ -47,5 +49,5 @@ def test():
     pass
     """
 
-    with pytest.raises(ArithmeticError):
+    with pytest.raises(InvalidType):
         get_contract(code)

--- a/tests/functional/builtins/codegen/test_uint2str.py
+++ b/tests/functional/builtins/codegen/test_uint2str.py
@@ -2,7 +2,8 @@ import math
 
 import pytest
 
-from vyper.exceptions import InvalidType
+from vyper.compiler import compile_code
+from vyper.exceptions import InvalidType, OverflowException
 
 VALID_BITS = list(range(8, 257, 8))
 
@@ -41,13 +42,23 @@ def foo(x: uint{bits}) -> uint256:
     assert c.foo(2**bits - 1) == 0, bits
 
 
-def test_int_fails(get_contract):
+def test_bignum_throws():
+    code = """
+@external
+def test():
+    a: String[78] = uint2str(2**256)
+    pass
+    """
+    with pytest.raises(OverflowException):
+        compile_code(code)
+
+
+def test_int_fails():
     code = """
 @external
 def test():
     a: String[78] = uint2str(-1)
     pass
     """
-
     with pytest.raises(InvalidType):
-        get_contract(code)
+        compile_code(code)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2091,12 +2091,14 @@ class Uint2Str(BuiltinFunction):
         return StringT(len_needed)
 
     def evaluate(self, node):
-        self._validate_arg_types(node)
         validate_call_args(node, 1)
         if not isinstance(node.args[0], vy_ast.Int):
             raise UnfoldableNode
 
-        value = str(node.args[0].value)
+        value = node.args[0].value
+        if value < 0:
+            raise InvalidType("Only unsigned ints allowed", node)
+        value = str(value)
         return vy_ast.Str.from_node(node, value=value)
 
     def infer_arg_types(self, node):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2091,6 +2091,7 @@ class Uint2Str(BuiltinFunction):
         return StringT(len_needed)
 
     def evaluate(self, node):
+        self._validate_arg_types(node)
         validate_call_args(node, 1)
         if not isinstance(node.args[0], vy_ast.Int):
             raise UnfoldableNode


### PR DESCRIPTION
### What I did

Closes https://github.com/vyperlang/vyper/issues/3641

### How I did it

### How to verify it

### Commit message

Fix type check for `uint2str` at compile-time, closes https://github.com/vyperlang/vyper/issues/3641

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
