### PR TITLE
feat[ir]: emit `djump` in dense selector table

### DIFF
--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -229,7 +229,9 @@ def _selector_section_dense(external_functions, module_t):
             error_msg="bad calldatasize or callvalue",
         )
         x.append(check_entry_conditions)
-        x.append(["jump", function_label])
+        jump_targets = [func.args[0].value for func in function_irs]
+        jump_instr = IRnode.from_list(["djump", function_label, *jump_targets])
+        x.append(jump_instr)
         selector_section.append(b1.resolve(x))
 
     bucket_headers = ["data", "BUCKET_HEADERS"]


### PR DESCRIPTION
### What I did

Updated the dense selector (used in optimization for codesize) to emit the target constrained `djump` instruction.

### How I did it

Made a list of the possible targets and emitted the `djump` instruction with that.

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.wired.com/photos/59328aa49be5e55af6c25c11/master/w_2240,c_limit/lead2.jpg)
