### PR TITLE
chore[ci]: reconfigure single commit validation

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -55,5 +55,3 @@ jobs:
           # type[scope]<optional !>: subject
           # use [] instead of () for aesthetics
           headerPattern: '^(\w*)(?:\[([\w$.\-*/ ]*)\])?!?: (.*)$'
-          validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
we don't need to use single commit validation, because in the github
settings for this repository we use "Pull request title and commit
details", instead of the default settings for squash merge.
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
