### PR TITLE
fix[tool]: star option in `outputSelection`

### DIFF
--- a/vyper/compiler/output_bundle.py
+++ b/vyper/compiler/output_bundle.py
@@ -194,7 +194,7 @@ class SolcJSONWriter(OutputBundleWriter):
 
     def write_compilation_target(self, targets: list[str]):
         for target in targets:
-            self._output["settings"]["outputSelection"][target] = "*"
+            self._output["settings"]["outputSelection"][target] = ["*"]
 
     def write_version(self, version):
         self._output["compiler_version"] = version


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
vyper will accept either `"*"` or `["*"]` for `outputSelection`, but
some verifiers expect it to always be a list. make `solc_json` output
choose the common formatting.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
