### PR TITLE
fix[venom]: move loop invariant assertion to entry block

### DIFF
--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -368,14 +368,14 @@ def foo():
     """
 @external
 def foo():
-    x: int128 = 5
+    x: int128 = 4
     for i: int128 in range(x, bound=4):
         pass
     """,
     """
 @external
 def foo():
-    x: int128 = 5
+    x: int128 = 4
     for i: int128 in range(0, x, bound=4):
         pass
     """,

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -494,6 +494,9 @@ def _convert_ir_bb(fn, ir, symbols):
         end = entry_block.append_instruction("add", start, end)
         if bound:
             bound = entry_block.append_instruction("add", start, bound)
+            xor_ret = entry_block.append_instruction("xor", counter_var, bound)
+            entry_block.append_instruction("assert", xor_ret)
+
         entry_block.append_instruction("jmp", cond_block.label)
 
         xor_ret = cond_block.append_instruction("xor", counter_var, end)
@@ -501,9 +504,6 @@ def _convert_ir_bb(fn, ir, symbols):
         fn.append_basic_block(cond_block)
 
         fn.append_basic_block(body_block)
-        if bound:
-            xor_ret = body_block.append_instruction("xor", counter_var, bound)
-            body_block.append_instruction("assert", xor_ret)
 
         emit_body_blocks()
         body_end = fn.get_basic_block()


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
loop invariant bound check was in the body of the loop, not the entry
block. move it up to the entry so we don't re-check the same assertion
every loop iteration.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
