### PR TITLE
fix: typos in documentation files

### DIFF
--- a/vyper/semantics/README.md
+++ b/vyper/semantics/README.md
@@ -23,7 +23,7 @@ Vyper abstract syntax tree (AST).
   * [`base.py`](analysis/base.py): Base validation class
   * [`common.py`](analysis/common.py): Base AST visitor class
   * [`data_positions`](analysis/data_positions.py): Functions for tracking storage variables and allocating storage slots
-  * [`levenhtein_utils.py`](analysis/levenshtein_utils.py): Helper for better error messages
+  * [`levenshtein_utils.py`](analysis/levenshtein_utils.py): Helper for better error messages
   * [`local.py`](analysis/local.py): Validates the local namespace of each function within a contract
   * [`pre_typecheck.py`](analysis/pre_typecheck.py): Evaluate foldable nodes and populate their metadata with the replacement nodes.
   * [`module.py`](analysis/module.py): Validates the module namespace of a contract.

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -169,7 +169,7 @@ class IRFunction:
                 continue
 
             if i < len(bbs) - 1:
-                # TODO: revisit this. When contructor calls internal functions
+                # TODO: revisit this. When constructor calls internal functions
                 # they are linked to the last ctor block. Should separate them
                 # before this so we don't have to handle this here
                 if bbs[i + 1].label.value.startswith("internal"):

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -375,7 +375,7 @@ class VenomCompiler:
             operands = [offset]
 
         # iload and istore are special cases because they can take a literal
-        # that is handled specialy with the _OFST macro. Look below, after the
+        # that is handled specially with the _OFST macro. Look below, after the
         # stack reordering.
         elif opcode == "iload":
             addr = inst.operands[0]


### PR DESCRIPTION
Corrected `levenhtein_utils` to `levenshtein_utils`
Corrected `contructor` to `constructor`
Corrected `specialy` to `specially`