### PR TITLE
fix[lang]: fix varinfo comparison

### DIFF
--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -897,3 +897,20 @@ def foo():
         compile_code(main, input_bundle=input_bundle)
 
     assert e.value._message == "Cannot modify loop variable `queue`"
+
+
+def test_iterator_modification_memory(get_contract):
+    code = """
+@external
+def foo() -> DynArray[uint256, 10]:
+    # check VarInfos are distinguished by decl_node when they have same type
+    alreadyDone: DynArray[uint256, 10] = []
+    _assets: DynArray[uint256, 10] = [1, 2, 3, 4, 3, 2, 1]
+    for a: uint256 in _assets:
+        if a in alreadyDone:
+            continue
+        alreadyDone.append(a)
+    return alreadyDone
+    """
+    c = get_contract(code)
+    assert c.foo() == [1, 2, 3, 4]

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -363,7 +363,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         # validate the value before adding it to the namespace
         self.expr_visitor.visit(node.value, typ)
 
-        self.namespace[name] = VarInfo(typ, location=DataLocation.MEMORY)
+        self.namespace[name] = VarInfo(typ, location=DataLocation.MEMORY, decl_node=node)
 
         self.expr_visitor.visit(node.target, typ)
 
@@ -575,7 +575,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             target_name = node.target.target.id
             # maybe we should introduce a new Modifiability: LOOP_VARIABLE
             self.namespace[target_name] = VarInfo(
-                target_type, modifiability=Modifiability.RUNTIME_CONSTANT
+                target_type, modifiability=Modifiability.RUNTIME_CONSTANT, decl_node=node.target
             )
 
             self.expr_visitor.visit(node.target.target, target_type)


### PR DESCRIPTION
for `VarInfo`s which are declared in memory, the `VarInfo` initialization is missing `decl_node` and therefore different variables with the same type get detected as overlapping in loop iterator modification detection. this commit properly initializes the `VarInfo`s in memory.

### What I did
fix #4163

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
