### PR TITLE
fix: remove .keyword from Call AST node

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1254,7 +1254,7 @@ class NotIn(Operator):
 
 
 class Call(ExprNode):
-    __slots__ = ("func", "args", "keywords", "keyword")
+    __slots__ = ("func", "args", "keywords")
 
 
 class keyword(VyperNode):


### PR DESCRIPTION
for some reason, there is a slot named "keyword" on the Call AST node, which is never used (and doesn't exist in the python AST!).

this commit removes it for hygienic purposes.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
