### PR TITLE
docs: add missing cli flag `metadata`

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -31,6 +31,7 @@ source_map         - Vyper source map
 method_identifiers - Dictionary of method signature to method identifier
 userdoc            - Natspec user documentation
 devdoc             - Natspec developer documentation
+metadata           - Contract metadata (intended for use by tooling developers)
 combined_json      - All of the above format options combined as single JSON output
 layout             - Storage layout of a Vyper contract
 ast                - AST (not yet annotated) in JSON format


### PR DESCRIPTION
### What I did

As title.

### How I did it

Update cli help documentation.

### How to verify it

Run:

```vy
vyper -f metadata filename.vy
```

### Commit message

```console
docs: add missing cli flag metadata
```

### Description for the changelog

docs: add missing cli flag `metadata`

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/c7f085a7-7c8a-4df7-956d-13866e8aac22)