### PR TITLE
refactor[tool]: refactor `compile_from_zip()`

### DIFF
--- a/vyper/cli/compile_archive.py
+++ b/vyper/cli/compile_archive.py
@@ -8,8 +8,9 @@ import json
 import zipfile
 from pathlib import PurePath
 
-from vyper.compiler import compile_from_file_input
+from vyper.compiler import outputs_from_compiler_data
 from vyper.compiler.input_bundle import FileInput, ZipInputBundle
+from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import Settings, merge_settings
 from vyper.exceptions import BadArchive
 
@@ -19,6 +20,11 @@ class NotZipInput(Exception):
 
 
 def compile_from_zip(file_name, output_formats, settings, no_bytecode_metadata):
+    compiler_data = compiler_data_from_zip(file_name, settings, no_bytecode_metadata)
+    return outputs_from_compiler_data(compiler_data, output_formats)
+
+
+def compiler_data_from_zip(file_name, settings, no_bytecode_metadata):
     with open(file_name, "rb") as f:
         bcontents = f.read()
 
@@ -59,11 +65,9 @@ def compile_from_zip(file_name, output_formats, settings, no_bytecode_metadata):
         settings, archive_settings, lhs_source="command line", rhs_source="archive settings"
     )
 
-    # TODO: validate integrity sum (probably in CompilerData)
-    return compile_from_file_input(
+    return CompilerData(
         file,
         input_bundle=input_bundle,
-        output_formats=output_formats,
         integrity_sum=integrity,
         settings=settings,
         no_bytecode_metadata=no_bytecode_metadata,

--- a/vyper/compiler/__init__.py
+++ b/vyper/compiler/__init__.py
@@ -99,13 +99,6 @@ def compile_from_file_input(
     """
     settings = settings or get_global_settings() or Settings()
 
-    if output_formats is None:
-        output_formats = ("bytecode",)
-
-    # make IR output the same between runs
-    # TODO: move this to CompilerData.__init__()
-    codegen.reset_names()
-
     compiler_data = CompilerData(
         file_input,
         input_bundle,
@@ -115,6 +108,17 @@ def compile_from_file_input(
         show_gas_estimates=show_gas_estimates,
         no_bytecode_metadata=no_bytecode_metadata,
     )
+
+    return outputs_from_compiler_data(compiler_data, output_formats, exc_handler)
+
+
+def outputs_from_compiler_data(
+    compiler_data: CompilerData,
+    output_formats: Optional[OutputFormats] = None,
+    exc_handler: Optional[Callable] = None,
+):
+    if output_formats is None:
+        output_formats = ("bytecode",)
 
     ret = {}
     with anchor_settings(compiler_data.settings):
@@ -126,7 +130,7 @@ def compile_from_file_input(
                 ret[output_format] = formatter(compiler_data)
             except Exception as exc:
                 if exc_handler is not None:
-                    exc_handler(str(file_input.path), exc)
+                    exc_handler(str(compiler_data.file_input.path), exc)
                 else:
                     raise exc
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from pathlib import Path, PurePath
 from typing import Any, Optional
 
+import vyper.codegen.core as codegen
 from vyper import ast as vy_ast
 from vyper.ast import natspec
 from vyper.codegen import module
@@ -304,6 +305,9 @@ def generate_ir_nodes(global_ctx: ModuleT, settings: Settings) -> tuple[IRnode, 
         IR to generate deployment bytecode
         IR to generate runtime bytecode
     """
+    # make IR output the same between runs
+    codegen.reset_names()
+
     with anchor_settings(settings):
         ir_nodes, ir_runtime = module.generate_ir_for_module(global_ctx)
     if settings.optimize != OptimizationLevel.NONE:


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
refactor `compile_from_zip()`, and also a generalized
`outputs_from_compiler_data()` so the user can pass a `CompilerData`
instead of `FileInput` + a bunch of settings.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
