### PR TITLE
fix: bad assertion in expr.py

### DIFF
--- a/tests/functional/syntax/test_constants.py
+++ b/tests/functional/syntax/test_constants.py
@@ -279,6 +279,13 @@ struct Foo:
 CONST_BAR: constant(Foo) = Foo({a: 1, b: 2})
     """,
     """
+CONST_EMPTY: constant(bytes32) = empty(bytes32)
+
+@internal
+def foo() -> bytes32:
+    return CONST_EMPTY
+    """,
+    """
 struct Foo:
     a: uint256
     b: uint256

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -190,9 +190,6 @@ class Expr:
             varinfo = self.context.globals[self.expr.id]
 
             if varinfo.is_constant:
-                # constants other than structs and interfaces should have already gotten
-                # propagated during constant folding
-                assert isinstance(varinfo.typ, (InterfaceT, StructT))
                 return Expr.parse_value_expr(varinfo.decl_node.value, self.context)
 
             assert varinfo.is_immutable, "not an immutable!"


### PR DESCRIPTION
in addition to structs and interfaces, some builtins can also be skipped by the constant folder.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
