### PR TITLE
feat[venom]: add `extract_literals` pass

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -12,8 +12,8 @@ from vyper.venom.ir_node_to_venom import ir_node_to_venom
 from vyper.venom.passes.algebraic_optimization import AlgebraicOptimizationPass
 from vyper.venom.passes.branch_optimization import BranchOptimizationPass
 from vyper.venom.passes.dft import DFTPass
-from vyper.venom.passes.make_ssa import MakeSSA
 from vyper.venom.passes.extract_literals import ExtractLiteralsPass
+from vyper.venom.passes.make_ssa import MakeSSA
 from vyper.venom.passes.mem2var import Mem2Var
 from vyper.venom.passes.remove_unused_variables import RemoveUnusedVariablesPass
 from vyper.venom.passes.sccp import SCCP

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -13,6 +13,7 @@ from vyper.venom.passes.algebraic_optimization import AlgebraicOptimizationPass
 from vyper.venom.passes.branch_optimization import BranchOptimizationPass
 from vyper.venom.passes.dft import DFTPass
 from vyper.venom.passes.make_ssa import MakeSSA
+from vyper.venom.passes.extract_literals import ExtractLiteralsPass
 from vyper.venom.passes.mem2var import Mem2Var
 from vyper.venom.passes.remove_unused_variables import RemoveUnusedVariablesPass
 from vyper.venom.passes.sccp import SCCP
@@ -53,6 +54,7 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel) -> None:
     SimplifyCFGPass(ac, fn).run_pass()
     AlgebraicOptimizationPass(ac, fn).run_pass()
     BranchOptimizationPass(ac, fn).run_pass()
+    ExtractLiteralsPass(ac, fn).run_pass()
     RemoveUnusedVariablesPass(ac, fn).run_pass()
     DFTPass(ac, fn).run_pass()
 

--- a/vyper/venom/passes/extract_literals.py
+++ b/vyper/venom/passes/extract_literals.py
@@ -1,4 +1,3 @@
-from vyper.utils import OrderedSet
 from vyper.venom.analysis.dfg import DFGAnalysis
 from vyper.venom.analysis.liveness import LivenessAnalysis
 from vyper.venom.basicblock import IRInstruction, IRLiteral
@@ -9,6 +8,7 @@ class ExtractLiteralsPass(IRPass):
     """
     This pass extracts literals so that they can be reordered by the DFT pass
     """
+
     def run_pass(self):
         for bb in self.function.get_basic_blocks():
             self._process_bb(bb)

--- a/vyper/venom/passes/extract_literals.py
+++ b/vyper/venom/passes/extract_literals.py
@@ -1,0 +1,37 @@
+from vyper.utils import OrderedSet
+from vyper.venom.analysis.dfg import DFGAnalysis
+from vyper.venom.analysis.liveness import LivenessAnalysis
+from vyper.venom.basicblock import IRInstruction, IRLiteral
+from vyper.venom.passes.base_pass import IRPass
+
+
+class ExtractLiteralsPass(IRPass):
+    """
+    This pass extracts literals so that they can be reordered by the DFT pass
+    """
+    def run_pass(self):
+        for bb in self.function.get_basic_blocks():
+            self._process_bb(bb)
+
+        self.analyses_cache.invalidate_analysis(DFGAnalysis)
+        self.analyses_cache.invalidate_analysis(LivenessAnalysis)
+
+    def _process_bb(self, bb):
+        i = 0
+        while i < len(bb.instructions):
+            inst = bb.instructions[i]
+            if inst.opcode == "store":
+                i += 1
+                continue
+
+            for j, op in enumerate(inst.operands):
+                # first operand to log is magic
+                if inst.opcode == "log" and j == 0:
+                    continue
+
+                if isinstance(op, IRLiteral):
+                    var = self.function.get_next_variable()
+                    to_insert = IRInstruction("store", [op], var)
+                    bb.insert_instruction(to_insert, index=i)
+                    inst.operands[j] = var
+            i += 1


### PR DESCRIPTION
### What I did
extract IRLiterals which are instruction arguments; this reduces pressure on the stack scheduler

not *sure* that this is a good idea, but empirically it seems to work. for example, CurveStableSwapNG-0.4.0.vy goes from from 21849 to 21645 (204 bytes, i.e. 1%)

### How I did it

### How to verify it

### Commit message

```
extract `IRLiterals` which are instruction arguments; this reduces
pressure on the stack scheduler because `_emit_input_operands` can cause
stack storms when we hit `_stack_reorder`. by extracting them, we allow
`DFTPass` to reorder literal emission in a more optimized way before
even getting to `_emit_input_operands`
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
