### PR TITLE
fix[codegen]: fix `make_setter` overlap in `dynarray_append`

### DIFF
--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -67,6 +67,7 @@ class VariableRecord:
             mutable=self.mutable,
             location=self.location,
         )
+        # CMC 2024-05-28 this seems not used?
         ret._referenced_variables = {self}
         if self.alloca is not None:
             ret.passthrough_metadata["alloca"] = self.alloca

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -67,8 +67,6 @@ class VariableRecord:
             mutable=self.mutable,
             location=self.location,
         )
-        # CMC 2024-05-28 this seems not used?
-        ret._referenced_variables = {self}
         if self.alloca is not None:
             ret.passthrough_metadata["alloca"] = self.alloca
         return ret

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -176,7 +176,7 @@ class Expr:
         assert varinfo is not None
 
         # local variable
-        if varinfo.is_local_variable():
+        if varname in self.context.vars:
             ret = self.context.lookup_var(varname).as_ir_node()
             ret._referenced_variables = {varinfo}
             return ret

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -170,7 +170,11 @@ class Expr:
         if self.expr.id == "self":
             return IRnode.from_list(["address"], typ=AddressT())
         elif self.expr.id in self.context.vars:
-            return self.context.lookup_var(self.expr.id).as_ir_node()
+            ret = self.context.lookup_var(self.expr.id).as_ir_node()
+            varinfo = self.expr._expr_info.var_info
+            assert varinfo is not None
+            ret._referenced_variables = {varinfo}
+            return ret
 
         elif (varinfo := self.expr._expr_info.var_info) is not None:
             if varinfo.is_constant:

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -13,6 +13,7 @@ from vyper.codegen.core import (
     get_element_ptr,
     get_type_for_exact_size,
     make_setter,
+    potential_overlap,
     wrap_value_for_external_return,
     writeable,
 )
@@ -70,10 +71,7 @@ class Stmt:
         dst = self._get_target(self.stmt.target)
 
         ret = ["seq"]
-        overlap = len(dst.referenced_variables & src.referenced_variables) > 0
-        overlap |= len(dst.referenced_variables) > 0 and src.contains_risky_call
-        overlap |= dst.contains_risky_call and len(src.referenced_variables) > 0
-        if overlap and not dst.typ._is_prim_word:
+        if potential_overlap(dst, src):
             # there is overlap between the lhs and rhs, and the type is
             # complex - i.e., it spans multiple words. for safety, we
             # copy to a temporary buffer before copying to the destination.

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -204,9 +204,6 @@ class VarInfo:
         # variable (it is magic), so we ignore it here.
         return self.location not in non_state_locations and not isinstance(self.typ, SelfT)
 
-    def is_local_variable(self):
-        return self.location in (DataLocation.MEMORY, DataLocation.CALLDATA)
-
     def get_size(self) -> int:
         return self.typ.get_size_in(self.location)
 

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -204,6 +204,9 @@ class VarInfo:
         # variable (it is magic), so we ignore it here.
         return self.location not in non_state_locations and not isinstance(self.typ, SelfT)
 
+    def is_local_variable(self):
+        return self.location in (DataLocation.MEMORY, DataLocation.CALLDATA)
+
     def get_size(self) -> int:
         return self.typ.get_size_in(self.location)
 


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/4056, which is another make_setter overlap bug

variant of #4037 and https://github.com/vyperlang/vyper/pull/3410

additionally adds an internal assertion to prevent future variants

### How I did it

### How to verify it

### Commit message

```
`make_setter` can potentially run into overlap when called from
`dynarray_append`; this commit copies to a temporary intermediate buffer
(as is done in `AnnAssign`) before copying to the destination if the
condition is detected.

this is a variant of the bugs fixed in ad9c10b0b98e2d and 1c8349e867b2b.

this commit also adds a util function to detect overlap, and adds an
assertion directly in `make_setter` so that future variants panic
instead of generating bad code.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
