### PR TITLE
docs: add missing cli flags

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -29,7 +29,7 @@ Include the ``-f`` flag to specify which output formats to return. Use ``vyper -
 
 ::
 
-    $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,combined_json,layout yourFileName.vy
+    $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,metadata,combined_json,layout yourFileName.vy
 
 .. note::
     The ``opcodes`` and ``opcodes_runtime`` output of the compiler has been returning incorrect opcodes since ``0.2.0`` due to a lack of 0 padding (patched via `PR 3735 <https://github.com/vyperlang/vyper/pull/3735>`_). If you rely on these functions for debugging, please use the latest patched versions.

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -29,7 +29,7 @@ Include the ``-f`` flag to specify which output formats to return. Use ``vyper -
 
 ::
 
-    $ vyper -f abi,bytecode,bytecode_runtime,ir,asm,source_map,method_identifiers yourFileName.vy
+    $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,combined_json,layout yourFileName.vy
 
 The ``-p`` flag allows you to set a root path that is used when searching for interface files to import.  If none is given, it will default to the current working directory. See :ref:`searching_for_imports` for more information.
 

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -32,7 +32,7 @@ Include the ``-f`` flag to specify which output formats to return. Use ``vyper -
     $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,combined_json,layout yourFileName.vy
 
 .. note::
-    The ``opcodes`` and ``opcodes_runtime`` output of the compiler has been returning incorrect opcodes since ``0.3.1`` due to a lack of 0 padding (patched via `PR 3735 <https://github.com/vyperlang/vyper/pull/3735>`_). If you rely on these functions for debugging, please use the latest patched versions.
+    The ``opcodes`` and ``opcodes_runtime`` output of the compiler has been returning incorrect opcodes since ``0.2.0`` due to a lack of 0 padding (patched via `PR 3735 <https://github.com/vyperlang/vyper/pull/3735>`_). If you rely on these functions for debugging, please use the latest patched versions.
 
 The ``-p`` flag allows you to set a root path that is used when searching for interface files to import.  If none is given, it will default to the current working directory. See :ref:`searching_for_imports` for more information.
 

--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -31,6 +31,9 @@ Include the ``-f`` flag to specify which output formats to return. Use ``vyper -
 
     $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,combined_json,layout yourFileName.vy
 
+.. note::
+    The ``opcodes`` and ``opcodes_runtime`` output of the compiler has been returning incorrect opcodes since ``0.3.1`` due to a lack of 0 padding (patched via `PR 3735 <https://github.com/vyperlang/vyper/pull/3735>`_). If you rely on these functions for debugging, please use the latest patched versions.
+
 The ``-p`` flag allows you to set a root path that is used when searching for interface files to import.  If none is given, it will default to the current working directory. See :ref:`searching_for_imports` for more information.
 
 ::

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -31,6 +31,7 @@ source_map         - Vyper source map
 method_identifiers - Dictionary of method signature to method identifier
 userdoc            - Natspec user documentation
 devdoc             - Natspec developer documentation
+metadata           - Contract metadata (intended for use by tooling developers)
 combined_json      - All of the above format options combined as single JSON output
 layout             - Storage layout of a Vyper contract
 ast                - AST (not yet annotated) in JSON format


### PR DESCRIPTION
### What I did

I add all missing CLI flags in the docs. Furthermore, I also add a note due to the patch in https://github.com/vyperlang/vyper/pull/3735. Eventually, I add the missing CLI flag `metadata`.

### How I did it

Compare the output of `vyper --help` with the documentation [here](https://docs.vyperlang.org/en/stable/compiling-a-contract.html#vyper).

### How to verify it

Run `vyper --help`:

![image](https://github.com/vyperlang/vyper/assets/25297591/75f7d1b2-670c-4a59-a368-122612484322)

### Commit message

```console
docs: add missing cli flags
```

### Description for the changelog

docs: Add missing CLI flags.

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/58950622-4984-4d34-9887-c5ede60aaa33)