### PR TITLE
fix[ir]: unique symbol name

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -670,7 +670,7 @@ def STORE(ptr: IRnode, val: IRnode) -> IRnode:
     if ptr.location in (MEMORY, IMMUTABLES):
         return IRnode.from_list(store)
 
-    return IRnode.from_list(ensure_eval_once(_freshname(f"{op}_"), store))
+    return IRnode.from_list(ensure_eval_once(f"{op}_", store))
 
 
 # Unwrap location


### PR DESCRIPTION
### What I did

``STORE()`` unique symbol name is computed as `_freshname(_freshname(f"{op}_"))` instead of `_freshname(f"{op}_")` after #3835. This PR fixes this.

### How I did it

Straightforward

### How to verify it

Compiling a contract with a single ``SSTORE`` will lead to an IR containing `[unique_symbol, sstore_1]` where it would previously contain `[unique_symbol, sstore_12`].

### Commit message

    fix: unique symbol name
  
### Description for the changelog

    Fix unique symbol name

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.fineartamerica.com/images/artworkimages/mediumlarge/3/sweet-adorable-racoon-peeking-close-up-ultra-hd-astonishing-arts.jpg)
