### PR TITLE
fix: replace `python_ast.Str` with `python_ast.Constant`

### DIFF
--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -235,7 +235,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         if node.body:
             n = node.body[0]
-            if isinstance(n, python_ast.Expr) and isinstance(n.value, python_ast.Str):
+            if isinstance(n, python_ast.Expr) and isinstance(n.value, python_ast.Constant):
                 self.generic_visit(n.value)
                 n.value.ast_type = "DocStr"
                 del node.body[0]


### PR DESCRIPTION
### What I did

python 3.12 complains about `python_ast.Str` being deprecated. This patch replaces it's use with `Constant`

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
