### PR TITLE
feat[lang]!: make `@external` modifier optional in `.vyi` files

### DIFF
--- a/tests/functional/codegen/test_interfaces.py
+++ b/tests/functional/codegen/test_interfaces.py
@@ -695,3 +695,34 @@ def test_call(a: address, b: {type_str}) -> {type_str}:
     make_file("jsonabi.json", json.dumps(convert_v1_abi(abi)))
     c3 = get_contract(code, input_bundle=input_bundle)
     assert c3.test_call(c1.address, value) == value
+
+
+def test_interface_function_without_visibility(make_input_bundle, get_contract):
+    interface_code = """
+def foo() -> uint256:
+    ...
+
+@external
+def bar() -> uint256:
+    ...
+    """
+
+    code = """
+import a as FooInterface
+
+implements: FooInterface
+
+@external
+def foo() -> uint256:
+    return 1
+
+@external
+def bar() -> uint256:
+    return 1
+    """
+
+    input_bundle = make_input_bundle({"a.vyi": interface_code})
+
+    c = get_contract(code, input_bundle=input_bundle)
+
+    assert c.foo() == c.bar() == 1

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -511,4 +511,3 @@ def bar():
         compiler.compile_code(code, input_bundle=input_bundle)
 
     assert e.value.message == "Contract does not implement all interface functions: bar(), foobar()"
-

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -510,4 +510,5 @@ def bar():
     with pytest.raises(InterfaceViolation) as e:
         compiler.compile_code(code, input_bundle=input_bundle)
 
-    assert e.value.message == "Implement all interface functions or fix visibility: bar(), foobar()"
+    assert e.value.message == "Contract does not implement all interface functions: bar(), foobar()"
+

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -193,7 +193,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
         self._imported_modules: dict[PurePath, vy_ast.VyperNode] = {}
 
         # keep track of exported functions to prevent duplicate exports
-        self._exposed_functions: dict[ContractFunctionT, vy_ast.VyperNode] = {}
+        self._all_functions: dict[ContractFunctionT, vy_ast.VyperNode] = {}
 
         self._events: list[EventT] = []
 
@@ -414,7 +414,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             raise StructureException(msg, node.annotation, hint=hint)
 
         # grab exposed functions
-        funcs = self._exposed_functions
+        funcs = self._all_functions
         type_.validate_implements(node, funcs)
 
         node._metadata["interface_type"] = type_
@@ -608,10 +608,10 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
     def _add_exposed_function(self, func_t, node, relax=True):
         # call this before self._self_t.typ.add_member() for exception raising
         # priority
-        if not relax and (prev_decl := self._exposed_functions.get(func_t)) is not None:
+        if not relax and (prev_decl := self._all_functions.get(func_t)) is not None:
             raise StructureException("already exported!", node, prev_decl=prev_decl)
 
-        self._exposed_functions[func_t] = node
+        self._all_functions[func_t] = node
 
     def visit_VariableDecl(self, node):
         # postcondition of VariableDecl.validate

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -414,7 +414,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             raise StructureException(msg, node.annotation, hint=hint)
 
         # grab exposed functions
-        funcs = self._all_functions
+        funcs = {fn_t: node for fn_t, node in self._all_functions.items() if fn_t.is_external}
         type_.validate_implements(node, funcs)
 
         node._metadata["interface_type"] = type_

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -330,6 +330,7 @@ class ContractFunctionT(VyperType):
         function_visibility, state_mutability, nonreentrant = _parse_decorators(funcdef)
 
         if nonreentrant:
+            # TODO: refactor so parse_decorators returns the AST location
             decorator = next(d for d in funcdef.decorator_list if d.id == "nonreentrant")
             raise FunctionDeclarationException(
                 "`@nonreentrant` not allowed in interfaces", decorator

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -334,7 +334,9 @@ class ContractFunctionT(VyperType):
         assert not nonreentrant
 
         # it's redundant to specify visibility in vyi - always should be external
-        function_visibility = function_visibility or FunctionVisibility.EXTERNAL
+        if function_visibility is None:
+            function_visibility = FunctionVisibility.EXTERNAL
+
         assert function_visibility == FunctionVisibility.EXTERNAL
 
         if funcdef.name == "__init__":
@@ -383,7 +385,8 @@ class ContractFunctionT(VyperType):
         function_visibility, state_mutability, nonreentrant = _parse_decorators(funcdef)
 
         # it's redundant to specify internal visibility - it's implied by not being external
-        function_visibility = function_visibility or FunctionVisibility.INTERNAL
+        if function_visibility is None:
+            function_visibility = FunctionVisibility.INTERNAL
 
         positional_args, keyword_args = _parse_args(funcdef)
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -726,7 +726,7 @@ def _parse_return_type(funcdef: vy_ast.FunctionDef) -> Optional[VyperType]:
 
 def _parse_decorators(
     funcdef: vy_ast.FunctionDef,
-) -> tuple[FunctionVisibility | None, StateMutability, bool]:
+) -> tuple[Optional[FunctionVisibility], StateMutability, bool]:
     function_visibility = None
     state_mutability = None
     nonreentrant_node = None

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -519,6 +519,8 @@ class ContractFunctionT(VyperType):
         if not self.is_external:  # pragma: nocover
             raise CompilerPanic("unreachable!")
 
+        assert self.visibility == other.visibility
+
         arguments, return_type = self._iface_sig
         other_arguments, other_return_type = other._iface_sig
 
@@ -531,10 +533,7 @@ class ContractFunctionT(VyperType):
         if return_type and not return_type.compare_type(other_return_type):  # type: ignore
             return False
 
-        if self.mutability != other.mutability:
-            return False
-
-        return self.visibility == other.visibility
+        return self.mutability == other.mutability
 
     @cached_property
     def default_values(self) -> dict[str, vy_ast.VyperNode]:

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -108,7 +108,7 @@ class InterfaceT(_UserType):
         self, node: vy_ast.ImplementsDecl, functions: dict[ContractFunctionT, vy_ast.VyperNode]
     ) -> None:
         # only external functions can implement interfaces
-        fns_by_name = {fn_t.name: fn_t for fn_t in functions.keys() if fn_t.is_external}
+        fns_by_name = {fn_t.name: fn_t for fn_t in functions.keys()}
 
         unimplemented = []
 
@@ -117,8 +117,8 @@ class InterfaceT(_UserType):
                 return False
 
             to_compare = fns_by_name[fn_name]
-            assert isinstance(to_compare, ContractFunctionT)
-            assert isinstance(fn_type, ContractFunctionT)
+            assert to_compare.is_external
+            assert all(isinstance(f, ContractFunctionT) for f in [to_compare, fn_type])
 
             return to_compare.implements(fn_type)
 

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -119,7 +119,7 @@ class InterfaceT(_UserType):
             assert isinstance(to_compare, ContractFunctionT)
             assert isinstance(fn_type, ContractFunctionT)
 
-            return fn_type.implements(to_compare)
+            return to_compare.implements(fn_type)
 
         # check for missing functions
         for name, type_ in self.functions.items():

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -117,8 +117,9 @@ class InterfaceT(_UserType):
 
             to_compare = fns_by_name[fn_name]
             assert isinstance(to_compare, ContractFunctionT)
+            assert isinstance(fn_type, ContractFunctionT)
 
-            return to_compare.implements(fn_type)
+            return fn_type.implements(to_compare)
 
         # check for missing functions
         for name, type_ in self.functions.items():
@@ -135,7 +136,7 @@ class InterfaceT(_UserType):
             # is off, etc).
             missing_str = ", ".join(sorted(unimplemented))
             raise InterfaceViolation(
-                f"Contract does not implement all interface functions: {missing_str}", node
+                f"Implement all interface functions or fix visibility: {missing_str}", node
             )
 
     def to_toplevel_abi_dict(self) -> list[dict]:

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -118,7 +118,8 @@ class InterfaceT(_UserType):
 
             to_compare = fns_by_name[fn_name]
             assert to_compare.is_external
-            assert all(isinstance(f, ContractFunctionT) for f in [to_compare, fn_type])
+            assert isinstance(to_compare, ContractFunctionT)
+            assert isinstance(fn_type, ContractFunctionT)
 
             return to_compare.implements(fn_type)
 

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -107,7 +107,8 @@ class InterfaceT(_UserType):
     def validate_implements(
         self, node: vy_ast.ImplementsDecl, functions: dict[ContractFunctionT, vy_ast.VyperNode]
     ) -> None:
-        fns_by_name = {fn_t.name: fn_t for fn_t in functions.keys()}
+        # only external functions can implement interfaces
+        fns_by_name = {fn_t.name: fn_t for fn_t in functions.keys() if fn_t.is_external}
 
         unimplemented = []
 
@@ -136,7 +137,7 @@ class InterfaceT(_UserType):
             # is off, etc).
             missing_str = ", ".join(sorted(unimplemented))
             raise InterfaceViolation(
-                f"Implement all interface functions or fix visibility: {missing_str}", node
+                f"Contract does not implement all interface functions: {missing_str}", node
             )
 
     def to_toplevel_abi_dict(self) -> list[dict]:


### PR DESCRIPTION
### What I did
- as per https://github.com/vyperlang/vyper/issues/4169#issuecomment-2203672462: make `@external` visibility in `vyi` files optional
- also should fix: https://github.com/vyperlang/vyper/issues/4169

### How to verify it
- added some tests

### Commit Message
```
make `@external` visibility in `.vyi` files optional.

additionally, fix a panic when functions in an interface have the wrong
visibility
```

edit: linked wrong issue
