### PR TITLE
chore: test all output formats

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,8 +279,8 @@ def _get_contract(
     settings.optimize = override_opt_level or optimize
     out = compiler.compile_code(
         source_code,
-        # test that metadata and natspecs get generated
-        output_formats=["abi", "bytecode", "metadata", "userdoc", "devdoc"],
+        # test that all output formats can get generated
+        output_formats=list(compiler.OUTPUT_FORMATS.keys()),
         settings=settings,
         input_bundle=input_bundle,
         show_gas_estimates=True,  # Enable gas estimates for testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,7 +352,7 @@ def _deploy_blueprint_for(w3, source_code, optimize, initcode_prefix=b"", **kwar
     settings.optimize = optimize
     out = compiler.compile_code(
         source_code,
-        output_formats=["abi", "bytecode", "metadata", "userdoc", "devdoc"],
+        output_formats=list(compiler.OUTPUT_FORMATS.keys()),
         settings=settings,
         show_gas_estimates=True,  # Enable gas estimates for testing
     )


### PR DESCRIPTION
right now only certain output formats are tested in the main compiler test harness, namely bytecode, abi, metadata and some natspec outputs. in the past, there have been issues where output formats get broken but don't get detected until release testing or even after release.

this commit adds a hook in `get_contract()` to generate all output formats, which will help detect broken output formats sooner.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
