### PR TITLE
chore[docs]: remove experimental note for cancun

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -121,8 +121,7 @@ def _parse_args(argv):
     )
     parser.add_argument(
         "--evm-version",
-        help=f"Select desired EVM version (default {evm.DEFAULT_EVM_VERSION}). "
-        "note: cancun support is EXPERIMENTAL",
+        help=f"Select desired EVM version (default {evm.DEFAULT_EVM_VERSION})",
         choices=list(evm.EVM_VERSIONS),
         dest="evm_version",
     )


### PR DESCRIPTION
### What I did
remove the experimental note in:
```
  --evm-version {istanbul,berlin,london,paris,shanghai,cancun}
                        Select desired EVM version (default shanghai). note: cancun support is EXPERIMENTAL
```

respective code was properly audited 
