### PR TITLE
fix[lang]: fix a hint in global initializer check

### DIFF
--- a/tests/functional/syntax/modules/test_initializers.py
+++ b/tests/functional/syntax/modules/test_initializers.py
@@ -1383,3 +1383,34 @@ def foo():
     hint = f"add `uses: {lib}` or `initializes: {lib}` as a top-level statement to your contract"
     assert e.value._hint == hint
     assert e.value.annotations[0].lineno == 6
+
+
+def test_global_initialize_missed_import_hint(make_input_bundle):
+    lib1 = """
+import lib2
+import lib3
+
+initializes: lib2[
+    lib3 := lib3
+]
+    """
+    lib2 = """
+import lib3
+
+uses: lib3
+
+@external
+def set_some_mod():
+    a: uint256 = lib3.var
+    """
+    lib3 = """
+var: uint256
+    """
+    main = """
+import lib1
+
+initializes: lib1
+    """
+
+    input_bundle = make_input_bundle({"lib1.vy": lib1, "lib2.vy": lib2, "lib3.vy": lib3})
+    compile_code(main, input_bundle=input_bundle)

--- a/tests/functional/syntax/modules/test_initializers.py
+++ b/tests/functional/syntax/modules/test_initializers.py
@@ -1385,7 +1385,7 @@ def foo():
     assert e.value.annotations[0].lineno == 6
 
 
-def test_global_initialize_missed_import_hint(make_input_bundle):
+def test_global_initialize_missed_import_hint(make_input_bundle, chdir_tmp_path):
     lib1 = """
 import lib2
 import lib3
@@ -1413,4 +1413,7 @@ initializes: lib1
     """
 
     input_bundle = make_input_bundle({"lib1.vy": lib1, "lib2.vy": lib2, "lib3.vy": lib3})
-    compile_code(main, input_bundle=input_bundle)
+    with pytest.raises(InitializerException) as e:
+        compile_code(main, input_bundle=input_bundle)
+    assert e.value._message == "module `lib3.vy` is used but never initialized!"
+    assert e.value._hint is None

--- a/vyper/semantics/analysis/global_.py
+++ b/vyper/semantics/analysis/global_.py
@@ -58,6 +58,10 @@ def _validate_global_initializes_constraint(module_t: ModuleT):
 
     for u, uses in all_used_modules.items():
         if u not in all_initialized_modules:
+            msg = f"module `{u}` is used but never initialized!"
+
+            # construct a hint if the module is in scope
+            hint = None
             found_module = module_t.find_module_info(u)
             if found_module is not None:
                 # TODO: do something about these constants
@@ -66,13 +70,7 @@ def _validate_global_initializes_constraint(module_t: ModuleT):
                 else:
                     module_str = f"`{module_t}`"
                 hint = f"add `initializes: {found_module.alias}` to {module_str}"
-            else:
-                # CMC 2024-02-06 is this actually reachable?
-                hint = f"ensure `{module_t}` is imported in your main contract!"
-            err_list.append(
-                InitializerException(
-                    f"module `{u}` is used but never initialized!", *uses, hint=hint
-                )
-            )
+
+            err_list.append(InitializerException(msg, *uses, hint=hint))
 
     err_list.raise_if_not_empty()


### PR DESCRIPTION
the hint is bad because the invalid `uses:` statement might not be in the main contract.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
