### PR TITLE
fit typo README.md

### DIFF
--- a/vyper/semantics/README.md
+++ b/vyper/semantics/README.md
@@ -23,7 +23,7 @@ Vyper abstract syntax tree (AST).
   * [`base.py`](analysis/base.py): Base validation class
   * [`common.py`](analysis/common.py): Base AST visitor class
   * [`data_positions`](analysis/data_positions.py): Functions for tracking storage variables and allocating storage slots
-  * [`levenhtein_utils.py`](analysis/levenshtein_utils.py): Helper for better error messages
+  * [`levenshtein_utils.py`](analysis/levenshtein_utils.py): Helper for better error messages
   * [`local.py`](analysis/local.py): Validates the local namespace of each function within a contract
   * [`pre_typecheck.py`](analysis/pre_typecheck.py): Evaluate foldable nodes and populate their metadata with the replacement nodes.
   * [`module.py`](analysis/module.py): Validates the module namespace of a contract.


### PR DESCRIPTION
### What I did

Fixed a typo in the filename `levenhtein_utils.py`, changing it to the correct `levenshtein_utils.py`.

### How I did it

Updated the reference in the documentation to the correct filename.

### How to verify it

Check that the link in the documentation now correctly points to `levenshtein_utils.py`.

### Commit message

Fix typo in documentation: correct filename from `levenhtein_utils.py` to `levenshtein_utils.py`

### Description for the changelog

Fixed a typo in the documentation for the Levenshtein utility file link.

### Cute Animal Picture

![the cutest animal is me!❤️]()
