### PR TITLE
fix[lang]: prevent modules as storage variables

### DIFF
--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -272,6 +272,7 @@ class ModuleT(VyperType):
 
     _attribute_in_annotation = True
     _invalid_locations = (
+        DataLocation.STORAGE,
         DataLocation.CALLDATA,
         DataLocation.CODE,
         DataLocation.MEMORY,


### PR DESCRIPTION
prevent modules being initialized as storage variables.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
