### PR TITLE
Fixed the Incorrect error messages during compilation #3994.

### DIFF
--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1440,7 +1440,7 @@ class VariableDecl(VyperNode):
 
         if not self.is_constant and self.value is not None:
             raise VariableDeclarationException(
-                f"{self._pretty_location} variables cannot have an initial value", self.value
+                f"{self._pretty_location()} variables cannot have an initial value", self.value
             )
         if not isinstance(self.target, Name):
             raise VariableDeclarationException("Invalid variable declaration", self.target)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1663,7 +1663,7 @@ class _CreateBase(BuiltinFunctionT):
     @process_inputs
     def build_IR(self, expr, args, kwargs, context):
         # errmsg something like f"Cannot use {self._id} in pure fn"
-        context.check_is_not_constant(f"use {self._id}", expr)
+        context.check_is_not_constant(f"Error: {self._id} is not a constant")
 
         should_use_create2 = "salt" in [kwarg.arg for kwarg in expr.keywords]
 


### PR DESCRIPTION
…build_IR

### What I did
 I updated issue in VariableDecl.validate() and update string formatting in build_IR codes.
### How I did it
I cloned the repo and fixed that part of the code.
### How to verify it
run pytest
### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog
Improved: Updated VariableDecl.validate() to correctly use self._pretty_location() for consistent variable location formatting.
Fixed: Modified _CreateBase.build_IR to use an f-string in context.check_is_not_constant, ensuring self._id is properly displayed in error messages.
### Cute Animal Picture
It's a cute piglet.
![Put a link to a cute animal picture inside the parenthesis-->](https://chromewebstore.google.com/detail/cute-animals-wallpaper/njfipgfibcmkmgpgljmgjkcplnkjhaop?hl=de)
