### PR TITLE
fix[venom]: fix return opcode handling in mem2var

### DIFF
--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -55,6 +55,5 @@ class Mem2Var(IRPass):
                     bb = inst.parent
                     idx = bb.instructions.index(inst)
                     bb.insert_instruction(
-                        IRInstruction("mstore", [IRVariable(var_name), inst.operands[1]]),
-                        idx,
+                        IRInstruction("mstore", [IRVariable(var_name), inst.operands[1]]), idx
                     )

--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -53,10 +53,8 @@ class Mem2Var(IRPass):
                     inst.operands = [IRVariable(var_name)]
                 elif inst.opcode == "return":
                     bb = inst.parent
-                    new_var = self.function.get_next_variable()
                     idx = bb.instructions.index(inst)
                     bb.insert_instruction(
-                        IRInstruction("mstore", [IRVariable(var_name), inst.operands[1]], new_var),
+                        IRInstruction("mstore", [IRVariable(var_name), inst.operands[1]]),
                         idx,
                     )
-                    inst.operands[1] = new_var


### PR DESCRIPTION
### What I did

I fixed mem2var that was creating a bogus instruction in certain cases of returning values. 

### How I did it

### How to verify it

### Commit message

```
the `mem2var` venom pass was creating an `mstore` instruction with a
bogus output variable when promoting a variable to memory for `RETURN`s.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
