### PR TITLE
fix[lang]: fix `pow` folding when args are not literals

### DIFF
--- a/tests/functional/codegen/types/numbers/test_exponents.py
+++ b/tests/functional/codegen/types/numbers/test_exponents.py
@@ -17,6 +17,16 @@ def f0():
         compile_code(code)
 
 
+def test_fold_nonliteral(get_contract):
+    # test we can fold non-literal constants
+    code = """
+N: constant(uint256) = 3
+N2: public(constant(uint256)) = N**N
+    """
+    c = get_contract(code)
+    assert c.N2() == 3**3
+
+
 @pytest.mark.fuzzing
 @pytest.mark.parametrize("power", range(2, 255))
 def test_exp_uint256(get_contract, tx_failed, power):

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -151,9 +151,9 @@ class NumericT(_PrimT):
 
         def _get_lr():
             if isinstance(node, vy_ast.BinOp):
-                return node.left, node.right
+                return node.left.reduced(), node.right.reduced()
             elif isinstance(node, vy_ast.AugAssign):
-                return node.target, node.value
+                return node.target.reduced(), node.value.reduced()
             else:
                 raise CompilerPanic(f"Unexpected node type for numeric op: {type(node).__name__}")
 


### PR DESCRIPTION
### What I did
fix #3948 

### How I did it

### How to verify it

### Commit message

```
this commit fixes folding of the `**` operator when the arguments are
constants, but not literals.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
