### PR TITLE
chore[ci]: merge mypy job into lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Run isort
       run: isort --check-only --diff ./vyper ./tests ./setup.py
 
+    - name: Run mypy
+      run: make mypy
+
   docs:
     runs-on: ubuntu-latest
 
@@ -52,24 +55,6 @@ jobs:
 
       - name: Run Tox
         run: TOXENV=docs tox -r
-
-  mypy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-        cache: "pip"
-
-    - name: Install Dependencies
-      run: pip install .[lint]
-
-    - name: Run mypy
-      run: make mypy
 
   # "Regular"/core tests.
   tests:


### PR DESCRIPTION
reduce the number of jobs, since mypy really belongs in the lint job anyways.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
