### PR TITLE
chore[tool]: add help text for `hex-ir` CLI flag

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -137,9 +137,7 @@ def _parse_args(argv):
         action="store_true",
     )
     parser.add_argument(
-        "--hex-ir",
-        help="Represent integers as hex values in the IR",
-        action="store_true",
+        "--hex-ir", help="Represent integers as hex values in the IR", action="store_true"
     )
     parser.add_argument(
         "--path", "-p", help="Set the root path for contract imports", action="append", dest="paths"

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -136,7 +136,11 @@ def _parse_args(argv):
         help="Switch to standard JSON mode. Use `--standard-json -h` for available options.",
         action="store_true",
     )
-    parser.add_argument("--hex-ir", action="store_true")
+    parser.add_argument(
+        "--hex-ir",
+        help="Represent integers as hex values in the IR",
+        action="store_true",
+    )
     parser.add_argument(
         "--path", "-p", help="Set the root path for contract imports", action="append", dest="paths"
     )


### PR DESCRIPTION
### What I did

I noticed `--hex-ir` was missing a help.
Simple PR adds one.

side nit: I notice inconsistencies with CLI help texts... Some start with capital letter, some have periods at the end, etc.

### How I did it

`help=`

### How to verify it

vyper --help

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

woof
