### PR TITLE
Introducing Vyper Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 [![Coverage Status](https://codecov.io/gh/vyperlang/vyper/branch/master/graph/badge.svg)](https://codecov.io/gh/vyperlang/vyper "Codecov")
 [![Language grade: Python](https://github.com/vyperlang/vyper/workflows/CodeQL/badge.svg)](https://github.com/vyperlang/vyper/actions/workflows/codeql.yml)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Vyper%20Guru-006BFF)](https://gurubase.io/g/vyper)
 
 # Getting Started
 See [Installing Vyper](http://docs.vyperlang.org/en/latest/installing-vyper.html) to install vyper.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Vyper Guru](https://gurubase.io/g/vyper) to Gurubase. Vyper Guru uses the data from this repo and data from the [docs](https://docs.vyperlang.org/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Vyper Guru", which highlights that Vyper now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Vyper Guru in Gurubase, just let me know that's totally fine.
