### PR TITLE
fix[lang]: typecheck hashmap indexes with folding

### DIFF
--- a/tests/functional/codegen/storage_variables/test_getters.py
+++ b/tests/functional/codegen/storage_variables/test_getters.py
@@ -121,7 +121,6 @@ def __init__():
         ("int256", "2**256 - 5", TypeMismatch),
         ("int256", "2 * 2**254", TypeMismatch),
         ("int8", "*".join(["2"] * 7), TypeMismatch),
-        ("int256", "*".join(["2"] * 255), TypeMismatch),
     ],
 )
 def test_hashmap_index_checks(typ, index, expected_error):

--- a/tests/functional/codegen/storage_variables/test_getters.py
+++ b/tests/functional/codegen/storage_variables/test_getters.py
@@ -118,7 +118,7 @@ def __init__():
         ("int256", "-2**255", TypeMismatch),
         ("int256", "-2**256", OverflowException),
         ("int256", "2**255", TypeMismatch),
-        ("int256", "2**256 - 5", TypeMismatch),
+        ("int256", "2**256 - 5", OverflowException),
         ("int256", "2 * 2**254", TypeMismatch),
         ("int8", "*".join(["2"] * 7), TypeMismatch),
     ],

--- a/tests/functional/codegen/storage_variables/test_getters.py
+++ b/tests/functional/codegen/storage_variables/test_getters.py
@@ -111,12 +111,17 @@ def __init__():
     [
         ("uint256", "-1", TypeMismatch),
         ("uint256", "0-1", TypeMismatch),
+        ("uint256", "0-1+1", TypeMismatch),
         ("uint256", "2**256", OverflowException),
+        ("uint256", "2**256 // 2", OverflowException),
         ("uint256", "2 * 2**255", OverflowException),
         ("int256", "-2**255", TypeMismatch),
         ("int256", "-2**256", OverflowException),
         ("int256", "2**255", TypeMismatch),
+        ("int256", "2**256 - 5", TypeMismatch),
         ("int256", "2 * 2**254", TypeMismatch),
+        ("int8", "*".join(["2"] * 7), TypeMismatch),
+        ("int256", "*".join(["2"] * 255), TypeMismatch),
     ],
 )
 def test_hashmap_index_checks(typ, index, expected_error):

--- a/tests/functional/codegen/storage_variables/test_getters.py
+++ b/tests/functional/codegen/storage_variables/test_getters.py
@@ -1,3 +1,9 @@
+import pytest
+
+from vyper import compile_code
+from vyper.exceptions import OverflowException, TypeMismatch
+
+
 def test_state_accessor(get_contract):
     state_accessor = """
 y: HashMap[int128, int128]
@@ -98,3 +104,28 @@ def __init__():
         if item["type"] == "constructor":
             continue
         assert item["stateMutability"] == "view"
+
+
+@pytest.mark.parametrize(
+    "typ,index,expected_error",
+    [
+        ("uint256", "-1", TypeMismatch),
+        ("uint256", "0-1", TypeMismatch),
+        ("uint256", "2**256", OverflowException),
+        ("uint256", "2 * 2**255", OverflowException),
+        ("int256", "-2**255", TypeMismatch),
+        ("int256", "-2**256", OverflowException),
+        ("int256", "2**255", TypeMismatch),
+        ("int256", "2 * 2**254", TypeMismatch),
+    ],
+)
+def test_hashmap_index_checks(typ, index, expected_error):
+    code = f"""
+m: HashMap[{typ}, uint256]
+
+@external
+def foo():
+    self.m[{index}] = 2
+    """
+    with pytest.raises(expected_error):
+        compile_code(code)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -917,7 +917,7 @@ class ExprVisitor(VyperNodeVisitorBase):
         # get the correct type for the index, it might
         # not be exactly base_type.key_type
         # note: index_type is validated in types_from_Subscript
-        for index_type in get_possible_types_from_node(node.slice):
+        for index_type in reversed(get_possible_types_from_node(node.slice)):
             if base_type.key_type.compare_type(index_type):
                 break
         else:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -918,10 +918,15 @@ class ExprVisitor(VyperNodeVisitorBase):
         # not be exactly base_type.key_type
         # note: index_type is validated in types_from_Subscript
         index_types = get_possible_types_from_node(node.slice)
-        index_type = index_types.pop()
+        index_type = index_types[0]
 
         self.visit(node.slice, index_type)
         self.visit(node.value, base_type)
+
+        if node.slice.has_folded_value:
+            self.visit(node.slice.get_folded_value(), index_type)
+        if node.value.has_folded_value:
+            self.visit(node.value.get_folded_value(), base_type)
 
     def visit_Tuple(self, node: vy_ast.Tuple, typ: VyperType) -> None:
         if isinstance(typ, TYPE_T):

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -15,6 +15,7 @@ from vyper.exceptions import (
     NonPayableViolation,
     StateAccessViolation,
     StructureException,
+    TypeCheckFailure,
     TypeMismatch,
     VariableDeclarationException,
     VyperException,
@@ -898,15 +899,28 @@ class ExprVisitor(VyperNodeVisitorBase):
             # don't recurse; can't annotate AST children of type definition
             return
 
-        base_type = get_exact_type_from_node(node.value)
-        self.visit(node.value, base_type)
+        if isinstance(node.value, (vy_ast.List, vy_ast.Subscript)):
+            possible_base_types = get_possible_types_from_node(node.value)
+
+            for possible_type in possible_base_types:
+                if typ.compare_type(possible_type.value_type):
+                    base_type = possible_type
+                    break
+            else:
+                # this should have been caught in
+                # `get_possible_types_from_node` but wasn't.
+                raise TypeCheckFailure(f"Expected {typ} but it is not a possible type", node)
+
+        else:
+            base_type = get_exact_type_from_node(node.value)
 
         if isinstance(base_type, HashMapT):
-            # for hash maps we enforce the index to be key_type
             index_type = base_type.key_type
         else:
             # Arrays allow most int types as index: Take the least specific
             index_type = get_possible_types_from_node(node.slice).pop()
+
+        self.visit(node.value, base_type)
         self.visit(node.slice, index_type)
 
     def visit_Tuple(self, node: vy_ast.Tuple, typ: VyperType) -> None:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -917,8 +917,13 @@ class ExprVisitor(VyperNodeVisitorBase):
         # get the correct type for the index, it might
         # not be exactly base_type.key_type
         # note: index_type is validated in types_from_Subscript
-        index_types = get_possible_types_from_node(node.slice)
-        index_type = index_types[0]
+        for index_type in get_possible_types_from_node(node.slice):
+            if base_type.key_type.compare_type(index_type):
+                break
+        else:
+            raise TypeCheckFailure(
+                f"Expected {base_type.key_type} but it is not a possible type", node.slice
+            )
 
         self.visit(node.slice, index_type)
         self.visit(node.value, base_type)

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -37,7 +37,7 @@ class _SubscriptableT(VyperType):
         # TODO: break this cycle
         from vyper.semantics.analysis.utils import validate_expected_type
 
-        validate_expected_type(node, self.key_type)
+        validate_expected_type(node.reduced(), self.key_type)
 
 
 class HashMapT(_SubscriptableT):

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -37,7 +37,7 @@ class _SubscriptableT(VyperType):
         # TODO: break this cycle
         from vyper.semantics.analysis.utils import validate_expected_type
 
-        validate_expected_type(node.reduced(), self.key_type)
+        validate_expected_type(node, self.key_type)
 
 
 class HashMapT(_SubscriptableT):


### PR DESCRIPTION
Fixes #3984

### What I did
- Updated index checks for when the subscript is folded

### How I did it
- Use the reduced (i.e. folded) value when checking the index type

### How to verify it
- Tests are included

### Commit message
```
this commit fixes a bug in typechecking of folded values for hashmap
indexes. there was previously a carveout for subscript typechecking for
arrays; however, it should not apply to hashmap indexes.

this was introduced as an edge case resulting from the semantic changes
in 56c4c9dbc0. a related fix was applied in 75fb0594ab3, but it did not
handle hashmaps.
```

### Description for the changelog
`HashMap index is checked when the subscript is folded`

### Cute Animal Picture
![image](https://github.com/vyperlang/vyper/assets/2369243/58b3757b-d33f-46b9-8542-420fbd722b7d)
