### PR TITLE
Fix/builtins tstorage codegen

### DIFF
--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -367,7 +367,7 @@ class Slice(BuiltinFunctionT):
 
             # add 32 bytes to the buffer size bc word access might
             # be unaligned (see below)
-            if src.location == STORAGE:
+            if src.location.word_addressable:
                 buflen += 32
 
             # Get returntype string or bytes
@@ -394,8 +394,8 @@ class Slice(BuiltinFunctionT):
                 src_data = bytes_data_ptr(src)
 
             # general case. byte-for-byte copy
-            if src.location == STORAGE:
-                # because slice uses byte-addressing but storage
+            if src.location.word_addressable:
+                # because slice uses byte-addressing but storage/tstorage
                 # is word-aligned, this algorithm starts at some number
                 # of bytes before the data section starts, and might copy
                 # an extra word. the pseudocode is:

--- a/vyper/evm/address_space.py
+++ b/vyper/evm/address_space.py
@@ -28,6 +28,10 @@ class AddrSpace:
     # TODO maybe make positional instead of defaulting to None
     store_op: Optional[str] = None
 
+    @property
+    def word_addressable(self) -> bool:
+        return self.word_scale == 1
+
 
 # alternative:
 # class Memory(AddrSpace):


### PR DESCRIPTION
### What I did
- fix for: https://github.com/vyperlang/vyper/issues/3801

### How I did it
- check location for `word_addressable` and the usage of generic load ops

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
