### PR TITLE
refactor[venom]: make venom repr parseable

### DIFF
--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -105,7 +105,7 @@ class IRDebugInfo:
 
     def __repr__(self) -> str:
         src = self.src if self.src else ""
-        return f"\t# line {self.line_no}: {src}".expandtabs(20)
+        return f"\t; line {self.line_no}: {src}".expandtabs(20)
 
 
 class IROperand:
@@ -360,20 +360,6 @@ class IRInstruction:
                 return inst.ast_source
         return self.parent.parent.ast_source
 
-    def str_short(self) -> str:
-        s = ""
-        if self.output:
-            s += f"{self.output} = "
-        opcode = f"{self.opcode} " if self.opcode != "store" else ""
-        s += opcode
-        operands = self.operands
-        if opcode not in ["jmp", "jnz", "invoke"]:
-            operands = list(reversed(operands))
-        s += ", ".join(
-            [(f"label %{op}" if isinstance(op, IRLabel) else str(op)) for op in operands]
-        )
-        return s
-
     def __repr__(self) -> str:
         s = ""
         if self.output:
@@ -383,9 +369,7 @@ class IRInstruction:
         operands = self.operands
         if opcode not in ["jmp", "jnz", "invoke"]:
             operands = reversed(operands)  # type: ignore
-        s += ", ".join(
-            [(f"label %{op}" if isinstance(op, IRLabel) else str(op)) for op in operands]
-        )
+        s += ", ".join([(f'@"{op}"' if isinstance(op, IRLabel) else str(op)) for op in operands])
 
         if self.annotation:
             s += f" <{self.annotation}>"
@@ -645,9 +629,9 @@ class IRBasicBlock:
 
     def __repr__(self) -> str:
         s = (
-            f"{repr(self.label)}:  IN={[bb.label for bb in self.cfg_in]}"
+            f"{self.label}:  ;  IN={[bb.label for bb in self.cfg_in]}"
             f" OUT={[bb.label for bb in self.cfg_out]} => {self.out_vars}\n"
         )
         for instruction in self.instructions:
-            s += f"    {str(instruction).strip()}\n"
+            s += f"  {str(instruction).strip()}\n"
         return s

--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -62,14 +62,14 @@ class IRContext:
         return "\n".join(s)
 
     def __repr__(self) -> str:
-        s = ["IRContext:"]
+        s = []
         for fn in self.functions.values():
             s.append(fn.__repr__())
             s.append("\n")
 
         if len(self.data_segment) > 0:
-            s.append("\nData segment:")
+            s.append("\n[data]:")
             for inst in self.data_segment:
-                s.append(f"{inst}")
+                s.append(f"  {inst}")
 
         return "\n".join(s)

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -1,3 +1,4 @@
+import textwrap
 from typing import Iterator, Optional
 
 from vyper.codegen.ir_node import IRnode
@@ -222,7 +223,9 @@ class IRFunction:
         return "\n".join(ret)
 
     def __repr__(self) -> str:
-        str = f"IRFunction: {self.name}\n"
+        ret = f"function {self.name} {{\n"
         for bb in self.get_basic_blocks():
-            str += f"{bb}\n"
-        return str.strip()
+            bb_str = textwrap.indent(str(bb), "  ")
+            ret += f"{bb_str}\n"
+        ret = ret.strip() + "\n}"
+        return ret.strip()

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -41,8 +41,8 @@ VENOM_PARSER = Lark(
 
     CONST: INT
     OPCODE: CNAME
-    VAR_IDENT: "%" INT (":" INT)?
-    LABEL: "@" NAME
+    VAR_IDENT: "%" INT (":" INT)?  # TODO: allow arbitrary strings
+    LABEL: "@" NAME  # TODO: allow arbitrary strings
     NAME: (DIGIT|LETTER|"_")+
 
     %ignore WS


### PR DESCRIPTION
make the repr implementations for venom data structures (IRContext, IRFunction, IRBasicBlock) emit strings which will round-trip through the parser.

remove a dead function (`str_short()`)

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
