### PR TITLE
fix: StringEnum._generate_next_value_ signature

### DIFF
--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -65,6 +65,7 @@ class OrderedSet(Generic[_T], dict[_T, None]):
 
 class StringEnum(enum.Enum):
     # Must be first, or else won't work, specifies what .value is
+    @staticmethod
     def _generate_next_value_(name, start, count, last_values):
         return name.lower()
 


### PR DESCRIPTION
per the documentation, _generate_next_value_ should be a staticmethod.

reference:
https://docs.python.org/3/library/enum.html#enum.Enum._generate_next_value_

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
