### PR TITLE
feat[lang]!: change the signature of `block.prevrandao`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,6 +49,8 @@ jobs:
           subjectPatternError: |
             Starts with uppercase letter: '{subject}'
             (Full PR title: '{title}')
-          headerPattern: '^(\w*)(?:\[([\w$.\-*/ ]*)\])?: (.*)$'
+          # type[scope]<optional !>: subject
+          # use [] instead of () for aesthetics
+          headerPattern: '^(\w*)(?:\[([\w$.\-*/ ]*)\])?!?: (.*)$'
           validateSingleCommit: true
           validateSingleCommitMatchesPrTitle: true

--- a/docs/constants-and-vars.rst
+++ b/docs/constants-and-vars.rst
@@ -16,7 +16,7 @@ Name                 Type             Value
 ==================== ================ =========================================================
 ``block.coinbase``   ``address``      Current block miner's address
 ``block.difficulty`` ``uint256``      Current block difficulty
-``block.prevrandao`` ``uint256``      Current randomness beacon provided by the beacon chain
+``block.prevrandao`` ``bytes32``      Current randomness beacon provided by the beacon chain
 ``block.number``     ``uint256``      Current block number
 ``block.prevhash``   ``bytes32``      Equivalent to ``blockhash(block.number - 1)``
 ``block.timestamp``  ``uint256``      Current block epoch timestamp
@@ -31,7 +31,7 @@ Name                 Type             Value
 
 .. note::
 
-    ``block.prevrandao`` is an alias for ``block.difficulty``. Since ``block.difficulty`` is considered deprecated according to `EIP-4399 <https://eips.ethereum.org/EIPS/eip-4399>`_ after "The Merge" (Paris hard fork), we recommend using ``block.prevrandao``.
+    ``block.prevrandao`` is an alias for the ``block.difficulty`` opcode. Since ``block.difficulty`` is considered deprecated according to `EIP-4399 <https://eips.ethereum.org/EIPS/eip-4399>`_ after "The Merge" (Paris hard fork), we recommend using ``block.prevrandao``.
 
 .. note::
 

--- a/tests/functional/syntax/test_block.py
+++ b/tests/functional/syntax/test_block.py
@@ -138,7 +138,7 @@ def foo():
     """
 @external
 def foo():
-    x: uint256 = block.prevrandao + 185
+    x: bytes32 = block.prevrandao
     if tx.origin == self:
         y: Bytes[35] = concat(block.prevhash, b"dog")
     """,

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -273,7 +273,7 @@ class Expr:
                     warning = "tried to use block.prevrandao in pre-Paris "
                     warning += "environment! Suggest using block.difficulty instead."
                     vyper_warn(warning, self.expr)
-                return IRnode.from_list(["prevrandao"], typ=UINT256_T)
+                return IRnode.from_list(["prevrandao"], typ=BYTES32_T)
             elif key == "block.difficulty":
                 if version_check(begin="paris"):
                     warning = "tried to use block.difficulty in post-Paris "

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -19,7 +19,7 @@ class _Block(_EnvType):
     _type_members = {
         "coinbase": AddressT(),
         "difficulty": UINT256_T,
-        "prevrandao": UINT256_T,
+        "prevrandao": BYTES32_T,
         "number": UINT256_T,
         "gaslimit": UINT256_T,
         "basefee": UINT256_T,


### PR DESCRIPTION
`block.prevrandao` is an opcode alias for `difficulty`. however, it returns a bytes object at the evm level (cf. for instance py-evm returns the value of `block.mixhash`). this commit changes the signature of block.prevrandao to be more consistent with the VM semantics.

### What I did

### How I did it

### How to verify it

### Commit message

```
`block.prevrandao` is an opcode alias for `difficulty`. however, it
returns a bytes object at the evm level (cf. for instance py-evm returns
the value of `block.mixhash`). this commit changes the signature of
`block.prevrandao` to be more consistent with the VM semantics.

also update PR title regex per conventional commit specification - add
optional `!` which indicates a breaking change
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
