### PR TITLE
chore[docs]: `nonpayable` `internal` function behaviour

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -75,6 +75,14 @@ Or for internal functions which are defined in :ref:`imported modules <modules>`
     def calculate(amount: uint256) -> uint256:
         return calculator_library._times_two(amount)
 
+Marking an internal function as ``payable`` specifies that the function can interact with ``msg.value``. A ``nonpayable`` internal function can be called from an external ``payable`` function, but it cannot access ``msg.value``.
+
+.. code-block:: vyper
+
+    @payable
+    def _foo() -> uint256:
+        return msg.value % 2
+
 .. note::
    As of v0.4.0, the ``@internal`` decorator is optional. That is, functions with no visibility decorator default to being ``internal``.
 
@@ -110,7 +118,7 @@ You can optionally declare a function's mutability by using a :ref:`decorator <f
     * ``@pure``: does not read from the contract state or any environment variables.
     * ``@view``: may read from the contract state, but does not alter it.
     * ``@nonpayable`` (default): may read from and write to the contract state, but cannot receive Ether.
-    * ``@payable``: may read from and write to the contract state, and can receive Ether.
+    * ``@payable``: may read from and write to the contract state, and can receive and access Ether via ``msg.value``.
 
 .. code-block:: vyper
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -132,6 +132,9 @@ Functions marked with ``@view`` cannot call mutable (``payable`` or ``nonpayable
 
 Functions marked with ``@pure`` cannot call non-``pure`` functions.
 
+.. note::
+    The ``@nonpayable`` decorator is not strictly enforced on ``internal`` functions when they are invoked through an ``external`` ``payable`` function. As a result, an ``external`` ``payable`` function can invoke an ``internal`` ``nonpayable`` function. However, the ``nonpayable`` ``internal`` function cannot have access to ``msg.value``.
+
 Re-entrancy Locks
 -----------------
 


### PR DESCRIPTION
### What I did

Resolves #37584of [Attackathon | Ethereum Protocol](https://immunefi.com/bounty/ethereum-protocol-attackathon). Add a note to clarify that `nonpayable` `internal` functions can be called via `external` `payable` functions.

### How I did it

Brain.

### How to verify it

Skills.

### Commit message

```
this commit adds a note to clarify that `nonpayable` `internal`
functions can be called via `external` `payable` functions.
```

### Description for the changelog

Add a note to clarify that `nonpayable` `internal` functions can be called via `external` `payable` functions.

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/e1fbd3df-ab81-424c-bff8-b1b49a4d11a1)