### PR TITLE
chore[ci]: roll back GH actions/*artifacts version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: dist/vyper.*
           name: vyper-${{ matrix.os }}
@@ -74,7 +74,7 @@ jobs:
           ./make.cmd freeze
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: dist/vyper.*
           name: vyper-windows
@@ -86,13 +86,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           path: artifacts/
 
       - name: Upload assets
         # fun - artifacts are downloaded into "artifact/".
-        # TODO: this needs to be tested since the upgrade to upload-artifact v4
+        # TODO: this needs to be tested when upgrading to upload-artifact v4
         working-directory: artifacts/artifact
         run: |
           set -Eeuxo pipefail


### PR DESCRIPTION
this commit fixes a regression introduced in 730679bd553d3487, which is that v4 of the artifact actions breaks the asset upload pipeline. roll back the changes for now

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
