### PR TITLE
feat[venom]: remove special cases in store elimination

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -53,6 +53,7 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel) -> None:
 
     SimplifyCFGPass(ac, fn).run_pass()
     MakeSSA(ac, fn).run_pass()
+    StoreElimination(ac, fn).run_pass()
     Mem2Var(ac, fn).run_pass()
     MakeSSA(ac, fn).run_pass()
     SCCP(ac, fn).run_pass()

--- a/vyper/venom/passes/store_elimination.py
+++ b/vyper/venom/passes/store_elimination.py
@@ -16,12 +16,6 @@ class StoreElimination(IRPass):
         for var, inst in dfg.outputs.items():
             if inst.opcode != "store":
                 continue
-            if not isinstance(inst.operands[0], IRVariable):
-                continue
-            if inst.operands[0].name in ["%ret_ofst", "%ret_size"]:
-                continue
-            if inst.output.name in ["%ret_ofst", "%ret_size"]:
-                continue
             self._process_store(dfg, inst, var, inst.operands[0])
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
remove special cases in store elimination, allowing elimination of
`%ret_ofst` and `%ret_size` store chains. this was previously to
protect correctness in `mem2var`, but it no longer seems to be needed.

running an additional store elimination before `mem2var` results in a
slight bytecode size improvement, since it allows more memory locations
to be promoted to stack variables.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
