### PR TITLE
refactor: for target parsing

### DIFF
--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -265,6 +265,22 @@ def foo():
         "No builtin or user-defined type named 'uint9'. Did you mean 'uint96', or maybe 'uint8'?",
         "uint9",
     ),
+    (
+        # test an even more deranged example
+        """
+@external
+def foo():
+    for i: \\
+        \\
+          DynArray[\\
+        uint9, 3\\
+        ] in [1,2,3]:
+        pass
+    """,
+        UnknownType,
+        "No builtin or user-defined type named 'uint9'. Did you mean 'uint96', or maybe 'uint8'?",
+        "uint9",
+    ),
 ]
 
 for_code_regex = re.compile(r"for .+ in (.*):", re.DOTALL)

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -247,9 +247,27 @@ def foo():
         "No builtin or user-defined type named 'DynArra'. Did you mean 'DynArray'?",
         "DynArra",
     ),
+    (
+        # test for loop target broken into multiple lines
+        """
+@external
+def foo():
+    for i: \\
+      \\
+        \\
+        \\
+        \\
+        \\
+        uint9 in [1,2,3]:
+        pass
+    """,
+        UnknownType,
+        "No builtin or user-defined type named 'uint9'. Did you mean 'uint96', or maybe 'uint8'?",
+        "uint9",
+    ),
 ]
 
-for_code_regex = re.compile(r"for .+ in (.*):")
+for_code_regex = re.compile(r"for .+ in (.*):", re.DOTALL)
 fail_test_names = [
     (
         f"{i:02d}: {for_code_regex.search(code).group(1)}"  # type: ignore[union-attr]

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -252,11 +252,12 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # (to best understand this, print out annotation_str and
         # self._source_code and compare them side-by-side).
         #
-        # add in a spurious target here which we will remove in a bit
-        # but for now lets us keep the line/col offset, and *also* gives
-        # us a valid AST.
+        # what we do here is add in a dummy target which we will remove
+        # in a bit, but for now lets us keep the line/col offset, and
+        # *also* gives us a valid AST. it doesn't matter what the dummy
+        # target name is, since it gets removed in a few lines.
         annotation_str = tokenize.untokenize(annotation_tokens)
-        annotation_str = f"COMPILER_INSERTED:" + annotation_str
+        annotation_str = "dummy_target:" + annotation_str
 
         try:
             fake_node = python_ast.parse(annotation_str).body[0]
@@ -270,8 +271,9 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # in the original source!
         self._tokens.mark_tokens(fake_node)
 
-        # replace the For node target with the new ann_assign
+        # replace the dummy target name with the real target name.
         fake_node.target = node.target
+        # replace the For node target with the new ann_assign
         node.target = fake_node
 
         return self.generic_visit(node)

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -249,6 +249,8 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # that's not a valid python Expr because it is indented.
         # but it's good because the code is indented to exactly the same
         # offset as it did in the original source!
+        # (to best understand this, print out annotation_str and
+        # self._source_code and compare them side-by-side).
         #
         # add in a spurious target here which we will remove in a bit
         # but for now lets us keep the line/col offset, and *also* gives

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -136,7 +136,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
         Compilation settings based on the directives in the source code
     ModificationOffsets
         A mapping of class names to their original class types.
-    dict[tuple[int, int], str]
+    dict[tuple[int, int], list[TokenInfo]]
         A mapping of line/column offsets of `For` nodes to the annotation of the for loop target
     str
         Reformatted python source string.


### PR DESCRIPTION
### What I did
use a parser trick to get always-correct source locations into for-loop target annotations.

follow-up to #3721; reverts the AnnAssign pre-parser change from there.

### How I did it
see commit

### How to verify it
check new test will not pass without the parser changes.

### Commit message

````
    use a parser trick to get always-correct source locations into for-loop
    target annotations.
````
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
