### PR TITLE
fix: pickleability of `CompilerData`

### DIFF
--- a/vyper/compiler/input_bundle.py
+++ b/vyper/compiler/input_bundle.py
@@ -48,6 +48,11 @@ class _NotFound(Exception):
     pass
 
 
+# an opaque object which consumers can get/set attributes on
+class _Cache(object):
+    pass
+
+
 # an "input bundle" to the compiler, representing the files which are
 # available to the compiler. it is useful because it parametrizes I/O
 # operations over different possible input types. you can think of it
@@ -66,9 +71,9 @@ class InputBundle:
         self._source_id_counter = 0
         self._source_ids: dict[PathLike, int] = {}
 
-        # this is a little bit cursed, but it allows consumers to cache data that
-        # share the same lifetime as this input bundle.
-        self._cache = lambda: None
+        # this is a little bit cursed, but it allows consumers to cache data
+        # that share the same lifetime as this input bundle.
+        self._cache = _Cache()
 
     def _normalize_path(self, path):
         raise NotImplementedError(f"not implemented! {self.__class__}._normalize_path()")

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -2,7 +2,6 @@ import binascii
 import contextlib
 import decimal
 import enum
-import functools
 import sys
 import time
 import traceback
@@ -431,17 +430,13 @@ def indent(text: str, indent_chars: Union[str, List[str]] = " ", level: int = 1)
     return "".join(indented_lines)
 
 
-def timeit(func):
-    @functools.wraps(func)
-    def timeit_wrapper(*args, **kwargs):
-        start_time = time.perf_counter()
-        result = func(*args, **kwargs)
-        end_time = time.perf_counter()
-        total_time = end_time - start_time
-        print(f"Function {func.__name__} Took {total_time:.4f} seconds")
-        return result
-
-    return timeit_wrapper
+@contextlib.contextmanager
+def timeit(msg):
+    start_time = time.perf_counter()
+    yield
+    end_time = time.perf_counter()
+    total_time = end_time - start_time
+    print(f"{msg}: Took {total_time:.4f} seconds")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
InputBundle has the `_cache` attribute, which was implemented using an anonymous function, which is not pickleable. Change `_cache` to use a dedicated object type.

also refactors `timeit()` to be a contextmanager instead of just a function decorator.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
