### PR TITLE
feat[lang]!: add feature flag for decimals

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.providers.eth_tester import EthereumTesterProvider
 
+import vyper.compiler.settings as compiler_settings
 import vyper.evm.opcodes as evm
 from tests.utils import working_directory
 from vyper import compiler
@@ -119,12 +120,12 @@ def evm_version(pytestconfig):
 @pytest.fixture(scope="session", autouse=True)
 def global_settings(evm_version, experimental_codegen, optimize, debug):
     evm.DEFAULT_EVM_VERSION = evm_version
+    compiler_settings.DEFAULT_ENABLE_DECIMALS = True
     settings = Settings(
         optimize=optimize,
         evm_version=evm_version,
         experimental_codegen=experimental_codegen,
         debug=debug,
-        enable_decimals=True,
     )
     set_global_settings(settings)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,7 @@ def global_settings(evm_version, experimental_codegen, optimize, debug):
         evm_version=evm_version,
         experimental_codegen=experimental_codegen,
         debug=debug,
+        enable_decimals=True,
     )
     set_global_settings(settings)
 

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -5,8 +5,10 @@ import pytest
 
 from tests.utils import decimal_to_int
 from vyper import compile_code
+from vyper.compiler.settings import Settings
 from vyper.exceptions import (
     DecimalOverrideException,
+    FeatureException,
     InvalidOperation,
     OverflowException,
     TypeMismatch,
@@ -317,3 +319,14 @@ def foo():
         compile_code(code)
 
     assert e.value._hint == "did you mean `5.0 / 9.0`?"
+
+
+def test_decimals_blocked():
+    code = """
+@external
+def foo(x: decimal):
+    pass
+    """
+    with pytest.raises(FeatureException) as e:
+        compile_code(code, settings=Settings(enable_decimals=False))
+    assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -3,9 +3,9 @@ from decimal import getcontext
 
 import pytest
 
+import vyper.compiler.settings as compiler_settings
 from tests.utils import decimal_to_int
 from vyper import compile_code
-import vyper.compiler.settings as compiler_settings
 from vyper.exceptions import (
     DecimalOverrideException,
     FeatureException,

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -1,10 +1,10 @@
 import pytest
 
+import vyper.compiler.settings as compiler_settings
 from vyper import compile_code
 from vyper.ast.pre_parser import pre_parse, validate_version_pragma
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings
-import vyper.compiler.settings as compiler_settings
 from vyper.exceptions import StructureException, VersionException
 
 SRC_LINE = (1, 0)  # Dummy source line

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -1,6 +1,5 @@
 import pytest
 
-import vyper.compiler.settings as compiler_settings
 from vyper import compile_code
 from vyper.ast.pre_parser import pre_parse, validate_version_pragma
 from vyper.compiler.phases import CompilerData

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -186,9 +186,8 @@ def test_parse_pragmas(code, pre_parse_settings, compiler_data_settings, mock_ve
         # None is sentinel here meaning that nothing changed
         compiler_data_settings = pre_parse_settings
 
-    # defaults
+    # experimental_codegen is False by default
     compiler_data_settings.experimental_codegen = False
-    compiler_data_settings.enable_decimals = compiler_settings.DEFAULT_ENABLE_DECIMALS
 
     assert compiler_data.settings == compiler_data_settings
 

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -4,6 +4,7 @@ from vyper import compile_code
 from vyper.ast.pre_parser import pre_parse, validate_version_pragma
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings
+import vyper.compiler.settings as compiler_settings
 from vyper.exceptions import StructureException, VersionException
 
 SRC_LINE = (1, 0)  # Dummy source line
@@ -185,8 +186,9 @@ def test_parse_pragmas(code, pre_parse_settings, compiler_data_settings, mock_ve
         # None is sentinel here meaning that nothing changed
         compiler_data_settings = pre_parse_settings
 
-    # cannot be set via pragma, don't check
+    # defaults
     compiler_data_settings.experimental_codegen = False
+    compiler_data_settings.enable_decimals = compiler_settings.DEFAULT_ENABLE_DECIMALS
 
     assert compiler_data.settings == compiler_data_settings
 

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -191,6 +191,7 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
                         validate_version_pragma(compiler_version, code, start)
                         settings.compiler_version = compiler_version
 
+                    # TODO: refactor these to something like Settings.from_pragma
                     elif pragma.startswith("optimize "):
                         if settings.optimize is not None:
                             raise StructureException("pragma optimize specified twice!", start)
@@ -212,6 +213,12 @@ def pre_parse(code: str) -> tuple[Settings, ModificationOffsets, dict, str]:
                                 "pragma experimental-codegen specified twice!", start
                             )
                         settings.experimental_codegen = True
+                    elif pragma.startswith("enable-decimals"):
+                        if settings.enable_decimals is not None:
+                            raise StructureException(
+                                "pragma enable_decimals specified twice!", start
+                            )
+                        settings.enable_decimals = True
 
                     else:
                         raise StructureException(f"Unknown pragma `{pragma.split()[0]}`")

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -147,6 +147,7 @@ def _parse_args(argv):
         action="store_true",
         dest="experimental_codegen",
     )
+    parser.add_argument("--enable-decimals", help="Enable decimals", action="store_true")
 
     args = parser.parse_args(argv)
 
@@ -185,6 +186,9 @@ def _parse_args(argv):
 
     if args.debug:
         settings.debug = args.debug
+
+    if args.enable_decimals:
+        settings.enable_decimals = args.enable_decimals
 
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from pathlib import Path, PurePath
 from typing import Optional
 
+import vyper.compiler.settings as compiler_settings
 from vyper import ast as vy_ast
 from vyper.codegen import module
 from vyper.codegen.ir_node import IRnode
@@ -141,6 +142,9 @@ class CompilerData:
 
         if self.settings.experimental_codegen is None:
             self.settings.experimental_codegen = False
+
+        if self.settings.enable_decimals is None:
+            self.settings.enable_decimals = compiler_settings.DEFAULT_ENABLE_DECIMALS
 
         # note self.settings.compiler_version is erased here as it is
         # not used after pre-parsing

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -37,6 +37,7 @@ def _merge_settings(cli: Settings, pragma: Settings):
     ret.experimental_codegen = _merge_one(
         cli.experimental_codegen, pragma.experimental_codegen, "experimental codegen"
     )
+    ret.enable_decimals = _merge_one(cli.enable_decimals, pragma.enable_decimals, "enable-decimals")
 
     return ret
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -4,7 +4,6 @@ from functools import cached_property
 from pathlib import Path, PurePath
 from typing import Optional
 
-import vyper.compiler.settings as compiler_settings
 from vyper import ast as vy_ast
 from vyper.codegen import module
 from vyper.codegen.ir_node import IRnode
@@ -142,9 +141,6 @@ class CompilerData:
 
         if self.settings.experimental_codegen is None:
             self.settings.experimental_codegen = False
-
-        if self.settings.enable_decimals is None:
-            self.settings.enable_decimals = compiler_settings.DEFAULT_ENABLE_DECIMALS
 
         # note self.settings.compiler_version is erased here as it is
         # not used after pre-parsing

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -50,6 +50,12 @@ class Settings:
     debug: Optional[bool] = None
     enable_decimals: Optional[bool] = None
 
+    # CMC 2024-04-10 consider hiding the `enable_decimals` member altogether
+    def get_enable_decimals(self) -> bool:
+        if self.enable_decimals is None:
+            return DEFAULT_ENABLE_DECIMALS
+        return self.enable_decimals
+
 
 # CMC 2024-04-10 do we need it to be Optional?
 _settings = None

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -38,6 +38,9 @@ class OptimizationLevel(Enum):
         return cls.GAS
 
 
+DEFAULT_ENABLE_DECIMALS = False
+
+
 @dataclass
 class Settings:
     compiler_version: Optional[str] = None

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -45,6 +45,7 @@ class Settings:
     evm_version: Optional[str] = None
     experimental_codegen: Optional[bool] = None
     debug: Optional[bool] = None
+    enable_decimals: Optional[bool] = None
 
 
 # CMC 2024-04-10 do we need it to be Optional?

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -354,6 +354,10 @@ class UnimplementedException(VyperException):
     """Some feature is known to be not implemented"""
 
 
+class FeatureException(VyperException):
+    """Some feature flag is not enabled"""
+
+
 class StaticAssertionException(VyperException):
     """An assertion is proven to fail at compile-time."""
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -20,6 +20,8 @@ from vyper.exceptions import (
     VariableDeclarationException,
     VyperException,
 )
+
+# TODO consolidate some of these imports
 from vyper.semantics.analysis.base import (
     Modifiability,
     ModuleInfo,
@@ -36,8 +38,6 @@ from vyper.semantics.analysis.utils import (
     validate_expected_type,
 )
 from vyper.semantics.data_locations import DataLocation
-
-# TODO consolidate some of these imports
 from vyper.semantics.environment import CONSTANT_ENVIRONMENT_VARS
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types import (
@@ -875,10 +875,7 @@ class ExprVisitor(VyperNodeVisitorBase):
             self.visit(node.right, rtyp)
 
     def visit_Constant(self, node: vy_ast.Constant, typ: VyperType) -> None:
-        if isinstance(typ, DecimalT):
-            settings = get_global_settings()
-            if not settings.enable_decimals:
-                raise VyperException("Decimals are not allowed unless `--enable-decimals` is set")
+        pass
 
     def visit_IfExp(self, node: vy_ast.IfExp, typ: VyperType) -> None:
         self.visit(node.test, BoolT())

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -875,7 +875,10 @@ class ExprVisitor(VyperNodeVisitorBase):
             self.visit(node.right, rtyp)
 
     def visit_Constant(self, node: vy_ast.Constant, typ: VyperType) -> None:
-        pass
+        if isinstance(typ, DecimalT):
+            settings = get_global_settings()
+            if not settings.enable_decimals:
+                raise VyperException("Decimals are not allowed unless `--enable-decimals` is set")
 
     def visit_IfExp(self, node: vy_ast.IfExp, typ: VyperType) -> None:
         self.visit(node.test, BoolT())

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -97,7 +97,7 @@ def type_from_annotation(
     if isinstance(typ, DecimalT):
         # is there a better place to put this check?
         settings = get_global_settings()
-        if settings and not settings.enable_decimals:
+        if settings and not settings.get_enable_decimals():
             raise FeatureException("decimals are not allowed unless `--enable-decimals` is set")
 
     return typ

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -3,12 +3,12 @@ from vyper.compiler.settings import get_global_settings
 from vyper.exceptions import (
     ArrayIndexException,
     CompilerPanic,
+    FeatureException,
     InstantiationException,
     InvalidType,
     StructureException,
     UndeclaredDefinition,
     UnknownType,
-    VyperException,
 )
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.data_locations import DataLocation
@@ -98,7 +98,7 @@ def type_from_annotation(
         # is there a better place to put this check?
         settings = get_global_settings()
         if settings and not settings.enable_decimals:
-            raise VyperException("decimals are not allowed unless `--enable-decimals` is set")
+            raise FeatureException("decimals are not allowed unless `--enable-decimals` is set")
 
     return typ
 


### PR DESCRIPTION
### What I did

depends https://github.com/vyperlang/vyper/pull/3929

### How I did it

### How to verify it

### Commit message

```
hide decimals behind a feature flag. this informally lets us "break the
compatibility contract" with users by moving decimals into
quasi-experimental status; this way we can iterate on the decimals
design faster in the 0.4.x series instead of needing to wait for
breaking releases to make changes.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
