### PR TITLE
fix[ci]: fix commithash calculation for pypi release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ jobs:
             # need to fetch unshallow so that setuptools_scm can infer the version
             fetch-depth: 0
 
+      # debug
+      - name: Git shorthash
+        run: git rev-parse --short HEAD
+
       - name: Python
         uses: actions/setup-python@v5
         with:
@@ -59,6 +63,10 @@ jobs:
             ref: ${{ github.event.inputs.tag }}
             # need to fetch unshallow so that setuptools_scm can infer the version
             fetch-depth: 0
+
+      # debug
+      - name: Git shorthash
+        run: git rev-parse --short HEAD
 
       - name: Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -20,6 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # fetch unshallow so commit hash matches github release.
+        # see https://github.com/vyperlang/vyper/blob/8f9a8cac49aafb3fbc9dde78f0f6125c390c32f0/.github/workflows/build.yml#L27-L32
+        fetch-depth: 0
 
     - name: Python
       uses: actions/setup-python@v5

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -25,6 +25,10 @@ jobs:
         # see https://github.com/vyperlang/vyper/blob/8f9a8cac49aafb3fbc9dde78f0f6125c390c32f0/.github/workflows/build.yml#L27-L32
         fetch-depth: 0
 
+    # debug
+    - name: Git shorthash
+      run: git rev-parse --short HEAD
+
     - name: Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/4308

### How I did it

### How to verify it

### Commit message

````
there is a mismatch between the commit hash in the binary of the github
release vs the pypi release. for example,
```bash
~ $ vyper --version  # pipx install vyper==0.4.0
0.4.0+commit.e9db8d9
```
```bash
~ $ .vvm/vyper-0.4.0 --version
0.4.0+commit.e9db8d9f
```

this is due to how git computes the shorthash. when checkout is run for
release-pypi.yml, it doesn't fetch the full commit history, and so there
are fewer commits, so `git rev-parse --short HEAD` returns a smaller
fingerprint for the commit hash.

this commit amends the pypi release checkout step so that it matches the
github release workflow.

it also adds a debug step to the relevant workflows so that we can debug
the commit hash during the github action.
````

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
