### PR TITLE
feat: add short options `-v` and `-O` to the CLI

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -111,6 +111,7 @@ def _parse_args(argv):
     )
     parser.add_argument("--no-optimize", help="Do not optimize", action="store_true")
     parser.add_argument(
+        "-O",
         "--optimize",
         help="Optimization flag (defaults to 'gas')",
         choices=["gas", "codesize", "none"],
@@ -125,6 +126,7 @@ def _parse_args(argv):
         type=int,
     )
     parser.add_argument(
+        "-v",
         "--verbose",
         help="Turn on compiler verbose output. "
         "Currently an alias for --traceback-limit but "


### PR DESCRIPTION
this commit adds `-v` and `-O` as aliases for `--verbose` and `--optimize`, respectively.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
