### PR TITLE
chore: improve diagnostics for invalid for loop annotation

### DIFF
--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -11,7 +11,9 @@ from vyper.exceptions import (
     NamespaceCollision,
     StateAccessViolation,
     StructureException,
+    SyntaxException,
     TypeMismatch,
+    UnknownType,
 )
 
 BASIC_FOR_LOOP_CODE = [
@@ -802,6 +804,33 @@ def test_for() -> int128:
     return a
     """,
         TypeMismatch,
+    ),
+    (
+        """
+@external
+def foo():
+    for i in [1, 2, 3]:
+        pass
+    """,
+        SyntaxException,
+    ),
+    (
+        """
+@external
+def foo():
+    for i: $$$ in [1, 2, 3]:
+        pass
+    """,
+        SyntaxException,
+    ),
+    (
+        """
+@external
+def foo():
+    for i: DynArra[uint256, 3] in [1, 2, 3]:
+        pass
+    """,
+        UnknownType,
     ),
 ]
 

--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -827,7 +827,7 @@ def foo():
         """
 @external
 def foo():
-    for i: DynArra[uint256, 3] in [1, 2, 3]:
+    for i: uint9 in [1, 2, 3]:
         pass
     """,
         UnknownType,

--- a/tests/functional/syntax/exceptions/test_syntax_exception.py
+++ b/tests/functional/syntax/exceptions/test_syntax_exception.py
@@ -86,6 +86,18 @@ def f(a:uint256,/):  # test posonlyargs blocked
 def g():
     self.f()
     """,
+    """
+@external
+def foo():
+    for i in range(0, 10):
+        pass
+    """,
+    """
+@external
+def foo():
+    for i: $$$ in range(0, 10):
+        pass
+    """,
 ]
 
 

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -244,8 +244,8 @@ def foo():
         pass
     """,
         UnknownType,
-        "No builtin or user-defined type named 'DynArra[uint256, 3]'. ",
-        "DynArra[uint256, 3]",
+        "No builtin or user-defined type named 'DynArra'. Did you mean 'DynArray'?",
+        "DynArra",
     ),
 ]
 

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -8,6 +8,7 @@ from vyper.exceptions import (
     StateAccessViolation,
     StructureException,
     TypeMismatch,
+    UnknownType,
 )
 
 fail_list = [
@@ -234,6 +235,17 @@ def foo():
         StructureException,
         "Bound must be at least 1",
         "FOO",
+    ),
+    (
+        """
+@external
+def foo():
+    for i: DynArra[uint256, 3] in [1, 2, 3]:
+        pass
+    """,
+        UnknownType,
+        "No builtin or user-defined type named 'DynArra[uint256, 3]'. ",
+        "DynArra[uint256, 3]",
     ),
 ]
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -1,4 +1,5 @@
 import ast as python_ast
+import itertools
 import tokenize
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union, cast
@@ -261,7 +262,8 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # this step improves the diagnostics during semantics analysis as otherwise
         # the code displayed in the error message would be incorrectly based on the
         # full source code with the location of the type annotation as an expression
-        for n in python_ast.iter_child_nodes(node.target.annotation):
+        annotation_child_nodes = python_ast.iter_child_nodes(node.target.annotation)
+        for n in itertools.chain(annotation_child_nodes, [node.target.annotation]):
             # override the source code to show the spliced type annotation
             n.node_source_code = raw_annotation
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -261,8 +261,8 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # this step improves the diagnostics during semantics analysis as otherwise
         # the code displayed in the error message would be incorrectly based on the
         # full source code with the location of the type annotation as an expression
-        annotation_child_nodes = python_ast.iter_child_nodes(node.target.annotation)
-        for n in [*annotation_child_nodes, node.target.annotation]:
+        annotation_children = python_ast.iter_child_nodes(node.target.annotation)
+        for n in [*annotation_children, node.target.annotation]:
             # override the source code to show the spliced type annotation
             n.node_source_code = raw_annotation
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -258,6 +258,19 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         self.generic_visit(node)
 
+        # this step improves the diagnostics during semantics analysis as otherwise
+        # the code displayed in the error message would be incorrectly based on the
+        # full source code with the location of the type annotation as an expression
+        for n in python_ast.iter_child_nodes(node.target.annotation):
+            # override the source code to show the spliced type annotation
+            n.node_source_code = raw_annotation
+
+            # override the locations to show the `For` node
+            n.lineno = node.lineno
+            n.col_offset = node.col_offset
+            n.end_lineno = node.end_lineno
+            n.end_col_offset = node.end_col_offset
+
         return node
 
     def visit_Expr(self, node):

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -1,5 +1,4 @@
 import ast as python_ast
-import itertools
 import tokenize
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union, cast
@@ -263,7 +262,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # the code displayed in the error message would be incorrectly based on the
         # full source code with the location of the type annotation as an expression
         annotation_child_nodes = python_ast.iter_child_nodes(node.target.annotation)
-        for n in itertools.chain(annotation_child_nodes, [node.target.annotation]):
+        for n in list(annotation_child_nodes) + [node.target.annotation]:
             # override the source code to show the spliced type annotation
             n.node_source_code = raw_annotation
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -268,10 +268,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
             n.node_source_code = raw_annotation
 
             # override the locations to show the `For` node
-            n.lineno = node.lineno
-            n.col_offset = node.col_offset
-            n.end_lineno = node.end_lineno
-            n.end_col_offset = node.end_col_offset
+            python_ast.copy_location(n, node)
 
         return node
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -258,16 +258,59 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         self.generic_visit(node)
 
+
+        start_lineno = node.lineno - 1
+        end_lineno = node.end_lineno - 1
+        col_offset = node.col_offset
+        end_col_offset = node.end_col_offset
+
+        print("for node token deets")
+        print(node.first_token.string)
+        print(node.first_token.start)
+        print(node.first_token.end)
+        print(node.first_token.line)
+        print(node.first_token.startpos)
+        print(node.first_token.endpos)
+
+        for n in python_ast.walk(node.target.annotation):
+            if not n.lineno:
+                continue
+
+            print("annotation node token deets")
+            print(n.first_token.string)
+            print(n.first_token.start)
+            print(n.first_token.end)
+            print(n.first_token.line)
+            print(n.first_token.startpos)
+            print(n.first_token.endpos)
+            
+            print("type(token.start): ", type(n.first_token.start))
+            #n.first_token._replace(start=(0, 2))
+
+            line_offset = node.end_lineno - node.lineno
+
+            n.lineno = start_lineno + line_offset
+            n.end_lineno = end_lineno + line_offset
+
+            node_col_offset = n.end_col_offset - n.col_offset
+
+            n.col_offset = col_offset + node_col_offset
+            n.end_col_offset = end_col_offset + node_col_offset
+
+        #self.generic_visit(node.target.annotation)
+            
+
         # this step improves the diagnostics during semantics analysis as otherwise
         # the code displayed in the error message would be incorrectly based on the
         # full source code with the location of the type annotation as an expression
         annotation_children = python_ast.iter_child_nodes(node.target.annotation)
         for n in [*annotation_children, node.target.annotation]:
             # override the source code to show the spliced type annotation
-            n.node_source_code = raw_annotation
+            #n.node_source_code = raw_annotation
 
             # override the locations to show the `For` node
-            python_ast.copy_location(n, node)
+            #python_ast.copy_location(n, node)
+            continue
 
         return node
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -1,7 +1,6 @@
 import ast as python_ast
 import string
 import tokenize
-
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union, cast
 
@@ -141,7 +140,6 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         self.counter: int = 0
 
-
     def generic_visit(self, node):
         """
         Annotate a node with information that simplifies Vyper node generation.
@@ -275,14 +273,14 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                     start=_add_pair(n.first_token.start, adjustment),
                     end=_add_pair(n.first_token.end, adjustment),
                     startpos=n.first_token.startpos + og_target.first_token.startpos,
-                    endpos=n.first_token.startpos + og_target.first_token.startpos
+                    endpos=n.first_token.startpos + og_target.first_token.startpos,
                 )
             if hasattr(n, "last_token"):
                 n.last_token = n.last_token._replace(
                     start=_add_pair(n.last_token.start, adjustment),
                     end=_add_pair(n.last_token.end, adjustment),
                     startpos=n.last_token.startpos + og_target.first_token.startpos,
-                    endpos=n.last_token.endpos + og_target.first_token.startpos
+                    endpos=n.last_token.endpos + og_target.first_token.startpos,
                 )
 
         node.target = annotation
@@ -448,8 +446,8 @@ def annotate_python_ast(
     source_code : str
         The originating source code of the AST.
     loop_var_annotations: dict, optional
-        A mapping of line numbers of `For` nodes to the type annotation of the iterator
-        extracted during pre-parsing.
+        A mapping of line numbers of `For` nodes to the tokens of the type annotation
+        of the iterator extracted during pre-parsing.
     modification_offsets : dict, optional
         A mapping of class names to their original class types.
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -262,7 +262,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # the code displayed in the error message would be incorrectly based on the
         # full source code with the location of the type annotation as an expression
         annotation_child_nodes = python_ast.iter_child_nodes(node.target.annotation)
-        for n in list(annotation_child_nodes) + [node.target.annotation]:
+        for n in [*annotation_child_nodes, node.target.annotation]:
             # override the source code to show the spliced type annotation
             n.node_source_code = raw_annotation
 

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -141,8 +141,9 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
         Compilation settings based on the directives in the source code
     ModificationOffsets
         A mapping of class names to their original class types.
-    dict[tuple[int, int], str]
-        A mapping of line/column offsets of `For` nodes to the annotation of the for loop target
+    dict[tuple[int, int], list[TokenInfo]]
+        A mapping of line/column offsets of `For` nodes to the tokens of the annotation of the
+        for loop target
     str
         Reformatted python source string.
     """
@@ -225,9 +226,6 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
 
     for_loop_annotations = {}
     for k, v in for_parser.annotations.items():
-        #v_source = untokenize(v)
-        # untokenize adds backslashes and whitespace, strip them.
-        #v_source = v_source.replace("\\", "").strip()
         for_loop_annotations[k] = v.copy()
 
     return settings, modification_offsets, for_loop_annotations, untokenize(result).decode("utf-8")

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -106,7 +106,6 @@ class _BaseVyperException(Exception):
                     line_numbers=VYPER_ERROR_LINE_NUMBERS,
                 )
             except Exception:
-                print("EXC", node.full_source_code, node.node_source_code, node.lineno, node.col_offset)
                 # necessary for certain types of syntax exceptions
                 return self.message
 

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -106,6 +106,7 @@ class _BaseVyperException(Exception):
                     line_numbers=VYPER_ERROR_LINE_NUMBERS,
                 )
             except Exception:
+                print("EXC", node.full_source_code, node.node_source_code, node.lineno, node.col_offset)
                 # necessary for certain types of syntax exceptions
                 return self.message
 


### PR DESCRIPTION
### What I did

Improve diagnostics for invalid loop variable annotation and add tests for #3596.

Compiling this contract throws an error that does not make sense
```
@external
def foo():
    for i: uint9 in [1, 2, 3]:
        pass
```
```
vyper.exceptions.UnknownType: No builtin or user-defined type named '@exte'. 
  contract "tmp/old_for.vy:1", function "foo", line 1:0 
  ---> 1 @external
  -------^
       2 def foo():
```

This PR changes the error message to:
```
vyper.exceptions.UnknownType: No builtin or user-defined type named 'uint9'. Did you mean 'uint96', or maybe 'uint8'?
  contract "tmp/old_for.vy:3", function "foo", line 3:4 
       2 def foo():
  ---> 3     for i: uint9 in [1, 2, 3]:
  -----------^
       4         pass
```

### How I did it

Propagate the annotation source code and `For` node locations to the annotation and all its child nodes

### How to verify it

See tests.

### Commit message

```
chore: improve diagnostics for invalid for loop annotation
```

### Description for the changelog

Improve diagnostics for invalid for loop annotation

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fpz7qltuhh9g71.jpg)
