### PR TITLE
chore[docs]: add `method_id` to `abi_encode` signature

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -1023,7 +1023,7 @@ Utilities
         >>> ExampleContract.foo()
 	0xa9059cbb
 
-.. py:function:: abi_encode(*args, ensure_tuple: bool = True) -> Bytes[<depends on input>]
+.. py:function:: abi_encode(*args, ensure_tuple: bool = True, method_id: Bytes[4] = None) -> Bytes[<depends on input>]
 
     Takes a variable number of args as input, and returns the ABIv2-encoded bytestring. Used for packing arguments to raw_call, EIP712 and other cases where a consistent and efficient serialization method is needed.
     Once this function has seen more use we provisionally plan to put it into the ``ethereum.abi`` namespace.


### PR DESCRIPTION
### What I did

This PR adds the missing `method_id` parameter to the function signature of `abi_encode` in the documentation.

### How I did it

Skills.

### How to verify it

Brain.

### Commit message

```
this commit adds the missing `method_id` parameter to the
function signature of `abi_encode` in the documentation
```

### Description for the changelog

docs[chore]: add `method_id` to function signature of `abi_encode`

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/5fa9b88e-f40b-455f-9ac9-d3f74bb50e0a)