### PR TITLE
Fix article usage in type description Update types.rst

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -141,7 +141,7 @@ Unsigned Integer (N bit)
 
 **Keyword:** ``uintN`` (e.g., ``uint8``)
 
-A unsigned integer which can store positive integers. ``N`` must be a multiple of 8 between 8 and 256 (inclusive).
+An unsigned integer which can store positive integers. ``N`` must be a multiple of 8 between 8 and 256 (inclusive).
 
 Values
 ******


### PR DESCRIPTION
### What I did

This update corrects a minor grammatical issue in the documentation where the article "A" was incorrectly used before the word "unsigned." Since "unsigned" begins with a vowel sound, the correct article is "An," not "A."

### Commit message

Thanks for review!

### Cute Animal Picture

![Hello](https://www.planetnatural.com/wp-content/uploads/2023/06/meerkat-compressed.jpg)

