### PR TITLE
feat[venom]: improve liveness computation

### DIFF
--- a/tests/functional/codegen/features/test_constructor.py
+++ b/tests/functional/codegen/features/test_constructor.py
@@ -1,7 +1,4 @@
-import pytest
-
 from tests.evm_backends.base_env import _compile
-from vyper.exceptions import StackTooDeep
 from vyper.utils import method_id
 
 

--- a/tests/functional/codegen/features/test_constructor.py
+++ b/tests/functional/codegen/features/test_constructor.py
@@ -169,7 +169,6 @@ def get_foo() -> uint256:
     assert c.get_foo() == 39
 
 
-@pytest.mark.venom_xfail(raises=StackTooDeep, reason="stack scheduler regression")
 def test_nested_dynamic_array_constructor_arg_2(env, get_contract):
     code = """
 foo: int128

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -11,7 +11,6 @@ from vyper.exceptions import (
     CompilerPanic,
     ImmutableViolation,
     OverflowException,
-    StackTooDeep,
     StateAccessViolation,
     TypeMismatch,
 )

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -737,7 +737,6 @@ def test_array_decimal_return3() -> DynArray[DynArray[decimal, 2], 2]:
     ]
 
 
-@pytest.mark.venom_xfail(raises=StackTooDeep, reason="stack scheduler regression")
 def test_mult_list(get_contract):
     code = """
 nest3: DynArray[DynArray[DynArray[uint256, 2], 2], 2]

--- a/tests/unit/compiler/venom/test_branch_optimizer.py
+++ b/tests/unit/compiler/venom/test_branch_optimizer.py
@@ -16,6 +16,7 @@ def test_simple_jump_case():
     fn.append_basic_block(br2)
 
     p1 = bb.append_instruction("param")
+    p2 = bb.append_instruction("param")
     op1 = bb.append_instruction("store", p1)
     op2 = bb.append_instruction("store", 64)
     op3 = bb.append_instruction("add", op1, op2)
@@ -24,7 +25,7 @@ def test_simple_jump_case():
 
     br1.append_instruction("add", op3, p1)
     br1.append_instruction("stop")
-    br2.append_instruction("add", op3, 10)
+    br2.append_instruction("add", op3, p2)
     br2.append_instruction("stop")
 
     term_inst = bb.instructions[-1]

--- a/tests/unit/compiler/venom/test_sccp.py
+++ b/tests/unit/compiler/venom/test_sccp.py
@@ -167,8 +167,8 @@ def test_cont_phi_case():
     assert sccp.lattice[IRVariable("%2")].value == 32
     assert sccp.lattice[IRVariable("%3")].value == 64
     assert sccp.lattice[IRVariable("%4")].value == 96
-    assert sccp.lattice[IRVariable("%5", version=1)].value == 106
-    assert sccp.lattice[IRVariable("%5", version=2)] == LatticeEnum.BOTTOM
+    assert sccp.lattice[IRVariable("%5", version=2)].value == 106
+    assert sccp.lattice[IRVariable("%5", version=1)] == LatticeEnum.BOTTOM
     assert sccp.lattice[IRVariable("%5")].value == 2
 
 
@@ -207,8 +207,9 @@ def test_cont_phi_const_case():
     assert sccp.lattice[IRVariable("%2")].value == 32
     assert sccp.lattice[IRVariable("%3")].value == 64
     assert sccp.lattice[IRVariable("%4")].value == 96
-    assert sccp.lattice[IRVariable("%5", version=1)].value == 106
-    assert sccp.lattice[IRVariable("%5", version=2)].value == 97
+    # dependent on cfg traversal order
+    assert sccp.lattice[IRVariable("%5", version=2)].value == 106
+    assert sccp.lattice[IRVariable("%5", version=1)].value == 97
     assert sccp.lattice[IRVariable("%5")].value == 2
 
 

--- a/vyper/venom/analysis/cfg.py
+++ b/vyper/venom/analysis/cfg.py
@@ -22,16 +22,13 @@ class CFGAnalysis(IRAnalysis):
         for bb in fn.get_basic_blocks():
             assert bb.is_terminated
 
-            for inst in bb.instructions:
-                if inst.opcode in CFG_ALTERING_INSTRUCTIONS:
-                    ops = inst.get_label_operands()
-                    for op in ops:
-                        fn.get_basic_block(op.value).add_cfg_in(bb)
-
-        # Fill in the "out" set for each basic block
-        for bb in fn.get_basic_blocks():
-            for in_bb in bb.cfg_in:
-                in_bb.add_cfg_out(bb)
+            term = bb.instructions[-1]
+            if term.opcode in CFG_ALTERING_INSTRUCTIONS:
+                ops = term.get_label_operands()
+                for op in ops:
+                    next_bb = fn.get_basic_block(op.value)
+                    next_bb.add_cfg_in(bb)
+                    bb.add_cfg_out(next_bb)
 
     def _compute_dfs_r(self, bb, visited=None):
         assert self._dfs is not None  # help mypy

--- a/vyper/venom/analysis/cfg.py
+++ b/vyper/venom/analysis/cfg.py
@@ -28,14 +28,11 @@ class CFGAnalysis(IRAnalysis):
             term = bb.instructions[-1]
             if term.opcode in CFG_ALTERING_INSTRUCTIONS:
                 ops = term.get_label_operands()
-                for op in ops:
+                # order of cfg_out matters to performance!
+                for op in reversed(list(ops)):
                     next_bb = fn.get_basic_block(op.value)
+                    bb.add_cfg_out(next_bb)
                     next_bb.add_cfg_in(bb)
-
-        for bb in fn.get_basic_blocks():
-            for in_bb in bb.cfg_in:
-                # order here matters to performance!
-                in_bb.add_cfg_out(bb)
 
         self._compute_dfs_r(self.function.entry)
 

--- a/vyper/venom/analysis/cfg.py
+++ b/vyper/venom/analysis/cfg.py
@@ -28,7 +28,11 @@ class CFGAnalysis(IRAnalysis):
                 for op in ops:
                     next_bb = fn.get_basic_block(op.value)
                     next_bb.add_cfg_in(bb)
-                    bb.add_cfg_out(next_bb)
+
+        for bb in fn.get_basic_blocks():
+            for in_bb in bb.cfg_in:
+                # order here matters to performance
+                in_bb.add_cfg_out(bb)
 
     def _compute_dfs_r(self, bb, visited=None):
         assert self._dfs is not None  # help mypy

--- a/vyper/venom/analysis/dominators.py
+++ b/vyper/venom/analysis/dominators.py
@@ -1,3 +1,6 @@
+from functools import cached_property
+from typing import Iterator
+
 from vyper.exceptions import CompilerPanic
 from vyper.utils import OrderedSet
 from vyper.venom.analysis import CFGAnalysis, IRAnalysis
@@ -14,8 +17,6 @@ class DominatorTreeAnalysis(IRAnalysis):
 
     fn: IRFunction
     entry_block: IRBasicBlock
-    dfs_order: dict[IRBasicBlock, int]
-    dfs_walk: list[IRBasicBlock]
     dominators: dict[IRBasicBlock, OrderedSet[IRBasicBlock]]
     immediate_dominators: dict[IRBasicBlock, IRBasicBlock]
     dominated: dict[IRBasicBlock, OrderedSet[IRBasicBlock]]
@@ -27,14 +28,12 @@ class DominatorTreeAnalysis(IRAnalysis):
         """
         self.fn = self.function
         self.entry_block = self.fn.entry
-        self.dfs_order = {}
-        self.dfs_walk = []
         self.dominators = {}
         self.immediate_dominators = {}
         self.dominated = {}
         self.dominator_frontiers = {}
 
-        self.analyses_cache.request_analysis(CFGAnalysis)
+        self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
 
         self._compute_dfs(self.entry_block, OrderedSet())
         self._compute_dominators()
@@ -131,21 +130,13 @@ class DominatorTreeAnalysis(IRAnalysis):
                 bb2 = self.immediate_dominators[bb2]
         return bb1
 
-    def _compute_dfs(self, entry: IRBasicBlock, visited):
-        """
-        Depth-first search to compute the DFS order of the basic blocks. This
-        is used to compute the dominator tree. The sequence of basic blocks in
-        the DFS order is stored in `self.dfs_walk`. The DFS order of each basic
-        block is stored in `self.dfs_order`.
-        """
-        visited.add(entry)
+    @cached_property
+    def dfs_walk(self) -> Iterator[IRBasicBlock]:
+        return self.cfg.dfs_walk
 
-        for bb in entry.cfg_out:
-            if bb not in visited:
-                self._compute_dfs(bb, visited)
-
-        self.dfs_walk.append(entry)
-        self.dfs_order[entry] = len(self.dfs_walk)
+    @cached_property
+    def dfs_order(self) -> dict[IRBasicBlock, int]:
+        return {bb: idx for idx, bb in enumerate(self.dfs_walk)}
 
     def as_graph(self) -> str:
         """

--- a/vyper/venom/analysis/dominators.py
+++ b/vyper/venom/analysis/dominators.py
@@ -1,5 +1,4 @@
 from functools import cached_property
-from typing import Iterator
 
 from vyper.exceptions import CompilerPanic
 from vyper.utils import OrderedSet

--- a/vyper/venom/analysis/dominators.py
+++ b/vyper/venom/analysis/dominators.py
@@ -35,7 +35,6 @@ class DominatorTreeAnalysis(IRAnalysis):
 
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
 
-        self._compute_dfs(self.entry_block, OrderedSet())
         self._compute_dominators()
         self._compute_idoms()
         self._compute_df()
@@ -131,8 +130,8 @@ class DominatorTreeAnalysis(IRAnalysis):
         return bb1
 
     @cached_property
-    def dfs_walk(self) -> Iterator[IRBasicBlock]:
-        return self.cfg.dfs_walk
+    def dfs_walk(self) -> list[IRBasicBlock]:
+        return list(self.cfg.dfs_walk)
 
     @cached_property
     def dfs_order(self) -> dict[IRBasicBlock, int]:

--- a/vyper/venom/analysis/liveness.py
+++ b/vyper/venom/analysis/liveness.py
@@ -12,11 +12,10 @@ class LivenessAnalysis(IRAnalysis):
     """
 
     def analyze(self):
-        self.analyses_cache.request_analysis(CFGAnalysis)
+        cfg = self.analyses_cache.request_analysis(CFGAnalysis)
         self._reset_liveness()
 
-        self._worklist = deque()
-        self._worklist.extend(self.function.get_basic_blocks())
+        self._worklist = deque(cfg.dfs_walk)
 
         while len(self._worklist) > 0:
             changed = False

--- a/vyper/venom/analysis/liveness.py
+++ b/vyper/venom/analysis/liveness.py
@@ -64,7 +64,7 @@ class LivenessAnalysis(IRAnalysis):
         bb.out_vars = OrderedSet()
         for out_bb in bb.cfg_out:
             target_vars = self.input_vars_from(bb, out_bb)
-            bb.out_vars = bb.out_vars.union(target_vars)
+            bb.out_vars.update(target_vars)
         return out_vars != bb.out_vars
 
     # calculate the input variables into self from source

--- a/vyper/venom/analysis/liveness.py
+++ b/vyper/venom/analysis/liveness.py
@@ -15,17 +15,18 @@ class LivenessAnalysis(IRAnalysis):
         cfg = self.analyses_cache.request_analysis(CFGAnalysis)
         self._reset_liveness()
 
-        self._worklist = deque(cfg.dfs_walk)
+        worklist = deque(cfg.dfs_walk)
 
-        while len(self._worklist) > 0:
+        while len(worklist) > 0:
             changed = False
-            bb = self._worklist.popleft()
+
+            bb = worklist.popleft()
             changed |= self._calculate_out_vars(bb)
             changed |= self._calculate_liveness(bb)
             # recompute liveness for basic blocks pointing into
             # this basic block
             if changed:
-                self._worklist.extend(bb.cfg_in)
+                worklist.extend(bb.cfg_in)
 
     def _reset_liveness(self) -> None:
         for bb in self.function.get_basic_blocks():

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -185,15 +185,6 @@ class IRLabel(IROperand):
         self.value = value
         self.is_symbol = is_symbol
 
-    def __eq__(self, other):
-        # no need for is_symbol to participate in equality
-        return super().__eq__(other)
-
-    def __hash__(self):
-        # __hash__ is required when __eq__ is overridden --
-        # https://docs.python.org/3/reference/datamodel.html#object.__hash__
-        return super().__hash__()
-
 
 class IRInstruction:
     """

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -384,7 +384,6 @@ class IRBasicBlock:
     # stack items which this basic block produces
     out_vars: OrderedSet[IRVariable]
 
-    reachable: OrderedSet["IRBasicBlock"]
     is_reachable: bool = False
 
     def __init__(self, label: IRLabel, parent: "IRFunction") -> None:
@@ -395,7 +394,6 @@ class IRBasicBlock:
         self.cfg_in = OrderedSet()
         self.cfg_out = OrderedSet()
         self.out_vars = OrderedSet()
-        self.reachable = OrderedSet()
         self.is_reachable = False
 
     def add_cfg_in(self, bb: "IRBasicBlock") -> None:

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -98,21 +98,16 @@ class IRFunction:
             if not bb.is_reachable:
                 removed.add(bb)
 
-        for bb in removed:
-            self.remove_basic_block(bb)
-
         # Remove phi instructions that reference removed basic blocks
         for bb in self.get_basic_blocks():
-            modified = False
             for in_bb in list(bb.cfg_in):
                 if in_bb not in removed:
                     continue
 
-                modified = True
                 bb.remove_cfg_in(in_bb)
 
-            if modified or True:
-                bb.fix_phi_instructions()
+            # TODO: only run this if cfg_in changed
+            bb.fix_phi_instructions()
 
         return len(removed)
 

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -1,8 +1,7 @@
 from typing import Iterator, Optional
 
 from vyper.codegen.ir_node import IRnode
-from vyper.utils import OrderedSet
-from vyper.venom.basicblock import CFG_ALTERING_INSTRUCTIONS, IRBasicBlock, IRLabel, IRVariable
+from vyper.venom.basicblock import IRBasicBlock, IRLabel, IRVariable
 
 
 class IRFunction:
@@ -89,7 +88,7 @@ class IRFunction:
         return f"%{self.last_variable}"
 
     def remove_unreachable_blocks(self) -> int:
-        self._compute_reachability()
+        # pre: requires CFG analysis!
 
         removed = []
 
@@ -119,30 +118,6 @@ class IRFunction:
                         out_bb.remove_instruction(inst)
 
         return len(removed)
-
-    def _compute_reachability(self) -> None:
-        """
-        Compute reachability of basic blocks.
-        """
-        for bb in self.get_basic_blocks():
-            bb.reachable = OrderedSet()
-            bb.is_reachable = False
-
-        self._compute_reachability_from(self.entry)
-
-    def _compute_reachability_from(self, bb: IRBasicBlock) -> None:
-        """
-        Compute reachability of basic blocks from bb.
-        """
-        if bb.is_reachable:
-            return
-        bb.is_reachable = True
-        for inst in bb.instructions:
-            if inst.opcode in CFG_ALTERING_INSTRUCTIONS:
-                for op in inst.get_label_operands():
-                    out_bb = self.get_basic_block(op.value)
-                    bb.reachable.add(out_bb)
-                    self._compute_reachability_from(out_bb)
 
     @property
     def normalized(self) -> bool:

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -89,6 +89,7 @@ class IRFunction:
 
     def remove_unreachable_blocks(self) -> int:
         # pre: requires CFG analysis!
+        # NOTE: should this be a pass?
 
         removed = []
 

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -98,6 +98,9 @@ class IRFunction:
             if not bb.is_reachable:
                 removed.add(bb)
 
+        for bb in removed:
+            self.remove_basic_block(bb)
+
         # Remove phi instructions that reference removed basic blocks
         for bb in self.get_basic_blocks():
             for in_bb in list(bb.cfg_in):

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -71,7 +71,7 @@ class SCCP(IRPass):
 
         if self.cfg_dirty:
             self.analyses_cache.force_analysis(CFGAnalysis)
-            self._fix_phi_nodes()
+            self.fn.remove_unreachable_blocks()
 
         self.analyses_cache.invalidate_analysis(DFGAnalysis)
 
@@ -312,33 +312,6 @@ class SCCP(IRPass):
                 lat = self.lattice[op]
                 if isinstance(lat, IRLiteral):
                     inst.operands[i] = lat
-
-    def _fix_phi_nodes(self):
-        # fix basic blocks whose cfg in was changed
-        # maybe this should really be done in _visit_phi
-        for bb in self.fn.get_basic_blocks():
-            cfg_in_labels = OrderedSet(in_bb.label for in_bb in bb.cfg_in)
-
-            needs_sort = False
-            for inst in bb.instructions:
-                if inst.opcode != "phi":
-                    break
-                needs_sort |= self._fix_phi_inst(inst, cfg_in_labels)
-
-            # move phi instructions to the top of the block
-            if needs_sort:
-                bb.instructions.sort(key=lambda inst: inst.opcode != "phi")
-
-    def _fix_phi_inst(self, inst: IRInstruction, cfg_in_labels: OrderedSet):
-        operands = [op for label, op in inst.phi_operands if label in cfg_in_labels]
-
-        if len(operands) != 1:
-            return False
-
-        assert inst.output is not None
-        inst.opcode = "store"
-        inst.operands = operands
-        return True
 
 
 def _meet(x: LatticeItem, y: LatticeItem) -> LatticeItem:

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from vyper.exceptions import CompilerPanic, StaticAssertionException
 from vyper.utils import OrderedSet
-from vyper.venom.analysis import CFGAnalysis, DFGAnalysis, DominatorTreeAnalysis, IRAnalysesCache
+from vyper.venom.analysis import CFGAnalysis, DFGAnalysis, IRAnalysesCache
 from vyper.venom.basicblock import (
     IRBasicBlock,
     IRInstruction,

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -50,7 +50,6 @@ class SCCP(IRPass):
     """
 
     fn: IRFunction
-    dom: DominatorTreeAnalysis
     dfg: DFGAnalysis
     lattice: Lattice
     work_list: list[WorkListItem]
@@ -66,7 +65,6 @@ class SCCP(IRPass):
 
     def run_pass(self):
         self.fn = self.function
-        self.dom = self.analyses_cache.request_analysis(DominatorTreeAnalysis)
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
         self._calculate_sccp(self.fn.entry)
         self._propagate_constants()
@@ -269,7 +267,7 @@ class SCCP(IRPass):
         with their actual values. It also replaces conditional jumps
         with unconditional jumps if the condition is a constant value.
         """
-        for bb in self.dom.dfs_walk:
+        for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
                 self._replace_constants(inst)
 

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -122,16 +122,16 @@ class SimplifyCFGPass(IRPass):
 
         for _ in range(fn.num_basic_blocks):
             changes = self._optimize_empty_basicblocks()
+            self.analyses_cache.force_analysis(CFGAnalysis)
             changes += fn.remove_unreachable_blocks()
             if changes == 0:
                 break
         else:
             raise CompilerPanic("Too many iterations removing empty basic blocks")
 
-        self.analyses_cache.force_analysis(CFGAnalysis)
-
         for _ in range(fn.num_basic_blocks):  # essentially `while True`
             self._collapse_chained_blocks(entry)
+            self.analyses_cache.force_analysis(CFGAnalysis)
             if fn.remove_unreachable_blocks() == 0:
                 break
         else:

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -10,7 +10,12 @@ from vyper.ir.compile_ir import (
     optimize_assembly,
 )
 from vyper.utils import MemoryPositions, OrderedSet
-from vyper.venom.analysis import IRAnalysesCache, LivenessAnalysis, VarEquivalenceAnalysis
+from vyper.venom.analysis import (
+    CFGAnalysis,
+    IRAnalysesCache,
+    LivenessAnalysis,
+    VarEquivalenceAnalysis,
+)
 from vyper.venom.basicblock import (
     IRBasicBlock,
     IRInstruction,
@@ -152,6 +157,7 @@ class VenomCompiler:
                 NormalizationPass(ac, fn).run_pass()
                 self.liveness_analysis = ac.request_analysis(LivenessAnalysis)
                 self.equivalence = ac.request_analysis(VarEquivalenceAnalysis)
+                ac.request_analysis(CFGAnalysis)
 
                 assert fn.normalized, "Non-normalized CFG!"
 
@@ -308,7 +314,7 @@ class VenomCompiler:
 
         ref.extend(asm)
 
-        for bb in basicblock.reachable:
+        for bb in basicblock.cfg_out:
             self._generate_evm_for_basicblock_r(ref, bb, stack.copy())
 
     # pop values from stack at entry to bb


### PR DESCRIPTION
### What I did
move dfs order calculation from domtree to cfg analysis.

remove unnecessary calculation of domtree in sccp

remove redundant `IRFunction.compute_reachability`

change cfg_out order

refactor shared phi fixup code

### How I did it

### How to verify it

### Commit message

```
feat[venom]: improve liveness computation

traversing in reverse topsort order improves stack scheduling slightly

this commit also adds a topsort method to CFGAnalysis, and speeds it up
by only checking the terminator instruction instead of iterating over
all the instructions in every basic block.

additional refactors:
- move dfs order calculation from domtree to cfg analysis.
- remove unnecessary calculation of domtree in sccp
- remove redundant IRFunction.compute_reachability
- change cfg_out order
- refactor shared phi fixup code
- remove useless `__eq__()` and `__hash__()` for IRBasicBlock
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
