### PR TITLE
Typos fix

### DIFF
--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -168,7 +168,7 @@ class IRFunction:
                 continue
 
             if i < len(bbs) - 1:
-                # TODO: revisit this. When contructor calls internal functions
+                # TODO: revisit this. When constructor calls internal functions
                 # they are linked to the last ctor block. Should separate them
                 # before this so we don't have to handle this here
                 if bbs[i + 1].label.value.startswith("internal"):

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -27,7 +27,7 @@ class AlgebraicOptimizationPass(IRPass):
                     opcode = use_inst.opcode
 
                     if opcode == "iszero":
-                        # We keep iszero instuctions as is
+                        # We keep iszero instructions as is
                         continue
                     if opcode in ("jnz", "assert"):
                         # instructions that accept a truthy value as input:

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -369,7 +369,7 @@ class VenomCompiler:
             operands = [offset]
 
         # iload and istore are special cases because they can take a literal
-        # that is handled specialy with the _OFST macro. Look below, after the
+        # that is handled specially with the _OFST macro. Look below, after the
         # stack reordering.
         elif opcode == "iload":
             addr = inst.operands[0]


### PR DESCRIPTION
# Fix: Corrected typos in comments

## What was changed
- **Corrected typos**  to improve clarity and professionalism.

## Why these changes were made
- **Fixing typos** enhances the clarity and readability of the codebase, making it more professional and easier to understand.

## Additional Notes
- These changes focus solely on correcting typographical errors in comments and do not affect the functionality of the code.
