### PR TITLE
fix[lang]: fix recursive interface imports

### DIFF
--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -381,13 +381,22 @@ def test_interfaces_success(good_code):
 
 
 def test_imports_and_implements_within_interface(make_input_bundle):
-    interface_code = """
+    ibar_code = """
+@external
+def foobar():
+    ...
+"""
+    ifoo_code = """
+import bar
+
+implements: bar
+
 @external
 def foobar():
     ...
 """
 
-    input_bundle = make_input_bundle({"foo.vyi": interface_code})
+    input_bundle = make_input_bundle({"foo.vyi": ifoo_code, "bar.vyi": ibar_code})
 
     code = """
 import foo as Foo

--- a/vyper/semantics/analysis/imports.py
+++ b/vyper/semantics/analysis/imports.py
@@ -194,6 +194,7 @@ class ImportAnalyzer:
             file = self.input_bundle.load_file(path.with_suffix(".vyi"))
             assert isinstance(file, FileInput)  # mypy hint
             module_ast = self._ast_from_file(file)
+            self.resolve_imports(module_ast)
 
             # language does not yet allow recursion for vyi files
             # self.resolve_imports(module_ast)


### PR DESCRIPTION
fix a bug where imports inside of interfaces are not recursed into in the import resolution pass. this is a regression in 6843e7915729f3a3ea0d8c765dffa52033f5818e.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
