### PR TITLE
fix[lang]: fix `.vyi` function body check

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -347,7 +347,7 @@ class ContractFunctionT(VyperType):
         body = funcdef.body
 
         if len(body) != 1 or not (
-            isinstance(body[0], vy_ast.Expr) and isinstance(body[0].get("value"), vy_ast.Ellipsis)
+            isinstance(body[0], vy_ast.Expr) and isinstance(body[0].value, vy_ast.Ellipsis)
         ):
             raise FunctionDeclarationException(
                 "function body in an interface can only be `...`!", funcdef

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -344,7 +344,11 @@ class ContractFunctionT(VyperType):
 
         return_type = _parse_return_type(funcdef)
 
-        if len(funcdef.body) != 1 or not isinstance(funcdef.body[0].get("value"), vy_ast.Ellipsis):
+        body = funcdef.body
+
+        if len(body) != 1 or not (
+            isinstance(body[0], vy_ast.Expr) and isinstance(body[0].get("value"), vy_ast.Ellipsis)
+        ):
             raise FunctionDeclarationException(
                 "function body in an interface can only be `...`!", funcdef
             )


### PR DESCRIPTION
### What I did
- make interface body stricter to only allow exprs
- fix https://github.com/vyperlang/vyper/issues/4122

### How to verify it
- added both a failing and passing tests

### commit message
````
previously the validation for function bodies in interfaces incorrectly
allowed other types of expressions with the `.value` member, e.g.

```vyper
@external
def some_interface_function():
    return ...
```
although the body should only be allowed to be an ellipsis expr (`...`).

this commit correctly rejects the above source code
````