### PR TITLE
feat[venom]: offset instruction

### DIFF
--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -128,6 +128,7 @@ def test_interleaved_case(interleave_point):
     else:
         assert bb.instructions[-1].operands[0] == op3
 
+
 def test_offsets():
     ctx = IRContext()
     fn = ctx.create_function("_global")
@@ -164,18 +165,16 @@ def test_offsets():
     op16 = br2.append_instruction("iszero", op15)
     br2.append_instruction("return", p1, op16)
 
-
-
     ac = IRAnalysesCache(fn)
     MakeSSA(ac, fn).run_pass()
     AlgebraicOptimizationPass(ac, fn).run_pass()
     RemoveUnusedVariablesPass(ac, fn).run_pass()
-    
+
     offset_count = 0
     for bb in fn.get_basic_blocks():
         for instruction in bb.instructions:
             assert instruction.opcode != "add"
             if instruction.opcode == "offset":
                 offset_count += 1
-    
+
     assert offset_count == 3

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -127,3 +127,55 @@ def test_interleaved_case(interleave_point):
         assert bb.instructions[-1].operands[0] == op3_inv
     else:
         assert bb.instructions[-1].operands[0] == op3
+
+def test_offsets():
+    ctx = IRContext()
+    fn = ctx.create_function("_global")
+
+    bb = fn.get_basic_block()
+
+    br1 = IRBasicBlock(IRLabel("then"), fn)
+    fn.append_basic_block(br1)
+    br2 = IRBasicBlock(IRLabel("else"), fn)
+    fn.append_basic_block(br2)
+
+    p1 = bb.append_instruction("param")
+    op1 = bb.append_instruction("store", 32)
+    op2 = bb.append_instruction("add", 0, IRLabel("mem"))
+    op3 = bb.append_instruction("store", 64)
+    bb.append_instruction("dloadbytes", op1, op2, op3)
+    op5 = bb.append_instruction("mload", op3)
+    op6 = bb.append_instruction("iszero", op5)
+    bb.append_instruction("jnz", op6, br1.label, br2.label)
+
+    op01 = br1.append_instruction("store", 32)
+    op02 = br1.append_instruction("add", 0, IRLabel("mem"))
+    op03 = br1.append_instruction("store", 64)
+    br1.append_instruction("dloadbytes", op01, op02, op03)
+    op05 = br1.append_instruction("mload", op03)
+    op06 = br1.append_instruction("iszero", op05)
+    br1.append_instruction("return", p1, op06)
+
+    op11 = br2.append_instruction("store", 32)
+    op12 = br2.append_instruction("add", 0, IRLabel("mem"))
+    op13 = br2.append_instruction("store", 64)
+    br2.append_instruction("dloadbytes", op11, op12, op13)
+    op15 = br2.append_instruction("mload", op13)
+    op16 = br2.append_instruction("iszero", op15)
+    br2.append_instruction("return", p1, op16)
+
+
+
+    ac = IRAnalysesCache(fn)
+    MakeSSA(ac, fn).run_pass()
+    AlgebraicOptimizationPass(ac, fn).run_pass()
+    RemoveUnusedVariablesPass(ac, fn).run_pass()
+    
+    offset_count = 0
+    for bb in fn.get_basic_blocks():
+        for instruction in bb.instructions:
+            assert instruction.opcode != "add"
+            if instruction.opcode == "offset":
+                offset_count += 1
+    
+    assert offset_count == 3

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -61,6 +61,9 @@ class AlgebraicOptimizationPass(IRPass):
     def _handle_offsets(self):
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
+                # check if the instruction is of the form
+                # `add <ptr> <label>`
+                # this works only if store chains have been eliminated.
                 if (
                     inst.opcode == "add"
                     and isinstance(inst.operands[0], IRLiteral)

--- a/vyper/venom/passes/extract_literals.py
+++ b/vyper/venom/passes/extract_literals.py
@@ -20,7 +20,7 @@ class ExtractLiteralsPass(IRPass):
         i = 0
         while i < len(bb.instructions):
             inst = bb.instructions[i]
-            if inst.opcode in ["store", "offset"]:
+            if inst.opcode in ("store", "offset"):
                 i += 1
                 continue
 

--- a/vyper/venom/passes/extract_literals.py
+++ b/vyper/venom/passes/extract_literals.py
@@ -20,7 +20,7 @@ class ExtractLiteralsPass(IRPass):
         i = 0
         while i < len(bb.instructions):
             inst = bb.instructions[i]
-            if inst.opcode == "store":
+            if inst.opcode in ["store", "offset"]:
                 i += 1
                 continue
 

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -430,8 +430,6 @@ class VenomCompiler:
             if cost_with_swap > cost_no_swap:
                 operands[-1], operands[-2] = operands[-2], operands[-1]
 
-
-
         # final step to get the inputs to this instruction ordered
         # correctly on the stack
         self._stack_reorder(assembly, stack, operands)

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -401,6 +401,12 @@ class VenomCompiler:
                 stack.poke(depth, ret)
             return apply_line_numbers(inst, assembly)
 
+        if opcode == "offset":
+            assembly.extend(["_OFST", f"_sym_{inst.operands[1].value}", inst.operands[0].value])
+            assert isinstance(inst.output, IROperand), "Offset must have output"
+            stack.push(inst.output)
+            return apply_line_numbers(inst, assembly)
+
         # Step 2: Emit instruction's input operands
         self._emit_input_operands(assembly, inst, operands, stack)
 
@@ -423,6 +429,8 @@ class VenomCompiler:
             cost_with_swap = self._stack_reorder([], stack, operands, dry_run=True)
             if cost_with_swap > cost_no_swap:
                 operands[-1], operands[-2] = operands[-2], operands[-1]
+
+
 
         # final step to get the inputs to this instruction ordered
         # correctly on the stack


### PR DESCRIPTION
### What I did
Created offset handling for statically resolvable values 

### How I did it
I introduced `offset` instruction that is emited in algebraic pass when the `add` instruction calculates offset with literal values

### How to verify it
Created new test in algebraic pass tests 

### Commit message
```
this commit introduces an `offset` instruction that is emitted in the
algebraic pass when the add instruction calculates an offset from a
code label, which is used for immutables. this allows compilation
directly to the magic `OFST` assembly instruction, which does
additional constant folding after symbol resolution.
```