### PR TITLE
fix[ci]: pin hexbytes to pre-1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ extras_require = {
         "hypothesis[lark]>=6.0,<7.0",
         "eth-stdlib==0.2.7",
         "setuptools",
+        "hexbytes<1.0",
         "typing_extensions",  # we can remove this once dependencies upgrade to eth-rlp>=2.0
     ],
     "lint": [


### PR DESCRIPTION
hexbytes introduces new behavior how it interacts with strings/bytes. this commit pins hexbytes as a stopgap solution until we update tests.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
