### PR TITLE
docs: typo in `on_chain_market_maker.vy`

### DIFF
--- a/examples/market_maker/on_chain_market_maker.vy
+++ b/examples/market_maker/on_chain_market_maker.vy
@@ -9,7 +9,7 @@ invariant: public(uint256)
 token_address: ERC20
 owner: public(address)
 
-# Sets the on chain market maker with its owner, intial token quantity,
+# Sets the on chain market maker with its owner, initial token quantity,
 # and initial ether quantity
 @external
 @payable


### PR DESCRIPTION


### What I did
intial -> initial
