### PR TITLE
fix[codegen]: fix `abi_encode` buffer size in external calls

### DIFF
--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -71,9 +71,9 @@ def _pack_arguments(fn_type, args, context):
     pack_args.append(["mstore", buf, util.method_id_int(abi_signature)])
 
     if len(args) != 0:
-        new_buf = add_ofst(buf, 32)
-        new_buflen = buflen - 32
-        pack_args.append(abi_encode(new_buf, args_as_tuple, context, bufsz=new_buflen))
+        encode_buf = add_ofst(buf, 32)
+        encode_buflen = buflen - 32
+        pack_args.append(abi_encode(encode_buf, args_as_tuple, context, bufsz=encode_buflen))
 
     return buf, pack_args, args_ofst, args_len
 

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -71,7 +71,7 @@ def _pack_arguments(fn_type, args, context):
     pack_args.append(["mstore", buf, util.method_id_int(abi_signature)])
 
     if len(args) != 0:
-        pack_args.append(abi_encode(add_ofst(buf, 32), args_as_tuple, context, bufsz=buflen))
+        pack_args.append(abi_encode(add_ofst(buf, 32), args_as_tuple, context, bufsz=buflen - 32))
 
     return buf, pack_args, args_ofst, args_len
 

--- a/vyper/codegen/external_call.py
+++ b/vyper/codegen/external_call.py
@@ -71,7 +71,9 @@ def _pack_arguments(fn_type, args, context):
     pack_args.append(["mstore", buf, util.method_id_int(abi_signature)])
 
     if len(args) != 0:
-        pack_args.append(abi_encode(add_ofst(buf, 32), args_as_tuple, context, bufsz=buflen - 32))
+        new_buf = add_ofst(buf, 32)
+        new_buflen = buflen - 32
+        pack_args.append(abi_encode(new_buf, args_as_tuple, context, bufsz=new_buflen))
 
     return buf, pack_args, args_ofst, args_len
 


### PR DESCRIPTION
### What I did
- fix https://github.com/vyperlang/vyper/issues/4188


### Commit Message
```
fix the buffer size passed to the abi encoder from the external call
argument packer. previously, the size was overestimated as it didn't
take into account pointer arithmetic performed on the buffer passed to
abi_encode.

this is a hygienic fix, no security implications were found for this
issue.
```
