### PR TITLE
docs: indexed arguments for events are limited

### DIFF
--- a/docs/event-logging.rst
+++ b/docs/event-logging.rst
@@ -66,11 +66,19 @@ Let's look at an event declaration in more detail.
         receiver: indexed(address)
         value: uint256
 
+The EVM currently has five opcodes for emitting event logs: ``LOG0``, ``LOG1``, ``LOG2``, ``LOG3``, and ``LOG4``.
+These opcodes can be used to create log records, where each log record consists of both **topics** and **data**.
+Topics are 32-byte ''words'' that are used to describe what is happening in an event.
+While topics are searchable, data is not.
+Event data is however not limited, which means that you can include large or complicated data like arrays or strings.
+Different opcodes (``LOG0`` through ``LOG4``) allow for different numbers of topics.
+For instance, ``LOG1`` includes one topic, ``LOG2`` includes two topics, and so on.
 Event declarations look similar to struct declarations, containing one or more arguments that are passed to the event. Typical events will contain two kinds of arguments:
 
-    * **Indexed** arguments, which can be searched for by listeners. Each indexed argument is identified by the ``indexed`` keyword.  Here, each indexed argument is an address. You can have any number of indexed arguments, but indexed arguments are not passed directly to listeners, although some of this information (such as the sender) may be available in the listener's `results` object.
-    * **Value** arguments, which are passed through to listeners. You can have any number of value arguments and they can have arbitrary names, but each is limited by the EVM to be no more than 32 bytes.
+    * **Indexed** arguments (topics), which can be searched for by listeners. Each indexed argument is identified by the ``indexed`` keyword.  Here, each indexed argument is an address. You can have up to four indexed arguments (``LOG4``), but indexed arguments are not passed directly to listeners, although some of this information (such as the sender) may be available in the listener's `results` object.
+    * **Value** arguments (data), which are passed through to listeners. You can have any number of value arguments and they can have arbitrary names, but each is limited by the EVM to be no more than 32 bytes.
 
+Note that the first topic of a log record consists of the signature of the name of the event that occurred, including the types of its parameters.
 It is also possible to create an event with no arguments. In this case, use the ``pass`` statement:
 
 .. code-block:: python


### PR DESCRIPTION
### What I did
Added additional information about EVM opcodes for log records, introduced topics and data, and corrected the limit for indexed arguments.

### Commit message

docs: indexed arguments for events are limited

The number of indexed arguments is limited by the EVM to a maximum of four. Include definition of topics and data.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.lubrisyn.com/wp-content/uploads/2017/04/Screen-Shot-2017-04-28-at-11.45.00-AM.png)
