### PR TITLE
feat[codegen]: remove returndatasize check in external_call.py

### DIFF
--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -86,9 +86,8 @@ def _unpack_returndata(buf, fn_type, call_kwargs, contract_address, context, exp
 
     abi_return_t = wrapped_return_t.abi_type
 
-    min_return_size = abi_return_t.min_size()
     max_return_size = abi_return_t.size_bound()
-    assert 0 < min_return_size <= max_return_size
+    assert 0 <= max_return_size
 
     ret_ofst = buf
     ret_len = max_return_size
@@ -102,15 +101,6 @@ def _unpack_returndata(buf, fn_type, call_kwargs, contract_address, context, exp
     buf.annotation = f"{expr.node_source_code} returndata buffer"
 
     unpacker = ["seq"]
-
-    # revert when returndatasize is not in bounds
-    # (except when return_override is provided.)
-    if not call_kwargs.skip_contract_check:
-        assertion = IRnode.from_list(
-            ["assert", ["ge", "returndatasize", min_return_size]],
-            error_msg="returndatasize too small",
-        )
-        unpacker.append(assertion)
 
     assert isinstance(wrapped_return_t, TupleT)
 


### PR DESCRIPTION
it is redundant now with the make_setter checks!

depends on https://github.com/vyperlang/vyper/pull/4091

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
