### PR TITLE
refactor[venom]: update translator for deploy instruction

### DIFF
--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -195,17 +195,19 @@ class IRFunction:
         """
         bbs = list(self.get_basic_blocks())
         for i, bb in enumerate(bbs):
-            if not bb.is_terminated:
-                if i < len(bbs) - 1:
-                    # TODO: revisit this. When contructor calls internal functions they
-                    # are linked to the last ctor block. Should separate them before this
-                    # so we don't have to handle this here
-                    if bbs[i + 1].label.value.startswith("internal"):
-                        bb.append_instruction("stop")
-                    else:
-                        bb.append_instruction("jmp", bbs[i + 1].label)
+            if bb.is_terminated:
+                continue
+
+            if i < len(bbs) - 1:
+                # TODO: revisit this. When contructor calls internal functions
+                # they are linked to the last ctor block. Should separate them
+                # before this so we don't have to handle this here
+                if bbs[i + 1].label.value.startswith("internal"):
+                    bb.append_instruction("stop")
                 else:
-                    bb.append_instruction("exit")
+                    bb.append_instruction("jmp", bbs[i + 1].label)
+            else:
+                bb.append_instruction("stop")
 
     def copy(self):
         new = IRFunction(self.name)

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -255,6 +255,7 @@ def _convert_ir_bb(fn, ir, symbols):
     elif ir.value == "deploy":
         ctx.ctor_mem_size = ir.args[0].value
         ctx.immutables_len = ir.args[2].value
+        fn.get_basic_block().append_instruction("exit")
         return None
     elif ir.value == "seq":
         if len(ir.args) == 0:
@@ -398,10 +399,7 @@ def _convert_ir_bb(fn, ir, symbols):
         bb = IRBasicBlock(label, fn)
         fn.append_basic_block(bb)
         code = ir.args[2]
-        if code.value == "pass":
-            bb.append_instruction("exit")
-        else:
-            _convert_ir_bb(fn, code, symbols)
+        _convert_ir_bb(fn, code, symbols)
     elif ir.value == "exit_to":
         args = _convert_ir_bb_list(fn, ir.args[1:], symbols)
         var_list = args


### PR DESCRIPTION
this commit updates `ir_node_to_venom.py` for the `deploy` instruction to properly emit the `exit` instruction. it also removes places in the translator where the `exit` instruction was improperly emitted.

misc:
- update style to continue early in the loop rather than nest.

### What I did
fix #4317 

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
