### PR TITLE
fix[tool]: update `InterfaceT.__str__` implementation

### DIFF
--- a/tests/functional/syntax/test_external_calls.py
+++ b/tests/functional/syntax/test_external_calls.py
@@ -305,7 +305,7 @@ def bar():
     extcall Foo(msg.sender)
     """,
         StructureException,
-        "Function `type(interface Foo)` cannot be called without assigning the result",
+        "Function `type(Foo)` cannot be called without assigning the result",
         None,
     ),
 ]

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -76,6 +76,9 @@ class InterfaceT(_UserType):
     def abi_type(self) -> ABIType:
         return ABI_Address()
 
+    def __str__ (self):
+        return self._id
+
     def __repr__(self):
         return f"interface {self._id}"
 

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -76,7 +76,7 @@ class InterfaceT(_UserType):
     def abi_type(self) -> ABIType:
         return ABI_Address()
 
-    def __str__ (self):
+    def __str__(self):
         return self._id
 
     def __repr__(self):


### PR DESCRIPTION
this doesn't affect anything in vyper codebase, but affects the serialization of interface types for tooling (including titanoboa)

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
