### PR TITLE
chore: remove tox rules for lint commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,9 @@ jobs:
 
     - name: Run flake8
       run: flake8 ./vyper ./tests ./setup.py
-      if: always()
 
     - name: Run isort
       run: isort --check-only --diff ./vyper ./tests ./setup.py
-      if: always()
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
         python-version: "3.11"
         cache: "pip"
 
+    - name: Install Dependencies
+      run: pip install .[lint]
+
     - name: Run mypy
       run: make mypy
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,8 @@ jobs:
         python-version: "3.11"
         cache: "pip"
 
-    - name: Install Tox
-      run: pip install tox
-
-    - name: Run Tox
-      run: TOXENV=mypy tox -r
+    - name: Run mypy
+      run: make mypy
 
   # "Regular"/core tests.
   tests:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,19 @@ dev-init:
 test:
 	pytest
 
-lint:
-	tox -e lint,mypy
+lint: mypy black flake8 isort
+
+mypy:
+	mypy --install-types --non-interactive --follow-imports=silent --ignore-missing-imports --implicit-optional -p vyper
+
+black:
+	black -C -t py311 vyper/ tests/ setup.py --force-exclude=vyper/version.py
+
+flake8: black
+	flake8 vyper/ tests/
+
+isort: black
+	isort vyper/ tests/ setup.py
 
 docs:
 	rm -f docs/vyper.rst

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
     py{310,311}
-    lint
-    mypy
     docs
 
 [testenv]
@@ -40,18 +38,3 @@ commands =
 extras =
     test
 whitelist_externals = make
-
-[testenv:lint]
-basepython = python3
-extras = lint
-commands =
-    black -C -t py311 {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
-    flake8 {toxinidir}/vyper {toxinidir}/tests
-    isort {toxinidir}/vyper {toxinidir}/tests {toxinidir}/setup.py
-
-[testenv:mypy]
-basepython = python3
-extras = lint
-passenv = TERM
-commands =
-    mypy --install-types --non-interactive --follow-imports=silent --ignore-missing-imports --implicit-optional -p vyper


### PR DESCRIPTION
this commit removes the tox rules for lint, as part of a larger movement to remove tox from the codebase (it's slow, confusing, and superseded by environment matrices on github actions).

the rules in the makefile are split apart so they can be run in parallel with `make -j lint`.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
