### PR TITLE
fix[venom]: add `unique_symbols` check to venom pipeline

### DIFF
--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -405,7 +405,8 @@ class IRnode:
         for arg in children:
             s = arg.unique_symbols
             non_uniques = ret.intersection(s)
-            assert len(non_uniques) == 0, f"non-unique symbols {non_uniques}"
+            if len(non_uniques) != 0:  # pragma: nocover
+                raise CompilerPanic(f"non-unique symbols {non_uniques}")
             ret |= s
         return ret
 

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -113,6 +113,8 @@ MAIN_ENTRY_LABEL_NAME = "__main_entry"
 
 # convert IRnode directly to venom
 def ir_node_to_venom(ir: IRnode) -> IRContext:
+    _ = ir.unique_symbols  # run unique symbols check
+
     global _global_symbols
     _global_symbols = {}
 


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/4072

### How I did it

### How to verify it

### Commit message

```
when `-Onone` is specified along with `--experimental-codegen`,
the unique symbols check does not get run. this calculates the
`ir_node.unique_symbols` property, which implicitly runs the unique
symbols check.

also, change an assertion to a proper panic exception
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
