### PR TITLE
feat[venom]: improve unused variable removal pass

### DIFF
--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -45,8 +45,15 @@ class OrderedSet(Generic[_T]):
     def first(self):
         return next(iter(self))
 
+    def pop(self):
+        return self._data.popitem()[0]
+
     def add(self, item: _T) -> None:
         self._data[item] = None
+
+    def addmany(self, iterable):
+        for item in iterable:
+            self._data[item] = None
 
     def remove(self, item: _T) -> None:
         del self._data[item]

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 from vyper.codegen.ir_node import IRnode
 from vyper.compiler.settings import OptimizationLevel
 from vyper.venom.analysis.analysis import IRAnalysesCache
-from vyper.venom.analysis.liveness import LivenessAnalysis
 from vyper.venom.context import IRContext
 from vyper.venom.function import IRFunction
 from vyper.venom.ir_node_to_venom import ir_node_to_venom

--- a/vyper/venom/analysis/dfg.py
+++ b/vyper/venom/analysis/dfg.py
@@ -22,10 +22,9 @@ class DFGAnalysis(IRAnalysis):
     def get_producing_instruction(self, op: IRVariable) -> Optional[IRInstruction]:
         return self._dfg_outputs.get(op)
 
-    def remove_use(self, op: IRVariable, inst: IRInstruction) -> list[IRInstruction]:
+    def remove_use(self, op: IRVariable, inst: IRInstruction):
         uses = self._dfg_inputs.get(op, [])
         uses.remove(inst)
-        return uses
 
     @property
     def outputs(self) -> dict[IRVariable, IRInstruction]:

--- a/vyper/venom/analysis/dfg.py
+++ b/vyper/venom/analysis/dfg.py
@@ -22,6 +22,11 @@ class DFGAnalysis(IRAnalysis):
     def get_producing_instruction(self, op: IRVariable) -> Optional[IRInstruction]:
         return self._dfg_outputs.get(op)
 
+    def remove_use(self, op: IRVariable, inst: IRInstruction) -> list[IRInstruction]:
+        uses = self._dfg_inputs.get(op, [])
+        uses.remove(inst)
+        return uses
+
     @property
     def outputs(self) -> dict[IRVariable, IRInstruction]:
         return self._dfg_outputs

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -8,6 +8,7 @@ class RemoveUnusedVariablesPass(IRPass):
     """
     This pass removes instructions that produce output that is never used.
     """
+
     dfg: DFGAnalysis
     work_list: OrderedSet[IRInstruction]
 

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -14,8 +14,8 @@ class RemoveUnusedVariablesPass(IRPass):
         work_list = OrderedSet()
         self.work_list = work_list
 
-        for bb in self.function.get_basic_blocks():
-            work_list.addmany(bb.instructions)
+        for _, inst in self.dfg.outputs.items():
+            work_list.add(inst)
 
         while len(work_list) > 0:
             inst = work_list.pop()

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -18,8 +18,8 @@ class RemoveUnusedVariablesPass(IRPass):
         work_list = OrderedSet()
         self.work_list = work_list
 
-        for _, inst in self.dfg.outputs.items():
-            work_list.add(inst)
+        uses = self.dfg.outputs.values()
+        work_list.addmany(uses)
 
         while len(work_list) > 0:
             inst = work_list.pop()
@@ -35,8 +35,8 @@ class RemoveUnusedVariablesPass(IRPass):
             return
 
         for operand in inst.get_inputs():
-            new_uses = self.dfg.remove_use(operand, inst)
-            for use in new_uses:
-                self.work_list.add(use)
+            self.dfg.remove_use(operand, inst)
+            new_uses = self.dfg.get_uses(operand)
+            self.work_list.addmany(new_uses)
 
         inst.parent.remove_instruction(inst)

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -5,6 +5,9 @@ from vyper.venom.passes.base_pass import IRPass
 
 
 class RemoveUnusedVariablesPass(IRPass):
+    """
+    This pass removes instructions that produce output that is never used.
+    """
     dfg: DFGAnalysis
     work_list: OrderedSet[IRInstruction]
 
@@ -22,9 +25,6 @@ class RemoveUnusedVariablesPass(IRPass):
             self._process_instruction(inst)
 
     def _process_instruction(self, inst):
-        """
-        Process an instruction.
-        """
         if inst.output is None:
             return
         if inst.volatile:


### PR DESCRIPTION
### What I did

Implemented a better variable elimination pass. This new implementation is efficient and manages to remove all unused variables in one run.

Additionally, this PR adds some extra utility functions to `OrderedSet()`

### How I did it

### How to verify it

### Commit message

```
This commit improves the variable elimination pass by efficiently removing 
all instructions that produce unused output. This new algorithm removes all
unused variables in one run.

Additionally, it adds the utility functions `pop()` and `addmany()` to the
`OrderedSet()` class.

The `DFTAnalysis` is also augmented with a method to remove uses:
`remove_use(self, op: IRVariable, inst: IRInstruction)`
```

### Description for the changelog

### Cute Animal Picture

```
                 __
                / _)--< 
       _.----._/ /          
     /          /  Dinosnek          
 __/ (  |  (   |             
/__.-'|_|--|__|             
```
