### PR TITLE
fix[ux]: improve error message for bad hex literals

### DIFF
--- a/tests/unit/ast/nodes/test_hex.py
+++ b/tests/unit/ast/nodes/test_hex.py
@@ -35,7 +35,7 @@ foo: constant(bytes4) = 0x12_34_56
     """,
     """
 foo: constant(bytes4) = 0X12345678
-    """
+    """,
 ]
 
 

--- a/tests/unit/ast/nodes/test_hex.py
+++ b/tests/unit/ast/nodes/test_hex.py
@@ -33,6 +33,9 @@ foo: constant(bytes20) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """
 foo: constant(bytes4) = 0x12_34_56
     """,
+    """
+foo: constant(bytes4) = 0X12345678
+    """
 ]
 
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -854,9 +854,14 @@ class Hex(Constant):
 
     def validate(self):
         if "_" in self.value:
+            # TODO: revisit this, we should probably allow underscores
             raise InvalidLiteral("Underscores not allowed in hex literals", self)
         if len(self.value) % 2:
             raise InvalidLiteral("Hex notation requires an even number of digits", self)
+
+        if self.value.startswith("0X"):
+            hint = f"Did you mean `0x{self.value[2:]}`?"
+            raise InvalidLiteral("Hex literal begins with 0X!", self, hint=hint)
 
     @property
     def n_nibbles(self):


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
improve the error message when a hex literal starts with `0X`. it is
accepted by the parser, but prior to this commit, would result in a
compiler panic. this commit validates the literal and provides a proper
error message.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
