### PR TITLE
chore[test]: fix a type hint

### DIFF
--- a/tests/functional/grammar/test_grammar.py
+++ b/tests/functional/grammar/test_grammar.py
@@ -37,7 +37,7 @@ def test_basic_grammar_empty():
     assert len(tree.children) == 0
 
 
-def fix_terminal(terminal: str) -> bool:
+def fix_terminal(terminal: str) -> str:
     # these throw exceptions in the grammar
     for bad in ("\x00", "\\ ", "\x0c"):
         terminal = terminal.replace(bad, " ")


### PR DESCRIPTION
## Description
Fix a type check warning reported by Pyre@Google, which was outdated after code modifications.

## Detail
update the return type of function `fix_terminal` from `bool` to `str`, since it could be `str` after commit https://github.com/vyperlang/vyper/commit/176e7f7f3a6a16bc09ec58d4bbc8dc515c48a0a8