### PR TITLE
chore: improve syntax error messages

### DIFF
--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -60,7 +60,7 @@ def parse_to_ast_with_settings(
         py_ast = python_ast.parse(python_source)
     except SyntaxError as e:
         # TODO: Ensure 1-to-1 match of source_code:reformatted_code SyntaxErrors
-        raise SyntaxException(str(e), vyper_source, e.lineno, e.offset) from e
+        raise SyntaxException(str(e), vyper_source, e.lineno, e.offset) from None
 
     # Add dummy function node to ensure local variables are treated as `AnnAssign`
     # instead of state variables (`VariableDecl`)


### PR DESCRIPTION
### What I did

Fix #3865

The exception now displays as:
```
vyper.exceptions.SyntaxException: invalid syntax (<unknown>, line 3)

  line 3:31 
       2 def foo():
  ---> 3     s: String[2] = staticcall staticcall concat('a', 'b')
  --------------------------------------^
       4     return
```

### How I did it

### How to verify it

Not sure how to go about writing a test for this

### Commit message

```
chore: improve syntax error handling

This PR improves the handling of syntax errors by obscuring
the underlying exception from the python parser.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/1b/8f/15/1b8f1523822e646a908a5ca78fbccb26.jpg)
