### PR TITLE
feat[venom]: reduce legacy opts when venom is enabled

### DIFF
--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from typing import Any, List, Optional, Union
 
 import vyper.ast as vy_ast
-from vyper.compiler.settings import VYPER_COLOR_OUTPUT
+from vyper.compiler.settings import VYPER_COLOR_OUTPUT, get_global_settings
 from vyper.evm.address_space import AddrSpace
 from vyper.evm.opcodes import get_ir_opcodes
 from vyper.exceptions import CodegenPanic, CompilerPanic
@@ -426,6 +426,10 @@ class IRnode:
 
     @property  # probably could be cached_property but be paranoid
     def _optimized(self):
+        if get_global_settings().experimental_codegen:
+            # in venom pipeline, we don't need to inline constants.
+            return self
+
         # TODO figure out how to fix this circular import
         from vyper.ir.optimizer import optimize
 


### PR DESCRIPTION
reduce legacy IR optimization when venom is enabled. the use of `IRnode._optimized` was there to decide if it was safe to inline an IRnode expression or it required a `with` statement; with venom, we don't need to inline the expressions, since the venom optimizer is more powerful. this leads to a 50% improvement in AST -> IRnode generation, which is a ~15% performance improvement in overall end-to-end compile time.

### What I did

### How I did it

### How to verify it
run `vyper --experimental-codegen` and compare bytecode against master. should be the same.

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
