### PR TITLE
fix[ci]: fix README encoding in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
 
 extras_require["dev"] = extras_require["dev"] + extras_require["test"] + extras_require["lint"]
 
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
### What I did
testing CI

### How I did it
fixes a blocker in https://github.com/vyperlang/vyper/pull/4342

### How to verify it

### Commit message

```
the call to `setup()` would fail on windows when there are unicode
characters in `README.md`, because files are apparently opened with
encoding `cp1252` by default on windows. this commit ensures the file
is opened with `utf-8` encoding.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
