### PR TITLE
fix: disable ir_dict output type for venom

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -89,6 +89,9 @@ def build_ir_runtime_output(compiler_data: CompilerData) -> IRnode:
 
 
 def _ir_to_dict(ir_node):
+    # Currently only supported with IRnode and not VenomIR
+    if not isinstance(ir_node, IRnode):
+        return
     args = ir_node.args
     if len(args) > 0 or ir_node.value == "seq":
         return {ir_node.value: [_ir_to_dict(x) for x in args]}


### PR DESCRIPTION
### What I did

Currently running tests with experimental codegen was failing due to ir_dict output not being compatible. 
This small patch disables ir_dict output for experimental codegen so testing with experimental codeine can resume.

### How I did it

### How to verify it

Set experimental_codegen = True in phases.py and run the test suite

### Commit message

Small patch that disables ir_dict output for experimental codegen

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
