### PR TITLE
fix[lang]!: forbid calling `__default__`

### DIFF
--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -605,7 +605,6 @@ def bar():
         compiler.compile_code(main, input_bundle=input_bundle)
 
 
-@pytest.mark.xfail
 def test_intrinsic_interfaces_default_function(make_input_bundle, get_contract):
     lib1 = """
 @external

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -622,6 +622,27 @@ def bar():
     """
     input_bundle = make_input_bundle({"lib1.vy": lib1})
 
-    # TODO make the exception more precise once fixed
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(ValueError):
+        compiler.compile_code(main, input_bundle=input_bundle)
+
+
+def test_intrinsic_interfaces_default_function_staticcall(make_input_bundle, get_contract):
+    lib1 = """
+@external
+@view
+def __default__() -> int128:
+    return 43
+    """
+    main = """
+import lib1
+
+@external
+def bar():
+    foo:int128 = 0
+    foo = staticcall lib1.__at__(self).__default__()
+    """
+    input_bundle = make_input_bundle({"lib1.vy": lib1})
+
+    with pytest.raises(ValueError):
+>>>>>>> 0903256f7 (test staticcall fails with default)
         compiler.compile_code(main, input_bundle=input_bundle)

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -3,6 +3,7 @@ import pytest
 from vyper import compiler
 from vyper.exceptions import (
     ArgumentException,
+    CallViolation,
     FunctionDeclarationException,
     InterfaceViolation,
     InvalidReference,
@@ -622,7 +623,7 @@ def bar():
     """
     input_bundle = make_input_bundle({"lib1.vy": lib1})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(CallViolation):
         compiler.compile_code(main, input_bundle=input_bundle)
 
 
@@ -643,6 +644,5 @@ def bar():
     """
     input_bundle = make_input_bundle({"lib1.vy": lib1})
 
-    with pytest.raises(ValueError):
->>>>>>> 0903256f7 (test staticcall fails with default)
+    with pytest.raises(CallViolation):
         compiler.compile_code(main, input_bundle=input_bundle)

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1286,7 +1286,7 @@ class ExtCall(ExprNode):
                 self.value,
                 hint="did you forget parentheses?",
             )
-        if hasattr(self.value.func, 'attr') and self.value.func.attr == "__default__":
+        if hasattr(self.value.func, "attr") and self.value.func.attr == "__default__":
             raise ValueError("function __default__ cannot be called")
 
 

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1300,6 +1300,8 @@ class StaticCall(ExprNode):
                 self.value,
                 hint="did you forget parentheses?",
             )
+        if hasattr(self.value.func, "attr") and self.value.func.attr == "__default__":
+            raise ValueError("function __default__ cannot be called")
 
 
 class keyword(VyperNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1286,8 +1286,6 @@ class ExtCall(ExprNode):
                 self.value,
                 hint="did you forget parentheses?",
             )
-        if hasattr(self.value.func, "attr") and self.value.func.attr == "__default__":
-            raise ValueError("function __default__ cannot be called")
 
 
 class StaticCall(ExprNode):
@@ -1300,8 +1298,6 @@ class StaticCall(ExprNode):
                 self.value,
                 hint="did you forget parentheses?",
             )
-        if hasattr(self.value.func, "attr") and self.value.func.attr == "__default__":
-            raise ValueError("function __default__ cannot be called")
 
 
 class keyword(VyperNode):

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1286,6 +1286,8 @@ class ExtCall(ExprNode):
                 self.value,
                 hint="did you forget parentheses?",
             )
+        if hasattr(self.value.func, 'attr') and self.value.func.attr == "__default__":
+            raise ValueError("function __default__ cannot be called")
 
 
 class StaticCall(ExprNode):

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -776,8 +776,8 @@ class ExprVisitor(VyperNodeVisitorBase):
                     hint = f"try `{should} {node.node_source_code}`"
                     raise CallViolation(msg, hint=hint)
 
-                if isinstance(node.func, vy_ast.Attribute) and node.func.attr == "__default__":
-                    raise CallViolation("function __default__ cannot be called")
+                if func_type.is_fallback:
+                    raise CallViolation("Function __default__ cannot be called directly")
             else:
                 if not node.is_plain_call:
                     kind = node.kind_str

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -777,7 +777,9 @@ class ExprVisitor(VyperNodeVisitorBase):
                     raise CallViolation(msg, hint=hint)
 
                 if func_type.is_fallback:
-                    raise CallViolation("`__default__` function cannot be called directly. if you mean to call the default function, use `raw_call`")
+                    msg = "`__default__` function cannot be called directly."
+                    msg += " If you mean to call the default function, use `raw_call`"
+                    raise CallViolation(msg)
             else:
                 if not node.is_plain_call:
                     kind = node.kind_str

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -777,7 +777,7 @@ class ExprVisitor(VyperNodeVisitorBase):
                     raise CallViolation(msg, hint=hint)
 
                 if func_type.is_fallback:
-                    raise CallViolation("Function __default__ cannot be called directly")
+                    raise CallViolation("`__default__` function cannot be called directly. if you mean to call the default function, use `raw_call`")
             else:
                 if not node.is_plain_call:
                     kind = node.kind_str

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -775,6 +775,9 @@ class ExprVisitor(VyperNodeVisitorBase):
                     msg += f"must use the `{should}` keyword."
                     hint = f"try `{should} {node.node_source_code}`"
                     raise CallViolation(msg, hint=hint)
+
+                if isinstance(node.func, vy_ast.Attribute) and node.func.attr == "__default__":
+                    raise CallViolation("function __default__ cannot be called")
             else:
                 if not node.is_plain_call:
                     kind = node.kind_str


### PR DESCRIPTION
### What I did
Forbid calling `__default__` by `staticcall` and `extcall`. Depends on https://github.com/vyperlang/vyper/pull/4090. 
Edit: Added dependency on the PR.
### How I did it
In `validate` functions check the attribute name if present.

### How to verify it

### Commit message
```
This commit forbids `extcall` and `staticcall`s to `__default__`. This
was not possible before the introduction of `__interface__()` and
`__at__()`; however, now that we have the possibility of casting
a module to its interface, it is possible to actually call the
`__default__()` function, which generates a "normal" ABI-encoded
call including the method id for `__default__()`. That could cause a
selector collision with a different function at target, and also leads
to confusing behavior (`__default__` gets called when no selector
matches).

The error message recommends the user to use `raw_call()` for this
use case.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
