### PR TITLE
feat[lang]: reject `implements` for empty interfaces

### DIFF
--- a/tests/functional/syntax/modules/test_implements.py
+++ b/tests/functional/syntax/modules/test_implements.py
@@ -1,4 +1,7 @@
+import pytest
+
 from vyper.compiler import compile_code
+from vyper.exceptions import StructureException
 
 
 def test_implements_from_vyi(make_input_bundle):
@@ -49,3 +52,21 @@ def foo():  # implementation
     input_bundle = make_input_bundle({"some_interface.vyi": vyi, "lib1.vy": lib1, "lib2.vy": lib2})
 
     assert compile_code(main, input_bundle=input_bundle) is not None
+
+
+def test_implements_empty_vyi(make_input_bundle, tmp_path):
+    vyi = ""
+    input_bundle = make_input_bundle({"some_interface.vyi": vyi})
+    main = """
+import some_interface
+
+implements: some_interface
+    """
+    with pytest.raises(StructureException) as e:
+        _ = compile_code(main, input_bundle=input_bundle)
+
+    vyi_path = (tmp_path / "some_interface.vyi").as_posix()
+    assert (
+        e.value._message
+        == f"Tried to implement `{vyi_path}`, but it has no functions to implement!"
+    )

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -112,6 +112,10 @@ class InterfaceT(_UserType):
     def validate_implements(
         self, node: vy_ast.ImplementsDecl, functions: dict[ContractFunctionT, vy_ast.VyperNode]
     ) -> None:
+        if len(self.functions) == 0:
+            msg = f"Tried to implement `{self}`, but it has no functions to implement!"
+            raise StructureException(msg, node)
+
         # only external functions can implement interfaces
         fns_by_name = {fn_t.name: fn_t for fn_t in functions.keys()}
 


### PR DESCRIPTION
`implements: <interface>` for an empty interface likely indicates a bug in user code, reject it.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
