### PR TITLE
docs: add missing `annotated_ast` flag

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -29,7 +29,7 @@ Include the ``-f`` flag to specify which output formats to return. Use ``vyper -
 
 .. code:: shell
 
-    $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,metadata,combined_json,layout yourFileName.vy
+    $ vyper -f abi,abi_python,bytecode,bytecode_runtime,interface,external_interface,ast,annotated_ast,ir,ir_json,ir_runtime,hex-ir,asm,opcodes,opcodes_runtime,source_map,method_identifiers,userdoc,devdoc,metadata,combined_json,layout yourFileName.vy
 
 .. note::
     The ``opcodes`` and ``opcodes_runtime`` output of the compiler has been returning incorrect opcodes since ``0.2.0`` due to a lack of 0 padding (patched via `PR 3735 <https://github.com/vyperlang/vyper/pull/3735>`_). If you rely on these functions for debugging, please use the latest patched versions.


### PR DESCRIPTION
### What I did

Nit follow-up PR for https://github.com/vyperlang/vyper/pull/3669 to add the newly introduced CLI flag `annotated_ast` to the docs.

### How I did it

See https://github.com/vyperlang/vyper/pull/3669.

### How to verify it

Invoke `vyper -h`.

### Commit message

```console
docs: add missing annotated_ast flag
```

### Description for the changelog

docs: add missing `annotated_ast` flag

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/104d24ff-1786-4de4-8cf3-469a6c12030d)