### PR TITLE
fix[test]: fix a bad bound in decimal fuzzing

### DIFF
--- a/tests/functional/builtins/codegen/test_convert.py
+++ b/tests/functional/builtins/codegen/test_convert.py
@@ -14,6 +14,7 @@ from vyper.semantics.types import AddressT, BoolT, BytesM_T, BytesT, DecimalT, I
 from vyper.semantics.types.shortcuts import BYTES20_T, BYTES32_T, UINT, UINT160_T, UINT256_T
 from vyper.utils import (
     DECIMAL_DIVISOR,
+    quantize,
     checksum_encode,
     int_bounds,
     is_checksum_encoded,
@@ -414,7 +415,7 @@ def _vyper_literal(val, typ):
         return "0x" + val.hex()
     if isinstance(typ, DecimalT):
         tmp = val
-        val = val.quantize(DECIMAL_EPSILON)
+        val = quantize(val)
         assert tmp == val
     return str(val)
 

--- a/tests/functional/builtins/codegen/test_convert.py
+++ b/tests/functional/builtins/codegen/test_convert.py
@@ -14,10 +14,10 @@ from vyper.semantics.types import AddressT, BoolT, BytesM_T, BytesT, DecimalT, I
 from vyper.semantics.types.shortcuts import BYTES20_T, BYTES32_T, UINT, UINT160_T, UINT256_T
 from vyper.utils import (
     DECIMAL_DIVISOR,
-    quantize,
     checksum_encode,
     int_bounds,
     is_checksum_encoded,
+    quantize,
     round_towards_zero,
     unsigned_to_signed,
 )

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -1,5 +1,5 @@
 import warnings
-from decimal import ROUND_DOWN, Decimal, getcontext
+from decimal import Decimal, getcontext
 
 import pytest
 
@@ -10,7 +10,7 @@ from vyper.exceptions import (
     OverflowException,
     TypeMismatch,
 )
-from vyper.utils import DECIMAL_EPSILON, SizeLimits
+from vyper.utils import DECIMAL_EPSILON, SizeLimits, quantize
 
 
 def test_decimal_override():
@@ -49,10 +49,6 @@ def foo(x: decimal) -> decimal:
     """
     with pytest.raises(InvalidOperation):
         compile_code(code)
-
-
-def quantize(x: Decimal) -> Decimal:
-    return x.quantize(DECIMAL_EPSILON, rounding=ROUND_DOWN)
 
 
 def test_decimal_test(get_contract_with_gas_estimation):

--- a/tests/unit/ast/nodes/test_fold_binop_decimal.py
+++ b/tests/unit/ast/nodes/test_fold_binop_decimal.py
@@ -42,7 +42,7 @@ def foo(a: decimal, b: decimal) -> decimal:
         ExprVisitor().visit(expr, DecimalT())
         new_node = expr.get_folded_value()
         is_valid = True
-    except ZeroDivisionException:
+    except (OverflowException, ZeroDivisionException):
         is_valid = False
 
     if is_valid:

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -26,7 +26,14 @@ from vyper.exceptions import (
     VyperException,
     ZeroDivisionException,
 )
-from vyper.utils import MAX_DECIMAL_PLACES, SizeLimits, annotate_source_code, evm_div, sha256sum
+from vyper.utils import (
+    MAX_DECIMAL_PLACES,
+    SizeLimits,
+    annotate_source_code,
+    evm_div,
+    quantize,
+    sha256sum,
+)
 
 NODE_BASE_ATTRIBUTES = (
     "_children",
@@ -824,6 +831,7 @@ class Decimal(Num):
         return ast_dict
 
     def validate(self):
+        # note: maybe use self.value == quantize(self.value) for this check
         if self.value.as_tuple().exponent < -MAX_DECIMAL_PLACES:
             raise InvalidLiteral("Vyper supports a maximum of ten decimal points", self)
         if self.value < SizeLimits.MIN_AST_DECIMAL:
@@ -1010,9 +1018,7 @@ class Mult(Operator):
         value = left * right
         if isinstance(left, decimal.Decimal):
             # ensure that the result is truncated to MAX_DECIMAL_PLACES
-            return value.quantize(
-                decimal.Decimal(f"{1:0.{MAX_DECIMAL_PLACES}f}"), decimal.ROUND_DOWN
-            )
+            return quantize(value)
         else:
             return value
 
@@ -1036,7 +1042,7 @@ class Div(Operator):
             # the EVM always truncates toward zero
             value = -(-left / right)
         # ensure that the result is truncated to MAX_DECIMAL_PLACES
-        return value.quantize(decimal.Decimal(f"{1:0.{MAX_DECIMAL_PLACES}f}"), decimal.ROUND_DOWN)
+        return quantize(value)
 
 
 class FloorDiv(VyperNode):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -407,6 +407,11 @@ class SizeLimits:
     MAX_UINT256 = 2**256 - 1
 
 
+def quantize(d: decimal.Decimal, places=MAX_DECIMAL_PLACES, rounding_mode=decimal.ROUND_DOWN):
+    quantizer = decimal.Decimal(f"{1:0.{places}f}")
+    return d.quantize(quantizer, rounding_mode)
+
+
 # List of valid IR macros.
 # TODO move this somewhere else, like ir_node.py
 VALID_IR_MACROS = {


### PR DESCRIPTION
fix a fuzz test, fix #2241, improve boundary conditions for some decimal fuzz tests.

### What I did

### How I did it

### How to verify it

### Commit message
```
the decimal fuzz test `is_valid` condition was based on an ancient
version of decimals which had bounds at `-2**127` and `2**127`. update
the condition to be compatible with the latest version of `decimal`.

also increase the range of decimals produced by the decimal fuzzing
strategy, so that the fuzzer finds overflow issues faster.

an additional issue was found in the fuzz tests, which is that some
decimal operations panic with `decimal.InvalidOperation` instead of a
proper exception. this is a known bug, see GH #2241. this fixes the
issue by catching the exception and raising an `OverflowException`.

misc/refactor:
- refactor several uses of quantize into a utility function
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
