### PR TITLE
fix[test]: fix failure in grammar fuzzing

### DIFF
--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -44,7 +44,7 @@ def fix_terminal(terminal: str) -> bool:
     return terminal
 
 
-ALLOWED_CHARS = st.characters(codec="utf-8", min_codepoint=1)
+ALLOWED_CHARS = st.characters(codec="ascii", min_codepoint=1)
 
 
 # With help from hyposmith


### PR DESCRIPTION
fixes a fuzz failure, which is that the strategy can put utf-8 characters in strings (which we reject at compile-time). the fix here is to just create programs with ascii. this bug was apparently introduced in 176e7f7f3a6a16bc09ec58d4bbc8dc515c48a0a8 due to the new alphabet parameter passed to the grammar strategy.

### What I did
fix https://github.com/vyperlang/vyper/issues/3875

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
