### PR TITLE
chore[ci]: pin eth-abi for decode regression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
         "pytest-xdist>=2.5,<3.0",
         "pytest-split>=0.7.0,<1.0",
         "eth-tester[py-evm]>=0.9.0b1,<0.10",
+        "eth_abi>=4.0.0,<5.0.0",
         "py-evm>=0.7.0a1,<0.8",
         "web3==6.0.0",
         "tox>=3.15,<4.0",


### PR DESCRIPTION
eth-abi 5.0.1 introduces a regression for eth-abi decoding due to the way that eth-tester enforces decoding of revert strings.

### What I did
fix CI failures, see for instance https://github.com/vyperlang/vyper/actions/runs/8153520136/job/22285100813?pr=3833#step:5:1331

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
