### PR TITLE
feat[ci]: update pypi release pipeline to use OIDC

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,5 +1,5 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# upload to pypi using the pypa publish action
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish to PyPI
 
@@ -8,12 +8,18 @@ on:
     types: [published]  # releases and pre-releases (release candidates)
 
 jobs:
-
-  deploy:
+  publish-pypi:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     - name: Python
       uses: actions/setup-python@v5
@@ -29,7 +35,4 @@ jobs:
       run: python setup.py sdist bdist_wheel
 
     - name: Publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: twine upload dist/*
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -11,15 +11,15 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v4
-
-    # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: release
-
+    # https://docs.pypi.org/trusted-publishers/using-a-publisher/
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+
+    steps:
+    - uses: actions/checkout@v4
 
     - name: Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
OIDC is pypi's current recommended best practice (see below). this commit modifies the pypi release pipeline to use the Trusted Publisher mechanism. it has already been configured on the PyPI side.

references:
- https://docs.pypi.org/trusted-publishers/

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
