### PR TITLE
fix[codegen]: same symbol jumpdest merge

### DIFF
--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -3,6 +3,7 @@ import pytest
 from vyper.compiler import compile_code
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.ir.compile_ir import _merge_jumpdests
 
 codes = [
     """
@@ -123,3 +124,15 @@ def foo():
 
     assert "unused1()" not in asm
     assert "unused2()" not in asm
+
+
+asms = [
+    ["_sym_label_1", "JUMP" "PUSH0", "_sym_label_1", "JUMPDEST", "_sym_label_0", "JUMPDEST"],
+    ["_sym_label_0", "JUMP" "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"],
+]
+
+
+@pytest.mark.parametrize("asm", asms)
+def test_merge_jumpdests(asm):
+    assert _merge_jumpdests(asm) == True
+    assert _merge_jumpdests(asm) == False, "Should not 'merge jumpdests' again"

--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -134,5 +134,5 @@ asms = [
 
 @pytest.mark.parametrize("asm", asms)
 def test_merge_jumpdests(asm):
-    assert _merge_jumpdests(asm) == True
-    assert _merge_jumpdests(asm) == False, "Should not 'merge jumpdests' again"
+    assert _merge_jumpdests(asm) is True
+    assert _merge_jumpdests(asm) is False, "Should not 'merge jumpdests' again"

--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -127,6 +127,6 @@ def foo():
 
 
 def test_merge_jumpdests():
-    asm = ["_sym_label_0", "JUMP" "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"]
+    asm = ["_sym_label_0", "JUMP", "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"]
 
     assert _merge_jumpdests(asm) is False, "should not return True as no changes were made"

--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -126,13 +126,8 @@ def foo():
     assert "unused2()" not in asm
 
 
-asms = [
-    ["_sym_label_1", "JUMP" "PUSH0", "_sym_label_1", "JUMPDEST", "_sym_label_0", "JUMPDEST"],
-    ["_sym_label_0", "JUMP" "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"],
-]
-
-
-@pytest.mark.parametrize("asm", asms)
-def test_merge_jumpdests(asm):
-    assert _merge_jumpdests(asm) is True
-    assert _merge_jumpdests(asm) is False, "Should not 'merge jumpdests' again"
+def test_merge_jumpdests():
+    asm = (
+        ["_sym_label_0", "JUMP" "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"],
+    )
+    assert _merge_jumpdests(asm) is False, "should not return True as no changes were made"

--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -127,7 +127,6 @@ def foo():
 
 
 def test_merge_jumpdests():
-    asm = (
-        ["_sym_label_0", "JUMP" "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"],
-    )
+    asm = ["_sym_label_0", "JUMP" "PUSH0", "_sym_label_0", "JUMPDEST", "_sym_label_0", "JUMPDEST"]
+
     assert _merge_jumpdests(asm) is False, "should not return True as no changes were made"

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -892,10 +892,14 @@ def _merge_jumpdests(assembly):
                 # replace all instances of _sym_x with _sym_y
                 # (except for _sym_x JUMPDEST - don't want duplicate labels)
                 new_symbol = assembly[i + 2]
-                for j in range(len(assembly)):
-                    if assembly[j] == current_symbol and i != j:
-                        assembly[j] = new_symbol
-                        changed = True
+                if new_symbol == current_symbol:
+                    del assembly[i : i + 2]
+                    changed = True
+                else:
+                    for j in range(len(assembly)):
+                        if assembly[j] == current_symbol and i != j:
+                            assembly[j] = new_symbol
+                            changed = True
             elif is_symbol(assembly[i + 2]) and assembly[i + 3] == "JUMP":
                 # _sym_x JUMPDEST _sym_y JUMP
                 # replace all instances of _sym_x with _sym_y

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -893,6 +893,8 @@ def _merge_jumpdests(assembly):
                 # (except for _sym_x JUMPDEST - don't want duplicate labels)
                 new_symbol = assembly[i + 2]
                 if new_symbol == current_symbol:
+                    # no need to replace if they are the same
+                    # just delete the extra JUMPDEST
                     del assembly[i : i + 2]
                     changed = True
                 else:

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -892,12 +892,7 @@ def _merge_jumpdests(assembly):
                 # replace all instances of _sym_x with _sym_y
                 # (except for _sym_x JUMPDEST - don't want duplicate labels)
                 new_symbol = assembly[i + 2]
-                if new_symbol == current_symbol:
-                    # no need to replace if they are the same
-                    # just delete the extra JUMPDEST
-                    del assembly[i : i + 2]
-                    changed = True
-                else:
+                if new_symbol != current_symbol:
                     for j in range(len(assembly)):
                         if assembly[j] == current_symbol and i != j:
                             assembly[j] = new_symbol


### PR DESCRIPTION
### What I did

Fixed assembly optimizer case where trying to optimize two consecutive `JUMPDEST`s with the same symbol results in no code change, while returning of `True` in changes. 

### How I did it

Made the optimization step return `False` as it should. 

### How to verify it

Through the included tests

### Commit message

```
Updates the assembly optimizer to return `False` when trying to 
optimize two consecutive `JUMPDEST`s with the same symbol. 
It used to return `True` when no change was made.

+ unit tests
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
