### PR TITLE
chore[tests]: Update hexbytes version and tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ extras_require = {
         "eth-tester[py-evm]>=0.10.0b4,<0.11",
         "eth_abi>=4.0.0,<5.0.0",
         "py-evm>=0.10.0b4,<0.11",
+        "hexbytes>1.0,<2.0",
         "web3==6.0.0",
         "lark==1.1.9",
         "hypothesis[lark]>=6.0,<7.0",

--- a/tests/functional/builtins/codegen/test_keccak256.py
+++ b/tests/functional/builtins/codegen/test_keccak256.py
@@ -18,10 +18,10 @@ def bar() -> bytes32:
 
     c = get_contract_with_gas_estimation(hash_code)
     for inp in (b"", b"cow", b"s" * 31, b"\xff" * 32, b"\n" * 33, b"g" * 64, b"h" * 65):
-        assert "0x" + c.foo(inp).hex() == keccak(inp).hex()
+        assert c.foo(inp).hex() == keccak(inp).hex()
 
-    assert "0x" + c.bar().hex() == keccak(b"inp").hex()
-    assert "0x" + c.foob().hex() == keccak(b"inp").hex()
+    assert c.bar().hex() == keccak(b"inp").hex()
+    assert c.foob().hex() == keccak(b"inp").hex()
 
 
 def test_hash_code2(get_contract_with_gas_estimation):
@@ -96,7 +96,7 @@ def foo() -> bytes32:
     return x
     """
     c = get_contract_with_gas_estimation(code)
-    assert "0x" + c.foo().hex() == keccak(hex_to_int(hex_val).to_bytes(32, "big")).hex()
+    assert c.foo().hex() == keccak(hex_to_int(hex_val).to_bytes(32, "big")).hex()
 
 
 def test_hash_constant_string(get_contract_with_gas_estimation, keccak):
@@ -110,4 +110,4 @@ def foo() -> bytes32:
     return x
     """
     c = get_contract_with_gas_estimation(code)
-    assert "0x" + c.foo().hex() == keccak(str_val.encode()).hex()
+    assert c.foo().hex() == keccak(str_val.encode()).hex()

--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -2503,7 +2503,7 @@ def foo(a: {typ}):
     pass
     """
     c1 = get_contract(code)
-    sig = keccak(f"foo({typ})".encode()).hex()[:10]
+    sig = keccak(f"foo({typ})".encode()).to_0x_hex()[:10]
     encoded = abi.encode(f"({typ})", (val,)).hex()
     data = f"{sig}{encoded}"
 
@@ -2528,7 +2528,7 @@ def foo(a: DynArray[{typ}, 3], b: String[5]):
     """
 
     c1 = get_contract(code)
-    sig = keccak(f"foo({typ}[],string)".encode()).hex()[:10]
+    sig = keccak(f"foo({typ}[],string)".encode()).to_0x_hex()[:10]
     encoded = abi.encode(f"({typ}[],string)", val).hex()
     data = f"{sig}{encoded}"
 

--- a/tests/functional/codegen/features/test_logging.py
+++ b/tests/functional/codegen/features/test_logging.py
@@ -34,7 +34,7 @@ def foo():
     event_id = keccak(bytes("MyLog()", "utf-8"))
 
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -66,7 +66,7 @@ def foo():
     event_id = keccak(bytes("MyLog(bytes)", "utf-8"))
 
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -96,7 +96,7 @@ def foo():
 
     event_id = keccak(bytes("MyLog(int128,bool,address)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -172,8 +172,8 @@ def bar():
 
     event_id = keccak(bytes("MyLog(int128,address)", "utf-8"))
     # Event id is always the first topic
-    assert receipt1["logs"][0]["topics"][0] == event_id.hex()
-    assert receipt2["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt1["logs"][0]["topics"][0] == event_id.to_0x_hex()
+    assert receipt2["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -224,7 +224,7 @@ def foo():
 
     event_id = keccak(bytes("MyLog(int128)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -260,7 +260,7 @@ def foo():
 
     event_id = keccak(bytes("MyLog(int128[2],uint256[3],int128[2][2])", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
 
     assert c._classic_contract.abi[0] == {
@@ -303,7 +303,7 @@ def foo(arg1: Bytes[29], arg2: Bytes[31]):
 
     event_id = keccak(bytes("MyLog(bytes,bytes,bytes)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -341,7 +341,7 @@ def foo(_arg1: Bytes[20]):
 
     event_id = keccak(bytes("MyLog(bytes)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "anonymous": False,
@@ -370,7 +370,7 @@ def foo(_arg1: Bytes[5]):
 
     event_id = keccak(bytes("MyLog(bytes)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "anonymous": False,
@@ -406,7 +406,7 @@ def foo():
 
     event_id = keccak(bytes("MyLog(int128,bytes,bytes,address,address,uint256)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -453,7 +453,7 @@ def foo():
 
     event_id = keccak(bytes("MyLog(int128,bytes)", "utf-8"))
     # Event id is always the first topic
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "anonymous": False,
@@ -506,8 +506,8 @@ def foo():
     event_id2 = keccak(bytes("YourLog(address,(uint256,bytes,(string,fixed168x10)))", "utf-8"))
 
     # Event id is always the first topic
-    assert logs1["topics"][0] == event_id1.hex()
-    assert logs2["topics"][0] == event_id2.hex()
+    assert logs1["topics"][0] == event_id1.to_0x_hex()
+    assert logs2["topics"][0] == event_id2.to_0x_hex()
     # Event abi is created correctly
     assert c._classic_contract.abi[0] == {
         "name": "MyLog",
@@ -1081,7 +1081,7 @@ def foo(a: Bytes[36], b: int128, c: String[7]):
 
     # Event id is always the first topic
     event_id = keccak(b"MyLog(bytes,int128,string)")
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
 
     topic1 = f"0x{keccak256(b'bar').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
@@ -1126,7 +1126,7 @@ def foo():
 
     # Event id is always the first topic
     event_id = keccak(b"MyLog(bytes,int128,string)")
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
 
     topic1 = f"0x{keccak256(b'potato').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
@@ -1180,7 +1180,7 @@ def foo():
 
     # Event id is always the first topic
     event_id = keccak(b"MyLog(bytes,int128,string)")
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
 
     topic1 = f"0x{keccak256(b'zonk').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1
@@ -1222,7 +1222,7 @@ def foo():
 
     # Event id is always the first topic
     event_id = keccak(b"MyLog(bytes,int128,string)")
-    assert receipt["logs"][0]["topics"][0] == event_id.hex()
+    assert receipt["logs"][0]["topics"][0] == event_id.to_0x_hex()
 
     topic1 = f"0x{keccak256(b'wow').hex()}"
     assert receipt["logs"][0]["topics"][1] == topic1

--- a/tests/functional/syntax/test_msg_data.py
+++ b/tests/functional/syntax/test_msg_data.py
@@ -41,7 +41,7 @@ def foo(bar: uint256) -> Bytes[36]:
     contract = get_contract(code)
 
     # 2fbebd38000000000000000000000000000000000000000000000000000000000000002a
-    method_id = keccak(text="foo(uint256)").hex()[2:10]  # 2fbebd38
+    method_id = keccak(text="foo(uint256)").hex()[:8]  # 2fbebd38
     encoded_42 = w3.to_bytes(42).hex()  # 2a
     expected_result = method_id + "00" * 31 + encoded_42
 


### PR DESCRIPTION
### What I did
- Updated the tests after they were broken by a HexBytes update.
- eth-account got bumped from 0.11.0 to 0.12.0, which in turn bumped hexbytes to 1.2.0.
- HexBytes 1.0.0 had a [breaking change](https://hexbytes.readthedocs.io/en/latest/release_notes.html) (Move HexBytes prepend of 0x from hex method to repr to not break hex of parent bytes class)

### How I did it
- Selected a more specific hexbytes version
- Updated the tests

### How to verify it
- Tests should now pass.

### Commit message
Update hexbytes version and tests

### Description for the changelog
Update hexbytes version

### Cute Animal Picture
![image](https://github.com/vyperlang/vyper/assets/2369243/fc1843c8-8e80-4ea2-88a8-fcfb40139613)
