### PR TITLE
refactor[venom]: use venom pass instances

### DIFF
--- a/tests/unit/compiler/venom/test_dominator_tree.py
+++ b/tests/unit/compiler/venom/test_dominator_tree.py
@@ -70,4 +70,4 @@ def test_phi_placement():
     bb2.insert_instruction(IRInstruction("add", [x, IRLiteral(1)], x), 0)
     bb7.insert_instruction(IRInstruction("mstore", [x, IRLiteral(0)]), 0)
 
-    MakeSSA.run_pass(ctx, bb1)
+    MakeSSA().run_pass(ctx, bb1)

--- a/tests/unit/compiler/venom/test_make_ssa.py
+++ b/tests/unit/compiler/venom/test_make_ssa.py
@@ -31,7 +31,7 @@ def test_phi_case():
     bb.append_instruction("jmp", bb_cont.label)
 
     calculate_cfg(ctx)
-    MakeSSA.run_pass(ctx, ctx.basic_blocks[0])
+    MakeSSA().run_pass(ctx, ctx.basic_blocks[0])
     calculate_liveness(ctx)
 
     condition_block = ctx.get_basic_block("condition")

--- a/tests/unit/compiler/venom/test_multi_entry_block.py
+++ b/tests/unit/compiler/venom/test_multi_entry_block.py
@@ -34,7 +34,7 @@ def test_multi_entry_block_1():
     calculate_cfg(ctx)
     assert not ctx.normalized, "CFG should not be normalized"
 
-    NormalizationPass.run_pass(ctx)
+    NormalizationPass().run_pass(ctx)
 
     assert ctx.normalized, "CFG should be normalized"
 
@@ -86,7 +86,7 @@ def test_multi_entry_block_2():
     calculate_cfg(ctx)
     assert not ctx.normalized, "CFG should not be normalized"
 
-    NormalizationPass.run_pass(ctx)
+    NormalizationPass().run_pass(ctx)
 
     assert ctx.normalized, "CFG should be normalized"
 
@@ -128,7 +128,7 @@ def test_multi_entry_block_with_dynamic_jump():
     calculate_cfg(ctx)
     assert not ctx.normalized, "CFG should not be normalized"
 
-    NormalizationPass.run_pass(ctx)
+    NormalizationPass().run_pass(ctx)
     assert ctx.normalized, "CFG should be normalized"
 
     finish_bb = ctx.get_basic_block(finish_label.value)

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -52,13 +52,14 @@ def _run_passes(ctx: IRFunction, optimize: OptimizationLevel) -> None:
         if bb.label.value.startswith("internal") and len(bb.cfg_in) == 0
     ]
 
-    SimplifyCFGPass.run_pass(ctx, ctx.basic_blocks[0])
+    SimplifyCFGPass().run_pass(ctx, ctx.basic_blocks[0])
     for entry in internals:
-        SimplifyCFGPass.run_pass(ctx, entry)
+        SimplifyCFGPass().run_pass(ctx, entry)
 
-    MakeSSA.run_pass(ctx, ctx.basic_blocks[0])
+    make_ssa_pass = MakeSSA()
+    make_ssa_pass.run_pass(ctx, ctx.basic_blocks[0])
     for entry in internals:
-        MakeSSA.run_pass(ctx, entry)
+        make_ssa_pass.run_pass(ctx, entry)
 
     while True:
         changes = 0
@@ -73,7 +74,7 @@ def _run_passes(ctx: IRFunction, optimize: OptimizationLevel) -> None:
         calculate_cfg(ctx)
         calculate_liveness(ctx)
 
-        changes += DFTPass.run_pass(ctx)
+        changes += DFTPass().run_pass(ctx)
 
         calculate_cfg(ctx)
         calculate_liveness(ctx)

--- a/vyper/venom/passes/base_pass.py
+++ b/vyper/venom/passes/base_pass.py
@@ -4,18 +4,16 @@ class IRPass:
     until no more changes are made.
     """
 
-    @classmethod
-    def run_pass(cls, *args, **kwargs):
-        t = cls()
+    def run_pass(self, *args, **kwargs):
         count = 0
 
         for _ in range(1000):
-            changes_count = t._run_pass(*args, **kwargs) or 0
+            changes_count = self._run_pass(*args, **kwargs) or 0
             count += changes_count
             if changes_count == 0:
                 break
         else:
-            raise Exception("Too many iterations in IR pass!", t.__class__)
+            raise Exception("Too many iterations in IR pass!", self.__class__)
 
         return count
 

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -146,7 +146,7 @@ class VenomCompiler:
 
         # Before emitting the assembly, we need to make sure that the
         # CFG is normalized. Calling calculate_cfg() will denormalize IR (reset)
-        # so it should not be called after calling NormalizationPass.run_pass().
+        # so it should not be called after calling NormalizationPass().run_pass().
         # Liveness is then computed for the normalized IR, and we can proceed to
         # assembly generation.
         # This is a side-effect of how dynamic jumps are temporarily being used

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -152,7 +152,7 @@ class VenomCompiler:
         # This is a side-effect of how dynamic jumps are temporarily being used
         # to support the O(1) dispatcher. -> look into calculate_cfg()
         for ctx in self.ctxs:
-            NormalizationPass.run_pass(ctx)
+            NormalizationPass().run_pass(ctx)
             calculate_cfg(ctx)
             calculate_liveness(ctx)
             calculate_dup_requirements(ctx)


### PR DESCRIPTION
### What I did

I made the pass "manager" to work with instances instead of classes

### How I did it

Updated tha pass handling code, the pass usage code, and the related tests. 

### How to verify it

### Commit message

```
future venom passes that are currently under development require that
the pass manager works with pass instances rather than classes. this is
a common change that should be merged upstream in order to carry around
less changes to future pull requests.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
