### PR TITLE
fix[venom]: add `sha3_64` effects

### DIFF
--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -68,6 +68,7 @@ _reads = {
     "revert": MEMORY,
     "return": MEMORY,
     "sha3": MEMORY,
+    "sha3_64": MEMORY,
     "msize": MSIZE,
 }
 


### PR DESCRIPTION
### What I did

I added the effects of `sha3_64` that were missing

### How I did it

### How to verify it

### Commit message

```
Adds the effects of the `sha3_64` instruction in `effects.py`
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
