### PR TITLE
chore[ci]: enable Python `3.13` tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
           # modes across all python versions - one is enough
           - python-version: ["3.10", "310"]
           - python-version: ["3.12", "312"]
+          - python-version: ["3.13", "313"]
 
           # os-specific rules
           - os: windows

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     package_data={"vyper.ast": ["grammar.lark"]},
     data_files=[("", [hash_file_rel_path])],


### PR DESCRIPTION
### What I did

This PR enables Python [`3.13`](https://docs.python.org/3/whatsnew/3.13.html)-based tests in the CI pipeline.

### How I did it

Upgrade the CI test file and `setup.py`.

### How to verify it

All tests should successfully pass.

### Commit message

```
enable Python `3.13`-based tests in the CI pipeline.
```

### Description for the changelog

chore[ci]: enable Python [`3.13`](https://docs.python.org/3/whatsnew/3.13.html)-based tests in the CI pipeline.

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/5c6abe9b-f38e-4480-bcc0-1c4176acf99e)