### PR TITLE
fix[ux]: improve initializer hint for unimported modules

### DIFF
--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -514,7 +514,8 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                     break
 
             if rhs is None:
-                hint = f"try importing {item.alias} first"
+                hint = f"try importing `{item.alias}` first "
+                hint += f"(located at `{item.module_t._module.path}`)"
             elif not isinstance(annotation, vy_ast.Subscript):
                 # it's `initializes: foo` instead of `initializes: foo[...]`
                 hint = f"did you mean {module_ref.id}[{lhs} := {rhs}]?"


### PR DESCRIPTION
improve initializer hint in the case that the needed module is not imported

### What I did
fix #4092 

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
