### PR TITLE
perf[venom]: improve OrderedSet operations

### DIFF
--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -104,10 +104,11 @@ class OrderedSet(Generic[_T]):
         if len(sets) == 0:
             raise ValueError("undefined: intersection of no sets")
 
-        ret = sets[0].copy()
-        for e in sets[0]:
-            if any(e not in s for s in sets[1:]):
-                ret.remove(e)
+        tmp = sets[0]._data.items()
+        for s in sets[1:]:
+            tmp &= s._data.items()
+        ret = cls.__new__(cls)
+        ret._data = dict(tmp)
         return ret
 
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -25,9 +25,10 @@ class OrderedSet(Generic[_T]):
     """
 
     def __init__(self, iterable=None):
-        self._data = dict()
-        if iterable is not None:
-            self.update(iterable)
+        if iterable is None:
+            self._data = dict()
+        else:
+            self._data = dict.fromkeys(iterable)
 
     def __repr__(self):
         keys = ", ".join(repr(k) for k in self)

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -58,6 +58,7 @@ class OrderedSet(Generic[_T]):
     def add(self, item: _T) -> None:
         self._data[item] = None
 
+    # NOTE to refactor: duplicate of self.update()
     def addmany(self, iterable):
         for item in iterable:
             self._data[item] = None

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -110,12 +110,11 @@ class OrderedSet(Generic[_T]):
         if len(sets) == 0:
             raise ValueError("undefined: intersection of no sets")
 
-        tmp = sets[0]._data.items()
+        tmp = sets[0]._data.keys()
         for s in sets[1:]:
-            tmp &= s._data.items()
-        ret = cls.__new__(cls)
-        ret._data = dict(tmp)
-        return ret
+            tmp &= s._data.keys()
+
+        return cls(tmp)
 
 
 class StringEnum(enum.Enum):


### PR DESCRIPTION
### What I did
improve time spent in venom by 25%

### How I did it
dict views support set operations, https://docs.python.org/3/library/stdtypes.html#dict-views

### How to verify it
check `time vyper --optimize none` vs `time vyper --experimental-codegen --optimize none` for a large-ish vyper contract

### Commit message

```
improve time spent in venom by 25%

dict views support set operations, which allows us to loop, using
`&=`. since our intersections are typically not between a large number
of OrderedSets, this results in faster execution time.

references:
- https://docs.python.org/3/library/stdtypes.html#dict-views
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
