### PR TITLE
fix: assembly dead code eliminator

### DIFF
--- a/tests/unit/compiler/venom/test_duplicate_operands.py
+++ b/tests/unit/compiler/venom/test_duplicate_operands.py
@@ -24,4 +24,4 @@ def test_duplicate_operands():
 
     asm = generate_assembly_experimental(ctx, optimize=OptimizationLevel.CODESIZE)
 
-    assert asm == ["PUSH1", 10, "DUP1", "DUP1", "DUP1", "ADD", "MUL", "STOP", "REVERT"]
+    assert asm == ["PUSH1", 10, "DUP1", "DUP1", "DUP1", "ADD", "MUL", "STOP"]

--- a/tests/unit/compiler/venom/test_duplicate_operands.py
+++ b/tests/unit/compiler/venom/test_duplicate_operands.py
@@ -22,6 +22,6 @@ def test_duplicate_operands():
     bb.append_instruction("mul", sum_, op)
     bb.append_instruction("stop")
 
-    asm = generate_assembly_experimental(ctx, optimize=OptimizationLevel.CODESIZE)
+    asm = generate_assembly_experimental(ctx, optimize=OptimizationLevel.GAS)
 
     assert asm == ["PUSH1", 10, "DUP1", "DUP1", "DUP1", "ADD", "MUL", "STOP"]

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -810,21 +810,21 @@ def _prune_unreachable_code(assembly):
     changed = False
     i = 0
     while i < len(assembly) - 1:
-        instr = assembly[i]
-        if isinstance(instr, list):
-            instr = assembly[i][-1]
+        if assembly[i] in _TERMINAL_OPS:
+            # find the next jumpdest or sublist
+            for j in range(i + 1, len(assembly)):
+                next_is_jumpdest = (
+                    j < len(assembly) - 1
+                    and is_symbol(assembly[j])
+                    and assembly[j + 1] == "JUMPDEST"
+                )
+                next_is_list = isinstance(assembly[j], list)
+                if next_is_jumpdest or next_is_list:
+                    break
+            changed = j > i + 1
+            del assembly[i + 1 : j]
 
-        is_terminal = assembly[i] in _TERMINAL_OPS
-        next_is_jumpdest = (
-            i + 2 < len(assembly) and is_symbol(assembly[i + 1]) and assembly[i + 2] == "JUMPDEST"
-        )
-        next_is_list = isinstance(assembly[i + 1], list)
-
-        if is_terminal and not (next_is_jumpdest or next_is_list):
-            changed = True
-            del assembly[i + 1]
-        else:
-            i += 1
+        i += 1
 
     return changed
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -821,6 +821,10 @@ def _prune_unreachable_code(assembly):
                 next_is_list = isinstance(assembly[j], list)
                 if next_is_jumpdest or next_is_list:
                     break
+            else:
+                # fixup an off-by-one if we made it to the end of the assembly
+                # without finding an jumpdest or sublist
+                j = len(assembly)
             changed = j > i + 1
             del assembly[i + 1 : j]
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -809,14 +809,18 @@ def _prune_unreachable_code(assembly):
     # unreachable
     changed = False
     i = 0
-    while i < len(assembly) - 2:
+    while i < len(assembly) - 1:
         instr = assembly[i]
         if isinstance(instr, list):
             instr = assembly[i][-1]
 
-        if assembly[i] in _TERMINAL_OPS and not (
-            is_symbol(assembly[i + 1]) or isinstance(assembly[i + 1], list)
-        ):
+        is_terminal = assembly[i] in _TERMINAL_OPS
+        next_is_jumpdest = (
+            i + 2 < len(assembly) and is_symbol(assembly[i + 1]) and assembly[i + 2] == "JUMPDEST"
+        )
+        next_is_list = isinstance(assembly[i + 1], list)
+
+        if is_terminal and not (next_is_jumpdest or next_is_list):
             changed = True
             del assembly[i + 1]
         else:
@@ -1230,7 +1234,6 @@ def assembly_to_evm_with_symbol_map(assembly, pc_ofst=0, insert_compiler_metadat
             if is_symbol_map_indicator(assembly[i + 1]):
                 # Don't increment pc as the symbol itself doesn't go into code
                 if item in symbol_map:
-                    print(assembly)
                     raise CompilerPanic(f"duplicate jumpdest {item}")
 
                 symbol_map[item] = pc


### PR DESCRIPTION
it was not aggressive enough, and could leave some instructions which mangle the assembly so it can't be turned into bytecode

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
