### PR TITLE
feat[ir]: return `IRnode` from `context.new_variable()`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from vyper import compiler
 from vyper.ast.grammar import parse_vyper_source
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.input_bundle import FilesystemInputBundle, InputBundle
-from vyper.compiler.settings import OptimizationLevel, Settings, _set_debug_mode
+from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings
 from vyper.ir import compile_ir, optimizer
 from vyper.utils import ERC5202_PREFIX
 
@@ -89,7 +89,7 @@ def optimize(pytestconfig):
 def debug(pytestconfig):
     debug = pytestconfig.getoption("enable_compiler_debug_mode")
     assert isinstance(debug, bool)
-    _set_debug_mode(debug)
+    return debug
 
 
 @pytest.fixture(scope="session")
@@ -97,6 +97,27 @@ def experimental_codegen(pytestconfig):
     ret = pytestconfig.getoption("experimental_codegen")
     assert isinstance(ret, bool)
     return ret
+
+
+@pytest.fixture(scope="session")
+def evm_version(pytestconfig):
+    # note: we configure the evm version that we emit code for,
+    # but eth-tester is only configured with the latest mainnet
+    # version. luckily, evms are backwards compatible.
+    evm_version_str = pytestconfig.getoption("evm_version")
+    assert isinstance(evm_version_str, str)
+    return evm_version_str
+
+
+@pytest.fixture(scope="session", autouse=True)
+def global_settings(evm_version, experimental_codegen, optimize, debug):
+    settings = Settings(
+        optimize=optimize,
+        evm_version=evm_version,
+        experimental_codegen=experimental_codegen,
+        debug=debug,
+    )
+    set_global_settings(settings)
 
 
 @pytest.fixture(autouse=True)
@@ -120,18 +141,6 @@ def venom_xfail(request, experimental_codegen):
         request.node.add_marker(pytest.mark.xfail(*args, strict=True, **kwargs))
 
     return _xfail
-
-
-@pytest.fixture(scope="session", autouse=True)
-def evm_version(pytestconfig):
-    # note: we configure the evm version that we emit code for,
-    # but eth-tester is only configured with the latest mainnet
-    # version.
-    evm_version_str = pytestconfig.getoption("evm_version")
-    evm.DEFAULT_EVM_VERSION = evm_version_str
-    # this should get overridden by anchor_evm_version,
-    # but set it anyway
-    evm.active_evm_version = evm.EVM_VERSIONS[evm_version_str]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def output_formats():
     return output_formats
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def optimize(pytestconfig):
     flag = pytestconfig.getoption("optimize")
     return OptimizationLevel.from_string(flag)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def optimize(pytestconfig):
     return OptimizationLevel.from_string(flag)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def debug(pytestconfig):
     debug = pytestconfig.getoption("enable_compiler_debug_mode")
     assert isinstance(debug, bool)

--- a/tests/unit/cli/vyper_json/test_get_settings.py
+++ b/tests/unit/cli/vyper_json/test_get_settings.py
@@ -10,7 +10,7 @@ def test_unknown_evm():
 
 
 @pytest.mark.parametrize(
-    "evm_version",
+    "evm_version_str",
     [
         "homestead",
         "tangerineWhistle",
@@ -22,11 +22,11 @@ def test_unknown_evm():
         "berlin",
     ],
 )
-def test_early_evm(evm_version):
+def test_early_evm(evm_version_str):
     with pytest.raises(JSONError):
-        get_evm_version({"settings": {"evmVersion": evm_version}})
+        get_evm_version({"settings": {"evmVersion": evm_version_str}})
 
 
-@pytest.mark.parametrize("evm_version", ["london", "paris", "shanghai", "cancun"])
-def test_valid_evm(evm_version):
-    assert evm_version == get_evm_version({"settings": {"evmVersion": evm_version}})
+@pytest.mark.parametrize("evm_version_str", ["london", "paris", "shanghai", "cancun"])
+def test_valid_evm(evm_version_str):
+    assert evm_version_str == get_evm_version({"settings": {"evmVersion": evm_version_str}})

--- a/tests/unit/compiler/ir/test_optimize_ir.py
+++ b/tests/unit/compiler/ir/test_optimize_ir.py
@@ -1,12 +1,9 @@
 import pytest
 
 from vyper.codegen.ir_node import IRnode
-from vyper.evm.opcodes import EVM_VERSIONS, anchor_evm_version
+from vyper.evm.opcodes import EVM_VERSIONS, anchor_evm_version, version_check
 from vyper.exceptions import StaticAssertionException
 from vyper.ir import optimizer
-
-POST_CANCUN = {k: v for k, v in EVM_VERSIONS.items() if v >= EVM_VERSIONS["cancun"]}
-
 
 optimize_list = [
     (["eq", 1, 2], [0]),
@@ -368,9 +365,9 @@ mload_merge_list = [
 
 
 @pytest.mark.parametrize("ir", mload_merge_list)
-@pytest.mark.parametrize("evm_version", list(POST_CANCUN.keys()))
 def test_mload_merge(ir, evm_version):
-    with anchor_evm_version(evm_version):
+    # TODO: use something like pytest.mark.post_cancun
+    if version_check(begin="cancun"):
         optimized = optimizer.optimize(IRnode.from_list(ir[0]))
         if ir[1] is None:
             # no-op, assert optimizer does nothing
@@ -379,3 +376,5 @@ def test_mload_merge(ir, evm_version):
             expected = IRnode.from_list(ir[1])
 
         assert optimized == expected
+    else:
+        pytest.skip("no mcopy available")

--- a/tests/unit/compiler/ir/test_optimize_ir.py
+++ b/tests/unit/compiler/ir/test_optimize_ir.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper.codegen.ir_node import IRnode
-from vyper.evm.opcodes import EVM_VERSIONS, anchor_evm_version, version_check
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import StaticAssertionException
 from vyper.ir import optimizer
 

--- a/tests/unit/compiler/test_default_settings.py
+++ b/tests/unit/compiler/test_default_settings.py
@@ -15,10 +15,10 @@ def test_default_opt_level():
     assert OptimizationLevel.default() == OptimizationLevel.GAS
 
 
-def test_codegen_opt_level():
-    assert core._opt_gas() is True  # check the default
-    assert core._opt_none() is False
-    assert core._opt_codesize() is False
+def test_codegen_opt_level(optimize):
+    assert core._opt_gas() == (optimize == OptimizationLevel.GAS)
+    assert core._opt_none() == (optimize == OptimizationLevel.NONE)
+    assert core._opt_codesize() == (optimize == OptimizationLevel.CODESIZE)
 
 
 def test_debug_mode(pytestconfig):

--- a/tests/unit/compiler/test_default_settings.py
+++ b/tests/unit/compiler/test_default_settings.py
@@ -16,8 +16,7 @@ def test_default_opt_level():
 
 
 def test_codegen_opt_level():
-    assert core._opt_level == OptimizationLevel.GAS
-    assert core._opt_gas() is True
+    assert core._opt_gas() is True  # check the default
     assert core._opt_none() is False
     assert core._opt_codesize() is False
 

--- a/tests/unit/compiler/test_opcodes.py
+++ b/tests/unit/compiler/test_opcodes.py
@@ -6,16 +6,6 @@ from vyper.evm import opcodes
 from vyper.exceptions import CompilerPanic
 
 
-@pytest.fixture(params=list(opcodes.EVM_VERSIONS))
-def evm_version(request):
-    default = opcodes.active_evm_version
-    try:
-        opcodes.active_evm_version = opcodes.EVM_VERSIONS[request.param]
-        yield request.param
-    finally:
-        opcodes.active_evm_version = default
-
-
 def test_opcodes():
     code = """
 @external

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2131,7 +2131,7 @@ class Uint2Str(BuiltinFunctionT):
             ret = [
                 "if",
                 ["eq", val, 0],
-                ["seq", ["mstore", buf + 1, ord("0")], ["mstore", buf, 1], buf],
+                ["seq", ["mstore", add_ofst(buf, 1), ord("0")], ["mstore", buf, 1], buf],
                 ["seq", ret, val],
             ]
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2451,7 +2451,7 @@ class ABIEncode(BuiltinFunctionT):
             # overwrite the 28 bytes of zeros with the bytestring length
             ret += [["mstore", add_ofst(buf, 4), method_id]]
             # abi encode, and grab length as stack item
-            length = abi_encode(buf + 36, encode_input, context, returns_len=True, bufsz=maxlen)
+            length = abi_encode(add_ofst(buf, 36), encode_input, context, returns_len=True, bufsz=maxlen)
             # write the output length to where bytestring stores its length
             ret += [["mstore", buf, ["add", length, 4]]]
 
@@ -2545,7 +2545,7 @@ class ABIDecode(BuiltinFunctionT):
 
             # sanity check buffer size for wrapped output type will not buffer overflow
             assert wrapped_typ.memory_bytes_required == output_typ.memory_bytes_required
-            ret.append(make_setter(output, to_decode))
+            ret.append(make_setter(output_buf, to_decode))
 
             ret.append(output)
             # finalize. set the type and location for the return buffer.

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2323,7 +2323,9 @@ class Print(BuiltinFunctionT):
             ret.append(["mstore", schema_buf, len(schema)])
 
             # TODO use Expr.make_bytelike, or better have a `bytestring` IRnode type
-            ret.append(["mstore", add_ofst(schema_buf, 32), bytes_to_int(schema.ljust(32, b"\x00"))])
+            ret.append(
+                ["mstore", add_ofst(schema_buf, 32), bytes_to_int(schema.ljust(32, b"\x00"))]
+            )
 
             payload_buflen = args_abi_t.size_bound()
             payload_t = BytesT(payload_buflen)
@@ -2350,7 +2352,9 @@ class Print(BuiltinFunctionT):
 
         # debug address that tooling uses
         CONSOLE_ADDRESS = 0x000000000000000000636F6E736F6C652E6C6F67
-        ret.append(["staticcall", "gas", CONSOLE_ADDRESS, add_ofst(buf, 28), ["add", 4, encode], 0, 0])
+        ret.append(
+            ["staticcall", "gas", CONSOLE_ADDRESS, add_ofst(buf, 28), ["add", 4, encode], 0, 0]
+        )
 
         return IRnode.from_list(ret, annotation="print:" + sig)
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -247,16 +247,16 @@ def _build_adhoc_slice_node(sub: IRnode, start: IRnode, length: IRnode, context:
 
     dst_typ = BytesT(length.value)
     # allocate a buffer for the return value
-    np = context.new_internal_variable(dst_typ)
+    buf = context.new_internal_variable(dst_typ)
 
     # `msg.data` by `calldatacopy`
     if sub.value == "~calldata":
         node = [
             "seq",
             _make_slice_bounds_check(start, length, "calldatasize"),
-            ["mstore", np, length],
-            ["calldatacopy", add_ofst(np, 32), start, length],
-            np,
+            ["mstore", buf, length],
+            ["calldatacopy", add_ofst(buf, 32), start, length],
+            buf,
         ]
 
     # `self.code` by `codecopy`
@@ -264,9 +264,9 @@ def _build_adhoc_slice_node(sub: IRnode, start: IRnode, length: IRnode, context:
         node = [
             "seq",
             _make_slice_bounds_check(start, length, "codesize"),
-            ["mstore", np, length],
-            ["codecopy", add_ofst(np, 32), start, length],
-            np,
+            ["mstore", buf, length],
+            ["codecopy", add_ofst(buf, 32), start, length],
+            buf,
         ]
 
     # `<address>.code` by `extcodecopy`
@@ -279,9 +279,9 @@ def _build_adhoc_slice_node(sub: IRnode, start: IRnode, length: IRnode, context:
             [
                 "seq",
                 _make_slice_bounds_check(start, length, ["extcodesize", "_extcode_address"]),
-                ["mstore", np, length],
-                ["extcodecopy", "_extcode_address", add_ofst(np, 32), start, length],
-                np,
+                ["mstore", buf, length],
+                ["extcodecopy", "_extcode_address", add_ofst(buf, 32), start, length],
+                buf,
             ],
         ]
 
@@ -551,10 +551,8 @@ class Concat(BuiltinFunctionT):
 
         # respect API of copy_bytes
         bufsize = dst_maxlen + 32
-        buf = context.new_internal_variable(BytesT(bufsize))
-
-        # Node representing the position of the output in memory
-        dst = IRnode.from_list(buf, typ=ret_typ, location=MEMORY, annotation="concat destination")
+        dst = context.new_internal_variable(BytesT(bufsize))
+        dst.annotation = "concat destination"
 
         ret = ["seq"]
         # stack item representing our current offset in the dst buffer
@@ -782,9 +780,9 @@ class ECRecover(BuiltinFunctionT):
                 # clear output memory first, ecrecover can return 0 bytes
                 ["mstore", output_buf, 0],
                 ["mstore", input_buf, args[0]],
-                ["mstore", input_buf + 32, args[1]],
-                ["mstore", input_buf + 64, args[2]],
-                ["mstore", input_buf + 96, args[3]],
+                ["mstore", add_ofst(input_buf, 32), args[1]],
+                ["mstore", add_ofst(input_buf, 64), args[2]],
+                ["mstore", add_ofst(input_buf, 96), args[3]],
                 ["staticcall", "gas", 1, input_buf, 128, output_buf, 32],
                 ["mload", output_buf],
             ],
@@ -798,9 +796,7 @@ class _ECArith(BuiltinFunctionT):
         args_tuple = ir_tuple_from_args(_args)
 
         args_t = args_tuple.typ
-        input_buf = IRnode.from_list(
-            context.new_internal_variable(args_t), typ=args_t, location=MEMORY
-        )
+        input_buf = context.new_internal_variable(args_t)
         ret_t = self._return_type
 
         ret = ["seq"]
@@ -1149,9 +1145,7 @@ class RawCall(BuiltinFunctionT):
             args_ofst = add_ofst(input_buf, 32)
             args_len = ["mload", input_buf]
 
-        output_node = IRnode.from_list(
-            context.new_internal_variable(BytesT(outsize)), typ=BytesT(outsize), location=MEMORY
-        )
+        output_node = context.new_internal_variable(BytesT(outsize))
 
         bool_ty = BoolT()
 
@@ -1757,8 +1751,8 @@ class CreateMinimalProxyTo(_CreateBase):
         return [
             "seq",
             ["mstore", buf, forwarder_preamble],
-            ["mstore", ["add", buf, preamble_length], aligned_target],
-            ["mstore", ["add", buf, preamble_length + 20], forwarder_post],
+            ["mstore", add_ofst(buf, preamble_length), aligned_target],
+            ["mstore", add_ofst(buf, preamble_length + 20), forwarder_post],
             _create_ir(value, buf, buf_len, salt=salt),
         ]
 
@@ -1864,9 +1858,7 @@ class CreateFromBlueprint(_CreateBase):
             # pretend we allocated enough memory for the encoder
             # (we didn't, but we are clobbering unused memory so it's safe.)
             bufsz = to_encode.typ.abi_type.size_bound()
-            argbuf = IRnode.from_list(
-                context.new_internal_variable(get_type_for_exact_size(bufsz)), location=MEMORY
-            )
+            argbuf = context.new_internal_variable(get_type_for_exact_size(bufsz))
 
             # return a complex expression which writes to memory and returns
             # the length of the encoded data
@@ -2113,13 +2105,13 @@ class Uint2Str(BuiltinFunctionT):
                     # clobber val, and return it as a pointer
                     [
                         "seq",
-                        ["mstore", ["sub", buf + n_digits, i], i],
-                        ["set", val, ["sub", buf + n_digits, i]],
+                        ["mstore", ["sub", add_ofst(buf, n_digits), i], i],
+                        ["set", val, ["sub", add_ofst(buf, n_digits), i]],
                         "break",
                     ],
                     [
                         "seq",
-                        ["mstore", ["sub", buf + n_digits, i], ["add", 48, ["mod", val, 10]]],
+                        ["mstore", ["sub", add_ofst(buf, n_digits), i], ["add", 48, ["mod", val, 10]]],
                         ["set", val, ["div", val, 10]],
                     ],
                 ],
@@ -2313,7 +2305,7 @@ class Print(BuiltinFunctionT):
 
             ret = ["seq"]
             ret.append(["mstore", buf, method_id])
-            encode = abi_encode(buf + 32, args_as_tuple, context, buflen, returns_len=True)
+            encode = abi_encode(add_ofst(buf, 32), args_as_tuple, context, buflen, returns_len=True)
 
         else:
             method_id = method_id_int("log(string,bytes)")
@@ -2335,7 +2327,7 @@ class Print(BuiltinFunctionT):
             # 32 bytes extra space for the method id
             payload_buf = context.new_internal_variable(payload_t)
             encode_payload = abi_encode(
-                payload_buf + 32, args_as_tuple, context, payload_buflen, returns_len=True
+                add_ofst(payload_buf, 32), args_as_tuple, context, payload_buflen, returns_len=True
             )
 
             ret.append(["mstore", payload_buf, encode_payload])
@@ -2457,7 +2449,7 @@ class ABIEncode(BuiltinFunctionT):
             # <32 bytes length> | <4 bytes method_id> | <everything else>
             # write the unaligned method_id first, then we will
             # overwrite the 28 bytes of zeros with the bytestring length
-            ret += [["mstore", buf + 4, method_id]]
+            ret += [["mstore", add_ofst(buf, 4), method_id]]
             # abi encode, and grab length as stack item
             length = abi_encode(buf + 36, encode_input, context, returns_len=True, bufsz=maxlen)
             # write the output length to where bytestring stores its length
@@ -2465,7 +2457,7 @@ class ABIEncode(BuiltinFunctionT):
 
         else:
             # abi encode and grab length as stack item
-            length = abi_encode(buf + 32, encode_input, context, returns_len=True, bufsz=maxlen)
+            length = abi_encode(add_ofst(buf, 32), encode_input, context, returns_len=True, bufsz=maxlen)
             # write the output length to where bytestring stores its length
             ret += [["mstore", buf, length]]
 
@@ -2550,7 +2542,6 @@ class ABIDecode(BuiltinFunctionT):
             # input validation
 
             output_buf = context.new_internal_variable(wrapped_typ)
-            output = IRnode.from_list(output_buf, typ=wrapped_typ, location=MEMORY)
 
             # sanity check buffer size for wrapped output type will not buffer overflow
             assert wrapped_typ.memory_bytes_required == output_typ.memory_bytes_required

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2111,7 +2111,11 @@ class Uint2Str(BuiltinFunctionT):
                     ],
                     [
                         "seq",
-                        ["mstore", ["sub", add_ofst(buf, n_digits), i], ["add", 48, ["mod", val, 10]]],
+                        [
+                            "mstore",
+                            ["sub", add_ofst(buf, n_digits), i],
+                            ["add", 48, ["mod", val, 10]],
+                        ],
                         ["set", val, ["div", val, 10]],
                     ],
                 ],
@@ -2451,13 +2455,17 @@ class ABIEncode(BuiltinFunctionT):
             # overwrite the 28 bytes of zeros with the bytestring length
             ret += [["mstore", add_ofst(buf, 4), method_id]]
             # abi encode, and grab length as stack item
-            length = abi_encode(add_ofst(buf, 36), encode_input, context, returns_len=True, bufsz=maxlen)
+            length = abi_encode(
+                add_ofst(buf, 36), encode_input, context, returns_len=True, bufsz=maxlen
+            )
             # write the output length to where bytestring stores its length
             ret += [["mstore", buf, ["add", length, 4]]]
 
         else:
             # abi encode and grab length as stack item
-            length = abi_encode(add_ofst(buf, 32), encode_input, context, returns_len=True, bufsz=maxlen)
+            length = abi_encode(
+                add_ofst(buf, 32), encode_input, context, returns_len=True, bufsz=maxlen
+            )
             # write the output length to where bytestring stores its length
             ret += [["mstore", buf, length]]
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -255,7 +255,7 @@ def _build_adhoc_slice_node(sub: IRnode, start: IRnode, length: IRnode, context:
             "seq",
             _make_slice_bounds_check(start, length, "calldatasize"),
             ["mstore", np, length],
-            ["calldatacopy", np + 32, start, length],
+            ["calldatacopy", add_ofst(np, 32), start, length],
             np,
         ]
 
@@ -265,7 +265,7 @@ def _build_adhoc_slice_node(sub: IRnode, start: IRnode, length: IRnode, context:
             "seq",
             _make_slice_bounds_check(start, length, "codesize"),
             ["mstore", np, length],
-            ["codecopy", np + 32, start, length],
+            ["codecopy", add_ofst(np, 32), start, length],
             np,
         ]
 
@@ -280,7 +280,7 @@ def _build_adhoc_slice_node(sub: IRnode, start: IRnode, length: IRnode, context:
                 "seq",
                 _make_slice_bounds_check(start, length, ["extcodesize", "_extcode_address"]),
                 ["mstore", np, length],
-                ["extcodecopy", "_extcode_address", np + 32, start, length],
+                ["extcodecopy", "_extcode_address", add_ofst(np, 32), start, length],
                 np,
             ],
         ]

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2555,7 +2555,7 @@ class ABIDecode(BuiltinFunctionT):
             assert wrapped_typ.memory_bytes_required == output_typ.memory_bytes_required
             ret.append(make_setter(output_buf, to_decode))
 
-            ret.append(output)
+            ret.append(output_buf)
             # finalize. set the type and location for the return buffer.
             # (note: unwraps the tuple type if necessary)
             ret = IRnode.from_list(ret, typ=output_typ, location=MEMORY)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2323,7 +2323,7 @@ class Print(BuiltinFunctionT):
             ret.append(["mstore", schema_buf, len(schema)])
 
             # TODO use Expr.make_bytelike, or better have a `bytestring` IRnode type
-            ret.append(["mstore", schema_buf + 32, bytes_to_int(schema.ljust(32, b"\x00"))])
+            ret.append(["mstore", add_ofst(schema_buf, 32), bytes_to_int(schema.ljust(32, b"\x00"))])
 
             payload_buflen = args_abi_t.size_bound()
             payload_t = BytesT(payload_buflen)
@@ -2346,11 +2346,11 @@ class Print(BuiltinFunctionT):
             buflen = 32 + args_as_tuple.typ.abi_type.size_bound()
             buf = context.new_internal_variable(get_type_for_exact_size(buflen))
             ret.append(["mstore", buf, method_id])
-            encode = abi_encode(buf + 32, args_as_tuple, context, buflen, returns_len=True)
+            encode = abi_encode(add_ofst(buf, 32), args_as_tuple, context, buflen, returns_len=True)
 
         # debug address that tooling uses
         CONSOLE_ADDRESS = 0x000000000000000000636F6E736F6C652E6C6F67
-        ret.append(["staticcall", "gas", CONSOLE_ADDRESS, buf + 28, ["add", 4, encode], 0, 0])
+        ret.append(["staticcall", "gas", CONSOLE_ADDRESS, add_ofst(buf, 28), ["add", 4, encode], 0, 0])
 
         return IRnode.from_list(ret, annotation="print:" + sig)
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -11,12 +11,7 @@ import vyper.codegen.ir_node as ir_node
 import vyper.evm.opcodes as evm
 from vyper.cli import vyper_json
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle
-from vyper.compiler.settings import (
-    VYPER_TRACEBACK_LIMIT,
-    OptimizationLevel,
-    Settings,
-    _set_debug_mode,
-)
+from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel, Settings
 from vyper.typing import ContractPath, OutputFormats
 
 T = TypeVar("T")
@@ -171,9 +166,6 @@ def _parse_args(argv):
 
     output_formats = tuple(uniq(args.format.split(",")))
 
-    if args.debug:
-        _set_debug_mode(True)
-
     if args.no_optimize and args.optimize:
         raise ValueError("Cannot use `--no-optimize` and `--optimize` at the same time!")
 
@@ -189,6 +181,9 @@ def _parse_args(argv):
 
     if args.experimental_codegen:
         settings.experimental_codegen = args.experimental_codegen
+
+    if args.debug:
+        settings.debug = settings.debug
 
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -184,7 +184,7 @@ def _parse_args(argv):
         settings.experimental_codegen = args.experimental_codegen
 
     if args.debug:
-        settings.debug = settings.debug
+        settings.debug = args.debug
 
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)

--- a/vyper/codegen/abi_encoder.py
+++ b/vyper/codegen/abi_encoder.py
@@ -159,9 +159,9 @@ def abi_encoding_matches_vyper(typ):
 # the abi_encode routine will push the output len onto the stack,
 # otherwise it will return 0 items to the stack.
 def abi_encode(dst, ir_node, context, bufsz, returns_len=False):
-    # TODO change dst to be an IRnode so it has type info to begin with.
-    # setting the typ of dst to ir_node.typ is a footgun.
+    # cast dst to the type of the input so that make_setter works
     dst = IRnode.from_list(dst, typ=ir_node.typ, location=MEMORY)
+
     abi_t = dst.typ.abi_type
     size_bound = abi_t.size_bound()
 

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -66,7 +66,7 @@ class VariableRecord:
             mutable=self.mutable,
             location=self.location,
         )
-        ret._referenced_vars = {self}
+        ret._referenced_variables = {self}
         if self.location == MEMORY:  # don't need alloca in other locations
             ret.passthrough_metadata["alloca"] = Alloca(
                 name=self.name, pos=self.pos, typ=self.typ, size=self.typ.memory_bytes_required

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -64,6 +64,7 @@ class VariableRecord:
             annotation=self.name,
             encoding=self.encoding,
             mutable=self.mutable,
+            location=self.location,
         )
         ret._referenced_vars = {self}
         if self.location == MEMORY:  # don't need alloca in other locations

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -226,12 +226,7 @@ class Context:
         if self.settings.experimental_codegen:
             # convert it into an abstract pointer
             pos = f"$alloca_{ofst}_{size}"
-            alloca = Alloca(
-                name=name,
-                offset=ofst,
-                typ=typ,
-                size=size,
-            )
+            alloca = Alloca(name=name, offset=ofst, typ=typ, size=size)
 
         var = VariableRecord(
             name=name,

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -214,7 +214,12 @@ class Context:
         del self.vars[var.name]
 
     def _new_variable(
-        self, name: str, typ: VyperType, is_internal: bool, is_mutable: bool = True
+        self,
+        name: str,
+        typ: VyperType,
+        is_internal: bool,
+        is_mutable: bool = True,
+        internal_function=False,
     ) -> IRnode:
         size = typ.memory_bytes_required
 
@@ -225,7 +230,10 @@ class Context:
         alloca = None
         if self.settings.experimental_codegen:
             # convert it into an abstract pointer
-            pos = f"$alloca_{ofst}_{size}"
+            if internal_function:
+                pos = f"$palloca_{ofst}_{size}"
+            else:
+                pos = f"$alloca_{ofst}_{size}"
             alloca = Alloca(name=name, offset=ofst, typ=typ, size=size)
 
         var = VariableRecord(
@@ -241,7 +249,9 @@ class Context:
         self.vars[name] = var
         return var.as_ir_node()
 
-    def new_variable(self, name: str, typ: VyperType, is_mutable: bool = True) -> IRnode:
+    def new_variable(
+        self, name: str, typ: VyperType, is_mutable: bool = True, internal_function=False
+    ) -> IRnode:
         """
         Allocate memory for a user-defined variable and return an IR node referencing it.
 
@@ -258,7 +268,9 @@ class Context:
             Memory offset for the variable
         """
 
-        return self._new_variable(name, typ, is_internal=False, is_mutable=is_mutable)
+        return self._new_variable(
+            name, typ, is_internal=False, is_mutable=is_mutable, internal_function=internal_function
+        )
 
     def fresh_varname(self, name: str) -> str:
         """

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1,8 +1,5 @@
-import contextlib
-from typing import Generator
-
 from vyper.codegen.ir_node import Encoding, IRnode
-from vyper.compiler.settings import OptimizationLevel
+from vyper.compiler.settings import _opt_codesize, _opt_gas, _opt_none
 from vyper.evm.address_space import (
     CALLDATA,
     DATA,
@@ -914,40 +911,6 @@ def make_setter(left, right):
     assert isinstance(left.typ, (SArrayT, TupleT, StructT))
 
     return _complex_make_setter(left, right)
-
-
-_opt_level = OptimizationLevel.GAS
-
-
-# FIXME: this is to get around the fact that we don't have a
-# proper context object in the IR generation phase.
-@contextlib.contextmanager
-def anchor_opt_level(new_level: OptimizationLevel) -> Generator:
-    """
-    Set the global optimization level variable for the duration of this
-    context manager.
-    """
-    assert isinstance(new_level, OptimizationLevel)
-
-    global _opt_level
-    try:
-        tmp = _opt_level
-        _opt_level = new_level
-        yield
-    finally:
-        _opt_level = tmp
-
-
-def _opt_codesize():
-    return _opt_level == OptimizationLevel.CODESIZE
-
-
-def _opt_gas():
-    return _opt_level == OptimizationLevel.GAS
-
-
-def _opt_none():
-    return _opt_level == OptimizationLevel.NONE
 
 
 def _complex_make_setter(left, right):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -432,10 +432,7 @@ def pop_dyn_array(darray_node, return_popped_item):
 # add an offset to a pointer, keeping location and encoding info
 def add_ofst(ptr, ofst):
     ret = ["add", ptr, ofst]
-    ret = IRnode.from_list(ret, location=ptr.location, encoding=ptr.encoding)
-    if "alloca" in ptr.passthrough_metadata:
-        ret.passthrough_metadata["alloca"] = ptr.passthrough_metadata["alloca"]
-    return ret
+    return IRnode.from_list(ret, location=ptr.location, encoding=ptr.encoding)
 
 
 # shorthand util

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -432,7 +432,10 @@ def pop_dyn_array(darray_node, return_popped_item):
 # add an offset to a pointer, keeping location and encoding info
 def add_ofst(ptr, ofst):
     ret = ["add", ptr, ofst]
-    return IRnode.from_list(ret, location=ptr.location, encoding=ptr.encoding)
+    ret = IRnode.from_list(ret, location=ptr.location, encoding=ptr.encoding)
+    if "alloca" in ptr.passthrough_metadata:
+        ret.passthrough_metadata["alloca"] = ptr.passthrough_metadata["alloca"]
+    return ret
 
 
 # shorthand util

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -168,17 +168,7 @@ class Expr:
         if self.expr.id == "self":
             return IRnode.from_list(["address"], typ=AddressT())
         elif self.expr.id in self.context.vars:
-            var = self.context.vars[self.expr.id]
-            ret = IRnode.from_list(
-                var.pos,
-                typ=var.typ,
-                location=var.location,  # either 'memory' or 'calldata' storage is handled above.
-                encoding=var.encoding,
-                annotation=self.expr.id,
-                mutable=var.mutable,
-            )
-            ret._referenced_variables = {var}
-            return ret
+            return self.context.get_var(self.expr.id).as_ir_node()
 
         elif (varinfo := self.expr._expr_info.var_info) is not None:
             if varinfo.is_constant:

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -168,7 +168,7 @@ class Expr:
         if self.expr.id == "self":
             return IRnode.from_list(["address"], typ=AddressT())
         elif self.expr.id in self.context.vars:
-            return self.context.get_var(self.expr.id).as_ir_node()
+            return self.context.lookup_var(self.expr.id).as_ir_node()
 
         elif (varinfo := self.expr._expr_info.var_info) is not None:
             if varinfo.is_constant:

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import copy
+from dataclasses import dataclass
 
 import vyper.utils as util
 from vyper.codegen.abi_encoder import abi_encode
@@ -99,7 +99,7 @@ def _unpack_returndata(buf, fn_type, call_kwargs, contract_address, context, exp
     buf = copy.copy(buf)
     buf.typ = wrapped_return_t
     buf.encoding = encoding
-    buf.annotation=f"{expr.node_source_code} returndata buffer"
+    buf.annotation = f"{expr.node_source_code} returndata buffer"
 
     unpacker = ["seq"]
 

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -4,6 +4,7 @@ import vyper.utils as util
 from vyper.codegen.abi_encoder import abi_encode
 from vyper.codegen.core import (
     _freshname,
+    add_ofst,
     calculate_type_for_external_return,
     check_assign,
     check_external_call,
@@ -54,7 +55,7 @@ def _pack_arguments(fn_type, args, context):
     buf_t = get_type_for_exact_size(buflen)
     buf = context.new_internal_variable(buf_t)
 
-    args_ofst = buf + 28
+    args_ofst = add_ofst(buf, 28)
     args_len = args_abi_t.size_bound() + 4
 
     abi_signature = fn_type.name + dst_tuple_t.abi_type.selector_name()
@@ -69,7 +70,7 @@ def _pack_arguments(fn_type, args, context):
     pack_args.append(["mstore", buf, util.method_id_int(abi_signature)])
 
     if len(args) != 0:
-        pack_args.append(abi_encode(buf + 32, args_as_tuple, context, bufsz=buflen))
+        pack_args.append(abi_encode(add_ofst(buf, 32), args_as_tuple, context, bufsz=buflen))
 
     return buf, pack_args, args_ofst, args_len
 
@@ -117,7 +118,6 @@ def _unpack_returndata(buf, fn_type, call_kwargs, contract_address, context, exp
     # unpack strictly
     if needs_clamp(wrapped_return_t, encoding):
         return_buf = context.new_internal_variable(wrapped_return_t)
-        return_buf = IRnode.from_list(return_buf, typ=wrapped_return_t, location=MEMORY)
 
         # note: make_setter does ABI decoding and clamps
         unpacker.append(make_setter(return_buf, buf))

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import copy
 
 import vyper.utils as util
 from vyper.codegen.abi_encoder import abi_encode
@@ -94,13 +95,11 @@ def _unpack_returndata(buf, fn_type, call_kwargs, contract_address, context, exp
 
     encoding = Encoding.ABI
 
-    buf = IRnode.from_list(
-        buf,
-        typ=wrapped_return_t,
-        location=MEMORY,
-        encoding=encoding,
-        annotation=f"{expr.node_source_code} returndata buffer",
-    )
+    assert buf.location == MEMORY
+    buf = copy.copy(buf)
+    buf.typ = wrapped_return_t
+    buf.encoding = encoding
+    buf.annotation=f"{expr.node_source_code} returndata buffer"
 
     unpacker = ["seq"]
 

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -35,8 +35,7 @@ def _register_function_args(func_t: ContractFunctionT, context: Context) -> list
 
         if needs_clamp(arg.typ, Encoding.ABI):
             # allocate a memory slot for it and copy
-            p = context.new_variable(arg.name, arg.typ, is_mutable=False)
-            dst = IRnode(p, typ=arg.typ, location=MEMORY)
+            dst = context.new_variable(arg.name, arg.typ, is_mutable=False)
 
             copy_arg = make_setter(dst, arg_ir)
             copy_arg.ast_source = arg.ast_source

--- a/vyper/codegen/function_definitions/external_function.py
+++ b/vyper/codegen/function_definitions/external_function.py
@@ -11,7 +11,7 @@ from vyper.codegen.function_definitions.common import (
 )
 from vyper.codegen.ir_node import Encoding, IRnode
 from vyper.codegen.stmt import parse_body
-from vyper.evm.address_space import CALLDATA, DATA, MEMORY
+from vyper.evm.address_space import CALLDATA, DATA
 from vyper.semantics.types import TupleT
 from vyper.semantics.types.function import ContractFunctionT
 from vyper.utils import calc_mem_gas
@@ -93,9 +93,7 @@ def _generate_kwarg_handlers(
         for i, arg_meta in enumerate(calldata_kwargs):
             k = func_t.n_positional_args + i
 
-            dst = context.lookup_var(arg_meta.name).pos
-
-            lhs = IRnode(dst, location=MEMORY, typ=arg_meta.typ)
+            lhs = context.lookup_var(arg_meta.name).as_ir_node()
 
             rhs = get_element_ptr(calldata_kwargs_ofst, k, array_bounds_check=False)
 
@@ -104,8 +102,7 @@ def _generate_kwarg_handlers(
             ret.append(copy_arg)
 
         for x in default_kwargs:
-            dst = context.lookup_var(x.name).pos
-            lhs = IRnode(dst, location=MEMORY, typ=x.typ)
+            lhs = context.lookup_var(x.name).as_ir_node()
             lhs.ast_source = x.ast_source
             kw_ast_val = func_t.default_values[x.name]  # e.g. `3` in x: int = 3
             rhs = Expr(kw_ast_val, context).ir_node

--- a/vyper/codegen/function_definitions/internal_function.py
+++ b/vyper/codegen/function_definitions/internal_function.py
@@ -49,7 +49,7 @@ def generate_ir_for_internal_function(
     for arg in func_t.arguments:
         # allocate a variable for every arg, setting mutability
         # to True to allow internal function arguments to be mutable
-        context.new_variable(arg.name, arg.typ, is_mutable=True)
+        context.new_variable(arg.name, arg.typ, is_mutable=True, internal_function=True)
 
     # Get nonreentrant lock
     nonreentrant_pre, nonreentrant_post = get_nonreentrant_lock(func_t)

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -77,9 +77,7 @@ def ir_for_self_call(stmt_expr, context):
     if args_as_tuple.contains_self_call:
         copy_args = ["seq"]
         # TODO deallocate me
-        tmp_args_buf = IRnode(
-            context.new_internal_variable(dst_tuple_t), typ=dst_tuple_t, location=MEMORY
-        )
+        tmp_args_buf = context.new_internal_variable(dst_tuple_t)
         copy_args.append(
             # --> args evaluate here <--
             make_setter(tmp_args_buf, args_as_tuple)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -7,6 +7,7 @@ from vyper.codegen.core import (
     LOAD,
     STORE,
     IRnode,
+    add_ofst,
     clamp_le,
     get_dyn_array_count,
     get_element_ptr,
@@ -136,14 +137,14 @@ class Stmt:
 
         # abi encode method_id + bytestring to `buf+32`, then
         # write method_id to `buf` and get out of here
-        payload_buf = buf + 32
+        payload_buf = add_ofst(buf, 32)
         bufsz -= 32  # reduce buffer by size of `method_id` slot
         encoded_length = abi_encode(payload_buf, msg_ir, self.context, bufsz, returns_len=True)
         with encoded_length.cache_when_complex("encoded_len") as (b1, encoded_length):
             revert_seq = [
                 "seq",
                 ["mstore", buf, method_id],
-                ["revert", buf + 28, ["add", 4, encoded_length]],
+                ["revert", add_ofst(buf, 28), ["add", 4, encoded_length]],
             ]
             revert_seq = b1.resolve(revert_seq)
 

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -7,7 +7,7 @@ import vyper.codegen.core as codegen
 import vyper.compiler.output as output
 from vyper.compiler.input_bundle import FileInput, InputBundle, PathLike
 from vyper.compiler.phases import CompilerData
-from vyper.compiler.settings import Settings
+from vyper.compiler.settings import Settings, anchor_settings
 from vyper.evm.opcodes import anchor_evm_version
 from vyper.typing import ContractPath, OutputFormats, StorageLayout
 
@@ -117,7 +117,7 @@ def compile_from_file_input(
     )
 
     ret = {}
-    with anchor_evm_version(compiler_data.settings.evm_version):
+    with anchor_settings(compiler_data.settings):
         for output_format in output_formats:
             if output_format not in OUTPUT_FORMATS:
                 raise ValueError(f"Unsupported format type {repr(output_format)}")

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -6,10 +6,9 @@ from typing import Optional
 
 from vyper import ast as vy_ast
 from vyper.codegen import module
-from vyper.codegen.core import anchor_opt_level
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle, InputBundle
-from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.compiler.settings import OptimizationLevel, Settings, anchor_settings
 from vyper.exceptions import StructureException
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics import analyze_module, set_data_positions, validate_compilation_target
@@ -178,7 +177,7 @@ class CompilerData:
     @cached_property
     def _ir_output(self):
         # fetch both deployment and runtime IR
-        return generate_ir_nodes(self.global_ctx, self.settings.optimize)
+        return generate_ir_nodes(self.global_ctx, self.settings)
 
     @property
     def ir_nodes(self) -> IRnode:
@@ -268,7 +267,7 @@ def generate_annotated_ast(vyper_module: vy_ast.Module, input_bundle: InputBundl
     return vyper_module
 
 
-def generate_ir_nodes(global_ctx: ModuleT, optimize: OptimizationLevel) -> tuple[IRnode, IRnode]:
+def generate_ir_nodes(global_ctx: ModuleT, settings: Settings) -> tuple[IRnode, IRnode]:
     """
     Generate the intermediate representation (IR) from the contextualized AST.
 
@@ -288,9 +287,9 @@ def generate_ir_nodes(global_ctx: ModuleT, optimize: OptimizationLevel) -> tuple
         IR to generate deployment bytecode
         IR to generate runtime bytecode
     """
-    with anchor_opt_level(optimize):
+    with anchor_settings(settings):
         ir_nodes, ir_runtime = module.generate_ir_for_module(global_ctx)
-    if optimize != OptimizationLevel.NONE:
+    if settings.optimize != OptimizationLevel.NONE:
         ir_nodes = optimizer.optimize(ir_nodes)
         ir_runtime = optimizer.optimize(ir_runtime)
     return ir_nodes, ir_runtime

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -1,7 +1,8 @@
+import contextlib
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Generator, Optional
 
 VYPER_COLOR_OUTPUT = os.environ.get("VYPER_COLOR_OUTPUT", "0") == "1"
 VYPER_ERROR_CONTEXT_LINES = int(os.environ.get("VYPER_ERROR_CONTEXT_LINES", "1"))
@@ -43,16 +44,61 @@ class Settings:
     optimize: Optional[OptimizationLevel] = None
     evm_version: Optional[str] = None
     experimental_codegen: Optional[bool] = None
+    debug: Optional[bool] = None
 
 
-_DEBUG = False
+_settings = None
+
+
+def get_global_settings() -> Optional[Settings]:
+    return _settings
+
+
+def set_global_settings(new_settings: Optional[Settings]) -> None:
+    assert isinstance(new_settings, Settings) or new_settings is None
+    # TODO evil circular import
+    from vyper.evm.opcodes import DEFAULT_EVM_VERSION, EVM_VERSIONS, set_global_evm_version
+
+    global _settings
+    _settings = new_settings
+
+    # set the global evm version so that version_check picks it up.
+    # this is a bit spooky, but it's generally always what we want
+    # when set_global_settings is called.
+    evm_version = DEFAULT_EVM_VERSION
+    if new_settings is not None and new_settings.evm_version is not None:
+        evm_version = new_settings.evm_version
+    set_global_evm_version(EVM_VERSIONS[evm_version])
+
+
+# could maybe refactor this, but it is easier for now than threading settings
+# around everywhere.
+@contextlib.contextmanager
+def anchor_settings(new_settings: Settings) -> Generator:
+    """
+    Set the globally available settings for the duration of this context manager
+    """
+    assert new_settings is not None
+    global _settings
+    try:
+        tmp = get_global_settings()
+        set_global_settings(new_settings)
+        yield
+    finally:
+        set_global_settings(tmp)
+
+
+def _opt_codesize():
+    return _settings.optimize == OptimizationLevel.CODESIZE
+
+
+def _opt_gas():
+    return _settings.optimize == OptimizationLevel.GAS
+
+
+def _opt_none():
+    return _settings.optimize == OptimizationLevel.NONE
 
 
 def _is_debug_mode():
-    global _DEBUG
-    return _DEBUG
-
-
-def _set_debug_mode(dbg: bool = False) -> None:
-    global _DEBUG
-    _DEBUG = dbg
+    return get_global_settings().debug

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -210,7 +210,7 @@ IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 def set_global_evm_version(evm_version: int) -> None:
     global active_evm_version
-    evm_version = evm_version
+    active_evm_version = evm_version
 
 
 @contextlib.contextmanager

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -208,16 +208,24 @@ PSEUDO_OPCODES: OpcodeMap = {
 IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 
-@contextlib.contextmanager
-def anchor_evm_version(evm_version: Optional[str] = None) -> Generator:
+def set_global_evm_version(evm_version: int) -> None:
     global active_evm_version
-    anchor = active_evm_version
-    evm_version = evm_version or DEFAULT_EVM_VERSION
-    active_evm_version = EVM_VERSIONS[evm_version]
+    evm_version = evm_version
+
+
+@contextlib.contextmanager
+def anchor_evm_version(evm_version: Optional[str]) -> Generator:
+    global active_evm_version
+    if evm_version is None:
+        evm_version = DEFAULT_EVM_VERSION
+
+    tmp = active_evm_version
+    evm_version_int = EVM_VERSIONS[evm_version]
+    set_global_evm_version(evm_version_int)
     try:
         yield
     finally:
-        active_evm_version = anchor
+        set_global_evm_version(tmp)
 
 
 def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -4,7 +4,6 @@ import decimal
 import enum
 import functools
 import hashlib
-import itertools
 import sys
 import time
 import traceback

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -4,6 +4,7 @@ import decimal
 import enum
 import functools
 import hashlib
+import itertools
 import sys
 import time
 import traceback

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -438,13 +438,9 @@ def _convert_ir_bb(ctx, ir, symbols):
     elif ir.value == "mload":
         arg_0 = _convert_ir_bb(ctx, ir.args[0], symbols)
         bb = ctx.get_basic_block()
-        if isinstance(arg_0, IRVariable):
-            return bb.append_instruction("mload", arg_0)
-
-        if isinstance(arg_0, IRLiteral):
-            avar = symbols.get(f"%{arg_0.value}")
-            if avar is not None:
-                return bb.append_instruction("mload", avar)
+        s = f"$$alloca{arg_0}"
+        if s in symbols:
+            return symbols[s]
 
         return bb.append_instruction("mload", arg_0)
     elif ir.value == "mstore":
@@ -452,10 +448,13 @@ def _convert_ir_bb(ctx, ir, symbols):
         # to fix upstream.
         arg_1, arg_0 = _convert_ir_bb_list(ctx, reversed(ir.args), symbols)
 
-        if isinstance(arg_1, IRVariable):
-            symbols[f"&{arg_0.value}"] = arg_1
+        s = f"$$alloca{arg_0}"
+        if s in symbols:
+            symbols[s] = ctx.get_basic_block().append_instruction("store", arg_1)
+            return
 
-        ctx.get_basic_block().append_instruction("mstore", arg_1, arg_0)
+        return ctx.get_basic_block().append_instruction("mstore", arg_0, arg_1)
+
     elif ir.value == "ceil32":
         x = ir.args[0]
         expanded = IRnode.from_list(["and", ["add", x, 31], ["not", 31]])
@@ -561,6 +560,10 @@ def _convert_ir_bb(ctx, ir, symbols):
         if ir.value.startswith("$alloca") and ir.value not in symbols:
             alloca = ir.passthrough_metadata["alloca"]
             ptr = ctx.get_basic_block().append_instruction("alloca", alloca.offset, alloca.size)
+            # tired: keep a separate map of alloca'ed symbols
+            # wired: use magic prefixes to indicate separate map
+            s = f"$$alloca{ptr}"
+            symbols[s] = ir.value
             symbols[ir.value] = ptr
         return symbols[ir.value]
     elif ir.is_literal:

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -1,4 +1,3 @@
-import contextlib
 import functools
 import re
 from typing import Optional

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -442,7 +442,7 @@ def _convert_ir_bb(ctx, ir, symbols):
         # to fix upstream.
         arg_1, arg_0 = _convert_ir_bb_list(ctx, reversed(ir.args), symbols)
 
-        return ctx.get_basic_block().append_instruction("mstore", arg_0, arg_1)
+        return ctx.get_basic_block().append_instruction("mstore", arg_1, arg_0)
 
     elif ir.value == "ceil32":
         x = ir.args[0]

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -62,9 +62,14 @@ PASS_THROUGH_INSTRUCTIONS = frozenset(
         "gasprice",
         "gaslimit",
         "returndatasize",
+        "mload",
+        "mstore",
         "iload",
+        "istore",
         "sload",
+        "sstore",
         "tload",
+        "tstore",
         "coinbase",
         "number",
         "prevrandao",
@@ -89,9 +94,6 @@ PASS_THROUGH_INSTRUCTIONS = frozenset(
         "codecopy",
         "returndatacopy",
         "revert",
-        "istore",
-        "sstore",
-        "tstore",
         "create",
         "create2",
         "addmod",
@@ -435,10 +437,6 @@ def _convert_ir_bb(ctx, ir, symbols):
         bb.append_instruction("dloadbytes", len_, src, dst)
         return None
 
-    elif ir.value == "mload":
-        arg_0 = _convert_ir_bb(ctx, ir.args[0], symbols)
-        bb = ctx.get_basic_block()
-        return bb.append_instruction("mload", arg_0)
     elif ir.value == "mstore":
         # some upstream code depends on reversed order of evaluation --
         # to fix upstream.

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -63,7 +63,6 @@ PASS_THROUGH_INSTRUCTIONS = frozenset(
         "gaslimit",
         "returndatasize",
         "mload",
-        "mstore",
         "iload",
         "istore",
         "sload",
@@ -440,9 +439,9 @@ def _convert_ir_bb(ctx, ir, symbols):
     elif ir.value == "mstore":
         # some upstream code depends on reversed order of evaluation --
         # to fix upstream.
-        arg_1, arg_0 = _convert_ir_bb_list(ctx, reversed(ir.args), symbols)
+        val, ptr = _convert_ir_bb_list(ctx, reversed(ir.args), symbols)
 
-        return ctx.get_basic_block().append_instruction("mstore", arg_1, arg_0)
+        return ctx.get_basic_block().append_instruction("mstore", val, ptr)
 
     elif ir.value == "ceil32":
         x = ir.args[0]

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -545,7 +545,11 @@ def _convert_ir_bb(ctx, ir, symbols):
         ctx.get_basic_block().append_instruction("log", topic_count, *args)
     elif isinstance(ir.value, str) and ir.value.upper() in get_opcodes():
         _convert_ir_opcode(ctx, ir, symbols)
-    elif isinstance(ir.value, str) and ir.value in symbols:
+    elif isinstance(ir.value, str):
+        if ir.value.startswith("$alloca") and ir.value not in symbols:
+            alloca = ir.passthrough_metadata["alloca"]
+            ptr = ctx.get_basic_block().append_instruction("alloca", alloca.offset, alloca.size)
+            symbols[ir.value] = ptr
         return symbols[ir.value]
     elif ir.is_literal:
         return IRLiteral(ir.value)

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -1,7 +1,7 @@
+import contextlib
 import functools
 import re
 from typing import Optional
-import contextlib
 
 from vyper.codegen.ir_node import IRnode
 from vyper.evm.opcodes import get_opcodes

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -438,20 +438,11 @@ def _convert_ir_bb(ctx, ir, symbols):
     elif ir.value == "mload":
         arg_0 = _convert_ir_bb(ctx, ir.args[0], symbols)
         bb = ctx.get_basic_block()
-        s = f"$$alloca{arg_0}"
-        if s in symbols:
-            return symbols[s]
-
         return bb.append_instruction("mload", arg_0)
     elif ir.value == "mstore":
         # some upstream code depends on reversed order of evaluation --
         # to fix upstream.
         arg_1, arg_0 = _convert_ir_bb_list(ctx, reversed(ir.args), symbols)
-
-        s = f"$$alloca{arg_0}"
-        if s in symbols:
-            symbols[s] = ctx.get_basic_block().append_instruction("store", arg_1)
-            return
 
         return ctx.get_basic_block().append_instruction("mstore", arg_0, arg_1)
 
@@ -560,10 +551,6 @@ def _convert_ir_bb(ctx, ir, symbols):
         if ir.value.startswith("$alloca") and ir.value not in symbols:
             alloca = ir.passthrough_metadata["alloca"]
             ptr = ctx.get_basic_block().append_instruction("alloca", alloca.offset, alloca.size)
-            # tired: keep a separate map of alloca'ed symbols
-            # wired: use magic prefixes to indicate separate map
-            s = f"$$alloca{ptr}"
-            symbols[s] = ir.value
             symbols[ir.value] = ptr
         return symbols[ir.value]
     elif ir.is_literal:

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -354,7 +354,8 @@ class VenomCompiler:
         if opcode in ["jmp", "djmp", "jnz", "invoke"]:
             operands = inst.get_non_label_operands()
         elif opcode == "alloca":
-            operands = inst.operands[1:2]
+            _size, offset = inst.operands
+            operands = [offset]
 
         # iload and istore are special cases because they can take a literal
         # that is handled specialy with the _OFST macro. Look below, after the

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -354,7 +354,7 @@ class VenomCompiler:
         if opcode in ["jmp", "djmp", "jnz", "invoke"]:
             operands = inst.get_non_label_operands()
         elif opcode == "alloca":
-            _size, offset = inst.operands
+            offset, _size = inst.operands
             operands = [offset]
 
         # iload and istore are special cases because they can take a literal


### PR DESCRIPTION
### What I did
per title, return IRnode from context.new_variable(). additionally, when experimental_codegen is enabled, return an abstract "alloca" object instead of an int. this allows us to treat allocated memory as abstract, which will enable mem2stack and related optimizations.

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
