### PR TITLE
fix[venom]: add missing extcodesize+hash effects

### DIFF
--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -68,6 +68,8 @@ _reads = {
     "balance": BALANCE,
     "selfbalance": BALANCE,
     "extcodecopy": EXTCODE,
+    "extcodesize": EXTCODE,
+    "extcodehash": EXTCODE,
     "selfdestruct": BALANCE,  # may modify code, but after the transaction
     "log": MEMORY,
     "revert": MEMORY,


### PR DESCRIPTION
per title -- effects.py was missing extcodesize and extcodehash effects.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
