### PR TITLE
fix[ir]: fix a latent bug in `sha3_64` codegen

### DIFF
--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -580,7 +580,9 @@ def _compile_to_assembly(code, withargs=None, existing_labels=None, break_dest=N
     # SHA3 a 64 byte value
     elif code.value == "sha3_64":
         o = _compile_to_assembly(code.args[0], withargs, existing_labels, break_dest, height)
-        o.extend(_compile_to_assembly(code.args[1], withargs, existing_labels, break_dest, height))
+        o.extend(
+            _compile_to_assembly(code.args[1], withargs, existing_labels, break_dest, height + 1)
+        )
         o.extend(
             [
                 *PUSH(MemoryPositions.FREE_VAR_SPACE2),


### PR DESCRIPTION
this commit fixes a latent bug in `sha3_64` asm generation, where the second argument to `sha3_64` is generated with the wrong stack height

note the bug cannot currently be triggered from vyper source code (hence, it is latent), because there is nowhere in IR generation that the second item is accessed as a witharg.

patches GHSA-6845-xw22-ffxv

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
