### PR TITLE
fix[docs]: fix clipped `endAuction` method in example section

### DIFF
--- a/docs/vyper-by-example.rst
+++ b/docs/vyper-by-example.rst
@@ -97,7 +97,7 @@ our new ``highestBid`` and ``highestBidder``.
 .. literalinclude:: ../examples/auctions/simple_open_auction.vy
   :language: vyper
   :lineno-start: 60
-  :lines: 60-85
+  :lines: 60-87
 
 With the ``endAuction()`` method, we check whether our current time is past
 the ``auctionEnd`` time we set upon initialization of the contract. We also


### PR DESCRIPTION
### What I did

The `endAuction` method in `vyper-by-example.rst` gets truncated before the beneficiary is sent the highest bid. This updates the line numbers to show the entire method

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.sierraclub.org/sites/default/files/styles/sierra_full_page_width/public/2024-02/SIERRA-OTTERS-WB.jpg.webp?itok=EE5alPbY)
