### PR TITLE
fix[venom]: fix list of volatile instructions

### DIFF
--- a/vyper/venom/analysis/cfg.py
+++ b/vyper/venom/analysis/cfg.py
@@ -1,6 +1,6 @@
 from vyper.utils import OrderedSet
 from vyper.venom.analysis.analysis import IRAnalysis
-from vyper.venom.basicblock import BB_TERMINATORS, CFG_ALTERING_INSTRUCTIONS
+from vyper.venom.basicblock import CFG_ALTERING_INSTRUCTIONS
 
 
 class CFGAnalysis(IRAnalysis):
@@ -18,9 +18,7 @@ class CFGAnalysis(IRAnalysis):
         for bb in fn.get_basic_blocks():
             assert len(bb.instructions) > 0, "Basic block should not be empty"
             last_inst = bb.instructions[-1]
-            assert (
-                last_inst.opcode in BB_TERMINATORS
-            ), f"Last instruction should be a terminator {bb}"
+            assert last_inst.is_bb_terminator, f"Last instruction should be a terminator {bb}"
 
             for inst in bb.instructions:
                 if inst.opcode in CFG_ALTERING_INSTRUCTIONS:

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -12,6 +12,8 @@ VOLATILE_INSTRUCTIONS = frozenset(
         "call",
         "staticcall",
         "delegatecall",
+        "create",
+        "create2",
         "invoke",
         "sload",
         "sstore",
@@ -34,6 +36,15 @@ VOLATILE_INSTRUCTIONS = frozenset(
         "ret",
         "jmp",
         "jnz",
+        "djmp",
+        "log",
+        "selfdestruct",
+        "invalid",
+        "revert",
+        "assert",
+        "assert_unreachable",
+        "stop",
+        "exit",
     ]
 )
 
@@ -41,7 +52,6 @@ NO_OUTPUT_INSTRUCTIONS = frozenset(
     [
         "mstore",
         "sstore",
-        "dstore",
         "istore",
         "tstore",
         "dloadbytes",
@@ -65,6 +75,10 @@ NO_OUTPUT_INSTRUCTIONS = frozenset(
         "log",
         "exit",
     ]
+)
+
+assert VOLATILE_INSTRUCTIONS.issuperset(NO_OUTPUT_INSTRUCTIONS), (
+    NO_OUTPUT_INSTRUCTIONS - VOLATILE_INSTRUCTIONS
 )
 
 CFG_ALTERING_INSTRUCTIONS = frozenset(["jmp", "djmp", "jnz"])
@@ -223,6 +237,10 @@ class IRInstruction:
     @property
     def volatile(self) -> bool:
         return self.opcode in VOLATILE_INSTRUCTIONS
+
+    @property
+    def is_bb_terminator(self) -> bool:
+        return self.opcode in BB_TERMINATORS
 
     def get_label_operands(self) -> Iterator[IRLabel]:
         """

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -235,7 +235,7 @@ class IRInstruction:
         self.error_msg = None
 
     @property
-    def volatile(self) -> bool:
+    def is_volatile(self) -> bool:
         return self.opcode in VOLATILE_INSTRUCTIONS
 
     @property

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -517,7 +517,7 @@ class IRBasicBlock:
         # if we can/need to append instructions to the basic block.
         if len(self.instructions) == 0:
             return False
-        return self.instructions[-1].opcode in BB_TERMINATORS
+        return self.instructions[-1].is_bb_terminator
 
     @property
     def is_terminal(self) -> bool:

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -1,6 +1,6 @@
 from vyper.utils import OrderedSet
 from vyper.venom.analysis.dfg import DFGAnalysis
-from vyper.venom.basicblock import BB_TERMINATORS, IRBasicBlock, IRInstruction, IRVariable
+from vyper.venom.basicblock import IRBasicBlock, IRInstruction, IRVariable
 from vyper.venom.function import IRFunction
 from vyper.venom.passes.base_pass import IRPass
 
@@ -30,7 +30,7 @@ class DFTPass(IRPass):
         self.visited_instructions.add(inst)
         self.inst_order_num += 1
 
-        if inst.opcode in BB_TERMINATORS:
+        if inst.is_bb_terminator:
             offset = len(bb.instructions)
 
         if inst.opcode == "phi":

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -55,7 +55,7 @@ class DFTPass(IRPass):
 
         for inst in bb.instructions:
             inst.fence_id = self.fence_id
-            if inst.volatile:
+            if inst.is_volatile:
                 self.fence_id += 1
 
         # We go throught the instructions and calculate the order in which they should be executed

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -31,7 +31,7 @@ class RemoveUnusedVariablesPass(IRPass):
     def _process_instruction(self, inst):
         if inst.output is None:
             return
-        if inst.volatile:
+        if inst.volatile or inst.is_terminator:
             return
         uses = self.dfg.get_uses(inst.output)
         if len(uses) > 0:

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -31,7 +31,7 @@ class RemoveUnusedVariablesPass(IRPass):
     def _process_instruction(self, inst):
         if inst.output is None:
             return
-        if inst.volatile or inst.is_terminator:
+        if inst.volatile or inst.is_bb_terminator:
             return
         uses = self.dfg.get_uses(inst.output)
         if len(uses) > 0:

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -31,7 +31,7 @@ class RemoveUnusedVariablesPass(IRPass):
     def _process_instruction(self, inst):
         if inst.output is None:
             return
-        if inst.volatile or inst.is_bb_terminator:
+        if inst.is_volatile or inst.is_bb_terminator:
             return
         uses = self.dfg.get_uses(inst.output)
         if len(uses) > 0:

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -305,7 +305,7 @@ class VenomCompiler:
         for i, inst in enumerate(bb.instructions):
             if inst.opcode != "param":
                 break
-            if inst.volatile and i + 1 < len(bb.instructions):
+            if inst.is_volatile and i + 1 < len(bb.instructions):
                 liveness = bb.instructions[i + 1].liveness
                 if inst.output is not None and inst.output not in liveness:
                     depth = stack.get_depth(inst.output)


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
`create` and `create2` are volatile instructions that were missing. the
other ones were already handled by the case for `output is None` in
`removed_unused_variables`.

misc:
- rename `volatile` to `is_volatile` for uniformity
- use `is_bb_terminator` instead of `in BB_TERMINATORS`
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
