### PR TITLE
fix: search path for json input

### DIFF
--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -279,7 +279,10 @@ def compile_from_input_dict(
     output_formats = get_output_formats(input_dict)
     compilation_targets = list(output_formats.keys())
 
-    input_bundle = JSONInputBundle(sources, search_paths=[Path(root_folder)])
+    search_paths = [Path(root_folder)]
+    if root_folder != ".":
+        search_paths.insert(0, Path("."))
+    input_bundle = JSONInputBundle(sources, search_paths=search_paths)
 
     res, warnings_dict = {}, {}
     warnings.simplefilter("always")


### PR DESCRIPTION
### What I did
fix for ape-vyper -- apparently, vvm is being called with `-p /home/a/b/c/my_project/contracts/`, and then the source filename in the json input is `foo.vy`.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
