### PR TITLE
Lark should go to the main install section as it used not only for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ extras_require = {
         "pytest-split>=0.7.0,<1.0",
         "eth_abi>=5.0.0,<6.0.0",
         "py-evm>=0.10.1b1,<0.11",
-        "lark==1.1.9",
         "hypothesis[lark]>=6.0,<7.0",
         "eth-stdlib==0.2.7",
         "eth-account==0.12.2",
@@ -92,6 +91,7 @@ setup(
     install_requires=[
         "cbor2>=5.4.6,<6",
         "asttokens>=2.0.5,<3",
+        "lark==1.1.9",
         "pycryptodome>=3.5.1,<4",
         "packaging>=23.1,<24",
         "importlib-metadata",


### PR DESCRIPTION
This patch moves Lark dependency from testing-only dependencies section to the main install section.

Lark is used by regular code, not only by testing code so it should be listed in a common install section.