### PR TITLE
chore[ux]: compute natspec as part of standard pipeline

### DIFF
--- a/tests/unit/ast/test_natspec.py
+++ b/tests/unit/ast/test_natspec.py
@@ -431,8 +431,8 @@ def test_natspec_parsed_implicitly():
         parse_natspec(code)
 
     # check we can get ast
-    compile_code(code, output_formats=["annotated_ast_dict"])
+    compile_code(code, output_formats=["ast_dict"])
 
     # anything beyond ast is blocked
     with pytest.raises(NatSpecSyntaxException):
-        compile_code(code, output_formats=["ir_dict"])
+        compile_code(code, output_formats=["annotated_ast_dict"])

--- a/vyper/ast/natspec.py
+++ b/vyper/ast/natspec.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from asttokens import LineNumbers
@@ -11,7 +12,13 @@ PARAM_FIELDS = ("param", "return")
 USERDOCS_FIELDS = ("notice",)
 
 
-def parse_natspec(annotated_vyper_module: vy_ast.Module) -> Tuple[dict, dict]:
+@dataclass
+class NatspecOutput:
+    userdoc: dict
+    devdoc: dict
+
+
+def parse_natspec(annotated_vyper_module: vy_ast.Module) -> NatspecOutput:
     """
     Parses NatSpec documentation from a contract.
 
@@ -63,7 +70,7 @@ def parse_natspec(annotated_vyper_module: vy_ast.Module) -> Tuple[dict, dict]:
             if fn_natspec:
                 devdoc.setdefault("methods", {})[method_id] = fn_natspec
 
-    return userdoc, devdoc
+    return NatspecOutput(userdoc=userdoc, devdoc=devdoc)
 
 
 def _parse_docstring(

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -2,7 +2,7 @@ import warnings
 from collections import deque
 from pathlib import PurePath
 
-from vyper.ast import ast_to_dict, parse_natspec
+from vyper.ast import ast_to_dict
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.utils import build_gas_estimates
@@ -30,13 +30,11 @@ def build_annotated_ast_dict(compiler_data: CompilerData) -> dict:
 
 
 def build_devdoc(compiler_data: CompilerData) -> dict:
-    userdoc, devdoc = parse_natspec(compiler_data.annotated_vyper_module)
-    return devdoc
+    return compiler_data.natspec.devdoc
 
 
 def build_userdoc(compiler_data: CompilerData) -> dict:
-    userdoc, devdoc = parse_natspec(compiler_data.annotated_vyper_module)
-    return userdoc
+    return compiler_data.natspec.userdoc
 
 
 def build_external_interface_output(compiler_data: CompilerData) -> str:

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -152,8 +152,18 @@ class CompilerData:
         return self._generate_ast
 
     @cached_property
+    def _annotate(self) -> tuple[natspec.NatspecOutput, vy_ast.Module]:
+        module = generate_annotated_ast(self.vyper_module, self.input_bundle)
+        nspec = natspec.parse_natspec(module)
+        return nspec, module
+
+    @cached_property
+    def natspec(self) -> natspec.NatspecOutput:
+        return self._annotate[0]
+
+    @cached_property
     def annotated_vyper_module(self) -> vy_ast.Module:
-        return generate_annotated_ast(self.vyper_module, self.input_bundle)
+        return self._annotate[1]
 
     @cached_property
     def compilation_target(self):
@@ -169,10 +179,6 @@ class CompilerData:
     def storage_layout(self) -> StorageLayout:
         module_ast = self.compilation_target
         return set_data_positions(module_ast, self.storage_layout_override)
-
-    @cached_property
-    def natspec(self) -> natspec.NatspecOutput:
-        return natspec.parse_natspec(self.annotated_vyper_module)
 
     @property
     def global_ctx(self) -> ModuleT:

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePath
 from typing import Optional
 
 from vyper import ast as vy_ast
+from vyper.ast import natspec
 from vyper.codegen import module
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle, InputBundle
@@ -169,10 +170,16 @@ class CompilerData:
         module_ast = self.compilation_target
         return set_data_positions(module_ast, self.storage_layout_override)
 
+    @cached_property
+    def natspec(self) -> natspec.NatspecOutput:
+        return natspec.parse_natspec(self.annotated_vyper_module)
+
     @property
     def global_ctx(self) -> ModuleT:
         # ensure storage layout is computed
         _ = self.storage_layout
+        # ensure natspec is computed
+        _ = self.natspec
         return self.annotated_vyper_module._metadata["type"]
 
     @cached_property


### PR DESCRIPTION
### Commit message

```
prior to this commit, natspec had to be explicitly requested by the user
(`-f userdoc`, `-f devdoc` or `-f combined_json`). this would lead to
discrepancies between development time and verification time, where a
contract could compile locally (because no natspec was requested), but
not on the verifier's pipeline (because the verifier would request the
natspec via one of the above methods). this commit computes the natspec
as part of the dependencies of the analysed AST (the reasoning being
that, a consumer might expect semantic analysis to include natspec
validation). so, there is no way to produce bytecode for a contract
without validating natspec.
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
