### PR TITLE
fix[codegen]: loop range overflow for signed types

### DIFF
--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -10,7 +10,6 @@ from vyper.codegen.core import (
     bytes_data_ptr,
     clamp,
     clamp_basetype,
-    clamp_le,
     get_bytearray_length,
     int_clamp,
     is_bytes_m_type,
@@ -111,7 +110,8 @@ def _clamp_numeric_convert(arg, arg_bounds, out_bounds, arg_is_signed):
         # out_hi must be smaller than MAX_UINT256, so clample makes sense.
         # add an assertion, just in case this assumption ever changes.
         assert out_hi < 2**256 - 1, "bad assumption in numeric convert"
-        arg = clamp_le(arg, out_hi, arg_is_signed)
+        LE = "sle" if arg_is_signed else "le"
+        arg = clamp(LE, arg, out_hi)
 
     return arg
 

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1182,11 +1182,6 @@ def clamp_nonzero(arg):
         return IRnode.from_list(b1.resolve(ret), typ=arg.typ)
 
 
-def clamp_le(arg, hi, signed):
-    LE = "sle" if signed else "le"
-    return clamp(LE, arg, hi)
-
-
 def clamp2(lo, arg, hi, signed):
     with IRnode.from_list(arg).cache_when_complex("clamp2_arg") as (b1, arg):
         GE = "sge" if signed else "ge"

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -7,7 +7,7 @@ from vyper.codegen.core import (
     LOAD,
     STORE,
     IRnode,
-    clamp_le,
+    clamp2,
     get_dyn_array_count,
     get_element_ptr,
     get_type_for_exact_size,
@@ -199,7 +199,8 @@ class Stmt:
             with end.cache_when_complex("end") as (b1, end):
                 # note: the check for rounds<=rounds_bound happens in asm
                 # generation for `repeat`.
-                clamped_start = clamp_le(start, end, target_type.is_signed)
+                # check: 0 <= start <= end
+                clamped_start = clamp2(0, start, end, target_type.is_signed)
                 rounds = b1.resolve(IRnode.from_list(["sub", end, clamped_start]))
             rounds_bound = kwargs.pop("bound").int_value()
         else:


### PR DESCRIPTION
also inlines the `clamp_le()` function defined in b4429cf83a, since it is only used in one place now (and based on recent bugfixes, `clamp_le` is probably not quite the right abstraction, we need a function which lets us reason about both sides of the bound).

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
