### PR TITLE
fix[venom]: remove duplicate volatile instructions

### DIFF
--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -21,8 +21,6 @@ VOLATILE_INSTRUCTIONS = frozenset(
         "istore",
         "tload",
         "tstore",
-        "assert",
-        "assert_unreachable",
         "mstore",
         "mload",
         "calldatacopy",


### PR DESCRIPTION
### What I did

Cleaned up the `VOLATILE_INSTRUCTIONS` from duplicates 

### How I did it

### How to verify it

### Commit message

```
Remove duplicate `assert`, `assert_unreachable` from `VOLATILE_INSTRUCTIONS` dictionary
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
