### PR TITLE
chore[build]: remove docs rule in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,11 @@ extras_require = {
         "isort==5.13.2",
         "mypy==1.5",
     ],
-    "docs": ["recommonmark", "sphinx>=6.0,<7.0", "sphinx_rtd_theme>=1.2,<1.3"],
     "dev": ["ipython", "pre-commit", "pyinstaller", "twine"],
 }
 
 extras_require["dev"] = (
-    extras_require["test"] + extras_require["lint"] + extras_require["docs"] + extras_require["dev"]
+    extras_require["test"] + extras_require["lint"] + extras_require["dev"]
 )
 
 with open("README.md", "r") as f:

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,7 @@ extras_require = {
     "dev": ["ipython", "pre-commit", "pyinstaller", "twine"],
 }
 
-extras_require["dev"] = (
-    extras_require["test"] + extras_require["lint"] + extras_require["dev"]
-)
+extras_require["dev"] = extras_require["test"] + extras_require["lint"] + extras_require["dev"]
 
 with open("README.md", "r") as f:
     long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     "dev": ["ipython", "pre-commit", "pyinstaller", "twine"],
 }
 
-extras_require["dev"] = extras_require["test"] + extras_require["lint"] + extras_require["dev"]
+extras_require["dev"] = extras_require["dev"] + extras_require["test"] + extras_require["lint"]
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
it is not used, and it conflicts with the requirements specified in
`docs-requirements.txt` (which is _actually_ used, in
`.readthedocs.yaml`).
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
