### PR TITLE
fix[lang]: transitive exports

### DIFF
--- a/tests/functional/codegen/modules/test_exports.py
+++ b/tests/functional/codegen/modules/test_exports.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_simple_export(make_input_bundle, get_contract):
     lib1 = """
 @external

--- a/tests/functional/codegen/modules/test_exports.py
+++ b/tests/functional/codegen/modules/test_exports.py
@@ -131,9 +131,7 @@ exports: lib2.lib1.foo
     assert c.foo() == 5
 
 
-# not sure if this one should work
-@pytest.mark.xfail(reason="ambiguous spec")
-def test_recursive_export(make_input_bundle, get_contract):
+def test_transitive_export(make_input_bundle, get_contract):
     lib1 = """
 @external
 def foo() -> uint256:

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -127,8 +127,9 @@ class _BaseVyperException(Exception):
             return None
 
         if isinstance(node, vy_ast.VyperNode):
-            module_node = node.get_ancestor(vy_ast.Module)
+            module_node = node.module_node
 
+            # TODO: handle cases where module is None or vy_ast.Module
             if module_node.get("path") not in (None, "<unknown>"):
                 node_msg = f'{node_msg}contract "{module_node.path}:{node.lineno}", '
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -524,7 +524,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 decl_node = func_t.decl_node
 
             if not isinstance(func_t, ContractFunctionT):
-                raise StructureException("not a function!", decl_node, item)
+                raise StructureException(f"not a function: `{func_t}`", decl_node, item)
             if not func_t.is_external:
                 raise StructureException("can't export non-external functions!", decl_node, item)
 

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -323,6 +323,9 @@ class ModuleT(VyperType):
             # can access interfaces in type position
             self._helper.add_member(name, TYPE_T(interface_t))
 
+    def __str__(self):
+        return f"module {self._id}"
+
     # __eq__ is very strict on ModuleT - object equality! this is because we
     # don't want to reason about where a module came from (i.e. input bundle,
     # search path, symlinked vs normalized path, etc.)

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -296,6 +296,10 @@ class ModuleT(VyperType):
             # note: this checks for collisions
             self.add_member(f.name, f._metadata["func_type"])
 
+        for item in self.exports_decls:
+            for fn_t in item._metadata["exports_info"].functions:
+                self.add_member(fn_t.name, fn_t)
+
         for e in self.event_defs:
             # add the type of the event so it can be used in call position
             self.add_member(e.name, TYPE_T(e._metadata["event_type"]))  # type: ignore

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -327,9 +327,6 @@ class ModuleT(VyperType):
             # can access interfaces in type position
             self._helper.add_member(name, TYPE_T(interface_t))
 
-    def __str__(self):
-        return f"module {self._id}"
-
     # __eq__ is very strict on ModuleT - object equality! this is because we
     # don't want to reason about where a module came from (i.e. input bundle,
     # search path, symlinked vs normalized path, etc.)


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/3881


### How I did it

### How to verify it

### Commit message

```
this commit fixes transitive exports, i.e. where `module1` exports
`module2.foo`, but it was previously not exportable from `module1`. this
is because previously exported functions were not added to the
`ModuleT`'s `exposed_functions` list.

a test had previously been written for this case, but it had been marked
xfail since the desired behavior was not clear until user feedback was
received. this commit removes the `xfail` marker from that test case.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
