### PR TITLE
refactor[ux]: add `venom` as `experimental-codegen` alias

### DIFF
--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -237,7 +237,7 @@ invalid_pragmas = [
 # pragma evm-version cancun
 # pragma evm-version shanghai
     """,
-    # duplicit setting of venom
+    # duplicate setting of venom
     """
     #pragma venom
     #pragma experimental-codegen

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -200,6 +200,7 @@ pragma_venom = [
     """,
 ]
 
+
 @pytest.mark.parametrize("code", pragma_venom)
 def test_parse_venom_pragma(code):
     pre_parse_result = pre_parse(code)

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -237,6 +237,15 @@ invalid_pragmas = [
 # pragma evm-version cancun
 # pragma evm-version shanghai
     """,
+    # duplicit setting of venom
+    """
+    #pragma venom
+    #pragma experimental-codegen
+    """,
+    """
+    #pragma venom
+    #pragma venom
+    """,
 ]
 
 

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -204,10 +204,10 @@ pragma_venom = [
 @pytest.mark.parametrize("code", pragma_venom)
 def test_parse_venom_pragma(code):
     pre_parse_result = pre_parse(code)
-    assert pre_parse_result.settings.experimental_codegen == True
+    assert pre_parse_result.settings.experimental_codegen is True
 
     compiler_data = CompilerData(code)
-    assert compiler_data.settings.experimental_codegen == True
+    assert compiler_data.settings.experimental_codegen is True
 
 
 invalid_pragmas = [

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -191,6 +191,24 @@ def test_parse_pragmas(code, pre_parse_settings, compiler_data_settings, mock_ve
     assert compiler_data.settings == compiler_data_settings
 
 
+pragma_venom = [
+    """
+    #pragma venom
+    """,
+    """
+    #pragma experimental-codegen
+    """,
+]
+
+@pytest.mark.parametrize("code", pragma_venom)
+def test_parse_venom_pragma(code):
+    pre_parse_result = pre_parse(code)
+    assert pre_parse_result.settings.experimental_codegen == True
+
+    compiler_data = CompilerData(code)
+    assert compiler_data.settings.experimental_codegen == True
+
+
 invalid_pragmas = [
     # evm-versionnn
     """

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -336,7 +336,7 @@ def test_compile_json_with_experimental_codegen():
     }
 
     settings = get_settings(code)
-    assert settings.experimental_codegen == True
+    assert settings.experimental_codegen is True
 
 
 def test_compile_json_with_both_venom_aliases():

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -9,6 +9,7 @@ from vyper.cli.vyper_json import (
     compile_json,
     exc_handler_to_dict,
     get_inputs,
+    get_settings,
 )
 from vyper.compiler import OUTPUT_FORMATS, compile_code, compile_from_file_input
 from vyper.compiler.input_bundle import JSONInputBundle
@@ -319,3 +320,26 @@ from . import stream
     """
     input_bundle = make_input_bundle({"stream.json": stream, "code.vy": code})
     vyper.compiler.compile_code(code, input_bundle=input_bundle)
+
+
+def test_compile_json_with_experimental_codegen():
+    code = {
+        "language": "Vyper",
+        "sources": {
+            "foo.vy": {
+                "content": "@external\ndef foo() -> bool:\n    return True"
+            }
+        },
+        "settings": {
+            "evmVersion": "cancun",
+            "optimize": "gas",
+            "venom": True,
+            "search_paths": [],
+            "outputSelection": {
+                "*": ["ast"],
+            }
+        }
+    }
+
+    settings = get_settings(code)
+    assert settings.experimental_codegen==True

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -337,3 +337,20 @@ def test_compile_json_with_experimental_codegen():
 
     settings = get_settings(code)
     assert settings.experimental_codegen == True
+
+
+def test_compile_json_with_both_venom_aliases():
+    code = {
+        "language": "Vyper",
+        "sources": {"foo.vy": {"content": ""}},
+        "settings": {
+            "evmVersion": "cancun",
+            "optimize": "gas",
+            "experimentalCodegen": False,
+            "venom": False,
+            "search_paths": [],
+            "outputSelection": {"*": ["ast"]},
+        },
+    }
+    with pytest.raises(JSONError):
+        get_settings(code)

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -325,21 +325,15 @@ from . import stream
 def test_compile_json_with_experimental_codegen():
     code = {
         "language": "Vyper",
-        "sources": {
-            "foo.vy": {
-                "content": "@external\ndef foo() -> bool:\n    return True"
-            }
-        },
+        "sources": {"foo.vy": {"content": "@external\ndef foo() -> bool:\n    return True"}},
         "settings": {
             "evmVersion": "cancun",
             "optimize": "gas",
             "venom": True,
             "search_paths": [],
-            "outputSelection": {
-                "*": ["ast"],
-            }
-        }
+            "outputSelection": {"*": ["ast"]},
+        },
     }
 
     settings = get_settings(code)
-    assert settings.experimental_codegen==True
+    assert settings.experimental_codegen == True

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -352,5 +352,6 @@ def test_compile_json_with_both_venom_aliases():
             "outputSelection": {"*": ["ast"]},
         },
     }
-    with pytest.raises(JSONError):
+    with pytest.raises(JSONError) as e:
         get_settings(code)
+    assert e.value.args[0] == "both experimentalCodegen and venom cannot be set"

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -265,10 +265,10 @@ def pre_parse(code: str) -> PreParseResult:
                         if evm_version not in EVM_VERSIONS:
                             raise StructureException(f"Invalid evm version: `{evm_version}`", start)
                         settings.evm_version = evm_version
-                    elif pragma.startswith("experimental-codegen"):
+                    elif pragma.startswith("experimental-codegen") or pragma.startswith("venom"):
                         if settings.experimental_codegen is not None:
                             raise StructureException(
-                                "pragma experimental-codegen specified twice!", start
+                                "pragma experimental-codegen/venom specified twice!", start
                             )
                         settings.experimental_codegen = True
                     elif pragma.startswith("enable-decimals"):

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -176,6 +176,7 @@ def _parse_args(argv):
     parser.add_argument("-o", help="Set the output path", dest="output_path")
     parser.add_argument(
         "--experimental-codegen",
+        "--venom",
         help="The compiler use the new IR codegen. This is an experimental feature.",
         action="store_true",
         dest="experimental_codegen",

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -253,9 +253,9 @@ def get_settings(input_dict: dict) -> Settings:
     evm_version = get_evm_version(input_dict)
 
     optimize = input_dict["settings"].get("optimize")
-    experimental_codegen = input_dict["settings"].get("experimentalCodegen") or input_dict[
-        "settings"
-    ].get("venom")
+    experimental_codegen = input_dict["settings"].get("experimentalCodegen")
+    if experimental_codegen is None:
+        experimental_codegen = input_dict["settings"].get("venom")
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility
         warnings.warn(

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -253,7 +253,9 @@ def get_settings(input_dict: dict) -> Settings:
     evm_version = get_evm_version(input_dict)
 
     optimize = input_dict["settings"].get("optimize")
-    experimental_codegen = input_dict["settings"].get("experimentalCodegen") or input_dict["settings"].get("venom")
+    experimental_codegen = input_dict["settings"].get("experimentalCodegen") or input_dict[
+        "settings"
+    ].get("venom")
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility
         warnings.warn(

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -253,7 +253,7 @@ def get_settings(input_dict: dict) -> Settings:
     evm_version = get_evm_version(input_dict)
 
     optimize = input_dict["settings"].get("optimize")
-    experimental_codegen = input_dict["settings"].get("experimentalCodegen")
+    experimental_codegen = input_dict["settings"].get("experimentalCodegen") or input_dict["settings"].get("venom")
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility
         warnings.warn(

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -253,9 +253,13 @@ def get_settings(input_dict: dict) -> Settings:
     evm_version = get_evm_version(input_dict)
 
     optimize = input_dict["settings"].get("optimize")
+
     experimental_codegen = input_dict["settings"].get("experimentalCodegen")
     if experimental_codegen is None:
         experimental_codegen = input_dict["settings"].get("venom")
+    elif input_dict["settings"].get("venom") is not None:
+        raise JSONError("both experimentalCodegen and venom cannot be set")
+
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility
         warnings.warn(

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -77,7 +77,7 @@ class Settings:
         if self.optimize is not None:
             ret.append(" --optimize " + str(self.optimize))
         if self.experimental_codegen is True:
-            ret.append(" --experimental-codegen")
+            ret.append(" --venom")
         if self.evm_version is not None:
             ret.append(" --evm-version " + self.evm_version)
         if self.debug is True:


### PR DESCRIPTION
### What I did
Make a "venom" alias to "experimental_codegen" flag.
See https://github.com/vyperlang/vyper/issues/4334.

### How I did it
Add the alias to cli, pre-parser, and json parser.
### How to verify it
All exisiting tests work with old flas as well as new tests with `venom`.

### Commit message

```
Make "venom" an alternative alias to the "experimental_codegen" flag.
Add the alias to cli, pre-parser, and json parser.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
