### PR TITLE
fix[ux]: fix `uses` error message

### DIFF
--- a/tests/functional/syntax/modules/test_initializers.py
+++ b/tests/functional/syntax/modules/test_initializers.py
@@ -915,7 +915,9 @@ initializes: lib1
 
     with pytest.raises(BorrowException) as e:
         compile_code(main, input_bundle=input_bundle)
-    assert e.value._message == "`lib1` is declared as used, but it is not actually used in lib2.vy!"
+    expected = "`lib1` is declared as used, but its state is not"
+    expected += " actually used in lib2.vy!"
+    assert e.value._message == expected
     assert e.value._hint == "delete `uses: lib1`"
 
 
@@ -956,7 +958,9 @@ def foo():
 
     with pytest.raises(BorrowException) as e:
         compile_code(main, input_bundle=input_bundle)
-    assert e.value._message == "`lib1` is declared as used, but it is not actually used in lib2.vy!"
+    expected = "`lib1` is declared as used, but its state is not "
+    expected += "actually used in lib2.vy!"
+    assert e.value._message == expected
     assert e.value._hint == "delete `uses: lib1`"
 
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -315,7 +315,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             err_list = ExceptionList()
             for used_module_info, uses_info in should_use.values():
                 msg = f"`{used_module_info.alias}` is declared as used, but "
-                msg += f"it is not actually used in {module_t}!"
+                msg += f"its state is not actually used in {module_t}!"
                 hint = f"delete `uses: {used_module_info.alias}`"
                 err_list.append(BorrowException(msg, uses_info.node, hint=hint))
 


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
when a stateless module is accidentally declared as being `used` by a
user, the error message is confusing. update the error message to
clarify `uses` refers to state being used.
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
