### PR TITLE
fix[ux]: fix error message for common typo

### DIFF
--- a/tests/functional/syntax/exceptions/test_syntax_exception.py
+++ b/tests/functional/syntax/exceptions/test_syntax_exception.py
@@ -118,7 +118,8 @@ def test_bad_staticcall_keyword():
 from ethereum.ercs import IERC20Detailed
 
 def foo():
-    staticcall ERC20(msg.sender).transfer(msg.sender, staticall IERC20Detailed(msg.sender).decimals())
+    staticcall ERC20(msg.sender).transfer(
+        msg.sender, staticall IERC20Detailed(msg.sender).decimals())
     """.strip()
     with pytest.raises(SyntaxException) as e:
         compile_code(bad_code)
@@ -126,10 +127,10 @@ def foo():
     expected_error = """
 Possible typo: `staticall`
 
-  line 4:54 
-       3 def foo():
-  ---> 4     staticcall ERC20(msg.sender).transfer(msg.sender, staticall IERC20Detailed(msg.sender).decimals())
-  -------------------------------------------------------------^
+  line 5:20 
+       4     staticcall ERC20(msg.sender).transfer(
+  ---> 5         msg.sender, staticall IERC20Detailed(msg.sender).decimals())
+  ---------------------------^
 
   (hint: did you mean `staticcall`?)
     """  # noqa

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -350,6 +350,17 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         start_pos = node.lineno, node.col_offset  # grab these before generic_visit modifies them
         self.generic_visit(node)
         node.ast_type = self._pre_parse_result.modification_offsets[start_pos]
+
+        # common typo - "staticcall" => "staticall"
+        if node.ast_type == "BadStaticCall":
+            raise SyntaxException(
+                "Possible typo: `staticall`",
+                self._source_code,
+                node.lineno,
+                node.col_offset,
+                hint="did you mean `staticcall`?",
+            )
+
         return node
 
     def visit_Call(self, node):

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -155,7 +155,11 @@ VYPER_CLASS_TYPES = {
 # simple statements that are replaced with `yield`
 CUSTOM_STATEMENT_TYPES = {"log": "Log"}
 # expression types that are replaced with `await`
-CUSTOM_EXPRESSION_TYPES = {"extcall": "ExtCall", "staticcall": "StaticCall"}
+CUSTOM_EXPRESSION_TYPES = {
+    "extcall": "ExtCall",
+    "staticcall": "StaticCall",
+    "staticall": "BadStaticCall",  # common typo - we parse it to AST for better error reporting
+}
 
 
 class PreParseResult:

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -184,12 +184,12 @@ class SyntaxException(VyperException):
 
     """Invalid syntax."""
 
-    def __init__(self, message, source_code, lineno, col_offset):
+    def __init__(self, message, source_code, lineno, col_offset, hint=None):
         item = types.SimpleNamespace()  # TODO: Create an actual object for this
         item.lineno = lineno
         item.col_offset = col_offset
         item.full_source_code = source_code
-        super().__init__(message, item)
+        super().__init__(message, item, hint=hint)
 
 
 class DecimalOverrideException(VyperException):


### PR DESCRIPTION
the `staticall` typo is very common, and was raising a hard-to-read error message from the python parser like "invalid syntax. Perhaps you forgot a comma?"

this commit adds it to the pre-parser, so we can raise an exception after we have successfully gone through the python parser and have the ability to add source info and a hint.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
