### PR TITLE
chore: bump sphinx version

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-sphinx==4.5.0
+sphinx==5.0.0
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
### What I did
apparently, readthedocs requires v5.0 of sphinx or greater now (see failing run at https://readthedocs.org/projects/vyper/builds/23107228/). bump the sphinx dependency.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
