### PR TITLE
refactor[venom]: refactor sccp pass to use dfg

### DIFF
--- a/vyper/venom/analysis/dfg.py
+++ b/vyper/venom/analysis/dfg.py
@@ -5,9 +5,10 @@ from vyper.venom.analysis.liveness import LivenessAnalysis
 from vyper.venom.basicblock import IRInstruction, IRVariable
 from vyper.venom.function import IRFunction
 
+from vyper.utils import OrderedSet
 
 class DFGAnalysis(IRAnalysis):
-    _dfg_inputs: dict[IRVariable, list[IRInstruction]]
+    _dfg_inputs: dict[IRVariable, OrderedSet[IRInstruction]]
     _dfg_outputs: dict[IRVariable, IRInstruction]
 
     def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction):
@@ -16,19 +17,19 @@ class DFGAnalysis(IRAnalysis):
         self._dfg_outputs = dict()
 
     # return uses of a given variable
-    def get_uses(self, op: IRVariable) -> list[IRInstruction]:
-        return self._dfg_inputs.get(op, [])
+    def get_uses(self, op: IRVariable) -> OrderedSet[IRInstruction]:
+        return self._dfg_inputs.get(op, OrderedSet())
 
     # the instruction which produces this variable.
     def get_producing_instruction(self, op: IRVariable) -> Optional[IRInstruction]:
         return self._dfg_outputs.get(op)
 
     def add_use(self, op: IRVariable, inst: IRInstruction):
-        uses = self._dfg_inputs.setdefault(op, [])
-        uses.append(inst)
+        uses = self._dfg_inputs.setdefault(op, OrderedSet())
+        uses.add(inst)
 
     def remove_use(self, op: IRVariable, inst: IRInstruction):
-        uses = self._dfg_inputs.get(op, [])
+        uses: OrderedSet = self._dfg_inputs.get(op, OrderedSet())
         uses.remove(inst)
 
     @property
@@ -48,10 +49,11 @@ class DFGAnalysis(IRAnalysis):
                 res = inst.get_outputs()
 
                 for op in operands:
-                    inputs = self._dfg_inputs.setdefault(op, [])
-                    inputs.append(inst)
+                    inputs = self._dfg_inputs.setdefault(op, OrderedSet())
+                    inputs.add(inst)
 
                 for op in res:  # type: ignore
+                    assert isinstance(op, IRVariable)
                     self._dfg_outputs[op] = inst
 
     def as_graph(self) -> str:

--- a/vyper/venom/analysis/dfg.py
+++ b/vyper/venom/analysis/dfg.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
+from vyper.utils import OrderedSet
 from vyper.venom.analysis.analysis import IRAnalysesCache, IRAnalysis
 from vyper.venom.analysis.liveness import LivenessAnalysis
 from vyper.venom.basicblock import IRInstruction, IRVariable
 from vyper.venom.function import IRFunction
 
-from vyper.utils import OrderedSet
 
 class DFGAnalysis(IRAnalysis):
     _dfg_inputs: dict[IRVariable, OrderedSet[IRInstruction]]

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from vyper.exceptions import CompilerPanic, StaticAssertionException
 from vyper.utils import OrderedSet
-from vyper.venom.analysis import CFGAnalysis, DominatorTreeAnalysis, DFGAnalysis, IRAnalysesCache
+from vyper.venom.analysis import CFGAnalysis, DFGAnalysis, DominatorTreeAnalysis, IRAnalysesCache
 from vyper.venom.basicblock import (
     IRBasicBlock,
     IRInstruction,
@@ -52,7 +52,6 @@ class SCCP(IRPass):
     fn: IRFunction
     dom: DominatorTreeAnalysis
     dfg: DFGAnalysis
-    #uses: dict[IRVariable, OrderedSet[IRInstruction]]
     lattice: Lattice
     work_list: list[WorkListItem]
     cfg_in_exec: dict[IRBasicBlock, OrderedSet[IRBasicBlock]]

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -261,11 +261,8 @@ class SCCP(IRPass):
         return ret  # type: ignore
 
     def _add_ssa_work_items(self, inst: IRInstruction):
-        for target_inst in self._get_uses(inst.output):  # type: ignore
+        for target_inst in self.dfg.get_uses(inst.output):  # type: ignore
             self.work_list.append(SSAWorkListItem(target_inst))
-
-    def _get_uses(self, var: IRVariable):
-        return self.dfg.get_uses(var)
 
     def _propagate_constants(self):
         """


### PR DESCRIPTION
### What I did
used DFGAnalysis in SCCP instead of the computing the uses in the SCCP itself

### How I did it
Remove computation from the SCCP and added DFG analysis into it and changed the DFG analysis so it uses OrderedSet

### How to verify it

### Commit message
```
use `DFGAnalysis` in `SCCP` instead of duplicating the logic to compute
uses in the `SCCP` itself. also use `OrderedSet` for var uses, this
ensures we don't add the same instruction multiple times (as in `add
%2 %2`) to a var's use set, and also enables a cheaper `remove_use()`
implementation.
```

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
