### PR TITLE
chore[docs]: `implements` does not check event declarations

### DIFF
--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -182,11 +182,16 @@ You can define an interface for your contract with the ``implements`` statement:
     implements: FooBarInterface
 
 
-This imports the defined interface from the vyper file at ``an_interface.vy`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20. Please note that ``implements`` does not check if events defined in an interface are emitted.
+This imports the defined interface from the vyper file at ``an_interface.vy`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20.
 
 .. note::
 
   Interfaces that implement functions with return values that require an upper bound (e.g. ``Bytes``, ``DynArray``, or ``String``), the upper bound defined in the interface represents the lower bound of the implementation. Assuming a function ``my_func`` returns a value ``String[1]`` in the interface, this would mean for the implementation function of ``my_func`` that the return value must have **at least** length 1. This behavior might change in the future.
+
+.. note::
+
+  Prior to v0.4.0, ``implements`` required that events defined in an interface were re-defined in the top-level contract. As of v0.4.0, this is no longer required because events can be used just by importing them. Any events used in a contract will automatically be exported in the ABI output.
+
 
 Extracting Interfaces
 =====================

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -190,7 +190,7 @@ This imports the defined interface from the vyper file at ``an_interface.vy`` (o
 
 .. note::
 
-  Prior to v0.4.0, ``implements`` required that events defined in an interface were re-defined in the top-level contract. As of v0.4.0, this is no longer required because events can be used just by importing them. Any events used in a contract will automatically be exported in the ABI output.
+  Prior to v0.4.0, ``implements`` required that events defined in an interface were re-defined in the "implementing" contract. As of v0.4.0, this is no longer required because events can be used just by importing them. Any events used in a contract will automatically be exported in the ABI output.
 
 
 Extracting Interfaces

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -182,7 +182,7 @@ You can define an interface for your contract with the ``implements`` statement:
     implements: FooBarInterface
 
 
-This imports the defined interface from the vyper file at ``an_interface.vy`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20.
+This imports the defined interface from the vyper file at ``an_interface.vy`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20. Please note that ``implements`` does not check if events defined in an interface are emitted.
 
 .. note::
 


### PR DESCRIPTION
### What I did

Add a note in the docs that `implements` does not check emitted events.

### How I did it

Brain.

### How to verify it

Use hard skills.

### Commit message

```console
as of v0.4.0, `implements` does not check that events are (re-)defined
in the implementing contract
```

### Description for the changelog

Add a note in the docs that `implements` does not check emitted events.

### Cute Animal Picture

![image](https://github.com/vyperlang/vyper/assets/25297591/4d6308a5-faa1-4444-abb6-65d6265cd6ef)