### PR TITLE
refactor[codegen]: make settings into a global object

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from vyper import compiler
 from vyper.ast.grammar import parse_vyper_source
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.input_bundle import FilesystemInputBundle, InputBundle
-from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings
+from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings, get_global_settings
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import EvmVersionException
 from vyper.ir import compile_ir, optimizer
@@ -373,7 +373,7 @@ def _get_contract(
     input_bundle=None,
     **kwargs,
 ):
-    settings = Settings()
+    settings = get_global_settings()
     settings.optimize = override_opt_level or optimize
     settings.experimental_codegen = experimental_codegen
     out = compiler.compile_code(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.providers.eth_tester import EthereumTesterProvider
 
-import vyper.evm.opcodes as evm
 from tests.utils import working_directory
 from vyper import compiler
 from vyper.ast.grammar import parse_vyper_source
@@ -27,7 +26,7 @@ from vyper.compiler.settings import (
     get_global_settings,
     set_global_settings,
 )
-from vyper.evm.opcodes import version_check
+from vyper.evm.opcodes import EVM_VERSIONS, version_check
 from vyper.exceptions import EvmVersionException
 from vyper.ir import compile_ir, optimizer
 from vyper.utils import ERC5202_PREFIX, keccak256
@@ -70,7 +69,7 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--evm-version",
-        choices=list(evm.EVM_VERSIONS.keys()),
+        choices=list(EVM_VERSIONS.keys()),
         default="shanghai",
         help="set evm version",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.providers.eth_tester import EthereumTesterProvider
 
+import vyper.evm.opcodes as evm
 from tests.utils import working_directory
 from vyper import compiler
 from vyper.ast.grammar import parse_vyper_source
@@ -117,6 +118,7 @@ def evm_version(pytestconfig):
 
 @pytest.fixture(scope="session", autouse=True)
 def global_settings(evm_version, experimental_codegen, optimize, debug):
+    evm.DEFAULT_EVM_VERSION = evm_version
     settings = Settings(
         optimize=optimize,
         evm_version=evm_version,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,12 @@ from vyper import compiler
 from vyper.ast.grammar import parse_vyper_source
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.input_bundle import FilesystemInputBundle, InputBundle
-from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings, get_global_settings
+from vyper.compiler.settings import (
+    OptimizationLevel,
+    Settings,
+    get_global_settings,
+    set_global_settings,
+)
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import EvmVersionException
 from vyper.ir import compile_ir, optimizer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def output_formats():
     return output_formats
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def optimize(pytestconfig):
     flag = pytestconfig.getoption("optimize")
     return OptimizationLevel.from_string(flag)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def optimize(pytestconfig):
     return OptimizationLevel.from_string(flag)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def debug(pytestconfig):
     debug = pytestconfig.getoption("enable_compiler_debug_mode")
     assert isinstance(debug, bool)

--- a/tests/unit/cli/vyper_json/test_get_settings.py
+++ b/tests/unit/cli/vyper_json/test_get_settings.py
@@ -10,7 +10,7 @@ def test_unknown_evm():
 
 
 @pytest.mark.parametrize(
-    "evm_version",
+    "evm_version_str",
     [
         "homestead",
         "tangerineWhistle",
@@ -22,11 +22,11 @@ def test_unknown_evm():
         "berlin",
     ],
 )
-def test_early_evm(evm_version):
+def test_early_evm(evm_version_str):
     with pytest.raises(JSONError):
-        get_evm_version({"settings": {"evmVersion": evm_version}})
+        get_evm_version({"settings": {"evmVersion": evm_version_str}})
 
 
-@pytest.mark.parametrize("evm_version", ["london", "paris", "shanghai", "cancun"])
-def test_valid_evm(evm_version):
-    assert evm_version == get_evm_version({"settings": {"evmVersion": evm_version}})
+@pytest.mark.parametrize("evm_version_str", ["london", "paris", "shanghai", "cancun"])
+def test_valid_evm(evm_version_str):
+    assert evm_version_str == get_evm_version({"settings": {"evmVersion": evm_version_str}})

--- a/tests/unit/compiler/ir/test_optimize_ir.py
+++ b/tests/unit/compiler/ir/test_optimize_ir.py
@@ -1,12 +1,9 @@
 import pytest
 
 from vyper.codegen.ir_node import IRnode
-from vyper.evm.opcodes import EVM_VERSIONS, anchor_evm_version
+from vyper.evm.opcodes import EVM_VERSIONS, anchor_evm_version, version_check
 from vyper.exceptions import StaticAssertionException
 from vyper.ir import optimizer
-
-POST_CANCUN = {k: v for k, v in EVM_VERSIONS.items() if v >= EVM_VERSIONS["cancun"]}
-
 
 optimize_list = [
     (["eq", 1, 2], [0]),
@@ -368,9 +365,9 @@ mload_merge_list = [
 
 
 @pytest.mark.parametrize("ir", mload_merge_list)
-@pytest.mark.parametrize("evm_version", list(POST_CANCUN.keys()))
 def test_mload_merge(ir, evm_version):
-    with anchor_evm_version(evm_version):
+    # TODO: use something like pytest.mark.post_cancun
+    if version_check(begin="cancun"):
         optimized = optimizer.optimize(IRnode.from_list(ir[0]))
         if ir[1] is None:
             # no-op, assert optimizer does nothing
@@ -379,3 +376,5 @@ def test_mload_merge(ir, evm_version):
             expected = IRnode.from_list(ir[1])
 
         assert optimized == expected
+    else:
+        pytest.skip("no mcopy available")

--- a/tests/unit/compiler/ir/test_optimize_ir.py
+++ b/tests/unit/compiler/ir/test_optimize_ir.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper.codegen.ir_node import IRnode
-from vyper.evm.opcodes import EVM_VERSIONS, anchor_evm_version, version_check
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import StaticAssertionException
 from vyper.ir import optimizer
 

--- a/tests/unit/compiler/test_default_settings.py
+++ b/tests/unit/compiler/test_default_settings.py
@@ -15,10 +15,10 @@ def test_default_opt_level():
     assert OptimizationLevel.default() == OptimizationLevel.GAS
 
 
-def test_codegen_opt_level():
-    assert core._opt_gas() is True  # check the default
-    assert core._opt_none() is False
-    assert core._opt_codesize() is False
+def test_codegen_opt_level(optimize):
+    assert core._opt_gas() == (optimize == OptimizationLevel.GAS)
+    assert core._opt_none() == (optimize == OptimizationLevel.NONE)
+    assert core._opt_codesize() == (optimize == OptimizationLevel.CODESIZE)
 
 
 def test_debug_mode(pytestconfig):

--- a/tests/unit/compiler/test_default_settings.py
+++ b/tests/unit/compiler/test_default_settings.py
@@ -16,8 +16,7 @@ def test_default_opt_level():
 
 
 def test_codegen_opt_level():
-    assert core._opt_level == OptimizationLevel.GAS
-    assert core._opt_gas() is True
+    assert core._opt_gas() is True  # check the default
     assert core._opt_none() is False
     assert core._opt_codesize() is False
 

--- a/tests/unit/compiler/test_opcodes.py
+++ b/tests/unit/compiler/test_opcodes.py
@@ -6,16 +6,6 @@ from vyper.evm import opcodes
 from vyper.exceptions import CompilerPanic
 
 
-@pytest.fixture(params=list(opcodes.EVM_VERSIONS))
-def evm_version(request):
-    default = opcodes.active_evm_version
-    try:
-        opcodes.active_evm_version = opcodes.EVM_VERSIONS[request.param]
-        yield request.param
-    finally:
-        opcodes.active_evm_version = default
-
-
 def test_opcodes():
     code = """
 @external

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -11,12 +11,7 @@ import vyper.codegen.ir_node as ir_node
 import vyper.evm.opcodes as evm
 from vyper.cli import vyper_json
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle
-from vyper.compiler.settings import (
-    VYPER_TRACEBACK_LIMIT,
-    OptimizationLevel,
-    Settings,
-    _set_debug_mode,
-)
+from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel, Settings
 from vyper.typing import ContractPath, OutputFormats
 
 T = TypeVar("T")
@@ -172,9 +167,6 @@ def _parse_args(argv):
 
     output_formats = tuple(uniq(args.format.split(",")))
 
-    if args.debug:
-        _set_debug_mode(True)
-
     if args.no_optimize and args.optimize:
         raise ValueError("Cannot use `--no-optimize` and `--optimize` at the same time!")
 
@@ -190,6 +182,9 @@ def _parse_args(argv):
 
     if args.experimental_codegen:
         settings.experimental_codegen = args.experimental_codegen
+
+    if args.debug:
+        settings.debug = settings.debug
 
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -184,7 +184,7 @@ def _parse_args(argv):
         settings.experimental_codegen = args.experimental_codegen
 
     if args.debug:
-        settings.debug = settings.debug
+        settings.debug = args.debug
 
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1,8 +1,5 @@
-import contextlib
-from typing import Generator
-
 from vyper.codegen.ir_node import Encoding, IRnode
-from vyper.compiler.settings import OptimizationLevel
+from vyper.compiler.settings import _opt_codesize, _opt_gas, _opt_none
 from vyper.evm.address_space import (
     CALLDATA,
     DATA,
@@ -914,40 +911,6 @@ def make_setter(left, right):
     assert isinstance(left.typ, (SArrayT, TupleT, StructT))
 
     return _complex_make_setter(left, right)
-
-
-_opt_level = OptimizationLevel.GAS
-
-
-# FIXME: this is to get around the fact that we don't have a
-# proper context object in the IR generation phase.
-@contextlib.contextmanager
-def anchor_opt_level(new_level: OptimizationLevel) -> Generator:
-    """
-    Set the global optimization level variable for the duration of this
-    context manager.
-    """
-    assert isinstance(new_level, OptimizationLevel)
-
-    global _opt_level
-    try:
-        tmp = _opt_level
-        _opt_level = new_level
-        yield
-    finally:
-        _opt_level = tmp
-
-
-def _opt_codesize():
-    return _opt_level == OptimizationLevel.CODESIZE
-
-
-def _opt_gas():
-    return _opt_level == OptimizationLevel.GAS
-
-
-def _opt_none():
-    return _opt_level == OptimizationLevel.NONE
 
 
 def _complex_make_setter(left, right):

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -96,7 +96,8 @@ def compile_from_file_input(
         Compiler output as `{'output key': "output data"}`
     """
 
-    settings = settings or Settings()
+    # global settings can be set in test suite
+    settings = settings or get_global_settings() or Settings()
 
     if output_formats is None:
         output_formats = ("bytecode",)

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -7,7 +7,7 @@ import vyper.codegen.core as codegen
 import vyper.compiler.output as output
 from vyper.compiler.input_bundle import FileInput, InputBundle, PathLike
 from vyper.compiler.phases import CompilerData
-from vyper.compiler.settings import Settings
+from vyper.compiler.settings import Settings, anchor_settings
 from vyper.evm.opcodes import anchor_evm_version
 from vyper.typing import ContractPath, OutputFormats, StorageLayout
 
@@ -117,7 +117,7 @@ def compile_from_file_input(
     )
 
     ret = {}
-    with anchor_evm_version(compiler_data.settings.evm_version):
+    with anchor_settings(compiler_data.settings):
         for output_format in output_formats:
             if output_format not in OUTPUT_FORMATS:
                 raise ValueError(f"Unsupported format type {repr(output_format)}")

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -8,7 +8,6 @@ import vyper.compiler.output as output
 from vyper.compiler.input_bundle import FileInput, InputBundle, PathLike
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import Settings, anchor_settings
-from vyper.evm.opcodes import anchor_evm_version
 from vyper.typing import ContractPath, OutputFormats, StorageLayout
 
 OUTPUT_FORMATS = {

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -95,9 +95,7 @@ def compile_from_file_input(
     Dict
         Compiler output as `{'output key': "output data"}`
     """
-
-    # global settings can be set in test suite
-    settings = settings or get_global_settings() or Settings()
+    settings = settings or Settings()
 
     if output_formats is None:
         output_formats = ("bytecode",)

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -6,10 +6,9 @@ from typing import Optional
 
 from vyper import ast as vy_ast
 from vyper.codegen import module
-from vyper.codegen.core import anchor_opt_level
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle, InputBundle
-from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.compiler.settings import OptimizationLevel, Settings, anchor_settings
 from vyper.exceptions import StructureException
 from vyper.ir import compile_ir, optimizer
 from vyper.semantics import analyze_module, set_data_positions, validate_compilation_target
@@ -178,7 +177,7 @@ class CompilerData:
     @cached_property
     def _ir_output(self):
         # fetch both deployment and runtime IR
-        return generate_ir_nodes(self.global_ctx, self.settings.optimize)
+        return generate_ir_nodes(self.global_ctx, self.settings)
 
     @property
     def ir_nodes(self) -> IRnode:
@@ -268,7 +267,7 @@ def generate_annotated_ast(vyper_module: vy_ast.Module, input_bundle: InputBundl
     return vyper_module
 
 
-def generate_ir_nodes(global_ctx: ModuleT, optimize: OptimizationLevel) -> tuple[IRnode, IRnode]:
+def generate_ir_nodes(global_ctx: ModuleT, settings: Settings) -> tuple[IRnode, IRnode]:
     """
     Generate the intermediate representation (IR) from the contextualized AST.
 
@@ -288,9 +287,9 @@ def generate_ir_nodes(global_ctx: ModuleT, optimize: OptimizationLevel) -> tuple
         IR to generate deployment bytecode
         IR to generate runtime bytecode
     """
-    with anchor_opt_level(optimize):
+    with anchor_settings(settings):
         ir_nodes, ir_runtime = module.generate_ir_for_module(global_ctx)
-    if optimize != OptimizationLevel.NONE:
+    if settings.optimize != OptimizationLevel.NONE:
         ir_nodes = optimizer.optimize(ir_nodes)
         ir_runtime = optimizer.optimize(ir_runtime)
     return ir_nodes, ir_runtime

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -57,7 +57,7 @@ def get_global_settings() -> Optional[Settings]:
 def set_global_settings(new_settings: Optional[Settings]) -> None:
     assert isinstance(new_settings, Settings) or new_settings is None
     # TODO evil circular import
-    from vyper.evm.opcodes import DEFAULT_EVM_VERSION, EVM_VERSIONS, set_global_evm_version
+    from vyper.evm.opcodes import EVM_VERSIONS, set_global_evm_version
 
     global _settings
     _settings = new_settings
@@ -65,10 +65,9 @@ def set_global_settings(new_settings: Optional[Settings]) -> None:
     # set the global evm version so that version_check picks it up.
     # this is a bit spooky, but it's generally always what we want
     # when set_global_settings is called.
-    evm_version = DEFAULT_EVM_VERSION
     if new_settings is not None and new_settings.evm_version is not None:
         evm_version = new_settings.evm_version
-    set_global_evm_version(EVM_VERSIONS[evm_version])
+        set_global_evm_version(EVM_VERSIONS[evm_version])
 
 
 # could maybe refactor this, but it is easier for now than threading settings

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -1,7 +1,8 @@
+import contextlib
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Generator, Optional
 
 VYPER_COLOR_OUTPUT = os.environ.get("VYPER_COLOR_OUTPUT", "0") == "1"
 VYPER_ERROR_CONTEXT_LINES = int(os.environ.get("VYPER_ERROR_CONTEXT_LINES", "1"))
@@ -43,16 +44,61 @@ class Settings:
     optimize: Optional[OptimizationLevel] = None
     evm_version: Optional[str] = None
     experimental_codegen: Optional[bool] = None
+    debug: Optional[bool] = None
 
 
-_DEBUG = False
+_settings = None
+
+
+def get_global_settings() -> Optional[Settings]:
+    return _settings
+
+
+def set_global_settings(new_settings: Optional[Settings]) -> None:
+    assert isinstance(new_settings, Settings) or new_settings is None
+    # TODO evil circular import
+    from vyper.evm.opcodes import DEFAULT_EVM_VERSION, EVM_VERSIONS, set_global_evm_version
+
+    global _settings
+    _settings = new_settings
+
+    # set the global evm version so that version_check picks it up.
+    # this is a bit spooky, but it's generally always what we want
+    # when set_global_settings is called.
+    evm_version = DEFAULT_EVM_VERSION
+    if new_settings is not None and new_settings.evm_version is not None:
+        evm_version = new_settings.evm_version
+    set_global_evm_version(EVM_VERSIONS[evm_version])
+
+
+# could maybe refactor this, but it is easier for now than threading settings
+# around everywhere.
+@contextlib.contextmanager
+def anchor_settings(new_settings: Settings) -> Generator:
+    """
+    Set the globally available settings for the duration of this context manager
+    """
+    assert new_settings is not None
+    global _settings
+    try:
+        tmp = get_global_settings()
+        set_global_settings(new_settings)
+        yield
+    finally:
+        set_global_settings(tmp)
+
+
+def _opt_codesize():
+    return _settings.optimize == OptimizationLevel.CODESIZE
+
+
+def _opt_gas():
+    return _settings.optimize == OptimizationLevel.GAS
+
+
+def _opt_none():
+    return _settings.optimize == OptimizationLevel.NONE
 
 
 def _is_debug_mode():
-    global _DEBUG
-    return _DEBUG
-
-
-def _set_debug_mode(dbg: bool = False) -> None:
-    global _DEBUG
-    _DEBUG = dbg
+    return get_global_settings().debug

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -47,6 +47,7 @@ class Settings:
     debug: Optional[bool] = None
 
 
+# CMC 2024-04-10 do we need it to be Optional?
 _settings = None
 
 
@@ -56,18 +57,9 @@ def get_global_settings() -> Optional[Settings]:
 
 def set_global_settings(new_settings: Optional[Settings]) -> None:
     assert isinstance(new_settings, Settings) or new_settings is None
-    # TODO evil circular import
-    from vyper.evm.opcodes import EVM_VERSIONS, set_global_evm_version
 
     global _settings
     _settings = new_settings
-
-    # set the global evm version so that version_check picks it up.
-    # this is a bit spooky, but it's generally always what we want
-    # when set_global_settings is called.
-    if new_settings is not None and new_settings.evm_version is not None:
-        evm_version = new_settings.evm_version
-        set_global_evm_version(EVM_VERSIONS[evm_version])
 
 
 # could maybe refactor this, but it is easier for now than threading settings

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional
 
+from vyper.compiler.settings import get_global_settings
 from vyper.exceptions import CompilerPanic
 from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRulesetValue, OpcodeValue
 
@@ -13,9 +14,7 @@ from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRules
 _evm_versions = ("london", "paris", "shanghai", "cancun")
 EVM_VERSIONS: dict[str, int] = dict((v, i) for i, v in enumerate(_evm_versions))
 
-
-DEFAULT_EVM_VERSION: str = "shanghai"
-active_evm_version: int = EVM_VERSIONS[DEFAULT_EVM_VERSION]
+DEFAULT_EVM_VERSION = "shanghai"
 
 
 # opcode as hex value
@@ -207,11 +206,6 @@ PSEUDO_OPCODES: OpcodeMap = {
 IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 
-def set_global_evm_version(evm_version: int) -> None:
-    global active_evm_version
-    active_evm_version = evm_version
-
-
 def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:
     gas: OpcodeGasCost = value[3]
     if isinstance(gas, int):
@@ -237,15 +231,23 @@ _ir_opcodes: Dict[int, OpcodeRulesetMap] = {
 }
 
 
+def get_active_evm_version():
+    settings = get_global_settings()
+    evm_version_str = settings and settings.evm_version or DEFAULT_EVM_VERSION
+    return EVM_VERSIONS[evm_version_str]
+
+
 def get_opcodes() -> OpcodeRulesetMap:
-    return _evm_opcodes[active_evm_version]
+    return _evm_opcodes[get_active_evm_version()]
 
 
 def get_ir_opcodes() -> OpcodeRulesetMap:
-    return _ir_opcodes[active_evm_version]
+    return _ir_opcodes[get_active_evm_version()]
 
 
 def version_check(begin: Optional[str] = None, end: Optional[str] = None) -> bool:
+    active_evm_version = get_active_evm_version()
+
     if begin is None and end is None:
         raise CompilerPanic("Either beginning or end fork ruleset must be set.")
     if begin is None:

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -210,7 +210,7 @@ IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 def set_global_evm_version(evm_version: int) -> None:
     global active_evm_version
-    evm_version = evm_version
+    active_evm_version = evm_version
 
 
 @contextlib.contextmanager

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -1,5 +1,4 @@
-import contextlib
-from typing import Dict, Generator, Optional
+from typing import Dict, Optional
 
 from vyper.exceptions import CompilerPanic
 from vyper.typing import OpcodeGasCost, OpcodeMap, OpcodeRulesetMap, OpcodeRulesetValue, OpcodeValue
@@ -211,21 +210,6 @@ IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 def set_global_evm_version(evm_version: int) -> None:
     global active_evm_version
     active_evm_version = evm_version
-
-
-@contextlib.contextmanager
-def anchor_evm_version(evm_version: Optional[str]) -> Generator:
-    global active_evm_version
-    if evm_version is None:
-        evm_version = DEFAULT_EVM_VERSION
-
-    tmp = active_evm_version
-    evm_version_int = EVM_VERSIONS[evm_version]
-    set_global_evm_version(evm_version_int)
-    try:
-        yield
-    finally:
-        set_global_evm_version(tmp)
 
 
 def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -208,16 +208,24 @@ PSEUDO_OPCODES: OpcodeMap = {
 IR_OPCODES: OpcodeMap = {**OPCODES, **PSEUDO_OPCODES}
 
 
-@contextlib.contextmanager
-def anchor_evm_version(evm_version: Optional[str] = None) -> Generator:
+def set_global_evm_version(evm_version: int) -> None:
     global active_evm_version
-    anchor = active_evm_version
-    evm_version = evm_version or DEFAULT_EVM_VERSION
-    active_evm_version = EVM_VERSIONS[evm_version]
+    evm_version = evm_version
+
+
+@contextlib.contextmanager
+def anchor_evm_version(evm_version: Optional[str]) -> Generator:
+    global active_evm_version
+    if evm_version is None:
+        evm_version = DEFAULT_EVM_VERSION
+
+    tmp = active_evm_version
+    evm_version_int = EVM_VERSIONS[evm_version]
+    set_global_evm_version(evm_version_int)
     try:
         yield
     finally:
-        active_evm_version = anchor
+        set_global_evm_version(tmp)
 
 
 def _gas(value: OpcodeValue, idx: int) -> Optional[OpcodeRulesetValue]:

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -4,7 +4,6 @@ import decimal
 import enum
 import functools
 import hashlib
-import itertools
 import sys
 import time
 import traceback

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -4,6 +4,7 @@ import decimal
 import enum
 import functools
 import hashlib
+import itertools
 import sys
 import time
 import traceback


### PR DESCRIPTION
### What I did

### How I did it
cherry-picked relevant commits from https://github.com/vyperlang/vyper/pull/3905

### How to verify it

### Commit message
```
this commit adds a global settings object, unifying various functions
which modify global settings:
anchor_opt_level, anchor_evm_version, _set_debug
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
