### PR TITLE
feat[ci]: add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.com/docs/codecovyml-reference
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        #target: auto
+        threshold: 0.5%
+        #base: auto 


### PR DESCRIPTION
set threshold for reporting codecov failure at -0.5%, there is usually some noise in the coverage (+-0.1% or so) from fuzzing.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
