### PR TITLE
feat: more frontend optimizations

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -267,7 +267,7 @@ class VyperNode:
             Dictionary of fields to be included within the node.
         """
         self.set_parent(parent)
-        self._children: set = set()
+        self._children: list = []
         self._metadata: NodeMetadata = NodeMetadata()
         self._original_node = None
         self._descendants = None
@@ -299,7 +299,7 @@ class VyperNode:
 
         # add to children of parent last to ensure an accurate hash is generated
         if parent is not None:
-            parent._children.add(self)
+            parent._children.append(self)
 
     # set parent, can be useful when inserting copied nodes into the AST
     def set_parent(self, parent: "VyperNode"):
@@ -672,7 +672,7 @@ class Module(TopLevel):
         self.body.append(node)
         node._depth = self._depth + 1
         node._parent = self
-        self._children.add(node)
+        self._children.append(node)
 
     def remove_from_body(self, node: VyperNode) -> None:
         """

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -364,6 +364,7 @@ class VyperNode:
         return hash(tuple(values))
 
     def __deepcopy__(self, memo):
+        # default implementation of deepcopy is a hotspot
         return pickle.loads(pickle.dumps(self))
 
     def __eq__(self, other):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -274,15 +274,12 @@ class VyperNode:
 
         for field_name in NODE_SRC_ATTRIBUTES:
             # when a source offset is not available, use the parent's source offset
-            value = kwargs.get(field_name)
-            if kwargs.get(field_name) is None:
+            value = kwargs.pop(field_name, None)
+            if value is None:
                 value = getattr(parent, field_name, None)
             setattr(self, field_name, value)
 
         for field_name, value in kwargs.items():
-            if field_name in NODE_SRC_ATTRIBUTES:
-                continue
-
             if field_name in self._translated_fields:
                 field_name = self._translated_fields[field_name]
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -527,14 +527,17 @@ class VyperNode:
         list
             Child nodes matching the filter conditions.
         """
-        children = self._children.copy()
+        children = iter(self._children)
+
         if node_type is not None:
-            children = [i for i in children if isinstance(i, node_type)]
+            children = (i for i in children if isinstance(i, node_type))
+        if filters is not None:
+            children = (i for i in children if _node_filter(i, filters))
+
+        children = list(children)
         if reverse:
             children.reverse()
-        if filters is None:
-            return children
-        return [i for i in children if _node_filter(i, filters)]
+        return children
 
     def get_descendants(
         self,

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -593,16 +593,16 @@ class VyperNode:
         return _apply_filters(ret, node_type, filters, reverse)
 
     def _get_descendants(self, include_self=True):
-        # get descendants in breadth-first order
+        # get descendants in topsort order
         if self._cache_descendants is None:
             ret = [self]
-            ret.extend(self._children)
             for node in self._children:
-                ret.extend(node._get_descendants(include_self=False))
+                ret.extend(node._get_descendants())
 
             self._cache_descendants = ret
 
         ret = iter(self._cache_descendants)
+
         if not include_self:
             s = next(ret)  # pop
             assert s is self

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -581,8 +581,10 @@ class VyperNode:
         """
         ret = self._get_descendants()
 
-        if not include_self:
-            ret.pop(0)  # pop self
+        if include_self:
+            ret = ret.copy()
+        else:
+            ret = ret[1:]  # pop self
 
         if node_type:
             ret = [node for node in ret if isinstance(node, node_type)]

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -28,13 +28,13 @@ from vyper.utils import MAX_DECIMAL_PLACES, SizeLimits, annotate_source_code
 
 NODE_BASE_ATTRIBUTES = (
     "_children",
-    "_descendants",
     "_depth",
     "_parent",
     "ast_type",
     "node_id",
     "_metadata",
     "_original_node",
+    "_cache_descendants",
 )
 NODE_SRC_ATTRIBUTES = (
     "col_offset",

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -270,7 +270,7 @@ class VyperNode:
         self._children: list = []
         self._metadata: NodeMetadata = NodeMetadata()
         self._original_node = None
-        self._descendants = None
+        self._cache_descendants = None
 
         for field_name in NODE_SRC_ATTRIBUTES:
             # when a source offset is not available, use the parent's source offset
@@ -597,15 +597,15 @@ class VyperNode:
         return ret
 
     def _get_descendants(self):
-        if self._descendants is not None:
-            return self._descendants
+        if self._cache_descendants is not None:
+            return self._cache_descendants
 
         ret = [self]
         ret.extend(self._children)
         for node in self._children:
             ret.extend(node._get_descendants())
 
-        self._descendants = ret
+        self._cache_descendants = ret
         return ret
 
     def get(self, field_str: str) -> Any:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -225,7 +225,6 @@ def _apply_filters(node_iter, node_type, filters, reverse):
     return ret
 
 
-
 def _raise_syntax_exc(error_msg: str, ast_struct: dict) -> None:
     # helper function to raise a SyntaxException from a dict representing a node
     raise SyntaxException(

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -1,6 +1,8 @@
 import ast as python_ast
+import io
 import tokenize
 from decimal import Decimal
+from functools import cached_property
 from typing import Any, Dict, List, Optional, Union, cast
 
 import asttokens
@@ -266,6 +268,12 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         node.ast_type = self._modification_offsets[(node.lineno, node.col_offset)]
         return node
 
+    @cached_property
+    def _dummy_tokens(self):
+        bytez = "dummy_target:\\\n foo".encode("utf-8")
+        token_list = list(tokenize.tokenize(io.BytesIO(bytez).readline))[:3]
+        return token_list
+
     def visit_For(self, node):
         """
         Visit a For node, splicing in the loop variable annotation provided by
@@ -300,8 +308,19 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # in a bit, but for now lets us keep the line/col offset, and
         # *also* gives us a valid AST. it doesn't matter what the dummy
         # target name is, since it gets removed in a few lines.
+
+        # tokenization is a perf hotspot, so we manually construct the token
+        # list to pass to ASTTokens.
+        annotation_tokens = self._dummy_tokens + annotation_tokens
+
+        # ensure tokens are properly terminated
+        endline = annotation_tokens[-1].start[0]
+        annotation_tokens.append(
+            tokenize.TokenInfo(
+                type=tokenize.ENDMARKER, string="", start=(endline, 0), end=(endline, 0), line=""
+            )
+        )
         annotation_str = tokenize.untokenize(annotation_tokens)
-        annotation_str = "dummy_target:" + annotation_str
 
         try:
             fake_node = python_ast.parse(annotation_str).body[0]
@@ -310,10 +329,8 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                 "invalid type annotation", self._source_code, node.lineno, node.col_offset
             ) from e
 
-        # fill in with asttokens info. note we can use `self._tokens` because
-        # it is indented to exactly the same position where it appeared
-        # in the original source!
-        self._tokens.mark_tokens(fake_node)
+        # fill in with asttokens info.
+        asttokens.ASTTokens(annotation_str, tree=fake_node, tokens=annotation_tokens)
 
         # replace the dummy target name with the real target name.
         fake_node.target = node.target

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -480,6 +480,7 @@ def get_expr_info(node: vy_ast.ExprNode, is_callable: bool = False) -> ExprInfo:
 
 
 def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> List:
+    # this function is a performance hotspot
     """
     Return a list of common possible types between one or more nodes.
 

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -251,7 +251,12 @@ class IntegerT(NumericT):
         return ABI_GIntM(self.bits, self.is_signed)
 
     def compare_type(self, other: VyperType) -> bool:
-        # hotspot
+        # this function is performance sensitive
+        # originally:
+        # if not super().compare_type(other):
+        #    return False
+        # return self.is_signed == other.is_signed and self.bits == other.bits
+
         return (  # noqa: E721
             self.__class__ == other.__class__
             and self.is_signed == other.is_signed  # type: ignore

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -251,11 +251,12 @@ class IntegerT(NumericT):
         return ABI_GIntM(self.bits, self.is_signed)
 
     def compare_type(self, other: VyperType) -> bool:
-        if not super().compare_type(other):
-            return False
-        assert isinstance(other, IntegerT)  # mypy
-
-        return self.is_signed == other.is_signed and self.bits == other.bits
+        # hotspot
+        return (  # noqa: E721
+            type(self) == type(other)
+            and self.is_signed == other.is_signed  # type: ignore
+            and self.bits == other.bits  # type: ignore
+        )
 
 
 # helper function for readability.

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -253,7 +253,7 @@ class IntegerT(NumericT):
     def compare_type(self, other: VyperType) -> bool:
         # hotspot
         return (  # noqa: E721
-            type(self) == type(other)
+            self.__class__ == other.__class__
             and self.is_signed == other.is_signed  # type: ignore
             and self.bits == other.bits  # type: ignore
         )


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
- optimize `VyperNode.get_descendants()` and `get_children()`
- get rid of `sort_nodes()`, we can guarantee ordering the old fashioned
  way (topsort)
- optimize `VyperNode.__hash__()` and `VyperNode.__init__()`
- optimize `IntegerT.compare_type()`

optimizes front-end compilation time by another 25%
```

### Description for the changelog

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/3867501/61c16e11-7700-4c14-a586-539e1e9f6f35)
