### PR TITLE
chore[tool]: remove `vyper-serve` from `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ setup(
     entry_points={
         "console_scripts": [
             "vyper=vyper.cli.vyper_compile:_parse_cli_args",
-            "vyper-serve=vyper.cli.vyper_serve:_parse_cli_args",
             "fang=vyper.cli.vyper_ir:_parse_cli_args",
             "vyper-json=vyper.cli.vyper_json:_parse_cli_args",
         ]


### PR DESCRIPTION
### What I did

- Removed `vyper-serve` from `setup.py`

### How I did it

- Removed its reference from `entry_points` in `setup.py`

### How to verify it

- N/A

### Commit message

```
remove reference to the vyper-serve entry point; it no longer exists as
of 98f502bae
```
### Description for the changelog

resolves #3935 

### Cute Animal Picture

[Cute hamster](https://unsplash.com/photos/selective-focus-photography-of-brown-hamster-adK3Vu70DEQ)
