### PR TITLE
fix[test]: fix fuzzer test setup failure

### DIFF
--- a/tests/functional/codegen/test_call_graph_stability.py
+++ b/tests/functional/codegen/test_call_graph_stability.py
@@ -11,6 +11,11 @@ from vyper.compiler.phases import CompilerData
 
 
 def _valid_identifier(attr):
+    if attr == "foo":
+        # the entry point to the test is named foo(),
+        # skip it to avoid collision
+        return False
+
     return attr not in RESERVED_KEYWORDS
 
 


### PR DESCRIPTION
the call graph stability fuzzer could generate an internal function named `foo()`, which is the same name as the entry function in the test contract.

### What I did
fix https://github.com/vyperlang/vyper/issues/4061

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
