### PR TITLE
feat[venom]: improve mem2var and store elimination passes

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -48,10 +48,17 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel) -> None:
     ac = IRAnalysesCache(fn)
 
     SimplifyCFGPass(ac, fn).run_pass()
+
     MakeSSA(ac, fn).run_pass()
+
+    # run store elim before mem2var, eliminating store instructions
+    # which block var lifting
+    StoreElimination(ac, fn).run_pass()
     Mem2Var(ac, fn).run_pass()
+
     MakeSSA(ac, fn).run_pass()
     SCCP(ac, fn).run_pass()
+
     StoreElimination(ac, fn).run_pass()
     SimplifyCFGPass(ac, fn).run_pass()
     AlgebraicOptimizationPass(ac, fn).run_pass()

--- a/vyper/venom/passes/store_elimination.py
+++ b/vyper/venom/passes/store_elimination.py
@@ -18,10 +18,6 @@ class StoreElimination(IRPass):
                 continue
             if not isinstance(inst.operands[0], IRVariable):
                 continue
-            if inst.operands[0].name in ["%ret_ofst", "%ret_size"]:
-                continue
-            if inst.output.name in ["%ret_ofst", "%ret_size"]:
-                continue
             self._process_store(dfg, inst, var, inst.operands[0])
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)


### PR DESCRIPTION
run an extra store elimination before mem2var. this eliminates dummy stores which (currently) block lifting in mem2var.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
