### PR TITLE
chore[ci]: enable python3.12 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,6 @@ jobs:
           - python-version: ["3.12", "312"]
             opt-mode: gas
             debug: false
-            evm-version: shanghai
 
     name: py${{ matrix.python-version[1] }}-opt-${{ matrix.opt-mode }}${{ matrix.debug && '-debug' || '' }}-${{ matrix.evm-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,9 +93,10 @@ jobs:
             opt-mode: gas
             debug: false
             evm-version: shanghai
-
-          # TODO 3.12 doesn't work yet, investigate - may be hypothesis issue
-          #- python-version: ["3.12", "312"]
+          - python-version: ["3.12", "312"]
+            opt-mode: gas
+            debug: false
+            evm-version: shanghai
 
     name: py${{ matrix.python-version[1] }}-opt-${{ matrix.opt-mode }}${{ matrix.debug && '-debug' || '' }}-${{ matrix.evm-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Install Dependencies
       run: pip install .[lint]
 
+    - name: Debug dependencies
+      run: pip freeze
+
     - name: Run Black
       run: black --check -C --force-exclude=vyper/version.py ./vyper ./tests ./setup.py
 
@@ -114,6 +117,9 @@ jobs:
 
     - name: Install dependencies
       run: pip install .[test]
+
+    - name: Debug dependencies
+      run: pip freeze
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
           - python-version: ["3.12", "312"]
             opt-mode: gas
             debug: false
+            evm-version: shanghai
 
     name: py${{ matrix.python-version[1] }}-opt-${{ matrix.opt-mode }}${{ matrix.debug && '-debug' || '' }}-${{ matrix.evm-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
         "web3==6.0.0",
         "tox>=3.15,<4.0",
         "lark==1.1.9",
-        "hypothesis[lark]>=5.37.1,<6.0",
+        "hypothesis[lark]>=6.0,<7.0",
         "eth-stdlib==0.2.6",
         "setuptools",
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ extras_require = {
         "lark==1.1.9",
         "hypothesis[lark]>=5.37.1,<6.0",
         "eth-stdlib==0.2.6",
+        "setuptools",
     ],
     "lint": [
         "black==23.12.0",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 extras_require = {
     "test": [
-        "pytest>=6.2.5,<7.0",
+        "pytest>=8.0,<9.0",
         "pytest-cov>=2.10,<3.0",
         "pytest-instafail>=0.4,<1.0",
         "pytest-xdist>=2.5,<3.0",

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     package_data={"vyper.ast": ["grammar.lark"]},
     data_files=[("", [hash_file_rel_path])],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
         "tox>=3.15,<4.0",
         "lark==1.1.9",
         "hypothesis[lark]>=6.0,<7.0",
-        "eth-stdlib==0.2.6",
+        "eth-stdlib==0.2.7",
         "setuptools",
     ],
     "lint": [

--- a/tests/functional/builtins/folding/test_powmod.py
+++ b/tests/functional/builtins/folding/test_powmod.py
@@ -4,7 +4,7 @@ from hypothesis import strategies as st
 
 from tests.utils import parse_and_fold
 
-st_uint256 = st.integers(min_value=0, max_value=2**256)
+st_uint256 = st.integers(min_value=0, max_value=(2**256 - 1))
 
 
 @pytest.mark.fuzzing

--- a/tests/functional/codegen/types/test_bytes_zero_padding.py
+++ b/tests/functional/codegen/types/test_bytes_zero_padding.py
@@ -25,7 +25,7 @@ def get_count(counter: uint256) -> Bytes[24]:
 
 
 @pytest.mark.fuzzing
-@hypothesis.given(value=hypothesis.strategies.integers(min_value=0, max_value=2**64))
+@hypothesis.given(value=hypothesis.strategies.integers(min_value=0, max_value=(2**64 - 1)))
 def test_zero_pad_range(little_endian_contract, value):
     actual_bytes = value.to_bytes(8, byteorder="little")
     contract_bytes = little_endian_contract.get_count(value)

--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -37,6 +37,20 @@ def test_basic_grammar_empty():
     assert len(tree.children) == 0
 
 
+def utf8_encodable(terminal: str) -> bool:
+    try:
+        if "\x00" not in terminal and "\\ " not in terminal and "\x0c" not in terminal:
+            terminal.encode("utf-8-sig")
+            return True
+        else:
+            return False
+    except UnicodeEncodeError:  # pragma: no cover
+        # Very rarely, a "." in some terminal regex will generate a surrogate
+        # character that cannot be encoded as UTF-8.  We apply this filter to
+        # ensure it doesn't happen at runtime, but don't worry about coverage.
+        return False
+
+
 ALLOWED_CHARS = st.characters(codec="utf-8", min_codepoint=1)
 
 
@@ -46,7 +60,7 @@ class GrammarStrategy(LarkStrategy):
     def __init__(self, grammar, start, explicit_strategies):
         super().__init__(grammar, start, explicit_strategies, alphabet=ALLOWED_CHARS)
         self.terminal_strategies = {
-            k: v.map(lambda s: s.replace("\0", ""))
+            k: v.map(lambda s: s.replace("\0", "")).filter(utf8_encodable)
             for k, v in self.terminal_strategies.items()  # type: ignore
         }
 
@@ -91,7 +105,7 @@ def has_no_docstrings(c):
 
 
 @pytest.mark.fuzzing
-@given(code=from_grammar())
+@given(code=from_grammar().filter(lambda c: utf8_encodable(c)))
 @hypothesis.settings(
     max_examples=500, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much]
 )

--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -92,7 +92,9 @@ def has_no_docstrings(c):
 
 @pytest.mark.fuzzing
 @given(code=from_grammar())
-@hypothesis.settings(max_examples=500, suppress_health_check=[HealthCheck.too_slow])
+@hypothesis.settings(
+    max_examples=500, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much]
+)
 def test_grammar_bruteforce(code):
     _, _, _, reformatted_code = pre_parse(code + "\n")
     tree = parse_to_ast(reformatted_code)

--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -51,11 +51,14 @@ def utf8_encodable(terminal: str) -> bool:
         return False
 
 
+ALLOWED_CHARS = st.characters(codec="utf-8", min_codepoint=1)
+
+
 # With help from hyposmith
 # https://github.com/Zac-HD/hypothesmith/blob/master/src/hypothesmith/syntactic.py
 class GrammarStrategy(LarkStrategy):
     def __init__(self, grammar, start, explicit_strategies):
-        super().__init__(grammar, start, explicit_strategies)
+        super().__init__(grammar, start, explicit_strategies, alphabet=ALLOWED_CHARS)
         self.terminal_strategies = {
             k: v.map(lambda s: s.replace("\0", "")).filter(utf8_encodable)
             for k, v in self.terminal_strategies.items()  # type: ignore

--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -65,11 +65,11 @@ class GrammarStrategy(LarkStrategy):
         }
 
     def draw_symbol(self, data, symbol, draw_state):  # type: ignore
-        count = len(draw_state.result)
+        count = len(draw_state)
         super().draw_symbol(data, symbol, draw_state)
         try:
             compile(
-                source="".join(draw_state.result[count:])
+                source="".join(draw_state[count:])
                 .replace("contract", "class")
                 .replace("struct", "class"),  # HACK: Python ast.parse
                 filename="<string>",

--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -37,20 +37,6 @@ def test_basic_grammar_empty():
     assert len(tree.children) == 0
 
 
-def utf8_encodable(terminal: str) -> bool:
-    try:
-        if "\x00" not in terminal and "\\ " not in terminal and "\x0c" not in terminal:
-            terminal.encode("utf-8-sig")
-            return True
-        else:
-            return False
-    except UnicodeEncodeError:  # pragma: no cover
-        # Very rarely, a "." in some terminal regex will generate a surrogate
-        # character that cannot be encoded as UTF-8.  We apply this filter to
-        # ensure it doesn't happen at runtime, but don't worry about coverage.
-        return False
-
-
 ALLOWED_CHARS = st.characters(codec="utf-8", min_codepoint=1)
 
 
@@ -60,7 +46,7 @@ class GrammarStrategy(LarkStrategy):
     def __init__(self, grammar, start, explicit_strategies):
         super().__init__(grammar, start, explicit_strategies, alphabet=ALLOWED_CHARS)
         self.terminal_strategies = {
-            k: v.map(lambda s: s.replace("\0", "")).filter(utf8_encodable)
+            k: v.map(lambda s: s.replace("\0", ""))
             for k, v in self.terminal_strategies.items()  # type: ignore
         }
 
@@ -105,10 +91,9 @@ def has_no_docstrings(c):
 
 
 @pytest.mark.fuzzing
-@given(code=from_grammar().filter(lambda c: utf8_encodable(c)))
+@given(code=from_grammar())
 @hypothesis.settings(max_examples=500, suppress_health_check=[HealthCheck.too_slow])
 def test_grammar_bruteforce(code):
-    if utf8_encodable(code):
-        _, _, _, reformatted_code = pre_parse(code + "\n")
-        tree = parse_to_ast(reformatted_code)
-        assert isinstance(tree, Module)
+    _, _, _, reformatted_code = pre_parse(code + "\n")
+    tree = parse_to_ast(reformatted_code)
+    assert isinstance(tree, Module)

--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -37,8 +37,11 @@ def test_basic_grammar_empty():
     assert len(tree.children) == 0
 
 
-def good_terminal(terminal: str) -> bool:
-    return all(bad not in terminal for bad in ("\x00", "\\ ", "\x0c"))
+def fix_terminal(terminal: str) -> bool:
+    # these throw exceptions in the grammar
+    for bad in ("\x00", "\\ ", "\x0c"):
+        terminal = terminal.replace(bad, " ")
+    return terminal
 
 
 ALLOWED_CHARS = st.characters(codec="utf-8", min_codepoint=1)
@@ -50,8 +53,7 @@ class GrammarStrategy(LarkStrategy):
     def __init__(self, grammar, start, explicit_strategies):
         super().__init__(grammar, start, explicit_strategies, alphabet=ALLOWED_CHARS)
         self.terminal_strategies = {
-            k: v.map(lambda s: s.replace("\0", "")).filter(good_terminal)
-            for k, v in self.terminal_strategies.items()  # type: ignore
+            k: v.map(fix_terminal) for k, v in self.terminal_strategies.items()  # type: ignore
         }
 
     def draw_symbol(self, data, symbol, draw_state):  # type: ignore

--- a/tests/functional/syntax/test_structs.py
+++ b/tests/functional/syntax/test_structs.py
@@ -589,9 +589,9 @@ def foo():
     with warnings.catch_warnings(record=True) as w:
         assert compiler.compile_code(code) is not None
 
-        expected = "Instantiating a struct using a dictionary is deprecated "
-        expected += "as of v0.4.0 and will be disallowed in a future release. "
-        expected += "Use kwargs instead e.g. Foo(a=1, b=2)"
+    expected = "Instantiating a struct using a dictionary is deprecated "
+    expected += "as of v0.4.0 and will be disallowed in a future release. "
+    expected += "Use kwargs instead e.g. Foo(a=1, b=2)"
 
-        assert len(w) == 1
-        assert str(w[0].message).startswith(expected)
+    assert len(w) == 1, [s.message for s in w]
+    assert str(w[0].message).startswith(expected)

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -774,7 +774,6 @@ class Constant(ExprNode):
 class Num(Constant):
     # inherited class for all numeric constant node types
     __slots__ = ()
-    _translated_fields = {"n": "value"}
 
     @property
     def n(self):
@@ -843,7 +842,6 @@ class Hex(Constant):
     """
 
     __slots__ = ()
-    _translated_fields = {"n": "value"}
 
     def validate(self):
         if "_" in self.value:

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -435,7 +435,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                     node.col_offset,
                 )
             node.ast_type = "Hex"
-            node.n = value
+            node.value = value
 
         elif value.lower()[:2] == "0b":
             node.ast_type = "Bytes"
@@ -449,15 +449,15 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                 )
             node.value = int(value, 2).to_bytes(len(value) // 8, "big")
 
-        elif isinstance(node.n, float):
+        elif isinstance(node.value, float):
             node.ast_type = "Decimal"
-            node.n = Decimal(value)
+            node.value = Decimal(value)
 
-        elif isinstance(node.n, int):
+        elif isinstance(node.value, int):
             node.ast_type = "Int"
 
         else:
-            raise CompilerPanic(f"Unexpected type for Constant value: {type(node.n).__name__}")
+            raise CompilerPanic(f"Unexpected type for Constant value: {type(node.value).__name__}")
 
         return node
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -456,7 +456,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         elif isinstance(node.value, int):
             node.ast_type = "Int"
 
-        else:
+        else:  # pragma: nocover
             raise CompilerPanic(f"Unexpected type for Constant value: {type(node.value).__name__}")
 
         return node


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
add a python3.12 job in the CI.

also:
- update dependencies
- update tests for new dependencies
- refactor the grammar tests to use less filtering
- python3.12 deprecates the "n" field on constants; remove it
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
