### PR TITLE
docs: clarify `address.codehash` for empty account

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -299,7 +299,7 @@ Members
 Member          Type        Description
 =============== =========== ==========================================================================
 ``balance``     ``uint256`` Balance of an address
-``codehash``    ``bytes32`` Keccak of code at an address, ``EMPTY_BYTES32`` if no contract is deployed
+``codehash``    ``bytes32`` Keccak of code at an address, ``0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`` if no contract is deployed (see `EIP-1052 <https://eips.ethereum.org/EIPS/eip-1052>`_)
 ``codesize``    ``uint256`` Size of code deployed at an address, in bytes
 ``is_contract`` ``bool``    Boolean indicating if a contract is deployed at an address
 ``code``        ``Bytes``   Contract bytecode


### PR DESCRIPTION
### What I did

The `EXTCODEHASH` of an empty account is not `empty(bytes32)` but `keccak256("") = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`. See [EIP-1052](https://eips.ethereum.org/EIPS/eip-1052).

### How I did it

Fixed the docs. Please note that there is _no_ code bug, as any Vyper compiled contract will return `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` for an EOA or an empty account (see [here](https://github.com/vyperlang/vyper/blob/2df916ca453ddda4cf08878c4fdaaa55b963686c/vyper/codegen/expr.py#L250)).

### How to verify it

- [EIP-1052](https://eips.ethereum.org/EIPS/eip-1052)
- [Geth](https://github.com/ethereum/go-ethereum/blob/d2e3cb894b6deab6ef599c6c241527124d8984bd/core/types/hashes.go#L33)

### Commit message

```console
docs: clarify `address.codehash` for an empty account
```

### Description for the changelog

- docs: clarify `address.codehash` for an empty account

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/6884ecaf-022d-4787-8fd6-8705a9ec4a80)