### PR TITLE
fix[venom]: outputting of data segment in IRContext

### DIFF
--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -68,8 +68,8 @@ class IRContext:
             s.append("\n")
 
         if len(self.data_segment) > 0:
-            s += "\nData segment:\n"
+            s.append("\nData segment:")
             for inst in self.data_segment:
-                s += f"{inst}\n"
+                s.append(f"{inst}")
 
         return "\n".join(s)


### PR DESCRIPTION
### What I did

The data segment output from `IRContext` was printing one character per line. I fixed it.

### How I did it

### How to verify it

### Commit message

```
fix data segment output formatting by `IRContext`
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
