### PR TITLE
feat[venom]: allow alphanumeric variables and source comments

### DIFF
--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -47,8 +47,6 @@ VENOM_PARSER = Lark(
     LABEL: "@" NAME
     NAME: (DIGIT|LETTER|"_")+
 
-    COMMENT: ";"  /[^\\n]/*
-
     %ignore WS
     %ignore COMMENT
     """

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -177,7 +177,7 @@ class VenomTransformer(Transformer):
         varname = parts[0]
         version = None
         if len(parts) > 1:
-            version = parts[1]
+            version = int(parts[1])
         return IRVariable(varname, version=version)
 
     def CONST(self, val) -> IRLiteral:


### PR DESCRIPTION
### What I did

Implemented alphanumeric variables, and source code comments

### How I did it

### How to verify it

### Commit message

```
This commit implements minor improvements to the venom parser. 
Specifically it allows for alphanumeric variable names, and for single 
line source code comments in various styles: ";" "#" and "//"
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
