### PR TITLE
fix[ux]: fix false positive for overflow in type checker

### DIFF
--- a/tests/functional/codegen/types/numbers/test_exponents.py
+++ b/tests/functional/codegen/types/numbers/test_exponents.py
@@ -173,3 +173,18 @@ def foo(b: int128) -> int128:
     c.foo(max_power)
     with tx_failed():
         c.foo(max_power + 1)
+
+
+
+valid_list = [
+    """
+@external
+def foo() -> uint256:
+    return (10**18)**2
+    """
+]
+
+
+@pytest.mark.parametrize("good_code", valid_list)
+def test_exponent_success(good_code):
+    assert compile_code(good_code) is not None

--- a/tests/functional/codegen/types/numbers/test_exponents.py
+++ b/tests/functional/codegen/types/numbers/test_exponents.py
@@ -175,7 +175,6 @@ def foo(b: int128) -> int128:
         c.foo(max_power + 1)
 
 
-
 valid_list = [
     """
 @external

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -41,7 +41,7 @@ def _validate_op(node, types_list, validation_fn_name):
         try:
             _validate_fn(node)
             ret.append(type_)
-        except InvalidOperation as e:
+        except (InvalidOperation, OverflowException) as e:
             err_list.append(e)
 
     if ret:

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -173,11 +173,11 @@ class NumericT(_PrimT):
             if isinstance(left, vy_ast.Int):
                 if left.value >= 2**value_bits:
                     raise OverflowException(
-                        "Base is too large, calculation will always overflow", left
+                        f"Base is too large for {self}, calculation will always overflow", left
                     )
                 elif left.value < -(2**value_bits):
                     raise OverflowException(
-                        "Base is too small, calculation will always underflow", left
+                        f"Base is too small for {self}, calculation will always underflow", left
                     )
             elif isinstance(right, vy_ast.Int):
                 if right.value < 0:


### PR DESCRIPTION
### What I did

Fix #4383 

### How I did it

Catch `OverflowException` when finding possible types for `BinOp` node.

### How to verify it

See test.

### Commit message

```
this commit fixes a false positive for integer overflow in
the typechecker involving nested pow operations by filtering
`OverflowException` in `_validate_op`. the previous code assumed that
`validate_numeric_op` could throw anything besides `InvalidOperation`,
but for the `Pow` binop, it can throw `OverflowException`.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://t4.ftcdn.net/jpg/02/65/70/73/360_F_265707361_N79UdgpbERwsjHZxIWRixuodCKqYsBF5.jpg)
