### PR TITLE
fix[codegen]: panic on potential eval order issue for some builtins

### DIFF
--- a/tests/functional/builtins/codegen/test_extract32.py
+++ b/tests/functional/builtins/codegen/test_extract32.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper.evm.opcodes import version_check
+from vyper.exceptions import CompilerPanic
 
 
 @pytest.mark.parametrize("location", ["storage", "transient"])
@@ -100,6 +101,8 @@ def foq(inp: Bytes[32]) -> address:
         c.foq(b"crow" * 8)
 
 
+# to fix in future release
+@pytest.mark.xfail(raises=CompilerPanic, reason="risky overlap")
 def test_extract32_order_of_eval(get_contract):
     extract32_code = """
 var:DynArray[Bytes[96], 1]
@@ -121,6 +124,8 @@ def foo() -> bytes32:
     assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"
 
 
+# to fix in future release
+@pytest.mark.xfail(raises=CompilerPanic, reason="risky overlap")
 def test_extract32_order_of_eval_extcall(get_contract):
     slice_code = """
 var:DynArray[Bytes[96], 1]

--- a/tests/functional/builtins/codegen/test_extract32.py
+++ b/tests/functional/builtins/codegen/test_extract32.py
@@ -98,3 +98,24 @@ def foq(inp: Bytes[32]) -> address:
 
     with tx_failed():
         c.foq(b"crow" * 8)
+
+
+def test_extract32_order_of_eval(get_contract):
+    extract32_code = """
+var:DynArray[Bytes[96], 1]
+
+@internal
+def bar() -> uint256:
+    self.var[0] = b'hellohellohellohellohellohellohello'
+    self.var.pop()
+    return 3
+
+s:bool
+@external
+def foo() -> bytes32:
+    self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']
+    return extract32(self.var[0], self.bar(), output_type=bytes32)
+    """
+
+    c = get_contract(extract32_code)
+    assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"

--- a/tests/functional/builtins/codegen/test_extract32.py
+++ b/tests/functional/builtins/codegen/test_extract32.py
@@ -120,6 +120,7 @@ def foo() -> bytes32:
     c = get_contract(extract32_code)
     assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"
 
+
 def test_extract32_order_of_eval_extcall(get_contract):
     slice_code = """
 var:DynArray[Bytes[96], 1]
@@ -141,4 +142,4 @@ def foo() -> bytes32:
     """
 
     c = get_contract(slice_code)
-    assert c.foo() == b'defghijklmnopqrstuvwxyz123456789'
+    assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"

--- a/tests/functional/builtins/codegen/test_extract32.py
+++ b/tests/functional/builtins/codegen/test_extract32.py
@@ -119,3 +119,26 @@ def foo() -> bytes32:
 
     c = get_contract(extract32_code)
     assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"
+
+def test_extract32_order_of_eval_extcall(get_contract):
+    slice_code = """
+var:DynArray[Bytes[96], 1]
+
+interface Bar:
+    def bar() -> uint256: payable
+
+@external
+def bar() -> uint256:
+    self.var[0] = b'hellohellohellohellohellohellohello'
+    self.var.pop()
+    return 3
+
+s:bool
+@external
+def foo() -> bytes32:
+    self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']
+    return extract32(self.var[0], extcall Bar(self).bar(), output_type=bytes32)
+    """
+
+    c = get_contract(slice_code)
+    assert c.foo() == b'defghijklmnopqrstuvwxyz123456789'

--- a/tests/functional/builtins/codegen/test_extract32.py
+++ b/tests/functional/builtins/codegen/test_extract32.py
@@ -113,7 +113,6 @@ def bar() -> uint256:
     self.var.pop()
     return 3
 
-s:bool
 @external
 def foo() -> bytes32:
     self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']
@@ -139,7 +138,6 @@ def bar() -> uint256:
     self.var.pop()
     return 3
 
-s:bool
 @external
 def foo() -> bytes32:
     self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -5,7 +5,7 @@ from hypothesis import given, settings
 from vyper.compiler import compile_code
 from vyper.compiler.settings import OptimizationLevel, Settings
 from vyper.evm.opcodes import version_check
-from vyper.exceptions import ArgumentException, TypeMismatch
+from vyper.exceptions import ArgumentException, CompilerPanic, TypeMismatch
 
 _fun_bytes32_bounds = [(0, 32), (3, 29), (27, 5), (0, 5), (5, 3), (30, 2)]
 
@@ -564,6 +564,8 @@ def foo(cs: String[64]) -> uint256:
     assert c.foo(arg) == 1
 
 
+# to fix in future release
+@pytest.mark.xfail(raises=CompilerPanic, reason="risky overlap")
 def test_slice_order_of_eval(get_contract):
     slice_code = """
 var:DynArray[Bytes[96], 1]
@@ -588,6 +590,8 @@ def foo() -> Bytes[96]:
     assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"
 
 
+# to fix in future release
+@pytest.mark.xfail(raises=CompilerPanic, reason="risky overlap")
 def test_slice_order_of_eval2(get_contract):
     slice_code = """
 var:DynArray[Bytes[96], 1]

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -562,3 +562,27 @@ def foo(cs: String[64]) -> uint256:
     c = get_contract(code)
     # ensure that counter was incremented only once
     assert c.foo(arg) == 1
+
+
+def test_slice_order_of_eval(get_contract):
+    slice_code = """
+var:DynArray[Bytes[96], 1]
+
+interface Bar:
+    def bar() -> uint256: payable
+
+@external
+def bar() -> uint256:
+    self.var[0] = b'hellohellohellohellohellohellohello'
+    self.var.pop()
+    return 32
+
+s:bool
+@external
+def foo() -> Bytes[96]:
+    self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']
+    return slice(self.var[0], 3, extcall Bar(self).bar())
+    """
+
+    c = get_contract(slice_code)
+    assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -586,3 +586,27 @@ def foo() -> Bytes[96]:
 
     c = get_contract(slice_code)
     assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"
+
+
+def test_slice_order_of_eval2(get_contract):
+    slice_code = """
+var:DynArray[Bytes[96], 1]
+
+interface Bar:
+    def bar() -> uint256: payable
+
+@external
+def bar() -> uint256:
+    self.var[0] = b'hellohellohellohellohellohellohello'
+    self.var.pop()
+    return 3
+
+s:bool
+@external
+def foo() -> Bytes[96]:
+    self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']
+    return slice(self.var[0], extcall Bar(self).bar(), 32)
+    """
+
+    c = get_contract(slice_code)
+    assert c.foo() == b"defghijklmnopqrstuvwxyz123456789"

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -579,7 +579,6 @@ def bar() -> uint256:
     self.var.pop()
     return 32
 
-s:bool
 @external
 def foo() -> Bytes[96]:
     self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']
@@ -605,7 +604,6 @@ def bar() -> uint256:
     self.var.pop()
     return 3
 
-s:bool
 @external
 def foo() -> Bytes[96]:
     self.var = [b'abcdefghijklmnopqrstuvwxyz123456789']

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -9,7 +9,6 @@ from vyper.codegen.abi_encoder import abi_encode
 from vyper.codegen.context import Context, VariableRecord
 from vyper.codegen.core import (
     LOAD,
-    potential_overlap,
     STORE,
     IRnode,
     add_ofst,
@@ -30,6 +29,7 @@ from vyper.codegen.core import (
     get_type_for_exact_size,
     ir_tuple_from_args,
     make_setter,
+    potential_overlap,
     promote_signed_int,
     sar,
     shl,


### PR DESCRIPTION
### What I did
alternative to https://github.com/vyperlang/vyper/pull/4156; panic instead of changing codegen

### How I did it

### How to verify it

### Commit message

```
`extract32()` and `slice()` have an evaluation order issue when
the arguments touch the same data. specifically, the length and data
evaluation are interleaved with the index/start/length evaluations. in
unusual situations (such as those in the included test cases), this
can result in "invalid" reads where the data and length reads appear
out of order. this commit conservatively blocks compilation if the
preconditions for the interleaved evaluation are detected.

---------

Co-authored-by: trocher <trooocher@proton.me>
Co-authored-by: cyberthirst <cyberthirst.eth@gmail.com>
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
