### PR TITLE
add tstorage tests for builtins

### DIFF
--- a/tests/functional/builtins/codegen/test_addmod.py
+++ b/tests/functional/builtins/codegen/test_addmod.py
@@ -1,3 +1,9 @@
+import pytest
+
+from tests.utils import wrap_typ_with_storage_loc
+
+from vyper.evm.opcodes import version_check
+
 def test_uint256_addmod(tx_failed, get_contract_with_gas_estimation):
     uint256_code = """
 @external
@@ -58,9 +64,13 @@ def c() -> uint256:
     assert c.foo() == 2
 
 
-def test_uint256_addmod_evaluation_order(get_contract_with_gas_estimation):
-    code = """
-a: uint256
+@pytest.mark.parametrize('location', ["storage", "transient"])
+def test_uint256_addmod_evaluation_order(get_contract_with_gas_estimation, location):
+    if location == "transient" and not version_check(begin="cancun"):
+        pytest.skip("Skipping test as storage_location is 'transient' and EVM version is pre-Cancun")
+
+    code = f"""
+a: {wrap_typ_with_storage_loc("uint256", location)}
 
 @external
 def foo1() -> uint256:

--- a/tests/functional/builtins/codegen/test_ceil.py
+++ b/tests/functional/builtins/codegen/test_ceil.py
@@ -1,17 +1,23 @@
 import math
 from decimal import Decimal
 
+import pytest
+from tests.utils import wrap_typ_with_storage_loc
 
-def test_ceil(get_contract_with_gas_estimation):
-    code = """
-x: decimal
+from vyper.evm.opcodes import version_check
 
-@deploy
-def __init__():
-    self.x = 504.0000000001
+
+@pytest.mark.parametrize('location', ["storage", "transient"])
+def test_ceil(get_contract_with_gas_estimation, location):
+    if location == "transient" and not version_check(begin="cancun"):
+        pytest.skip("Skipping test as storage_location is 'transient' and EVM version is pre-Cancun")
+
+    code = f"""
+x: {wrap_typ_with_storage_loc("decimal", location)}
 
 @external
 def x_ceil() -> int256:
+    self.x = 504.0000000001
     return ceil(self.x)
 
 @external
@@ -49,16 +55,17 @@ def fou() -> int256:
 
 
 # ceil(x) should yield the smallest integer greater than or equal to x
-def test_ceil_negative(get_contract_with_gas_estimation):
-    code = """
-x: decimal
+@pytest.mark.parametrize("location", ["storage", "transient"])
+def test_ceil_negative(get_contract_with_gas_estimation, get_contract, location):
+    if location == "transient" and not version_check(begin="cancun"):
+        pytest.skip("Skipping test as storage_location is 'transient' and EVM version is pre-Cancun")
 
-@deploy
-def __init__():
-    self.x = -504.0000000001
+    code = f"""
+x: {wrap_typ_with_storage_loc("decimal", location)}
 
 @external
 def x_ceil() -> int256:
+    self.x = -504.0000000001
     return ceil(self.x)
 
 @external

--- a/tests/functional/builtins/codegen/test_concat.py
+++ b/tests/functional/builtins/codegen/test_concat.py
@@ -1,3 +1,10 @@
+import pytest
+
+from tests.utils import wrap_typ_with_storage_loc
+
+from vyper.evm.opcodes import version_check
+
+
 def test_concat(get_contract_with_gas_estimation):
     test_concat = """
 @external
@@ -21,7 +28,6 @@ def foo3(input1: Bytes[50], input2: Bytes[50], input3: Bytes[50]) -> Bytes[1000]
         c.foo3(b"horses" * 4, b"mice" * 7, b"crows" * 10)
         == b"horses" * 4 + b"mice" * 7 + b"crows" * 10
     )  # noqa: E501
-    print("Passed simple concat test")
 
 
 def test_concat2(get_contract_with_gas_estimation):
@@ -34,12 +40,15 @@ def foo(inp: Bytes[50]) -> Bytes[1000]:
 
     c = get_contract_with_gas_estimation(test_concat2)
     assert c.foo(b"horse" * 9 + b"vyper") == (b"horse" * 9 + b"vyper") * 10
-    print("Passed second concat test")
 
 
-def test_crazy_concat_code(get_contract_with_gas_estimation):
-    crazy_concat_code = """
-y: Bytes[10]
+@pytest.mark.parametrize('location', ["storage", "transient"])
+def test_crazy_concat_code(get_contract_with_gas_estimation, location):
+    if location == "transient" and not version_check(begin="cancun"):
+        pytest.skip("Skipping test as storage_location is 'transient' and EVM version is pre-Cancun")
+
+    crazy_concat_code = f"""
+y: {wrap_typ_with_storage_loc("Bytes[10]", location)}
 
 @external
 def krazykonkat(z: Bytes[10]) -> Bytes[25]:
@@ -51,8 +60,6 @@ def krazykonkat(z: Bytes[10]) -> Bytes[25]:
     c = get_contract_with_gas_estimation(crazy_concat_code)
 
     assert c.krazykonkat(b"moose") == b"cow horse moose"
-
-    print("Passed third concat test")
 
 
 def test_concat_buffer(get_contract):
@@ -92,15 +99,19 @@ def foo() -> int256:
     assert c.foo() == -1
 
 
-def test_concat_buffer3(get_contract):
+@pytest.mark.parametrize('location', ["storage", "transient"])
+def test_concat_buffer3(get_contract, location):
     # GHSA-2q8v-3gqq-4f8p
-    code = """
-s: String[1]
-s2: String[33]
-s3: String[34]
+    if location == "transient" and not version_check(begin="cancun"):
+        pytest.skip("Skipping test as storage_location is 'transient' and EVM version is pre-Cancun")
 
-@deploy
-def __init__():
+    code = f"""
+s:  {wrap_typ_with_storage_loc("String[1]", location)}
+s2: {wrap_typ_with_storage_loc("String[33]", location)}
+s3: {wrap_typ_with_storage_loc("String[34]", location)}
+
+@internal
+def init_test():
     self.s = "a"
     self.s2 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" # 33*'a'
 
@@ -111,6 +122,7 @@ def bar() -> uint256:
 
 @external
 def foo() -> int256:
+    self.init_test()
     i: int256 = -1
     b: uint256 = self.bar()
     return i
@@ -140,12 +152,14 @@ def fivetimes(inp: bytes32) -> Bytes[160]:
     assert c.sandwich(b"\x57" * 97, b"\x57" * 32) == b"\x57" * 161
     assert c.fivetimes(b"mongoose" * 4) == b"mongoose" * 20
 
-    print("Passed concat bytes32 test")
 
+@pytest.mark.parametrize('location', ["storage", "transient"])
+def test_konkat_code(get_contract_with_gas_estimation, location):
+    if location == "transient" and not version_check(begin="cancun"):
+        pytest.skip("Skipping test as storage_location is 'transient' and EVM version is pre-Cancun")
 
-def test_konkat_code(get_contract_with_gas_estimation):
-    konkat_code = """
-ecks: bytes32
+    konkat_code = f"""
+ecks: {wrap_typ_with_storage_loc("bytes32", location)}
 
 @external
 def foo(x: bytes32, y: bytes32) -> Bytes[64]:
@@ -166,8 +180,6 @@ def hoo(x: bytes32, y: bytes32) -> Bytes[64]:
     assert c.foo(b"\x35" * 32, b"\x00" * 32) == b"\x35" * 32 + b"\x00" * 32
     assert c.goo(b"\x35" * 32, b"\x00" * 32) == b"\x35" * 32 + b"\x00" * 32
     assert c.hoo(b"\x35" * 32, b"\x00" * 32) == b"\x35" * 32 + b"\x00" * 32
-
-    print("Passed second concat tests")
 
 
 def test_small_output(get_contract_with_gas_estimation):


### PR DESCRIPTION
### What I did
- add tstorage tests for builtins

### How I did it
- utilize the existing `storage` tests and parametrize them over both `storage` and `tstorage` without changing the semantics of the tests

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
