### PR TITLE
chore[test]: add macos to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,47 +148,15 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
 
-  windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [["3.12", "312"]]
-        evm-version: [shanghai]
-        evm-backend: [py-evm]
-
-    name: "py${{ matrix.python-version[1] }}-windows-${{ matrix.evm-version }}-${{ matrix.evm-backend }}"
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-          fetch-depth: 0  # we need the full history for setuptools_scm to infer the version
-
-    - name: Set up Python ${{ matrix.python-version[0] }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version[0] }}
-        cache: "pip"
-
-    - name: Install dependencies
-      run: pip install .[test]
-
-    - name: Run tests
-      run: >
-        pytest
-        -m "not fuzzing"
-        --evm-version ${{ matrix.evm-version }}
-        --evm-backend ${{ matrix.evm-backend }}
-        tests/
-
   core-tests-success:
     if: always()
     # summary result from test matrix.
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7
     runs-on: ubuntu-latest
-    needs: [tests, windows]
+    needs: [tests]
     steps:
       - name: Check tests tests all succeeded
-        if: ${{ needs.tests.result != 'success' || needs.windows.result != 'success' }}
+        if: ${{ needs.tests.result != 'success' }}
         run: exit 1
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
   tests:
     runs-on: ${{ matrix.os || 'ubuntu' }}-latest
     strategy:
-      fail-fast: false  # Todo: remove this once windows tests pass
       matrix:
         os: [ubuntu]
         python-version: [["3.11", "311"]]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,9 @@ jobs:
         experimental-codegen: [false]
         evm-backend: [revm]
 
+        # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
+          # test default settings with 3.11 across all supported evm versions
           - debug: false
             opt-mode: gas
             evm-version: london

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,60 +76,33 @@ jobs:
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           # test default settings with 3.11 across all supported evm versions
-          - debug: false
-            opt-mode: gas
-            evm-version: london
-
-          - debug: false
-            opt-mode: gas
-            evm-version: paris
-
-          - debug: false
-            opt-mode: gas
-            evm-version: cancun
+          - evm-version: london
+          - evm-version: paris
+          - evm-version: cancun
 
           # py-evm rules
-          - debug: false
-            opt-mode: codesize
-            evm-version: london
+          - evm-version: london
             evm-backend: py-evm
-
-          - debug: false
-            opt-mode: gas
-            evm-version: cancun
+          - evm-version: cancun
             evm-backend: py-evm
 
           # test experimental pipeline
-          - opt-mode: gas
-            debug: false
-            experimental-codegen: true
-
-          - opt-mode: codesize
-            debug: false
-            experimental-codegen: true
-
-          - opt-mode: none
-            debug: false
-            experimental-codegen: true
+          - experimental-codegen: true
+          - experimental-codegen: true
+            opt-mode: gas
+          - experimental-codegen: true
+            opt-mode: codesize
 
           # os-specific rules
           - os: windows
-            opt-mode: none
-            debug: false
-
           - os: macos
-            opt-mode: none
-            debug: false
 
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
           - python-version: ["3.10", "310"]
             opt-mode: gas
-            debug: false
-
           - python-version: ["3.12", "312"]
             opt-mode: gas
-            debug: false
 
     name: "py${{ matrix.python-version[1] || '311' }}\
       -opt-${{ matrix.opt-mode || 'none' }}\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,13 +65,8 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu' }}-latest
     strategy:
       matrix:
-        os: [ubuntu]
-        python-version: [["3.11", "311"]]
         opt-mode: ["gas", "none", "codesize"]
         debug: [true, false]
-        evm-version: [shanghai]
-        experimental-codegen: [false]
-        evm-backend: [revm]
 
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
@@ -83,10 +78,6 @@ jobs:
           - debug: false
             opt-mode: gas
             evm-version: paris
-
-          # redundant rule, for clarity
-          - debug: false
-            opt-mode: gas
 
           - debug: false
             opt-mode: gas
@@ -135,7 +126,7 @@ jobs:
             opt-mode: gas
             debug: false
 
-    name: "py${{ matrix.python-version[1] }}\
+    name: "py${{ matrix.python-version[1] || '311' }}\
       -opt-${{ matrix.opt-mode || 'none' }}\
       ${{ matrix.debug && '-debug' || '' }}\
       ${{ matrix.experimental-codegen && '-experimental' || '' }}\
@@ -149,10 +140,10 @@ jobs:
           # need to fetch unshallow so that setuptools_scm can infer the version
           fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version[0] }}
+    - name: Set up Python ${{ matrix.python-version[0] || '3.11' }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version[0] }}
+        python-version: ${{ matrix.python-version[0] || '3.11' }}
         cache: "pip"
 
     - name: Install dependencies
@@ -165,9 +156,9 @@ jobs:
       run: >
         pytest
         -m "not fuzzing"
-        --optimize ${{ matrix.opt-mode }}
-        --evm-version ${{ matrix.evm-version }}
-        ${{ matrix.evm-backend && format('--evm-backend {0}', matrix.evm-backend) || '' }}
+        --optimize ${{ matrix.opt-mode || 'none' }}
+        --evm-version ${{ matrix.evm-version || 'shanghai' }}
+        --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
   # "Regular"/core tests.
   tests:
-    runs-on: ${{ matrix.os || 'ubuntu' }}-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         os: [ubuntu]
@@ -76,39 +76,115 @@ jobs:
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           # test default settings with 3.11 across all supported evm versions
-          - evm-version: london
-          - evm-version: paris
-          - evm-version: cancun
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            debug: false
+            opt-mode: gas
+            evm-version: london
+            evm-backend: revm
+
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            debug: false
+            opt-mode: gas
+            evm-version: paris
+            evm-backend: revm
+
+          # redundant rule, for clarity
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            debug: false
+            opt-mode: gas
+            evm-version: shanghai
+            evm-backend: revm
+
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            debug: false
+            opt-mode: gas
+            evm-version: cancun
+            evm-backend: revm
 
           # py-evm rules
-          - evm-version: london
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            debug: false
+            opt-mode: codesize
+            evm-version: london
             evm-backend: py-evm
-          - evm-version: cancun
+
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            debug: false
+            opt-mode: gas
+            evm-version: cancun
             evm-backend: py-evm
 
           # test experimental pipeline
-          - experimental-codegen: true
-          - experimental-codegen: true
-            opt-mode: none
-          - experimental-codegen: true
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            opt-mode: gas
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: true
+
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             opt-mode: codesize
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: true
+
+          - os: ubuntu
+            python-version: ["3.11", "311"]
+            opt-mode: none
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: true
 
           # os-specific rules
           - os: windows
+            python-version: ["3.12", "312"]
+            opt-mode: none
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: false
+
           - os: macos
+            python-version: ["3.12", "312"]
+            opt-mode: none
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: false
 
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
-          - python-version: ["3.10", "310"]
-          - python-version: ["3.12", "312"]
+          - os: ubuntu
+            python-version: ["3.10", "310"]
+            opt-mode: gas
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
 
-    name: "py${{ matrix.python-version[1] || '311' }}\
-      -opt-${{ matrix.opt-mode || 'gas' }}\
+          - os: ubuntu
+            python-version: ["3.12", "312"]
+            opt-mode: gas
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+
+    name: "py${{ matrix.python-version[1] }}\
+      -opt-${{ matrix.opt-mode }}\
       ${{ matrix.debug && '-debug' || '' }}\
       ${{ matrix.experimental-codegen && '-experimental' || '' }}\
-      -${{ matrix.evm-version || 'shanghai' }}\
-      -${{ matrix.evm-backend || 'revm' }}\
-      -${{ matrix.os || 'ubuntu' }}"
+      -${{ matrix.evm-version }}\
+      -${{ matrix.evm-backend }}\
+      -${{ matrix.os }}"
 
     steps:
     - uses: actions/checkout@v4
@@ -116,10 +192,10 @@ jobs:
           # need to fetch unshallow so that setuptools_scm can infer the version
           fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version[0] || '3.11' }}
+    - name: Set up Python ${{ matrix.python-version[0] }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version[0] || '3.11' }}
+        python-version: ${{ matrix.python-version[0] }}
         cache: "pip"
 
     - name: Install dependencies
@@ -132,9 +208,9 @@ jobs:
       run: >
         pytest
         -m "not fuzzing"
-        --optimize ${{ matrix.opt-mode || 'gas' }}
-        --evm-version ${{ matrix.evm-version || 'shanghai' }}
-        --evm-backend ${{ matrix.evm-backend || 'revm' }}
+        --optimize ${{ matrix.opt-mode }}
+        --evm-version ${{ matrix.evm-version }}
+        --evm-backend ${{ matrix.evm-backend }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
   # "Regular"/core tests.
   tests:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os || 'ubuntu' }}-latest
     strategy:
       matrix:
         os: [ubuntu]
@@ -76,115 +76,39 @@ jobs:
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           # test default settings with 3.11 across all supported evm versions
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
-            opt-mode: gas
-            evm-version: london
-            evm-backend: revm
-
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
-            opt-mode: gas
-            evm-version: paris
-            evm-backend: revm
-
-          # redundant rule, for clarity
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
-            opt-mode: gas
-            evm-version: shanghai
-            evm-backend: revm
-
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
-            opt-mode: gas
-            evm-version: cancun
-            evm-backend: revm
+          - evm-version: london
+          - evm-version: paris
+          - evm-version: cancun
 
           # py-evm rules
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
-            opt-mode: codesize
-            evm-version: london
+          - evm-version: london
             evm-backend: py-evm
-
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
-            opt-mode: gas
-            evm-version: cancun
+          - evm-version: cancun
             evm-backend: py-evm
 
           # test experimental pipeline
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            opt-mode: gas
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: true
-
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            opt-mode: codesize
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: true
-
-          - os: ubuntu
-            python-version: ["3.11", "311"]
+          - experimental-codegen: true
+          - experimental-codegen: true
             opt-mode: none
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: true
+          - experimental-codegen: true
+            opt-mode: codesize
 
           # os-specific rules
           - os: windows
-            python-version: ["3.12", "312"]
-            opt-mode: none
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: false
-
           - os: macos
-            python-version: ["3.12", "312"]
-            opt-mode: none
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: false
 
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
-          - os: ubuntu
-            python-version: ["3.10", "310"]
-            opt-mode: gas
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
+          - python-version: ["3.10", "310"]
+          - python-version: ["3.12", "312"]
 
-          - os: ubuntu
-            python-version: ["3.12", "312"]
-            opt-mode: gas
-            debug: false
-            evm-version: shanghai
-            evm-backend: revm
-
-    name: "py${{ matrix.python-version[1] }}\
-      -opt-${{ matrix.opt-mode }}\
+    name: "py${{ matrix.python-version[1] || '311' }}\
+      -opt-${{ matrix.opt-mode || 'gas' }}\
       ${{ matrix.debug && '-debug' || '' }}\
       ${{ matrix.experimental-codegen && '-experimental' || '' }}\
-      -${{ matrix.evm-version }}\
-      -${{ matrix.evm-backend }}\
-      -${{ matrix.os }}"
+      -${{ matrix.evm-version || 'shanghai' }}\
+      -${{ matrix.evm-backend || 'revm' }}\
+      -${{ matrix.os || 'ubuntu' }}"
 
     steps:
     - uses: actions/checkout@v4
@@ -192,10 +116,10 @@ jobs:
           # need to fetch unshallow so that setuptools_scm can infer the version
           fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version[0] }}
+    - name: Set up Python ${{ matrix.python-version[0] || '3.11' }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version[0] }}
+        python-version: ${{ matrix.python-version[0] || '3.11' }}
         cache: "pip"
 
     - name: Install dependencies
@@ -208,9 +132,9 @@ jobs:
       run: >
         pytest
         -m "not fuzzing"
-        --optimize ${{ matrix.opt-mode }}
-        --evm-version ${{ matrix.evm-version }}
-        --evm-backend ${{ matrix.evm-backend }}
+        --optimize ${{ matrix.opt-mode || 'gas' }}
+        --evm-version ${{ matrix.evm-version || 'shanghai' }}
+        --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
           # test experimental pipeline
           - experimental-codegen: true
           - experimental-codegen: true
-            opt-mode: gas
+            opt-mode: none
           - experimental-codegen: true
             opt-mode: codesize
 
@@ -100,12 +100,10 @@ jobs:
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
           - python-version: ["3.10", "310"]
-            opt-mode: gas
           - python-version: ["3.12", "312"]
-            opt-mode: gas
 
     name: "py${{ matrix.python-version[1] || '311' }}\
-      -opt-${{ matrix.opt-mode || 'none' }}\
+      -opt-${{ matrix.opt-mode || 'gas' }}\
       ${{ matrix.debug && '-debug' || '' }}\
       ${{ matrix.experimental-codegen && '-experimental' || '' }}\
       -${{ matrix.evm-version || 'shanghai' }}\
@@ -134,7 +132,7 @@ jobs:
       run: >
         pytest
         -m "not fuzzing"
-        --optimize ${{ matrix.opt-mode || 'none' }}
+        --optimize ${{ matrix.opt-mode || 'gas' }}
         --evm-version ${{ matrix.evm-version || 'shanghai' }}
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,10 @@ jobs:
 
   # "Regular"/core tests.
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
+        os: [ubuntu]
         python-version: [["3.11", "311"]]
         opt-mode: ["gas", "none", "codesize"]
         debug: [true, false]
@@ -75,75 +76,103 @@ jobs:
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           # test default settings with 3.11 across all supported evm versions
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             debug: false
             opt-mode: gas
             evm-version: london
             evm-backend: revm
 
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             debug: false
             opt-mode: gas
             evm-version: paris
             evm-backend: revm
 
           # redundant rule, for clarity
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             debug: false
             opt-mode: gas
             evm-version: shanghai
             evm-backend: revm
 
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             debug: false
             opt-mode: gas
             evm-version: cancun
             evm-backend: revm
 
           # py-evm rules
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             debug: false
             opt-mode: codesize
             evm-version: london
             evm-backend: py-evm
 
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             debug: false
             opt-mode: gas
             evm-version: cancun
             evm-backend: py-evm
 
           # test experimental pipeline
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             opt-mode: gas
             debug: false
             evm-version: shanghai
             evm-backend: revm
             experimental-codegen: true
 
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             opt-mode: codesize
             debug: false
             evm-version: shanghai
             evm-backend: revm
             experimental-codegen: true
 
-          - python-version: ["3.11", "311"]
+          - os: ubuntu
+            python-version: ["3.11", "311"]
             opt-mode: none
             debug: false
             evm-version: shanghai
             evm-backend: revm
             experimental-codegen: true
 
+          # os-specific rules
+          - os: windows
+            python-version: ["3.12", "312"]
+            opt-mode: none
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: false
+
+          - os: macos
+            python-version: ["3.12", "312"]
+            opt-mode: none
+            debug: false
+            evm-version: shanghai
+            evm-backend: revm
+            experimental-codegen: false
+
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
-          - python-version: ["3.10", "310"]
+          - os: ubuntu
+            python-version: ["3.10", "310"]
             opt-mode: gas
             debug: false
             evm-version: shanghai
             evm-backend: revm
 
-          - python-version: ["3.12", "312"]
+          - os: ubuntu
+            python-version: ["3.12", "312"]
             opt-mode: gas
             debug: false
             evm-version: shanghai
@@ -154,7 +183,8 @@ jobs:
       ${{ matrix.debug && '-debug' || '' }}\
       ${{ matrix.experimental-codegen && '-experimental' || '' }}\
       -${{ matrix.evm-version }}\
-      -${{ matrix.evm-backend }}"
+      -${{ matrix.evm-backend }}\
+      -${{ matrix.os }}"
 
     steps:
     - uses: actions/checkout@v4
@@ -175,17 +205,17 @@ jobs:
       run: pip freeze
 
     - name: Run tests
-      run: |
-        pytest \
-          -m "not fuzzing" \
-          --optimize ${{ matrix.opt-mode }} \
-          --evm-version ${{ matrix.evm-version }} \
-          ${{ matrix.evm-backend && format('--evm-backend {0}', matrix.evm-backend) || '' }} \
-          ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }} \
-          ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }} \
-          --cov-branch \
-          --cov-report xml:coverage.xml \
-          --cov=vyper \
+      run: >
+        pytest
+          -m "not fuzzing"
+          --optimize ${{ matrix.opt-mode }}
+          --evm-version ${{ matrix.evm-version }}
+          ${{ matrix.evm-backend && format('--evm-backend {0}', matrix.evm-backend) || '' }}
+          ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
+          ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
+          --cov-branch
+          --cov-report xml:coverage.xml
+          --cov=vyper
           tests/
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,16 +164,16 @@ jobs:
     - name: Run tests
       run: >
         pytest
-          -m "not fuzzing"
-          --optimize ${{ matrix.opt-mode }}
-          --evm-version ${{ matrix.evm-version }}
-          ${{ matrix.evm-backend && format('--evm-backend {0}', matrix.evm-backend) || '' }}
-          ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
-          ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
-          --cov-branch
-          --cov-report xml:coverage.xml
-          --cov=vyper
-          tests/
+        -m "not fuzzing"
+        --optimize ${{ matrix.opt-mode }}
+        --evm-version ${{ matrix.evm-version }}
+        ${{ matrix.evm-backend && format('--evm-backend {0}', matrix.evm-backend) || '' }}
+        ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
+        ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
+        --cov-branch
+        --cov-report xml:coverage.xml
+        --cov=vyper
+        tests/
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,13 +64,17 @@ jobs:
   tests:
     runs-on: ${{ matrix.os || 'ubuntu' }}-latest
     strategy:
+      fail-fast: false  # Todo: remove this once windows tests pass
       matrix:
-        opt-mode: ["gas", "none", "codesize"]
+        os: [ubuntu]
+        python-version: [["3.11", "311"]]
+        opt-mode: [gas, none, codesize]
         debug: [true, false]
+        evm-version: [shanghai]
+        experimental-codegen: [false]
+        evm-backend: [revm]
 
-        # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
-          # test default settings with 3.11 across all supported evm versions
           - debug: false
             opt-mode: gas
             evm-version: london

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
   # "Regular"/core tests.
   tests:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os || 'ubuntu' }}-latest
     strategy:
       matrix:
         os: [ubuntu]
@@ -136,12 +136,12 @@ jobs:
             debug: false
 
     name: "py${{ matrix.python-version[1] }}\
-      -opt-${{ matrix.opt-mode }}\
+      -opt-${{ matrix.opt-mode || 'none' }}\
       ${{ matrix.debug && '-debug' || '' }}\
       ${{ matrix.experimental-codegen && '-experimental' || '' }}\
-      -${{ matrix.evm-version }}\
-      -${{ matrix.evm-backend }}\
-      -${{ matrix.os }}"
+      -${{ matrix.evm-version || 'shanghai' }}\
+      -${{ matrix.evm-backend || 'revm' }}\
+      -${{ matrix.os || 'ubuntu' }}"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,107 +76,64 @@ jobs:
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           # test default settings with 3.11 across all supported evm versions
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
+          - debug: false
             opt-mode: gas
             evm-version: london
-            evm-backend: revm
 
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
+          - debug: false
             opt-mode: gas
             evm-version: paris
-            evm-backend: revm
 
           # redundant rule, for clarity
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
+          - debug: false
             opt-mode: gas
-            evm-version: shanghai
-            evm-backend: revm
 
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
+          - debug: false
             opt-mode: gas
             evm-version: cancun
-            evm-backend: revm
 
           # py-evm rules
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
+          - debug: false
             opt-mode: codesize
             evm-version: london
             evm-backend: py-evm
 
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            debug: false
+          - debug: false
             opt-mode: gas
             evm-version: cancun
             evm-backend: py-evm
 
           # test experimental pipeline
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            opt-mode: gas
+          - opt-mode: gas
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
             experimental-codegen: true
 
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            opt-mode: codesize
+          - opt-mode: codesize
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
             experimental-codegen: true
 
-          - os: ubuntu
-            python-version: ["3.11", "311"]
-            opt-mode: none
+          - opt-mode: none
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
             experimental-codegen: true
 
           # os-specific rules
           - os: windows
-            python-version: ["3.12", "312"]
             opt-mode: none
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: false
 
           - os: macos
-            python-version: ["3.12", "312"]
             opt-mode: none
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
-            experimental-codegen: false
 
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
-          - os: ubuntu
-            python-version: ["3.10", "310"]
+          - python-version: ["3.10", "310"]
             opt-mode: gas
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
 
-          - os: ubuntu
-            python-version: ["3.12", "312"]
+          - python-version: ["3.12", "312"]
             opt-mode: gas
             debug: false
-            evm-version: shanghai
-            evm-backend: revm
 
     name: "py${{ matrix.python-version[1] }}\
       -opt-${{ matrix.opt-mode }}\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,13 +63,24 @@ jobs:
   # "Regular"/core tests.
   tests:
     runs-on: ${{ matrix.os || 'ubuntu' }}-latest
+    # IMPORTANT: Test defaults are duplicated in the "Run tests" step below!
+    # it is annoying that we need to duplicate them, but it is necessary
+    # to avoid repeating defaults for every "include" in the matrix.
+    name: "${{ matrix.os && matrix.os != 'ubuntu' && format('{0}-', matrix.os) || '' }}\
+      py${{ matrix.python-version[1] || '311' }}\
+      -opt-${{ matrix.opt-mode || 'gas' }}\
+      ${{ matrix.debug && '-debug' || '' }}\
+      ${{ matrix.experimental-codegen && '-experimental' || '' }}\
+      -${{ matrix.evm-version || 'shanghai' }}\
+      -${{ matrix.evm-backend || 'revm' }}"
     strategy:
       matrix:
+        # declare all variables used in the "include" section here! Conflicting jobs get overwritten by GitHub actions.
         os: [ubuntu]
-        python-version: [["3.11", "311"]]
+        python-version: [["3.11", "311"]]  # note: do not forget to replace 311 in the job names when upgrading!
         opt-mode: [gas, none, codesize]
         debug: [true, false]
-        evm-version: [shanghai]
+        evm-version: [shanghai]  # note: when upgrading, check the "include" section below for conflicting jobs
         experimental-codegen: [false]
         evm-backend: [revm]
 
@@ -81,10 +92,9 @@ jobs:
           - evm-version: cancun
 
           # py-evm rules
-          - evm-version: london
-            evm-backend: py-evm
-          - evm-version: cancun
-            evm-backend: py-evm
+          - evm-backend: py-evm
+          - evm-backend: py-evm
+            evm-version: cancun
 
           # test experimental pipeline
           - experimental-codegen: true
@@ -101,14 +111,6 @@ jobs:
           # modes across all python versions - one is enough
           - python-version: ["3.10", "310"]
           - python-version: ["3.12", "312"]
-
-    name: "py${{ matrix.python-version[1] || '311' }}\
-      -opt-${{ matrix.opt-mode || 'gas' }}\
-      ${{ matrix.debug && '-debug' || '' }}\
-      ${{ matrix.experimental-codegen && '-experimental' || '' }}\
-      -${{ matrix.evm-version || 'shanghai' }}\
-      -${{ matrix.evm-backend || 'revm' }}\
-      -${{ matrix.os || 'ubuntu' }}"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,14 +103,14 @@ jobs:
           - experimental-codegen: true
             opt-mode: codesize
 
-          # os-specific rules
-          - os: windows
-          - os: macos
-
           # run across other python versions. we don't really need to run all
           # modes across all python versions - one is enough
           - python-version: ["3.10", "310"]
           - python-version: ["3.12", "312"]
+
+          # os-specific rules
+          - os: windows
+          - os: macos
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### What I did
- Expanded the matrix to include macos and windows tests
- Removed unnecessary lines from the matrix definition

### How I did it
- All default values must be in the top-level matrix definition
- The `includes` section should contain alternative runs - these will not have all default values defined
  - Therefore reading from the matrix requires passing default values again
  - However we can still delete a lot of repetition

### How to verify it
- Tests should pass. We should have 2 extra jobs and the existing ones should keep on existing.

### Commit message

```
- Expanded the matrix to include macos and windows tests
- Refactor the matrix and removed unnecessary lines
- Remove now-redundant windows job

Note that all because of the way github creates matrix jobs, default
values must be in the top-level matrix definition. The includes section
should contain alternative runs - these will not have all default values
defined, therefore reading from the matrix requires passing default
values again.
```

### Description for the changelog
N/A

### Cute Animal Picture
![image](https://github.com/vyperlang/vyper/assets/2369243/390439e2-b3f4-43cb-86c6-6460410fe7e6)
