### PR TITLE
fix: disallow `value=` passing for delegate and static raw_calls

### DIFF
--- a/tests/functional/builtins/codegen/test_raw_call.py
+++ b/tests/functional/builtins/codegen/test_raw_call.py
@@ -608,6 +608,22 @@ def foo(_addr: address):
     (
         """
 @external
+def foo(_addr: address):
+    raw_call(_addr, method_id("foo()"), is_delegate_call=True, value=1)
+    """,
+        ArgumentException,
+    ),
+    (
+        """
+@external
+def foo(_addr: address):
+    raw_call(_addr, method_id("foo()"), is_static_call=True, value=1)
+    """,
+        ArgumentException,
+    ),
+    (
+        """
+@external
 @view
 def foo(_addr: address):
     raw_call(_addr, 256)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1115,13 +1115,16 @@ class RawCall(BuiltinFunctionT):
 
         if delegate_call and static_call:
             raise ArgumentException(
-                "Call may use one of `is_delegate_call` or `is_static_call`, not both", expr
+                "Call may use one of `is_delegate_call` or `is_static_call`, not both"
             )
+
+        if (delegate_call or static_call) and value.value != 0:
+            raise ArgumentException("value= may not be passed for static or delegate calls!")
+
         if not static_call and context.is_constant():
             raise StateAccessViolation(
                 f"Cannot make modifying calls from {context.pp_constancy()},"
-                " use `is_static_call=True` to perform this action",
-                expr,
+                " use `is_static_call=True` to perform this action"
             )
 
         if data.value == "~calldata":


### PR DESCRIPTION
### What I did
per title. also removed a couple unneeded expr traces

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
