### PR TITLE
chore: replace occurrences of 'enum' by 'flag'

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -23,7 +23,7 @@ Frameworks and tooling
 - `VyperDeployer – A helper smart contract to compile and test Vyper contracts in Foundry <https://github.com/pcaversaccio/snekmate/blob/main/lib/utils/VyperDeployer.sol>`_
 - `🐍 snekmate – Vyper smart contract building blocks <https://github.com/pcaversaccio/snekmate>`_
 - `Serpentor – A set of smart contracts tools for governance <https://github.com/yearn/serpentor>`_
-- `Smart contract development frameworks and tools for Vyper on Ethreum.org <https://ethereum.org/en/developers/docs/programming-languages/python/>`_
+- `Smart contract development frameworks and tools for Vyper on Ethereum.org <https://ethereum.org/en/developers/docs/programming-languages/python/>`_
 - `Vyper Online Compiler - an online platform for compiling and deploying Vyper smart contracts <https://github.com/0x0077/vyper-online-compiler>`_
 
 Security

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -675,6 +675,6 @@ All type conversions in Vyper must be made explicitly using the built-in ``conve
 * Narrowing conversions (e.g., ``int256 -> int128``) check that the input is in bounds for the output type.
 * Converting between bytes and int types results in sign-extension if the output type is signed. For instance, converting ``0xff`` (``bytes1``) to ``int8`` returns ``-1``.
 * Converting between bytes and int types which have different sizes follows the rule of going through the closest integer type, first. For instance, ``bytes1 -> int16`` is like ``bytes1 -> int8 -> int16`` (signextend, then widen). ``uint8 -> bytes20`` is like ``uint8 -> uint160 -> bytes20`` (rotate left 12 bytes).
-* Enums can be converted to and from ``uint256`` only.
+* Flags can be converted to and from ``uint256`` only.
 
 A small Python reference implementation is maintained as part of Vyper's test suite, it can be found `here <https://github.com/vyperlang/vyper/blob/c4c6afd07801a0cc0038cdd4007cc43860c54193/tests/parser/functions/test_convert.py#L318>`__. The motivation and more detailed discussion of the rules can be found `here <https://github.com/vyperlang/vyper/issues/2507>`__.

--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -308,7 +308,7 @@ def _to_int(expr, arg, out_typ):
     elif is_flag_type(arg.typ):
         if out_typ != UINT256_T:
             _FAIL(arg.typ, out_typ, expr)
-        # pretend enum is uint256
+        # pretend flag is uint256
         arg = IRnode.from_list(arg, typ=UINT256_T)
         # use int_to_int rules
         arg = _int_to_int(arg, out_typ)
@@ -442,12 +442,12 @@ def to_bytes(expr, arg, out_typ):
 
 
 @_input_types(IntegerT)
-def to_enum(expr, arg, out_typ):
+def to_flag(expr, arg, out_typ):
     if arg.typ != UINT256_T:
         _FAIL(arg.typ, out_typ, expr)
 
-    if len(out_typ._enum_members) < 256:
-        arg = int_clamp(arg, bits=len(out_typ._enum_members), signed=False)
+    if len(out_typ._flag_members) < 256:
+        arg = int_clamp(arg, bits=len(out_typ._flag_members), signed=False)
 
     return IRnode.from_list(arg, typ=out_typ)
 
@@ -469,7 +469,7 @@ def convert(expr, context):
         elif out_typ == AddressT():
             ret = to_address(arg_ast, arg, out_typ)
         elif is_flag_type(out_typ):
-            ret = to_enum(arg_ast, arg, out_typ)
+            ret = to_flag(arg_ast, arg, out_typ)
         elif is_integer_type(out_typ):
             ret = to_int(arg_ast, arg, out_typ)
         elif is_bytes_m_type(out_typ):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -860,7 +860,7 @@ def needs_clamp(t, encoding):
     if isinstance(t, (_BytestringT, DArrayT)):
         return True
     if isinstance(t, FlagT):
-        return len(t._enum_members) < 256
+        return len(t._flag_members) < 256
     if isinstance(t, SArrayT):
         return needs_clamp(t.value_type, encoding)
     if is_tuple_like(t):
@@ -1132,7 +1132,7 @@ def clamp_basetype(ir_node):
     ir_node = unwrap_location(ir_node)
 
     if isinstance(t, FlagT):
-        bits = len(t._enum_members)
+        bits = len(t._flag_members)
         # assert x >> bits == 0
         ret = int_clamp(ir_node, bits, signed=False)
 

--- a/vyper/semantics/README.md
+++ b/vyper/semantics/README.md
@@ -16,7 +16,7 @@ Vyper abstract syntax tree (AST).
   * [`primitives.py`](types/primitives.py): Address, boolean, fixed length byte, integer and decimal types
   * [`shortcuts.py`](types/shortcuts.py): Helper constants for commonly used types
   * [`subscriptable.py`](types/subscriptable.py): Mapping, array and tuple types
-  * [`user.py`](types/user.py): Enum, event, interface and struct types
+  * [`user.py`](types/user.py): Flag, event, interface and struct types
   * [`utils.py`](types/utils.py): Functions for generating and fetching type objects
 * [`analysis/`](analysis): Subpackage for type checking and syntax verification logic
   * [`annotation.py`](analysis/annotation.py): Annotates statements and expressions with the appropriate type information

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -764,7 +764,7 @@ class ExprVisitor(VyperNodeVisitorBase):
             else:
                 rtyp = get_exact_type_from_node(node.right)
                 if isinstance(rtyp, FlagT):
-                    # enum membership - `some_enum in other_enum`
+                    # flag membership - `some_flag in other_flag`
                     ltyp = rtyp
                 else:
                     # array membership - `x in my_list_variable`

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -376,7 +376,7 @@ class _ExprAnalyser:
             # when this is a type, we want to lower it
             if isinstance(t, VyperType):
                 # TYPE_T is used to handle cases where a type can occur in call or
-                # attribute conditions, like Enum.foo or MyStruct({...})
+                # attribute conditions, like Flag.foo or MyStruct({...})
                 return [TYPE_T(t)]
 
             return [t.typ]

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -389,7 +389,7 @@ class TYPE_T(VyperType):
         raise StructureException("Value is not callable", node)
 
     # dispatch into get_type_member if it's dereferenced, ex.
-    # MyEnum.FOO
+    # MyFlag.FOO
     def get_member(self, key, node):
         if hasattr(self.typedef, "get_type_member"):
             return self.typedef.get_type_member(key, node)


### PR DESCRIPTION
### What I did

Rename occurrences of `enum` by `flag` missed by #3697

### How I did it

control-F "enum", then replace relevant occurrences

### How to verify it

It should be straightforward from the changes

### Commit message

    chore: replace occurrences of 'enum' by 'flag'

### Description for the changelog

    replace occurrences of 'enum' by 'flag'

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hips.hearstapps.com/hmg-prod/images/cute-cat-names-2023-6500cf6ecd8ef.jpeg?crop=0.864xw:0.634xh;0.136xw,0.274xh&resize=640:*)
