### PR TITLE
fix[ux]: raise `VersionException` with source info

### DIFF
--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -231,7 +231,7 @@ def test_version_exception_in_import(make_input_bundle):
     lib_version = "~=0.3.10"
 
     lib_pragma = f"#pragma version {lib_version}\n"
-    lib = f"""
+    lib = """
 {lib_pragma}
 @external
 def foo():

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -227,7 +227,7 @@ def test_invalid_pragma(code):
         pre_parse(code)
 
 
-def test_version_conflict_with_imports(make_input_bundle, mock_version):
+def test_version_exception_in_import(make_input_bundle):
     lib_version = "~=0.3.10"
 
     lib_pragma = f"#pragma version {lib_version}\n"

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -229,16 +229,15 @@ def test_invalid_pragma(code):
 
 def test_version_exception_in_import(make_input_bundle):
     lib_version = "~=0.3.10"
+    lib = f"""
+#pragma version {lib_version}
 
-    lib_pragma = f"#pragma version {lib_version}\n"
-    lib = """
-{lib_pragma}
 @external
 def foo():
     pass
     """
 
-    code = f"""
+    code = """
 import lib
 
 uses: lib

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -229,7 +229,6 @@ def test_invalid_pragma(code):
 
 def test_version_conflict_with_imports(make_input_bundle, mock_version):
     lib_version = "~=0.3.10"
-    contract_version = "0.4.0"
 
     lib_pragma = f"#pragma version {lib_version}\n"
     lib = f"""
@@ -239,9 +238,7 @@ def foo():
     pass
     """
 
-    contract_pragma = f"#pragma version {contract_version}\n"
     code = f"""
-{contract_pragma}
 import lib
 
 uses: lib
@@ -252,7 +249,6 @@ def bar():
     """
     input_bundle = make_input_bundle({"lib.vy": lib})
 
-    mock_version(contract_version)
     with pytest.raises(VersionException) as excinfo:
         compile_code(code, input_bundle=input_bundle)
     annotation = excinfo.value.annotations[0]

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -258,4 +258,4 @@ def bar():
     annotation = excinfo.value.annotations[0]
     assert annotation.lineno == 2
     assert annotation.col_offset == 0
-    assert annotation.full_source_code == lib_pragma
+    assert annotation.full_source_code == lib

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -34,9 +34,7 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
         spec = SpecifierSet(version_str)
     except InvalidSpecifier:
         raise VersionException(
-            f'Version specification "{version_str}" is not a valid PEP440 specifier',
-            code,
-            *start
+            f'Version specification "{version_str}" is not a valid PEP440 specifier', code, *start
         )
 
     if not spec.contains(__version__, prereleases=True):
@@ -44,7 +42,7 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
             f'Version specification "{version_str}" is not compatible '
             f'with compiler version "{__version__}"',
             code,
-            *start
+            *start,
         )
 
 

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -15,14 +15,14 @@ from vyper.exceptions import StructureException, SyntaxException, VersionExcepti
 from vyper.typing import ModificationOffsets, ParserPosition
 
 
-def validate_version_pragma(version_str: str, code: str, start: ParserPosition) -> None:
+def validate_version_pragma(version_str: str, full_source_code: str, start: ParserPosition) -> None:
     """
     Validates a version pragma directive against the current compiler version.
     """
     from vyper import __version__
 
     if len(version_str) == 0:
-        raise VersionException("Version specification cannot be empty", code, *start)
+        raise VersionException("Version specification cannot be empty", full_source_code, *start)
 
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):
@@ -34,14 +34,16 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
         spec = SpecifierSet(version_str)
     except InvalidSpecifier:
         raise VersionException(
-            f'Version specification "{version_str}" is not a valid PEP440 specifier', code, *start
+            f'Version specification "{version_str}" is not a valid PEP440 specifier',
+            full_source_code,
+            *start,
         )
 
     if not spec.contains(__version__, prereleases=True):
         raise VersionException(
             f'Version specification "{version_str}" is not compatible '
             f'with compiler version "{__version__}"',
-            code,
+            full_source_code,
             *start,
         )
 
@@ -177,7 +179,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
                     if settings.compiler_version is not None:
                         raise StructureException("compiler version specified twice!", start)
                     compiler_version = contents.removeprefix("@version ").strip()
-                    validate_version_pragma(compiler_version, line, start)
+                    validate_version_pragma(compiler_version, code, start)
                     settings.compiler_version = compiler_version
 
                 if contents.startswith("pragma "):
@@ -186,7 +188,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
                         if settings.compiler_version is not None:
                             raise StructureException("pragma version specified twice!", start)
                         compiler_version = pragma.removeprefix("version ").strip()
-                        validate_version_pragma(compiler_version, line, start)
+                        validate_version_pragma(compiler_version, code, start)
                         settings.compiler_version = compiler_version
 
                     elif pragma.startswith("optimize "):

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -11,19 +11,18 @@ from vyper.compiler.settings import OptimizationLevel, Settings
 # seems a bit early to be importing this but we want it to validate the
 # evm-version pragma
 from vyper.evm.opcodes import EVM_VERSIONS
-from vyper.exceptions import StructureException, SyntaxException, VersionException
+from vyper.exceptions import StructureException, SyntaxException, VersionException, VyperException
 from vyper.typing import ModificationOffsets, ParserPosition
 
 
-def validate_version_pragma(version_str: str, code: str, start: ParserPosition) -> None:
+def _validate_version_pragma(version_str: str) -> None:
     """
     Validates a version pragma directive against the current compiler version.
     """
     from vyper import __version__
 
-    lineno, col_offset = start
     if len(version_str) == 0:
-        raise VersionException("Version specification cannot be empty", code, lineno, col_offset)
+        raise VyperException("Version specification cannot be empty")
 
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):
@@ -34,21 +33,22 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
     try:
         spec = SpecifierSet(version_str)
     except InvalidSpecifier:
-        raise VersionException(
-            f'Version specification "{version_str}" is not a valid PEP440 specifier',
-            code,
-            lineno,
-            col_offset,
+        raise VyperException(
+            f'Version specification "{version_str}" is not a valid PEP440 specifier'
         )
 
     if not spec.contains(__version__, prereleases=True):
-        raise VersionException(
+        raise VyperException(
             f'Version specification "{version_str}" is not compatible '
-            f'with compiler version "{__version__}"',
-            code,
-            lineno,
-            col_offset,
+            f'with compiler version "{__version__}"'
         )
+
+
+def validate_version(version_str: str, code: str, start: ParserPosition) -> None:
+    try:
+        _validate_version_pragma(version_str)
+    except VyperException as e:
+        raise VersionException(e.message, code, *start)
 
 
 class ForParserState(enum.Enum):
@@ -182,7 +182,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
                     if settings.compiler_version is not None:
                         raise StructureException("compiler version specified twice!", start)
                     compiler_version = contents.removeprefix("@version ").strip()
-                    validate_version_pragma(compiler_version, line, start)
+                    validate_version(compiler_version, line, start)
                     settings.compiler_version = compiler_version
 
                 if contents.startswith("pragma "):
@@ -191,7 +191,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
                         if settings.compiler_version is not None:
                             raise StructureException("pragma version specified twice!", start)
                         compiler_version = pragma.removeprefix("version ").strip()
-                        validate_version_pragma(compiler_version, line, start)
+                        validate_version(compiler_version, line, start)
                         settings.compiler_version = compiler_version
 
                     elif pragma.startswith("optimize "):

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -21,9 +21,8 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
     """
     from vyper import __version__
 
-    lineno, col_offset = start
     if len(version_str) == 0:
-        raise VersionException("Version specification cannot be empty", code, lineno, col_offset)
+        raise VersionException("Version specification cannot be empty", code, *start)
 
     # X.Y.Z or vX.Y.Z => ==X.Y.Z, ==vX.Y.Z
     if re.match("[v0-9]", version_str):
@@ -37,8 +36,7 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
         raise VersionException(
             f'Version specification "{version_str}" is not a valid PEP440 specifier',
             code,
-            lineno,
-            col_offset,
+            *start
         )
 
     if not spec.contains(__version__, prereleases=True):
@@ -46,8 +44,7 @@ def validate_version_pragma(version_str: str, code: str, start: ParserPosition) 
             f'Version specification "{version_str}" is not compatible '
             f'with compiler version "{__version__}"',
             code,
-            lineno,
-            col_offset,
+            *start
         )
 
 

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -204,7 +204,7 @@ class InstantiationException(StructureException):
     """Variable or expression cannot be instantiated"""
 
 
-class VersionException(VyperException):
+class VersionException(SyntaxException):
     """Version string is malformed or incompatible with this compiler version."""
 
 


### PR DESCRIPTION
### What I did

Fix #3910.

### How I did it

### How to verify it

See test

### Commit message

```
this commit adds source code information to the exception thrown in
`validate_version_pragma()` to improve user experience when dealing with
imports with invalid (or incompatible) version pragmas.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://m.media-amazon.com/images/I/61+Ycz-pnGL._AC_UF894,1000_QL80_.jpg)
