### PR TITLE
fix[venom]: alloca for default arguments

### DIFF
--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -109,12 +109,14 @@ NOOP_INSTRUCTIONS = frozenset(["pass", "cleanup_repeat", "var_list", "unique_sym
 SymbolTable = dict[str, Optional[IROperand]]
 _global_symbols: SymbolTable = {}
 MAIN_ENTRY_LABEL_NAME = "__main_entry"
+external_functions = {}
 
 
 # convert IRnode directly to venom
 def ir_node_to_venom(ir: IRnode) -> IRContext:
-    global _global_symbols
+    global _global_symbols, external_functions
     _global_symbols = {}
+    external_functions = {}
 
     ctx = IRContext()
     fn = ctx.create_function(MAIN_ENTRY_LABEL_NAME)
@@ -228,8 +230,6 @@ def pop_source_on_return(func):
 
     return pop_source
 
-
-external_functions = {}
 
 @pop_source_on_return
 def _convert_ir_bb(fn, ir, symbols):


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
this commit fixes an `ir_node_to_venom` translation bug. when there is
a default argument to an external function, it can generate multiple
allocas, because the entry points allocate separate symbol tables, but
actually they should all correspond to the same alloca. for instance,
`external 1 foo(uint256)12345` and `external 1 foo()67890` both feed
into the same `external 1 foo()__common`, but the current translator
mistakenly creates different symbol tables for the two "feeder" entry
points, resulting in separate allocas for the same logical variable.

this commit fixes the bug by fusing the symbol tables for multiple
entry points to the same external function.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
