### PR TITLE
fix[tool]: update VarAccess pickle implementation

### DIFF
--- a/tests/integration/test_pickle_ast.py
+++ b/tests/integration/test_pickle_ast.py
@@ -1,0 +1,19 @@
+import copy
+import pickle
+
+from vyper.compiler.phases import CompilerData
+
+
+def test_pickle_ast():
+    code = """
+@external
+def foo():
+    self.bar()
+    y: uint256 = 5
+    x: uint256 = 5
+def bar():
+    pass
+    """
+    f = CompilerData(code)
+    copy.deepcopy(f.annotated_vyper_module)
+    pickle.loads(pickle.dumps(f.annotated_vyper_module))

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -234,6 +234,9 @@ class VarAccess:
     # A sentinel indicating a subscript access
     SUBSCRIPT_ACCESS: ClassVar[Any] = object()
 
+    # custom __reduce__ and _produce implementations to work around
+    # a pickle bug.
+    # see https://github.com/python/cpython/issues/124937#issuecomment-2392227290
     def __reduce__(self):
         dict_obj = {f.name: getattr(self, f.name) for f in fields(self)}
         return self.__class__._produce, (dict_obj,)

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -1,5 +1,5 @@
 import enum
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Union
 
@@ -291,15 +291,14 @@ class ExprInfo:
     modifiability: Modifiability = Modifiability.MODIFIABLE
     attr: Optional[str] = None
 
-    _writes: OrderedSet[VarAccess] = field(default_factory=OrderedSet)
-    _reads: OrderedSet[VarAccess] = field(default_factory=OrderedSet)
-
     def __post_init__(self):
         should_match = ("typ", "location", "modifiability")
         if self.var_info is not None:
             for attr in should_match:
                 if getattr(self.var_info, attr) != getattr(self, attr):
                     raise CompilerPanic(f"Bad analysis: non-matching {attr}: {self}")
+        self._writes: OrderedSet[VarAccess] = OrderedSet()
+        self._reads: OrderedSet[VarAccess] = OrderedSet()
 
     @classmethod
     def from_varinfo(cls, var_info: VarInfo, **kwargs) -> "ExprInfo":

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -243,11 +243,7 @@ class VarAccess:
 
     @classmethod
     def _produce(cls, data):
-        ret = cls.__new__(cls)
-        # bypass blocking of setattr by `frozen=True`
-        for k, v in data.items():
-            object.__setattr__(ret, k, v)
-        return ret
+        return cls(**data)
 
     @cached_property
     def attrs(self):

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -242,7 +242,8 @@ class VarAccess:
     def _produce(cls, data):
         ret = cls.__new__(cls)
         # bypass blocking of setattr by `frozen=True`
-        ret.__dict__.update(data)
+        for k, v in data.items():
+            object.__setattr__(ret, k, v)
         return ret
 
     @cached_property

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -241,9 +241,9 @@ class VarAccess:
     @classmethod
     def _produce(cls, data):
         ret = cls.__new__(cls)
-        for k, v in data.items():
-            object.__setattr__(ret, k, v)
-        return cls
+        # bypass blocking of setattr by `frozen=True`
+        ret.__dict__.update(data)
+        return ret
 
     @cached_property
     def attrs(self):


### PR DESCRIPTION
### What I did
fix a bug where unpickling `annotated_vyper_module` would lead to a crash:
```
AttributeError: 'VarAccess' object has no attribute 'variable'
```
a repro can be found at https://github.com/charles-cooper/vyper/commit/2a5facf43ffb08b66f76d3d2b16b8f72f22d0625.

this is a blocker for tooling, for instance titanoboa relies on pickle/unpickle to cache CompilerData objects:
https://github.com/vyperlang/titanoboa/blob/86df8936654db20686410488738d7abaf165a4c9/boa/util/disk_cache.py#L65-L66

the underlying issue is that `pickle.loads()` calls `obj.__hash__()` for objects that are keys in a hashed data structure - namely, dicts, sets and frozensets. this causes a crash when there is a cycle in the object graph, because the object is not fully instantiated at the time that `__hash__()` is called. this is a cpython bug, reported at https://github.com/python/cpython/issues/124937.

@serhiy-storchaka suggested the approach taken in this PR, which breaks the loop before pickling: https://github.com/python/cpython/issues/124937#issuecomment-2392227290.

### How I did it

### How to verify it

### Commit message

````
fix a bug where unpickling `annotated_vyper_module` would lead to
a crash:

```
AttributeError: 'VarAccess' object has no attribute 'variable'
```

this is a blocker for tooling, for instance, titanoboa
relies on pickle/unpickle to cache `CompilerData` objects:
https://github.com/vyperlang/titanoboa/blob/86df8936654db2068641/boa/util/disk_cache.py#L65-L66

the underlying issue is that `pickle.loads()` calls `obj.__hash__()`
for objects that are keys in a hashed data structure - namely, dicts,
sets and frozensets. this causes a crash when there is a cycle in
the object graph, because the object is not fully instantiated at the
time that `__hash__()` is called. this is a cpython issue, reported at
python/cpython#124937.

@serhiy-storchaka suggested the approach taken in this PR, which breaks
the loop before pickling:
https://github.com/python/cpython/issues/124937#issuecomment-2392227290

note that the implementation of `__reduce__()` in this PR is safe, since
there is no cycle in the hash function itself, since the recursion
breaks in `VarInfo.__hash__()`. in other words, there is no possibility
of `VarAccess.__hash__()` changing mid-way through reconstructing the
object.
````
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
