### PR TITLE
feat: rename `vyper.interfaces` to `ethereum.ercs`

### DIFF
--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -160,11 +160,11 @@ In the above example, the ``my_project`` folder is set as the root path. A contr
 Built-in Interfaces
 ===================
 
-Vyper includes common built-in interfaces such as `ERC20 <https://eips.ethereum.org/EIPS/eip-20>`_ and `ERC721 <https://eips.ethereum.org/EIPS/eip-721>`_. These are imported from ``vyper.interfaces``:
+Vyper includes common built-in interfaces such as `ERC20 <https://eips.ethereum.org/EIPS/eip-20>`_ and `ERC721 <https://eips.ethereum.org/EIPS/eip-721>`_. These are imported from ``ethereum.ercs``:
 
 .. code-block:: python
 
-    from vyper.interfaces import ERC20
+    from ethereum.ercs import ERC20
 
     implements: ERC20
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -927,7 +927,7 @@ Here is the old changelog:
 * **2019.04.05**: Add stricter checking of unbalanced return statements. (`#590 <https://github.com/vyperlang/vyper/issues/590>`_)
 * **2019.03.04**: ``create_with_code_of`` has been renamed to ``create_forwarder_to``. (`#1177 <https://github.com/vyperlang/vyper/issues/1177>`_)
 * **2019.02.14**: Assigning a persistent contract address can only be done using the ``bar_contact = ERC20(<address>)`` syntax.
-* **2019.02.12**: ERC20 interface has to be imported using ``from ethereum.ercs import ERC20`` to use.
+* **2019.02.12**: ERC20 interface has to be imported using ``from vyper.interfaces import ERC20`` to use.
 * **2019.01.30**: Byte array literals need to be annoted using ``b""``, strings are represented as `""`.
 * **2018.12.12**: Disallow use of ``None``, disallow use of ``del``, implemented ``clear()`` built-in function.
 * **2018.11.19**: Change mapping syntax to use ``map()``. (`VIP564 <https://github.com/vyperlang/vyper/issues/564>`_)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -927,7 +927,7 @@ Here is the old changelog:
 * **2019.04.05**: Add stricter checking of unbalanced return statements. (`#590 <https://github.com/vyperlang/vyper/issues/590>`_)
 * **2019.03.04**: ``create_with_code_of`` has been renamed to ``create_forwarder_to``. (`#1177 <https://github.com/vyperlang/vyper/issues/1177>`_)
 * **2019.02.14**: Assigning a persistent contract address can only be done using the ``bar_contact = ERC20(<address>)`` syntax.
-* **2019.02.12**: ERC20 interface has to be imported using ``from vyper.interfaces import ERC20`` to use.
+* **2019.02.12**: ERC20 interface has to be imported using ``from ethereum.ercs import ERC20`` to use.
 * **2019.01.30**: Byte array literals need to be annoted using ``b""``, strings are represented as `""`.
 * **2018.12.12**: Disallow use of ``None``, disallow use of ``del``, implemented ``clear()`` built-in function.
 * **2018.11.19**: Change mapping syntax to use ``map()``. (`VIP564 <https://github.com/vyperlang/vyper/issues/564>`_)

--- a/examples/factory/Exchange.vy
+++ b/examples/factory/Exchange.vy
@@ -1,4 +1,4 @@
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 
 interface Factory:

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -1,4 +1,4 @@
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 interface Exchange:
     def token() -> ERC20: view

--- a/examples/market_maker/on_chain_market_maker.vy
+++ b/examples/market_maker/on_chain_market_maker.vy
@@ -1,4 +1,4 @@
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 
 totalEthQty: public(uint256)

--- a/examples/tokens/ERC1155ownable.vy
+++ b/examples/tokens/ERC1155ownable.vy
@@ -9,7 +9,7 @@
 """
 
 ############### imports ###############
-from vyper.interfaces import ERC165
+from ethereum.ercs import ERC165
 
 ############### variables ###############
 # maximum items in a batch call. Set to 128, to be determined what the practical limits are.

--- a/examples/tokens/ERC20.vy
+++ b/examples/tokens/ERC20.vy
@@ -6,8 +6,8 @@
 # @author Takayuki Jimba (@yudetamago)
 # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
 
-from vyper.interfaces import ERC20
-from vyper.interfaces import ERC20Detailed
+from ethereum.ercs import ERC20
+from ethereum.ercs import ERC20Detailed
 
 implements: ERC20
 implements: ERC20Detailed

--- a/examples/tokens/ERC4626.vy
+++ b/examples/tokens/ERC4626.vy
@@ -6,8 +6,8 @@
 ## THIS IS EXAMPLE CODE, NOT MEANT TO BE USED IN PRODUCTION! CAVEAT EMPTOR!
 ###########################################################################
 
-from vyper.interfaces import ERC20
-from vyper.interfaces import ERC4626
+from ethereum.ercs import ERC20
+from ethereum.ercs import ERC4626
 
 implements: ERC20
 implements: ERC4626

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -6,8 +6,8 @@
 # @author Ryuya Nakamura (@nrryuya)
 # Modified from: https://github.com/vyperlang/vyper/blob/de74722bf2d8718cca46902be165f9fe0e3641dd/examples/tokens/ERC721.vy
 
-from vyper.interfaces import ERC165
-from vyper.interfaces import ERC721
+from ethereum.ercs import ERC165
+from ethereum.ercs import ERC721
 
 implements: ERC721
 implements: ERC165

--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -2370,7 +2370,7 @@ def transfer(receiver: address, amount: uint256):
     """
 
     code = """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 @external
 def safeTransfer(erc20: ERC20, receiver: address, amount: uint256) -> uint256:
     assert erc20.transfer(receiver, amount, default_return_value=True)

--- a/tests/functional/codegen/modules/test_stateless_functions.py
+++ b/tests/functional/codegen/modules/test_stateless_functions.py
@@ -188,7 +188,7 @@ def qux() -> library.SomeStruct:
 # test calls to library functions in statement position
 def test_library_statement_calls(get_contract, make_input_bundle, tx_failed):
     library_source = """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 @internal
 def check_adds_to_ten(x: uint256, y: uint256):
     assert x + y == 10

--- a/tests/functional/codegen/test_interfaces.py
+++ b/tests/functional/codegen/test_interfaces.py
@@ -69,7 +69,7 @@ interface One:
 
 def test_basic_interface_implements(assert_compile_failed):
     code = """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 implements: ERC20
 
@@ -382,7 +382,7 @@ def transfer(to: address, amount: uint256) -> bool:
     """
 
     code = """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 
 token_address: ERC20

--- a/tests/functional/syntax/test_functions_call.py
+++ b/tests/functional/syntax/test_functions_call.py
@@ -52,7 +52,7 @@ def foo(x: int128) -> uint256:
     return convert(x, uint256)
     """,
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 interface Factory:
     def getExchange(token_addr: address) -> address: view

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -15,7 +15,7 @@ from vyper.exceptions import (
 fail_list = [
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 a: public(ERC20)
 @external
 def test():
@@ -25,7 +25,7 @@ def test():
     ),
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 aba: public(ERC20)
 @external
 def test():
@@ -35,7 +35,7 @@ def test():
     ),
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 a: address(ERC20) # invalid syntax now.
     """,
@@ -43,7 +43,7 @@ a: address(ERC20) # invalid syntax now.
     ),
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 @external
 def test():
@@ -63,7 +63,7 @@ def test():  # may not call normal address
     ),
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 @external
 def test(a: address):
     my_address: address = ERC20()
@@ -72,7 +72,7 @@ def test(a: address):
     ),
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 implements: ERC20 = 1
     """,
@@ -109,7 +109,7 @@ implements: Foo
     ),
     (
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 interface A:
     def f(): view
@@ -137,7 +137,7 @@ def f(a: uint256): # visibility is nonpayable instead of view
     (
         # `receiver` of `Transfer` event should be indexed
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 implements: ERC20
 
@@ -175,7 +175,7 @@ def approve(_spender : address, _value : uint256) -> bool:
     (
         # `value` of `Transfer` event should not be indexed
         """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 implements: ERC20
 
@@ -221,14 +221,14 @@ def test_interfaces_fail(bad_code):
 
 valid_list = [
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 b: ERC20
 @external
 def test(input: address):
     assert self.b.totalSupply() == ERC20(input).totalSupply()
     """,
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 interface Factory:
    def getExchange(token_addr: address) -> address: view
@@ -253,12 +253,12 @@ def test() -> (bool, Foo):
     return True, x
     """
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 a: public(ERC20)
     """,
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 a: public(ERC20)
 
@@ -267,7 +267,7 @@ def test() -> address:
     return self.a.address
     """,
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 a: public(ERC20)
 b: address
@@ -277,7 +277,7 @@ def test():
     self.b = self.a.address
     """,
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 
 struct aStruct:
    my_address: address
@@ -291,7 +291,7 @@ def test() -> address:
     return self.b.my_address
     """,
     """
-from vyper.interfaces import ERC20
+from ethereum.ercs import ERC20
 a: public(ERC20)
 @external
 def test():

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -502,7 +502,7 @@ def _import_to_path(level: int, module_str: str) -> PurePath:
 
 
 # can add more, e.g. "vyper.builtins.interfaces", etc.
-BUILTIN_PREFIXES = ["vyper.interfaces"]
+BUILTIN_PREFIXES = ["ethereum.ercs"]
 
 
 def _is_builtin(module_str):
@@ -524,10 +524,10 @@ def _load_builtin_import(level: int, module_str: str) -> InterfaceT:
     input_bundle = FilesystemInputBundle([search_path])
 
     # remap builtins directory --
-    # vyper/interfaces => vyper/builtins/interfaces
+    # ethereum/ercs => vyper/builtins/interfaces
     remapped_module = module_str
-    if remapped_module.startswith("vyper.interfaces"):
-        remapped_module = remapped_module.removeprefix("vyper.interfaces")
+    if remapped_module.startswith("ethereum.ercs"):
+        remapped_module = remapped_module.removeprefix("ethereum.ercs")
         remapped_module = vyper.builtins.interfaces.__package__ + remapped_module
 
     path = _import_to_path(level, remapped_module).with_suffix(".vyi")


### PR DESCRIPTION
### What I did

Fixed Issue #3675 

### How I did it

Honestly I just found and replaced, and it didn't break(??). Would double check but this seems to be working to me

### How to verify it

Run the tests, they seem to pass?

### Commit message

Aliased `vyper.interfaces` import to `ethereum.ercs`

### Description for the changelog

Aliased `vyper.interfaces` import to `ethereum.ercs`

### Cute Animal Picture

This is who you're bullying when your request changes on my PR (jk ... pls do whatever is necessary) 
![image](https://github.com/vyperlang/vyper/assets/44706811/3fa389bc-5fee-4fba-afdc-062cc40f2e09)
