### PR TITLE
fix[tool]: fix Makefile races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ dev-init:
 test:
 	pytest
 
-lint: mypy black flake8 isort
+lint: black
+	$(MAKE) mypy 
+	$(MAKE) flake8
+	$(MAKE) isort	
 
 mypy:
 	mypy \
@@ -52,7 +55,8 @@ release: clean
 	twine check dist/*
 	#twine upload dist/*
 
-freeze: clean init
+freeze: clean
+	$(MAKE) init
 	echo Generating binary...
 	export OS="$$(uname -s | tr A-Z a-z)" && \
 	export VERSION="$$(PYTHONPATH=. python vyper/cli/vyper_compile.py --version)" && \


### PR DESCRIPTION
### What I did

Made sure that Makefile dependencies execute in order in multicore mode

### How I did it

### How to verify it

### Commit message

```
Makefile dependencies for some targets could overrun each other on `-j n` with `n > 1`. Those where made into commands inside the target.
```

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
