### PR TITLE
fix[lang]: prevent eq/neq bytes folding

### DIFF
--- a/tests/unit/ast/nodes/test_fold_compare.py
+++ b/tests/unit/ast/nodes/test_fold_compare.py
@@ -110,3 +110,11 @@ def test_compare_type_mismatch(op):
     old_node = vyper_ast.body[0].value
     with pytest.raises(UnfoldableNode):
         old_node.get_folded_value()
+
+
+@pytest.mark.parametrize("op", ["==", "!="])
+def test_compare_eq_bytes(op):
+    vyper_ast = parse_and_fold(f"0xA1AAB33F {op} 0xa1aab33f")
+    old_node = vyper_ast.body[0].value
+    with pytest.raises(UnfoldableNode):
+        old_node.get_folded_value()

--- a/vyper/semantics/analysis/constant_folding.py
+++ b/vyper/semantics/analysis/constant_folding.py
@@ -176,7 +176,7 @@ class ConstantFolder(VyperNodeVisitorBase):
             raise UnfoldableNode("Cannot compare different literal types")
 
         # this is maybe just handled in the type checker.
-        if not isinstance(node.op, (vy_ast.Eq, vy_ast.NotEq)) and not isinstance(left, vy_ast.Num):
+        if not isinstance(node.op, (vy_ast.Eq, vy_ast.NotEq)) or not isinstance(left, vy_ast.Num):
             raise UnfoldableNode(
                 f"Invalid literal types for {node.op.description} comparison", node
             )


### PR DESCRIPTION
### What I did

Prevent `[bytesN] [==|!=] [bytesN]` to be folded as the operation was computed on python strings and not integer values.

### How I did it

Fixed the incorrect condition.

### How to verify it

The test is relatively explicit.

Before this, the following would hold.
```Vyper
@external
def foo() -> bool:
    a:bytes4 = 0xA1AAB33F
    b:bytes4 = 0xa1aab33f
    return a == b # returns True

@external
def bar() -> bool:
    return 0xA1AAB33F == 0xa1aab33f # returns False
```

### Commit message

    fix[lang]: prevent eq/neq bytes folding

### Description for the changelog

    prevent eq/neq bytes folding

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i2.wp.com/blog.backtotheroots.com/wp-content/uploads/2021/02/image2.jpg?w=1999&ssl=1)
