### PR TITLE
fix: prevent range over decimal

### DIFF
--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -713,7 +713,7 @@ def foo():
     for i: uint256 in range(a):
         pass
     """,
-        TypeMismatch,
+        StructureException,
     ),
     (
         """
@@ -723,7 +723,7 @@ def foo():
     for i: int128 in range(a,a-3):
         pass
     """,
-        TypeMismatch,
+        StructureException,
     ),
     # invalid argument length
     (

--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -10,7 +10,6 @@ from vyper.exceptions import (
     InvalidType,
     IteratorException,
     NamespaceCollision,
-    StateAccessViolation,
     StructureException,
     SyntaxException,
     TypeMismatch,
@@ -714,7 +713,7 @@ def foo():
     for i: uint256 in range(a):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
     ),
     (
         """
@@ -724,7 +723,7 @@ def foo():
     for i: int128 in range(a,a-3):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
     ),
     # invalid argument length
     (

--- a/tests/functional/syntax/exceptions/test_constancy_exception.py
+++ b/tests/functional/syntax/exceptions/test_constancy_exception.py
@@ -57,7 +57,7 @@ def foo() -> int128:
     return 5
 @external
 def bar():
-    for i: int128 in range(self.foo(), self.foo() + 1):
+    for i: int128 in range(self.foo(), bound=100):
         pass""",
         """
 glob: int128
@@ -68,12 +68,6 @@ def foo() -> int128:
 @external
 def bar():
     for i: int128 in [1,2,3,4,self.foo()]:
-        pass""",
-        """
-@external
-def foo():
-    x: int128 = 5
-    for i: int128 in range(x):
         pass""",
         """
 f:int128

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -3,14 +3,7 @@ import re
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import (
-    ArgumentException,
-    StateAccessViolation,
-    StructureException,
-    TypeCheckFailure,
-    TypeMismatch,
-    UnknownType,
-)
+from vyper.exceptions import ArgumentException, StructureException, TypeMismatch, UnknownType
 
 fail_list = [
     (
@@ -45,7 +38,7 @@ def foo():
     for _: uint256 in range(10, bound=x):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Bound must be a literal integer",
         None,
         "x",
@@ -107,7 +100,7 @@ def bar():
     for i: uint256 in range(x):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -120,7 +113,7 @@ def bar():
     for i: uint256 in range(0, x):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -133,7 +126,7 @@ def repeat(n: uint256) -> uint256:
         pass
     return n
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "n * 10",
@@ -146,7 +139,7 @@ def bar():
     for i: uint256 in range(0, x + 1):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x + 1",
@@ -171,7 +164,7 @@ def bar():
     for i: uint256 in range(x, x):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -184,7 +177,7 @@ def foo():
     for i: int128 in range(x, x + 10):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -197,7 +190,7 @@ def repeat(n: uint256) -> uint256:
         pass
     return x
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "n",
@@ -210,7 +203,7 @@ def foo(x: int128):
     for i: int128 in range(x, x + y):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -222,7 +215,7 @@ def bar(x: uint256):
     for i: uint256 in range(3, x):
         pass
     """,
-        StateAccessViolation,
+        TypeMismatch,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -311,10 +304,10 @@ def foo():
     for i:decimal in range(1.1, 2.2):
         pass
     """,
-        TypeCheckFailure,
-        "Range can only be defined over an integer type",
+        TypeMismatch,
+        "Value must be a literal integer, unless a bound is specified",
         None,
-        "decimal",
+        "1.1",
     ),
     (
         """
@@ -324,10 +317,10 @@ def foo():
     for i:decimal in range(x, x + 2.0, bound=10.1):
         pass
     """,
-        TypeCheckFailure,
-        "Range can only be defined over an integer type",
+        TypeMismatch,
+        "Bound must be a literal integer",
         None,
-        "decimal",
+        "10.1",
     ),
 ]
 

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -38,7 +38,7 @@ def foo():
     for _: uint256 in range(10, bound=x):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Bound must be a literal integer",
         None,
         "x",
@@ -100,7 +100,7 @@ def bar():
     for i: uint256 in range(x):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -113,7 +113,7 @@ def bar():
     for i: uint256 in range(0, x):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -126,7 +126,7 @@ def repeat(n: uint256) -> uint256:
         pass
     return n
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "n * 10",
@@ -139,7 +139,7 @@ def bar():
     for i: uint256 in range(0, x + 1):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x + 1",
@@ -164,7 +164,7 @@ def bar():
     for i: uint256 in range(x, x):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -177,7 +177,7 @@ def foo():
     for i: int128 in range(x, x + 10):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -190,7 +190,7 @@ def repeat(n: uint256) -> uint256:
         pass
     return x
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "n",
@@ -203,7 +203,7 @@ def foo(x: int128):
     for i: int128 in range(x, x + y):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -215,7 +215,7 @@ def bar(x: uint256):
     for i: uint256 in range(3, x):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "x",
@@ -304,7 +304,7 @@ def foo():
     for i:decimal in range(1.1, 2.2):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Value must be a literal integer, unless a bound is specified",
         None,
         "1.1",
@@ -317,7 +317,7 @@ def foo():
     for i:decimal in range(x, x + 2.0, bound=10.1):
         pass
     """,
-        TypeMismatch,
+        StructureException,
         "Bound must be a literal integer",
         None,
         "10.1",

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -45,7 +45,7 @@ def foo():
         pass
     """,
         StateAccessViolation,
-        "Bound must be a literal",
+        "Bound must be a literal integer",
         None,
         "x",
     ),
@@ -302,6 +302,31 @@ def foo():
         "No builtin or user-defined type named 'uint9'.",
         "Did you mean 'uint96', or maybe 'uint8'?",
         "uint9",
+    ),
+    (
+        """
+@external
+def foo():
+    for i:decimal in range(1.1, 2.2):
+        pass
+    """,
+        StateAccessViolation,
+        "Value must be a literal integer, unless a bound is specified",
+        None,
+        "1.1",
+    ),
+    (
+        """
+@external
+def foo():
+    x:decimal = 1.1
+    for i:decimal in range(x, x + 2.0, bound=10.1):
+        pass
+    """,
+        StateAccessViolation,
+        "Bound must be a literal integer",
+        None,
+        "10.1",
     ),
 ]
 

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -7,6 +7,7 @@ from vyper.exceptions import (
     ArgumentException,
     StateAccessViolation,
     StructureException,
+    TypeCheckFailure,
     TypeMismatch,
     UnknownType,
 )
@@ -310,10 +311,10 @@ def foo():
     for i:decimal in range(1.1, 2.2):
         pass
     """,
-        StateAccessViolation,
-        "Value must be a literal integer, unless a bound is specified",
+        TypeCheckFailure,
+        "Range can only be defined over an integer type",
         None,
-        "1.1",
+        "decimal",
     ),
     (
         """
@@ -323,10 +324,10 @@ def foo():
     for i:decimal in range(x, x + 2.0, bound=10.1):
         pass
     """,
-        StateAccessViolation,
-        "Bound must be a literal integer",
+        TypeCheckFailure,
+        "Range can only be defined over an integer type",
         None,
-        "10.1",
+        "decimal",
     ),
 ]
 

--- a/tests/unit/semantics/analysis/test_for_loop.py
+++ b/tests/unit/semantics/analysis/test_for_loop.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper.ast import parse_to_ast
-from vyper.exceptions import ArgumentException, ImmutableViolation, TypeMismatch
+from vyper.exceptions import ArgumentException, ImmutableViolation, StructureException, TypeMismatch
 from vyper.semantics.analysis import validate_semantics
 
 
@@ -83,7 +83,7 @@ def bar(n: uint256):
         x += i
     """
     vyper_module = parse_to_ast(code)
-    with pytest.raises(TypeMismatch):
+    with pytest.raises(StructureException):
         validate_semantics(vyper_module, dummy_input_bundle)
 
 

--- a/tests/unit/semantics/analysis/test_for_loop.py
+++ b/tests/unit/semantics/analysis/test_for_loop.py
@@ -1,12 +1,7 @@
 import pytest
 
 from vyper.ast import parse_to_ast
-from vyper.exceptions import (
-    ArgumentException,
-    ImmutableViolation,
-    StateAccessViolation,
-    TypeMismatch,
-)
+from vyper.exceptions import ArgumentException, ImmutableViolation, TypeMismatch
 from vyper.semantics.analysis import validate_semantics
 
 
@@ -88,7 +83,7 @@ def bar(n: uint256):
         x += i
     """
     vyper_module = parse_to_ast(code)
-    with pytest.raises(StateAccessViolation):
+    with pytest.raises(TypeMismatch):
         validate_semantics(vyper_module, dummy_input_bundle)
 
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -525,7 +525,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             self.namespace[target_name] = VarInfo(
                 target_type, modifiability=Modifiability.RUNTIME_CONSTANT
             )
-            # ideally should be performed before calling _analyse_range_iter 
+            # ideally should be performed before calling _analyse_range_iter
             # but there is a dependence on the namespace update
             if is_range:
                 validate_expected_type(node.target.target, IntegerT.any())

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -512,10 +512,11 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         target_type = type_from_annotation(node.target.annotation, DataLocation.MEMORY)
 
         iter_var = None
-        is_range = False
         if isinstance(node.iter, vy_ast.Call):
             self._analyse_range_iter(node.iter, target_type)
-            is_range = True
+
+            # sanity check the postcondition of analyse_range_iter
+            assert isinstance(target_type, IntegerT)
         else:
             iter_var = self._analyse_list_iter(node.iter, target_type)
 
@@ -525,10 +526,6 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             self.namespace[target_name] = VarInfo(
                 target_type, modifiability=Modifiability.RUNTIME_CONSTANT
             )
-            # ideally should be performed before calling _analyse_range_iter
-            # but there is a dependence on the namespace update
-            if is_range:
-                validate_expected_type(node.target.target, IntegerT.any())
 
             self.expr_visitor.visit(node.target.target, target_type)
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -870,16 +870,16 @@ def _validate_range_call(node: vy_ast.Call):
         bound = kwargs["bound"]
         if bound.has_folded_value:
             bound = bound.get_folded_value()
-        if not isinstance(bound, vy_ast.Num):
-            raise StateAccessViolation("Bound must be a literal", bound)
+        if not isinstance(bound, vy_ast.Int):
+            raise StateAccessViolation("Bound must be a literal integer", bound)
         if bound.value <= 0:
             raise StructureException("Bound must be at least 1", bound)
-        if isinstance(start, vy_ast.Num) and isinstance(end, vy_ast.Num):
+        if isinstance(start, vy_ast.Int) and isinstance(end, vy_ast.Int):
             error = "Please remove the `bound=` kwarg when using range with constants"
             raise StructureException(error, bound)
     else:
         for arg in (start, end):
-            if not isinstance(arg, vy_ast.Num):
+            if not isinstance(arg, vy_ast.Int):
                 error = "Value must be a literal integer, unless a bound is specified"
                 raise StateAccessViolation(error, arg)
         if end.value <= start.value:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -49,6 +49,7 @@ from vyper.semantics.types import (
     EventT,
     FlagT,
     HashMapT,
+    IntegerT,
     SArrayT,
     StringT,
     StructT,
@@ -59,7 +60,6 @@ from vyper.semantics.types import (
     map_void,
 )
 from vyper.semantics.types.function import ContractFunctionT, MemberFunctionT, StateMutability
-from vyper.semantics.types.primitives import IntegerT
 from vyper.semantics.types.utils import type_from_annotation
 
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -59,6 +59,7 @@ from vyper.semantics.types import (
     map_void,
 )
 from vyper.semantics.types.function import ContractFunctionT, MemberFunctionT, StateMutability
+from vyper.semantics.types.primitives import IntegerT
 from vyper.semantics.types.utils import type_from_annotation
 
 
@@ -512,6 +513,10 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
 
         iter_var = None
         if isinstance(node.iter, vy_ast.Call):
+            if not isinstance(target_type, IntegerT):
+                raise TypeCheckFailure(
+                    "Range can only be defined over an integer type", node.target.annotation
+                )
             self._analyse_range_iter(node.iter, target_type)
         else:
             iter_var = self._analyse_list_iter(node.iter, target_type)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -876,7 +876,7 @@ def _validate_range_call(node: vy_ast.Call):
         if bound.has_folded_value:
             bound = bound.get_folded_value()
         if not isinstance(bound, vy_ast.Int):
-            raise TypeMismatch("Bound must be a literal integer", bound)
+            raise StructureException("Bound must be a literal integer", bound)
         if bound.value <= 0:
             raise StructureException("Bound must be at least 1", bound)
         if isinstance(start, vy_ast.Int) and isinstance(end, vy_ast.Int):
@@ -886,6 +886,6 @@ def _validate_range_call(node: vy_ast.Call):
         for arg in (start, end):
             if not isinstance(arg, vy_ast.Int):
                 error = "Value must be a literal integer, unless a bound is specified"
-                raise TypeMismatch(error, arg)
+                raise StructureException(error, arg)
         if end.value <= start.value:
             raise StructureException("End must be greater than start", end)


### PR DESCRIPTION
### What I did

looping over a `range` was allowed if the iterator type was `decimal`, this PR prevents this unintended behaviour.

### How I did it

- Ensure the type of the iterator is an `IntegerT`.
- Ensure the literals in the `range()` expression are not only `Num` but `Int`.

### How to verify it

See tests

### Commit message

    fix: prevent range over decimal

### Description for the changelog

    prevent range over decimal

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s.yimg.com/ny/api/res/1.2/coxS4s7zvN3T0VoTvSDmLw--/YXBwaWQ9aGlnaGxhbmRlcjt3PTY0MDtoPTQyNw--/https://media.zenfs.com/en/swindon_advertiser_656/22b6b395be8c217615500116d061d999)
