### PR TITLE
fix: `opcodes` and `opcodes_runtime` outputs

### DIFF
--- a/tests/unit/compiler/test_opcodes.py
+++ b/tests/unit/compiler/test_opcodes.py
@@ -68,7 +68,10 @@ def test_get_opcodes(evm_version):
 
 
 def test_build_opcodes():
+    assert _build_opcodes(bytes.fromhex("610250")) == "PUSH2 0x0250"
+    assert _build_opcodes(bytes.fromhex("612500")) == "PUSH2 0x2500"
     assert _build_opcodes(bytes.fromhex("610100")) == "PUSH2 0x0100"
+    assert _build_opcodes(bytes.fromhex("611000")) == "PUSH2 0x1000"
     assert _build_opcodes(bytes.fromhex("62010300")) == "PUSH3 0x010300"
     assert (
         _build_opcodes(

--- a/tests/unit/compiler/test_opcodes.py
+++ b/tests/unit/compiler/test_opcodes.py
@@ -1,6 +1,7 @@
 import pytest
 
 import vyper
+from vyper.compiler.output import _build_opcodes
 from vyper.evm import opcodes
 from vyper.exceptions import CompilerPanic
 
@@ -64,3 +65,14 @@ def test_get_opcodes(evm_version):
     else:
         for op in ("TLOAD", "TSTORE", "MCOPY"):
             assert op not in ops
+
+
+def test_build_opcodes():
+    assert _build_opcodes(bytes.fromhex("610100")) == "PUSH2 0x0100"
+    assert _build_opcodes(bytes.fromhex("62010300")) == "PUSH3 0x010300"
+    assert (
+        _build_opcodes(
+            bytes.fromhex("7f6100000000000000000000000000000000000000000000000000000000000000")
+        )
+        == "PUSH32 0x6100000000000000000000000000000000000000000000000000000000000000"
+    )

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -330,7 +330,7 @@ def _build_opcodes(bytecode: bytes) -> str:
             # (instead of code) at end of contract
             # CMC 2023-07-13 maybe just strip known data segments?
             push_len = min(push_len, len(bytecode_sequence))
-            push_values = [hex(bytecode_sequence.popleft())[2:] for i in range(push_len)]
-            opcode_output.append(f"0x{''.join(push_values).upper()}")
+            push_values = [f"{bytecode_sequence.popleft():0>2X}" for i in range(push_len)]
+            opcode_output.append(f"0x{''.join(push_values)}")
 
     return " ".join(opcode_output)


### PR DESCRIPTION
### What I did

Fixed the `opcodes` and `opcodes_runtime` outputs as they would not respectively match the `bytecode` and `bytecode_runtime` outputs.

The value following a `PUSH` instruction could be incorrect. For example, when compiling some Vyper code that results in `PUSH2 0x100`:
- The `bytecode` output would be `610100`
- The `opcodes` output would be `PUSH2 0x10` instead of `PUSH2 0x100`

This issue is due to a lack of 0 padding.

### How I did it

In `build_opcodes`, left pad each byte to be concatenated with 0 to have a length of 2 digits

### How to verify it

Check the tests

### Commit message

```
Fixed the opcodes and opcodes_runtime outputs as they would not
respectively match the bytecode and bytecode_runtime outputs.

The value following a PUSH instruction could be incorrect. For example,
when compiling some Vyper code that results in `PUSH2 0x0100`:

- The bytecode output would be `610100`
- The opcodes output would be `PUSH2 0x10` instead of `PUSH2 0x0100`

Note this commit fixes an ambiguity here, as prior to this commit,
`610100` (`PUSH2 0x0100`) and `610010` (`PUSH2 0x0010`) would both get
formatted as `PUSH2 0x10`.

This issue is due to a lack of 0 padding.
```

### Description for the changelog

    fix: opcode and opcodes_runtime outputs

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.breatheazy.co.uk/wp-content/uploads/2023/09/Untitled-design-35-1080x675.png)
