### PR TITLE
fix[codegen]: fix double eval in dynarray append/pop

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -401,7 +401,7 @@ def append_dyn_array(darray_node, elem_node):
             )
 
             # store new length
-            ret.append(ensure_eval_once(STORE(darray_node, ["add", len_, 1])))
+            ret.append(ensure_eval_once("append_dynarray", STORE(darray_node, ["add", len_, 1])))
 
             return IRnode.from_list(b1.resolve(b2.resolve(ret)))
 
@@ -416,7 +416,7 @@ def pop_dyn_array(darray_node, return_popped_item):
 
         with new_len.cache_when_complex("new_len") as (b2, new_len):
             # store new length
-            ret.append(ensure_eval_once(STORE(darray_node, new_len)))
+            ret.append(ensure_eval_once("pop_dynarray", STORE(darray_node, new_len)))
 
             # NOTE skip array bounds check bc we already asserted len two lines up
             if return_popped_item:

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -401,7 +401,8 @@ def append_dyn_array(darray_node, elem_node):
             )
 
             # store new length
-            ret.append(STORE(darray_node, ["add", len_, 1]))
+            ret.append(ensure_eval_once(STORE(darray_node, ["add", len_, 1])))
+
             return IRnode.from_list(b1.resolve(b2.resolve(ret)))
 
 
@@ -415,7 +416,7 @@ def pop_dyn_array(darray_node, return_popped_item):
 
         with new_len.cache_when_complex("new_len") as (b2, new_len):
             # store new length
-            ret.append(STORE(darray_node, new_len))
+            ret.append(ensure_eval_once(STORE(darray_node, new_len)))
 
             # NOTE skip array bounds check bc we already asserted len two lines up
             if return_popped_item:


### PR DESCRIPTION
append/pop does not have an eval once fence for the cases where it is in memory. add a fence.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
