### PR TITLE
fix[lang]: fix panic in call cycle detection

### DIFF
--- a/tests/unit/semantics/analysis/test_cyclic_function_calls.py
+++ b/tests/unit/semantics/analysis/test_cyclic_function_calls.py
@@ -54,6 +54,21 @@ def potato():
         analyze_module(vyper_module, dummy_input_bundle)
 
 
+def test_recursive_function_call(dummy_input_bundle):
+    code = """
+@external
+def foo():
+    self.bar()
+
+@internal
+def bar():
+    self.bar()
+    """
+    vyper_module = parse_to_ast(code)
+    with pytest.raises(CallViolation):
+        analyze_module(vyper_module, dummy_input_bundle)
+
+
 def test_global_ann_assign_callable_no_crash(dummy_input_bundle):
     code = """
 balanceOf: public(HashMap[address, uint256])

--- a/tests/unit/semantics/analysis/test_cyclic_function_calls.py
+++ b/tests/unit/semantics/analysis/test_cyclic_function_calls.py
@@ -106,19 +106,6 @@ def potato():
     assert e.value.message == expected_message
 
 
-def test_cyclic_function_call_without_external(dummy_input_bundle):
-    code = """
-@internal
-def bar():
-    self.bar()
-    """
-    vyper_module = parse_to_ast(code)
-    with pytest.raises(CallViolation) as e:
-        analyze_module(vyper_module, dummy_input_bundle)
-
-    assert e.value.message == "Contract contains cyclic function call: bar -> bar"
-
-
 def test_global_ann_assign_callable_no_crash(dummy_input_bundle):
     code = """
 balanceOf: public(HashMap[address, uint256])

--- a/tests/unit/semantics/analysis/test_cyclic_function_calls.py
+++ b/tests/unit/semantics/analysis/test_cyclic_function_calls.py
@@ -65,8 +65,10 @@ def bar():
     self.bar()
     """
     vyper_module = parse_to_ast(code)
-    with pytest.raises(CallViolation):
+    with pytest.raises(CallViolation) as e:
         analyze_module(vyper_module, dummy_input_bundle)
+
+    assert e.value.message == "Contract contains recursion: bar -> bar"
 
 
 def test_global_ann_assign_callable_no_crash(dummy_input_bundle):

--- a/tests/unit/semantics/analysis/test_cyclic_function_calls.py
+++ b/tests/unit/semantics/analysis/test_cyclic_function_calls.py
@@ -32,7 +32,7 @@ def bar():
     with pytest.raises(CallViolation) as e:
         analyze_module(vyper_module, dummy_input_bundle)
 
-    assert e.value.message == "Contract contains cyclic function call: bar -> bar"
+    assert e.value.message == "Contract contains cyclic function call: foo -> bar -> bar"
 
 
 def test_cyclic_function_call(dummy_input_bundle):
@@ -101,7 +101,7 @@ def potato():
     with pytest.raises(CallViolation) as e:
         analyze_module(vyper_module, dummy_input_bundle)
 
-    expected_message = "Contract contains cyclic function call: bar -> baz -> potato -> bar"
+    expected_message = "Contract contains cyclic function call: foo -> bar -> baz -> potato -> bar"
 
     assert e.value.message == expected_message
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1267,6 +1267,8 @@ class RawLog(BuiltinFunctionT):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
+        context.check_is_not_constant(f"use {self._id}", expr)
+
         topics_length = len(expr.args[0].elements)
         topics = args[0].args
         topics = [unwrap_location(topic) for topic in topics]

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1267,8 +1267,6 @@ class RawLog(BuiltinFunctionT):
 
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
-        context.check_is_not_constant(f"use {self._id}", expr)
-
         topics_length = len(expr.args[0].elements)
         topics = args[0].args
         topics = [unwrap_location(topic) for topic in topics]

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -150,20 +150,17 @@ def _compute_reachable_set(fn_t: ContractFunctionT, path: list[ContractFunctionT
     path = path or []
 
     path.append(fn_t)
-    root = path[0]
 
     for g in fn_t.called_functions:
         if g in fn_t.reachable_internal_functions:
             # already seen
             continue
 
-        if g == root:
-            message = " -> ".join([f.name for f in path])
+        if g in path:
+            cycle_start = path.index(g)
+            extended_path = path[cycle_start:] + [g]
+            message = " -> ".join([f.name for f in extended_path])
             raise CallViolation(f"Contract contains cyclic function call: {message}")
-
-        if g == fn_t:
-            message = f"{g.name} -> {g.name}"
-            raise CallViolation(f"Contract contains recursion: {message}")
 
         _compute_reachable_set(g, path=path)
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -161,6 +161,10 @@ def _compute_reachable_set(fn_t: ContractFunctionT, path: list[ContractFunctionT
             message = " -> ".join([f.name for f in path])
             raise CallViolation(f"Contract contains cyclic function call: {message}")
 
+        if g == fn_t:
+            message = f"{g.name} -> {g.name}"
+            raise CallViolation(f"Contract contains recursion: {message}")
+
         _compute_reachable_set(g, path=path)
 
         g_reachable = g.reachable_internal_functions

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -157,8 +157,7 @@ def _compute_reachable_set(fn_t: ContractFunctionT, path: list[ContractFunctionT
             continue
 
         if g in path:
-            cycle_start = path.index(g)
-            extended_path = path[cycle_start:] + [g]
+            extended_path = path + [g]
             message = " -> ".join([f.name for f in extended_path])
             raise CallViolation(f"Contract contains cyclic function call: {message}")
 


### PR DESCRIPTION
### What I did
- fix: https://github.com/vyperlang/vyper/issues/4194

### How I did it
- check if the func called is the func itself

### How to verify it
- added test


### Commit Message
```
fix cycle detection in `_compute_reachable_set()` by adding a check for
subcycles in the current call path

the function was detecting cycles by checking for a cyclic call to the
*root* of the call path

if the cycle was within the call path (excluding the root) it could
fall into infinite recursion
```