### PR TITLE
chore: improve exception for type validation

### DIFF
--- a/tests/functional/builtins/codegen/test_minmax_value.py
+++ b/tests/functional/builtins/codegen/test_minmax_value.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vyper.exceptions import InvalidType, OverflowException
+from vyper.exceptions import OverflowException, TypeMismatch
 from vyper.semantics.types import DecimalT, IntegerT
 from vyper.semantics.types.shortcuts import INT256_T, UINT256_T
 
@@ -39,12 +39,12 @@ def foo():
     if typ == UINT256_T:
         assert_compile_failed(lambda: get_contract(upper), OverflowException)
     else:
-        assert_compile_failed(lambda: get_contract(upper), InvalidType)
+        assert_compile_failed(lambda: get_contract(upper), TypeMismatch)
 
     if typ == INT256_T:
         assert_compile_failed(lambda: get_contract(lower), OverflowException)
     else:
-        assert_compile_failed(lambda: get_contract(lower), InvalidType)
+        assert_compile_failed(lambda: get_contract(lower), TypeMismatch)
 
 
 @pytest.mark.parametrize("typ", [DecimalT()])

--- a/tests/functional/builtins/codegen/test_raw_call.py
+++ b/tests/functional/builtins/codegen/test_raw_call.py
@@ -3,7 +3,7 @@ from hexbytes import HexBytes
 
 from vyper import compile_code
 from vyper.builtins.functions import eip1167_bytecode
-from vyper.exceptions import ArgumentException, InvalidType, StateAccessViolation
+from vyper.exceptions import ArgumentException, StateAccessViolation, TypeMismatch
 
 pytestmark = pytest.mark.usefixtures("memory_mocker")
 
@@ -628,7 +628,7 @@ def foo(_addr: address):
 def foo(_addr: address):
     raw_call(_addr, 256)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/builtins/folding/test_abs.py
+++ b/tests/functional/builtins/folding/test_abs.py
@@ -3,7 +3,7 @@ from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 from tests.utils import parse_and_fold
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 
 @pytest.mark.fuzzing
@@ -34,7 +34,7 @@ def test_abs_upper_bound_folding(get_contract, a):
 def foo(a: int256) -> int256:
     return abs({a})
     """
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         get_contract(source)
 
 
@@ -56,5 +56,5 @@ def test_abs_lower_bound_folded(get_contract, tx_failed):
 def foo() -> int256:
     return abs(min_value(int256))
     """
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         get_contract(source)

--- a/tests/functional/codegen/calling_convention/test_default_parameters.py
+++ b/tests/functional/codegen/calling_convention/test_default_parameters.py
@@ -3,9 +3,9 @@ import pytest
 from vyper.compiler import compile_code
 from vyper.exceptions import (
     InvalidLiteral,
-    InvalidType,
     NonPayableViolation,
     StateAccessViolation,
+    TypeMismatch,
     UndeclaredDefinition,
 )
 
@@ -404,7 +404,7 @@ def foo(xx: int128, y: int128 = xx): pass
 @external
 def foo(a: uint256 = -1): pass
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -412,7 +412,7 @@ def foo(a: uint256 = -1): pass
 @external
 def foo(a: int128 = 170141183460469231731687303715884105728): pass
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -420,7 +420,7 @@ def foo(a: int128 = 170141183460469231731687303715884105728): pass
 @external
 def foo(a: uint256[2] = [13, -42]): pass
      """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -428,7 +428,7 @@ def foo(a: uint256[2] = [13, -42]): pass
 @external
 def foo(a: int128[2] = [12, 170141183460469231731687303715884105728]): pass
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -444,7 +444,7 @@ def foo(a: uint256[2] = [12, True]): pass
 @external
 def foo(a: uint256[2] = [1, 2, 3]): pass
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/codegen/calling_convention/test_return_tuple.py
+++ b/tests/functional/codegen/calling_convention/test_return_tuple.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 pytestmark = pytest.mark.usefixtures("memory_mocker")
 
@@ -159,5 +159,5 @@ def test_tuple_return_typecheck(tx_failed, get_contract_with_gas_estimation):
 def getTimeAndBalance() -> (bool, address):
     return block.timestamp, self.balance
     """
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         compile_code(code)

--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -790,7 +790,7 @@ def test_for() -> int128:
         a = i
     return a
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -207,7 +207,7 @@ def foo2() -> uint256:
     x += 1
     return x
 """
-    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), InvalidType)
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatch)
 
 
 def test_invalid_uin256_assignment_calculate_literals(get_contract_with_gas_estimation):

--- a/tests/functional/codegen/features/test_logging.py
+++ b/tests/functional/codegen/features/test_logging.py
@@ -565,7 +565,7 @@ def foo_():
     log MyLog(b'yo')
 """
 
-    with tx_failed(InvalidType):
+    with tx_failed(TypeMismatch):
         get_contract_with_gas_estimation(loggy_code)
 
 
@@ -580,7 +580,7 @@ def foo():
     log MyLog(b'bars')
 """
 
-    with tx_failed(InvalidType):
+    with tx_failed(TypeMismatch):
         get_contract_with_gas_estimation(loggy_code)
 
 
@@ -608,7 +608,7 @@ def foo():
     log MyLog(b'bars')
 """
 
-    with tx_failed(InvalidType):
+    with tx_failed(TypeMismatch):
         get_contract_with_gas_estimation(loggy_code)
 
 
@@ -1241,7 +1241,7 @@ fail_list = [
 def foo():
     raw_log([1, 2], b"moo")
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -1249,7 +1249,7 @@ def foo():
 def foo():
     raw_log([1, 2], b"moo")
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -1266,7 +1266,7 @@ def foo():
 def foo():
     raw_log([b"cow"], b"dog")
     """,
-        (StructureException, InvalidType),
+        (StructureException, TypeMismatch),
     ),
     (
         """
@@ -1275,7 +1275,7 @@ def foo():
     # bytes20 instead of bytes32
     raw_log([], 0x1234567890123456789012345678901234567890)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/codegen/types/numbers/test_signed_ints.py
+++ b/tests/functional/codegen/types/numbers/test_signed_ints.py
@@ -5,7 +5,12 @@ import random
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidOperation, InvalidType, OverflowException, ZeroDivisionException
+from vyper.exceptions import (
+    InvalidOperation,
+    OverflowException,
+    TypeMismatch,
+    ZeroDivisionException,
+)
 from vyper.semantics.types import IntegerT
 from vyper.utils import evm_div, evm_mod
 
@@ -214,7 +219,7 @@ def num_sub() -> {typ}:
     return 1-2**{typ.bits}
     """
 
-    exc = OverflowException if typ.bits == 256 else InvalidType
+    exc = OverflowException if typ.bits == 256 else TypeMismatch
     with pytest.raises(exc):
         compile_code(code)
 
@@ -331,7 +336,7 @@ def foo() -> {typ}:
                 get_contract(code_2).foo(x)
             with tx_failed():
                 get_contract(code_3).foo(y)
-            with pytest.raises((InvalidType, OverflowException)):
+            with pytest.raises((TypeMismatch, OverflowException)):
                 compile_code(code_4)
 
 
@@ -430,5 +435,5 @@ def test_binop_nested_intermediate_underflow():
 def foo():
     a: int256 = -2**255 * 2 - 10 + 100
     """
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         compile_code(code)

--- a/tests/functional/codegen/types/numbers/test_unsigned_ints.py
+++ b/tests/functional/codegen/types/numbers/test_unsigned_ints.py
@@ -5,7 +5,12 @@ import random
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidOperation, InvalidType, OverflowException, ZeroDivisionException
+from vyper.exceptions import (
+    InvalidOperation,
+    OverflowException,
+    TypeMismatch,
+    ZeroDivisionException,
+)
 from vyper.semantics.types import IntegerT
 from vyper.utils import SizeLimits, evm_div, evm_mod
 
@@ -164,7 +169,7 @@ def foo() -> {typ}:
                 get_contract(code_2).foo(x)
             with tx_failed():
                 get_contract(code_3).foo(y)
-            with pytest.raises((InvalidType, OverflowException)):
+            with pytest.raises((TypeMismatch, OverflowException)):
                 get_contract(code_4)
 
 
@@ -223,7 +228,7 @@ def test() -> {typ}:
 
     for val in bad_cases:
         exc = (
-            InvalidType
+            TypeMismatch
             if SizeLimits.MIN_INT256 <= val <= SizeLimits.MAX_UINT256
             else OverflowException
         )

--- a/tests/functional/codegen/types/test_bytes.py
+++ b/tests/functional/codegen/types/test_bytes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 
 def test_test_bytes(get_contract_with_gas_estimation, tx_failed):
@@ -310,7 +310,7 @@ def assign():
 def assign():
     xs: bytes6 = b"abcdef"
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -318,7 +318,7 @@ def assign():
 def assign():
     xs: bytes4 = 0xabcdef  # bytes3 literal
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -326,7 +326,7 @@ def assign():
 def assign():
     xs: bytes4 = 0x1234abcdef # bytes5 literal
     """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -7,7 +7,6 @@ from vyper.exceptions import (
     ArgumentException,
     ArrayIndexException,
     ImmutableViolation,
-    InvalidType,
     OverflowException,
     StateAccessViolation,
     TypeMismatch,
@@ -1124,7 +1123,7 @@ def foo() -> DynArray[{subtyp}, 3]:
     x.append({lit})
     return x
     """
-    assert_compile_failed(lambda: get_contract(code), InvalidType)
+    assert_compile_failed(lambda: get_contract(code), TypeMismatch)
 
 
 invalid_appends_pops = [

--- a/tests/functional/syntax/exceptions/test_invalid_type_exception.py
+++ b/tests/functional/syntax/exceptions/test_invalid_type_exception.py
@@ -22,29 +22,11 @@ def test_unknown_type_exception(bad_code, get_contract, assert_compile_failed):
 
 
 invalid_list = [
-    """
-@external
-def foo():
-    raw_log(b"cow", b"dog")
-    """,
-    """
-@external
-def foo():
-    xs: uint256[1] = []
-    """,
     # Must be a literal string.
     """
 @external
 def mint(_to: address, _value: uint256):
     assert msg.sender == self,msg.sender
-    """,
-    # literal longer than event member
-    """
-event Foo:
-    message: String[1]
-@external
-def foo():
-    log Foo("abcd")
     """,
     # Raise reason must be string
     """
@@ -58,10 +40,6 @@ x: int128[3.5]
     # Key of mapping must be a base type
     """
 b: HashMap[(int128, decimal), int128]
-    """,
-    # Address literal must be checksummed
-    """
-a: constant(address) = 0x3cd751e6b0078be393132286c442345e5dc49699
     """,
     """
 x: String <= 33

--- a/tests/functional/syntax/exceptions/test_type_mismatch_exception.py
+++ b/tests/functional/syntax/exceptions/test_type_mismatch_exception.py
@@ -25,6 +25,28 @@ def foo():
     b: Bytes[1] = b"\x05"
     x: uint256 = as_wei_value(b, "babbage")
     """,
+    """
+@external
+def foo():
+    raw_log(b"cow", b"dog")
+    """,
+    """
+@external
+def foo():
+    xs: uint256[1] = []
+    """,
+    # literal longer than event member
+    """
+event Foo:
+    message: String[1]
+@external
+def foo():
+    log Foo("abcd")
+    """,
+    # Address literal must be checksummed
+    """
+a: constant(address) = 0x3cd751e6b0078be393132286c442345e5dc49699
+    """,
 ]
 
 

--- a/tests/functional/syntax/test_abi_encode.py
+++ b/tests/functional/syntax/test_abi_encode.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -36,7 +36,7 @@ def foo(x: uint256) -> Bytes[36]:
 def foo(x: uint256) -> Bytes[36]:
     return _abi_encode(x, method_id=b"abcde")
     """,
-        InvalidType,  # len(method_id) must be less than 4
+        TypeMismatch,  # len(method_id) must be less than 4
     ),
     (
         """
@@ -44,7 +44,7 @@ def foo(x: uint256) -> Bytes[36]:
 def foo(x: uint256) -> Bytes[36]:
     return _abi_encode(x, method_id=0x1234567890)
     """,
-        InvalidType,  # len(method_id) must be less than 4
+        TypeMismatch,  # len(method_id) must be less than 4
     ),
 ]
 

--- a/tests/functional/syntax/test_abs.py
+++ b/tests/functional/syntax/test_abs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -12,7 +12,7 @@ def foo():
         -57896044618658097711785492504343953926634992332820282019728792003956564819968
     )
     """,
-        InvalidType,
+        TypeMismatch,
     )
 ]
 

--- a/tests/functional/syntax/test_addmulmod.py
+++ b/tests/functional/syntax/test_addmulmod.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (  # bad AST nodes given as arguments
@@ -10,7 +10,7 @@ fail_list = [
 def foo() -> uint256:
     return uint256_addmod(1.1, 1.2, 3.0)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (  # bad AST nodes given as arguments
         """
@@ -18,7 +18,7 @@ def foo() -> uint256:
 def foo() -> uint256:
     return uint256_mulmod(1.1, 1.2, 3.0)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/syntax/test_ann_assign.py
+++ b/tests/functional/syntax/test_ann_assign.py
@@ -4,7 +4,7 @@ from pytest import raises
 from vyper import compiler
 from vyper.exceptions import (
     InvalidAttribute,
-    InvalidType,
+    TypeMismatch,
     UndeclaredDefinition,
     UnknownAttribute,
     VariableDeclarationException,
@@ -41,7 +41,7 @@ def test():
 def test():
     a: int128 = 33.33
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -50,7 +50,7 @@ def data() -> int128:
     s: int128[5] = [1, 2, 3, 4, 5, 6]
     return 235357
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -62,7 +62,7 @@ def foo() -> int128:
     s: S = S({a: 1.2, b: 1})
     return s.a
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -105,7 +105,7 @@ def foo() -> bool:
     a: uint256 = -1
     return True
 """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -114,7 +114,7 @@ def foo() -> bool:
     a: uint256[2] = [13, -42]
     return True
 """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -123,7 +123,7 @@ def foo() -> bool:
     a: int128 = 170141183460469231731687303715884105728
     return True
 """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/syntax/test_as_wei_value.py
+++ b/tests/functional/syntax/test_as_wei_value.py
@@ -4,9 +4,9 @@ from vyper import compile_code
 from vyper.exceptions import (
     ArgumentException,
     InvalidLiteral,
-    InvalidType,
     OverflowException,
     StructureException,
+    TypeMismatch,
     UndeclaredDefinition,
 )
 
@@ -44,7 +44,7 @@ def foo() -> int128:
 def foo():
     x: int128 = as_wei_value(0xf5, "szabo")
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_block.py
+++ b/tests/functional/syntax/test_block.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import raises
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -11,7 +11,7 @@ fail_list = [
 def foo() -> int128[2]:
     return [3,block.timestamp]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -19,7 +19,7 @@ def foo() -> int128[2]:
 def foo() -> int128[2]:
     return [block.timestamp - block.timestamp, block.timestamp]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     """
 @external
@@ -34,7 +34,7 @@ def foo() -> decimal:
 def foo():
     x: Bytes[10] = slice(b"cow", -1, block.timestamp)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     """
 @external

--- a/tests/functional/syntax/test_bool.py
+++ b/tests/functional/syntax/test_bool.py
@@ -2,18 +2,15 @@ import pytest
 from pytest import raises
 
 from vyper import compiler
-from vyper.exceptions import InvalidOperation, InvalidType, SyntaxException, TypeMismatch
+from vyper.exceptions import InvalidOperation, SyntaxException, TypeMismatch
 
 fail_list = [
-    (
-        """
+    """
 @external
 def foo():
     x: bool = True
     x = 5
     """,
-        InvalidType,
-    ),
     (
         """
 @external
@@ -22,15 +19,12 @@ def foo():
     """,
         SyntaxException,
     ),
-    (
-        """
+    """
 @external
 def foo():
     x: bool = True
     x = 129
     """,
-        InvalidType,
-    ),
     (
         """
 @external
@@ -63,15 +57,12 @@ def foo(a: address) -> bool:
     """,
         InvalidOperation,
     ),
-    (
-        """
+    """
 @external
 def test(a: address) -> bool:
     assert(a)
     return True
     """,
-        TypeMismatch,
-    ),
 ]
 
 

--- a/tests/functional/syntax/test_bytes.py
+++ b/tests/functional/syntax/test_bytes.py
@@ -1,13 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import (
-    InvalidOperation,
-    InvalidType,
-    StructureException,
-    SyntaxException,
-    TypeMismatch,
-)
+from vyper.exceptions import InvalidOperation, StructureException, SyntaxException, TypeMismatch
 
 fail_list = [
     (
@@ -64,7 +58,7 @@ def foo() -> Bytes[10]:
     x = 0x1234567890123456789012345678901234567890
     return x
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -72,7 +66,7 @@ def foo() -> Bytes[10]:
 def foo() -> Bytes[10]:
     return "badmintonzz"
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_chainid.py
+++ b/tests/functional/syntax/test_chainid.py
@@ -3,7 +3,7 @@ import pytest
 from vyper import compiler
 from vyper.compiler.settings import Settings
 from vyper.evm.opcodes import EVM_VERSIONS
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 
 @pytest.mark.parametrize("evm_version", list(EVM_VERSIONS))
@@ -25,7 +25,7 @@ fail_list = [
 def foo() -> int128[2]:
     return [3,chain.id]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     """
 @external
@@ -60,7 +60,7 @@ def add_record():
 def foo(inp: Bytes[10]) -> Bytes[3]:
     return slice(inp, chain.id, -3)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import ArgumentException, InvalidType, TypeMismatch
+from vyper.exceptions import ArgumentException, TypeMismatch
 
 fail_list = [
     (
@@ -18,7 +18,7 @@ def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
 def cat(i1: Bytes[10], i2: Bytes[30]) -> Bytes[40]:
     return concat(i1, 5)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_constants.py
+++ b/tests/functional/syntax/test_constants.py
@@ -5,11 +5,11 @@ from vyper import compiler
 from vyper.exceptions import (
     ArgumentException,
     ImmutableViolation,
-    InvalidType,
     NamespaceCollision,
     StateAccessViolation,
     StructureException,
     SyntaxException,
+    TypeMismatch,
     VariableDeclarationException,
 )
 
@@ -33,14 +33,14 @@ VAL: constant(uint256, int128) = 12
         """
 VAL: constant(uint256) = "test"
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     # invalid range
     (
         """
 VAL: constant(uint256) = -1
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     # reserved keyword
     (
@@ -62,7 +62,7 @@ VAL: constant(uint256) = 11
         """
 VAL: constant(Bytes[4]) = b"testtest"
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     # global with same name
     (

--- a/tests/functional/syntax/test_extract32.py
+++ b/tests/functional/syntax/test_extract32.py
@@ -34,7 +34,7 @@ def foo(inp: Bytes[32]) -> int128:
 def foo(inp: Bytes[32]) -> int128:
     return extract32(inp, -1, output_type=int128)
     """,
-        InvalidType,  # `start` cannot be negative
+        TypeMismatch,  # `start` cannot be negative
     ),
     (
         """

--- a/tests/functional/syntax/test_invalids.py
+++ b/tests/functional/syntax/test_invalids.py
@@ -4,7 +4,6 @@ from vyper import compiler
 from vyper.exceptions import (
     FunctionDeclarationException,
     InvalidOperation,
-    InvalidType,
     StructureException,
     TypeMismatch,
     UndeclaredDefinition,
@@ -67,7 +66,7 @@ def foo():
     x: int128 = 5
     x = 0x1234567890123456789012345678901234567890
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_fail(
@@ -77,7 +76,7 @@ def foo():
     x: int128 = 5
     x = 3.5
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_succeed(
@@ -105,7 +104,7 @@ b: int128
 def foo():
     self.b = 7.5
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_succeed(
@@ -133,7 +132,7 @@ b: int128[5]
 def foo():
     self.b = 7
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_succeed(
@@ -152,7 +151,7 @@ b: HashMap[uint256, uint256]
 def foo():
     x: int128 = self.b[-5]
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_fail(
@@ -162,7 +161,7 @@ b: HashMap[int128, int128]
 def foo():
     x: int128 = self.b[5.7]
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_succeed(
@@ -181,7 +180,7 @@ b: HashMap[int128, int128]
 def foo():
     self.b[3] = 5.6
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_succeed(
@@ -236,7 +235,7 @@ bar: int128[3]
 def foo():
     self.bar = 5
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_succeed(
@@ -254,7 +253,7 @@ must_fail(
 def foo() -> address:
     return [1, 2, 3]
 """,
-    InvalidType,
+    TypeMismatch,
 )
 
 must_fail(

--- a/tests/functional/syntax/test_keccak256.py
+++ b/tests/functional/syntax/test_keccak256.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, UndeclaredDefinition
+from vyper.exceptions import TypeMismatch, UndeclaredDefinition
 
 type_fail_list = [
     """
@@ -14,7 +14,7 @@ def foo():
 
 @pytest.mark.parametrize("bad_code", type_fail_list)
 def test_block_type_fail(bad_code):
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         compiler.compile_code(bad_code)
 
 

--- a/tests/functional/syntax/test_list.py
+++ b/tests/functional/syntax/test_list.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidLiteral, InvalidType, StructureException, TypeMismatch
+from vyper.exceptions import InvalidLiteral, StructureException, TypeMismatch
 
 fail_list = [
     (
@@ -11,7 +11,7 @@ def foo():
     x: int128[3] = [1, 2, 3]
     x = 4
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -20,7 +20,7 @@ def foo():
     x: int128[3] = [1, 2, 3]
     x = [4, 5, 6, 7]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -28,7 +28,7 @@ def foo():
 def foo() -> int128[2]:
     return [3, 5, 7]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -36,7 +36,7 @@ def foo() -> int128[2]:
 def foo() -> int128[2]:
     return [3]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -94,7 +94,7 @@ bar: int128[3]
 def foo():
     self.bar = []
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -121,7 +121,7 @@ bar: int128[3][3]
 def foo():
     self.bar = 5
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -130,7 +130,7 @@ bar: int128[3][3]
 def foo():
     self.bar = [2, 5]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -139,7 +139,7 @@ bar: int128[3]
 def foo():
     self.bar = [1, 2, 3, 4]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -148,7 +148,7 @@ bar: int128[3]
 def foo():
     self.bar = [1, 2]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -157,7 +157,7 @@ b: int128[5]
 def foo():
     self.b[0] = 7.5
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -176,7 +176,7 @@ def foo()->bool[2]:
     a[0] = 1
     return a
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -186,7 +186,7 @@ def foo()->bool[2]:
     a[0] = 1
     return a
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_logging.py
+++ b/tests/functional/syntax/test_logging.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, StructureException, TypeMismatch
+from vyper.exceptions import StructureException, TypeMismatch
 
 fail_list = [
     """
@@ -23,8 +23,7 @@ def foo():
     x: decimal[4] = [0.0, 0.0, 0.0, 0.0]
     log Bar(x)
     """,
-    (
-        """
+    """
 event Test:
     n: uint256
 
@@ -32,19 +31,13 @@ event Test:
 def test():
     log Test(-7)
    """,
-        InvalidType,
-    ),
 ]
 
 
 @pytest.mark.parametrize("bad_code", fail_list)
 def test_logging_fail(bad_code):
-    if isinstance(bad_code, tuple):
-        with pytest.raises(bad_code[1]):
-            compiler.compile_code(bad_code[0])
-    else:
-        with pytest.raises(TypeMismatch):
-            compiler.compile_code(bad_code)
+    with pytest.raises(TypeMismatch):
+        compiler.compile_code(bad_code)
 
 
 @pytest.mark.parametrize("mutability", ["@pure", "@view"])

--- a/tests/functional/syntax/test_minmax.py
+++ b/tests/functional/syntax/test_minmax.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType, OverflowException, TypeMismatch
+from vyper.exceptions import OverflowException, TypeMismatch
 
 fail_list = [
     (
@@ -10,7 +10,7 @@ fail_list = [
 def foo():
     y: int128 = min(7, 0x1234567890123456789012345678901234567890)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_nested_list.py
+++ b/tests/functional/syntax/test_nested_list.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidLiteral, InvalidType, TypeMismatch
+from vyper.exceptions import InvalidLiteral, TypeMismatch
 
 fail_list = [
     (
@@ -11,7 +11,7 @@ bar: int128[3][3]
 def foo():
     self.bar = [[1, 2], [3, 4, 5], [6, 7, 8]]
     """,
-        InvalidType,  # casting darray to sarray
+        TypeMismatch,  # casting darray to sarray
     ),
     (
         """
@@ -28,7 +28,7 @@ def foo():
 def foo() -> int128[2]:
     return [[1,2],[3,4]]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -36,7 +36,7 @@ def foo() -> int128[2]:
 def foo() -> int128[2][2]:
     return [1,2]
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_powmod.py
+++ b/tests/functional/syntax/test_powmod.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -10,7 +10,7 @@ fail_list = [
 def foo():
     a: uint256 = pow_mod256(-1, -1)
     """,
-        InvalidType,
+        TypeMismatch,
     )
 ]
 

--- a/tests/functional/syntax/test_selfdestruct.py
+++ b/tests/functional/syntax/test_selfdestruct.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     """
@@ -14,7 +14,7 @@ def foo():
 
 @pytest.mark.parametrize("bad_code", fail_list)
 def test_block_fail(bad_code):
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         compiler.compile_code(bad_code)
 
 

--- a/tests/functional/syntax/test_send.py
+++ b/tests/functional/syntax/test_send.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -10,7 +10,7 @@ fail_list = [
 def foo():
     send(1, 2)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -18,7 +18,7 @@ def foo():
 def foo():
     send(0x1234567890123456789012345678901234567890, 2.5)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -26,7 +26,7 @@ def foo():
 def foo():
     send(0x1234567890123456789012345678901234567890, 0x1234567890123456789012345678901234567890)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -65,7 +65,7 @@ def foo():
 def foo():
     send(0x1234567890123456789012345678901234567890, 5, gas=1.5)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """
@@ -73,7 +73,7 @@ def foo():
 def foo():
     send(0x1234567890123456789012345678901234567890, 5, gas=-2)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_slice.py
+++ b/tests/functional/syntax/test_slice.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -26,7 +26,7 @@ def foo(inp: int128) -> Bytes[3]:
 def foo(inp: Bytes[10]) -> Bytes[3]:
     return slice(inp, 4.0, 3)
     """,
-        InvalidType,
+        TypeMismatch,
     ),
 ]
 

--- a/tests/functional/syntax/test_structs.py
+++ b/tests/functional/syntax/test_structs.py
@@ -3,7 +3,6 @@ import pytest
 from vyper import compiler
 from vyper.exceptions import (
     InstantiationException,
-    InvalidType,
     StructureException,
     TypeMismatch,
     UnknownAttribute,
@@ -254,7 +253,7 @@ nom: C[3]
 def foo():
     self.mom = Mom({a: self.nom, b: 5.5})
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (
         """

--- a/tests/functional/syntax/test_ternary.py
+++ b/tests/functional/syntax/test_ternary.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType, TypeMismatch
+from vyper.exceptions import TypeMismatch
 
 good_list = [
     # basic test
@@ -73,7 +73,7 @@ fail_list = [
 def foo() -> uint256:
     return 1 if 1 else 2
     """,
-        InvalidType,
+        TypeMismatch,
     ),
     (  # bad test type: constant
         """

--- a/tests/functional/syntax/test_unary.py
+++ b/tests/functional/syntax/test_unary.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidType
+from vyper.exceptions import TypeMismatch
 
 fail_list = [
     (
@@ -10,7 +10,7 @@ fail_list = [
 def foo() -> int128:
     return -2**127
     """,
-        InvalidType,
+        TypeMismatch,
     )
 ]
 

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -12,7 +12,7 @@ from vyper.cli.vyper_json import (
 )
 from vyper.compiler import OUTPUT_FORMATS, compile_code, compile_from_file_input
 from vyper.compiler.input_bundle import JSONInputBundle
-from vyper.exceptions import InvalidType, JSONError, SyntaxException
+from vyper.exceptions import JSONError, SyntaxException, TypeMismatch
 
 FOO_CODE = """
 import contracts.ibar as IBar
@@ -244,7 +244,7 @@ def test_exc_handler_to_dict_syntax(input_json):
 
 def test_exc_handler_raises_compiler(input_json):
     input_json["sources"]["badcode.vy"] = {"content": BAD_COMPILER_CODE}
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         compile_json(input_json)
 
 
@@ -256,7 +256,7 @@ def test_exc_handler_to_dict_compiler(input_json):
     assert len(result["errors"]) == 1
     error = result["errors"][0]
     assert error["component"] == "compiler"
-    assert error["type"] == "InvalidType"
+    assert error["type"] == "TypeMismatch"
 
 
 def test_source_ids_increment(input_json):

--- a/tests/unit/semantics/analysis/test_array_index.py
+++ b/tests/unit/semantics/analysis/test_array_index.py
@@ -4,7 +4,6 @@ from vyper.ast import parse_to_ast
 from vyper.exceptions import (
     ArrayIndexException,
     InvalidReference,
-    InvalidType,
     TypeMismatch,
     UndeclaredDefinition,
 )
@@ -37,7 +36,7 @@ def foo():
     self.a[{value}] = 12
     """
     vyper_module = parse_to_ast(code)
-    with pytest.raises(InvalidType):
+    with pytest.raises(TypeMismatch):
         validate_semantics(vyper_module, dummy_input_bundle)
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -609,8 +609,7 @@ def validate_expected_type(node, expected_type):
         if expected_type[0] == AddressT() and given_types[0] == BytesM_T(20):
             suggestion_str = f" Did you mean {checksum_encode(node.value)}?"
 
-        # CMC 2022-02-14 maybe TypeMismatch would make more sense here
-        raise InvalidType(
+        raise TypeMismatch(
             f"Expected {expected_str} but literal can only be cast as {given_str}.{suggestion_str}",
             node,
         )


### PR DESCRIPTION
### What I did

Change the exception for `validate_expected_type` from `InvalidType` to `TypeMismatch`.

### How I did it

### How to verify it

### Commit message

```
chore: change exception type for type validation

This PR changes the exception raised for `validate_expected_type`
from `InvalidType` to `TypeMismatch`.
```

### Description for the changelog

Change exception type for for type validation.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcQ_BA71hovar_orJSTjJnGGtdY0uqKiUl50nYXOSqoLMjaDgcRy)
