### PR TITLE
feat[venom]: separate Venom settings from the main compiler settings

### DIFF
--- a/tests/functional/venom/test_venom_repr.py
+++ b/tests/functional/venom/test_venom_repr.py
@@ -10,6 +10,7 @@ from vyper.compiler.phases import generate_bytecode
 from vyper.compiler.settings import OptimizationLevel
 from vyper.venom import generate_assembly_experimental, run_passes_on
 from vyper.venom.context import IRContext
+from vyper.venom.settings import VenomSettings
 
 """
 Check that venom text format round-trips through parser
@@ -97,7 +98,7 @@ def _helper1(vyper_source, optimize):
     run_passes_on(ctx, optimize)
 
     # test we can generate assembly+bytecode
-    asm = generate_assembly_experimental(ctx)
+    asm = generate_assembly_experimental(ctx, VenomSettings.from_optimization_level(optimize))
     generate_bytecode(asm, compiler_metadata=None)
 
 
@@ -119,7 +120,7 @@ def _helper2(vyper_source, optimize, compiler_settings):
     assert_ctx_eq(bb_runtime, ctx)
 
     # test we can generate assembly+bytecode
-    asm = generate_assembly_experimental(ctx, optimize=optimize)
+    asm = generate_assembly_experimental(ctx, VenomSettings.from_vyper_settings(settings))
     bytecode = generate_bytecode(asm, compiler_metadata=None)
 
     out = compile_code(vyper_source, settings=settings, output_formats=["bytecode_runtime"])

--- a/tests/functional/venom/test_venom_repr.py
+++ b/tests/functional/venom/test_venom_repr.py
@@ -119,8 +119,11 @@ def _helper2(vyper_source, optimize, compiler_settings):
 
     assert_ctx_eq(bb_runtime, ctx)
 
+    venom_settings = VenomSettings.from_vyper_settings(settings)
+    venom_settings.optimize = optimize
+
     # test we can generate assembly+bytecode
-    asm = generate_assembly_experimental(ctx, VenomSettings.from_vyper_settings(settings))
+    asm = generate_assembly_experimental(ctx, venom_settings)
     bytecode = generate_bytecode(asm, compiler_metadata=None)
 
     out = compile_code(vyper_source, settings=settings, output_formats=["bytecode_runtime"])

--- a/tests/unit/compiler/venom/test_duplicate_operands.py
+++ b/tests/unit/compiler/venom/test_duplicate_operands.py
@@ -3,6 +3,7 @@ from vyper.venom import generate_assembly_experimental
 from vyper.venom.analysis import IRAnalysesCache
 from vyper.venom.context import IRContext
 from vyper.venom.passes import StoreExpansionPass
+from vyper.venom.settings import VenomSettings
 
 
 def test_duplicate_operands():
@@ -29,5 +30,5 @@ def test_duplicate_operands():
     StoreExpansionPass(ac, fn).run_pass()
 
     optimize = OptimizationLevel.GAS
-    asm = generate_assembly_experimental(ctx, optimize=optimize)
+    asm = generate_assembly_experimental(ctx, VenomSettings.from_optimization_level(optimize))
     assert asm == ["PUSH1", 10, "DUP1", "DUP2", "ADD", "MUL", "POP", "STOP"]

--- a/tests/unit/compiler/venom/test_stack_cleanup.py
+++ b/tests/unit/compiler/venom/test_stack_cleanup.py
@@ -1,6 +1,7 @@
 from vyper.compiler.settings import OptimizationLevel
 from vyper.venom import generate_assembly_experimental
 from vyper.venom.context import IRContext
+from vyper.venom.settings import VenomSettings
 
 
 def test_cleanup_stack():
@@ -13,5 +14,7 @@ def test_cleanup_stack():
     bb.append_instruction("add", op, op2)
     bb.append_instruction("ret", ret_val)
 
-    asm = generate_assembly_experimental(ctx, optimize=OptimizationLevel.GAS)
+    asm = generate_assembly_experimental(
+        ctx, VenomSettings.from_optimization_level(OptimizationLevel.GAS)
+    )
     assert asm == ["PUSH1", 10, "DUP1", "ADD", "POP", "JUMP"]

--- a/vyper/cli/venom_main.py
+++ b/vyper/cli/venom_main.py
@@ -8,6 +8,7 @@ from vyper.compiler.phases import generate_bytecode
 from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings
 from vyper.venom import generate_assembly_experimental, run_passes_on
 from vyper.venom.parser import parse_venom
+from vyper.venom.settings import VenomSettings
 
 """
 Standalone entry point into venom compiler. Parses venom input and emits
@@ -56,7 +57,9 @@ def _parse_args(argv: list[str]):
 
     ctx = parse_venom(venom_source)
     run_passes_on(ctx, OptimizationLevel.default())
-    asm = generate_assembly_experimental(ctx)
+    asm = generate_assembly_experimental(
+        ctx, VenomSettings.from_optimization_level(OptimizationLevel.default())
+    )
     bytecode = generate_bytecode(asm, compiler_metadata=None)
     print(f"0x{bytecode.hex()}")
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -21,6 +21,7 @@ from vyper.semantics.types.module import ModuleT
 from vyper.typing import StorageLayout
 from vyper.utils import ERC5202_PREFIX, vyper_warn
 from vyper.venom import generate_assembly_experimental, generate_ir
+from vyper.venom.settings import VenomSettings
 
 DEFAULT_CONTRACT_PATH = PurePath("VyperContract.vy")
 
@@ -253,7 +254,9 @@ class CompilerData:
             deploy_code, runtime_code = self.venom_functions
             assert self.settings.optimize is not None  # mypy hint
             return generate_assembly_experimental(
-                runtime_code, deploy_code=deploy_code, optimize=self.settings.optimize
+                runtime_code,
+                deploy_code=deploy_code,
+                settings=VenomSettings.from_vyper_settings(self.settings),
             )
         else:
             return generate_assembly(self.ir_nodes, self.settings.optimize)
@@ -263,7 +266,9 @@ class CompilerData:
         if self.settings.experimental_codegen:
             _, runtime_code = self.venom_functions
             assert self.settings.optimize is not None  # mypy hint
-            return generate_assembly_experimental(runtime_code, optimize=self.settings.optimize)
+            return generate_assembly_experimental(
+                runtime_code, settings=VenomSettings.from_vyper_settings(self.settings)
+            )
         else:
             return generate_assembly(self.ir_runtime, self.settings.optimize)
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -252,7 +252,6 @@ class CompilerData:
     def assembly(self) -> list:
         if self.settings.experimental_codegen:
             deploy_code, runtime_code = self.venom_functions
-            assert self.settings.optimize is not None  # mypy hint
             return generate_assembly_experimental(
                 runtime_code,
                 deploy_code=deploy_code,
@@ -265,7 +264,6 @@ class CompilerData:
     def assembly_runtime(self) -> list:
         if self.settings.experimental_codegen:
             _, runtime_code = self.venom_functions
-            assert self.settings.optimize is not None  # mypy hint
             return generate_assembly_experimental(
                 runtime_code, settings=VenomSettings.from_vyper_settings(self.settings)
             )

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -26,6 +26,7 @@ from vyper.venom.passes import (
     StoreElimination,
     StoreExpansionPass,
 )
+from vyper.venom.settings import VenomSettings
 from vyper.venom.venom_to_assembly import VenomCompiler
 
 DEFAULT_OPT_LEVEL = OptimizationLevel.default()
@@ -33,8 +34,8 @@ DEFAULT_OPT_LEVEL = OptimizationLevel.default()
 
 def generate_assembly_experimental(
     runtime_code: IRContext,
+    settings: Optional[VenomSettings] = None,
     deploy_code: Optional[IRContext] = None,
-    optimize: OptimizationLevel = DEFAULT_OPT_LEVEL,
 ) -> list[str]:
     # note: VenomCompiler is sensitive to the order of these!
     if deploy_code is not None:
@@ -42,8 +43,11 @@ def generate_assembly_experimental(
     else:
         functions = [runtime_code]
 
-    compiler = VenomCompiler(functions)
-    return compiler.generate_evm(optimize == OptimizationLevel.NONE)
+    if settings is None:
+        settings = VenomSettings.from_optimization_level(OptimizationLevel.default())
+
+    compiler = VenomCompiler(functions, settings)
+    return compiler.generate_evm()
 
 
 def _run_passes(fn: IRFunction, optimize: OptimizationLevel) -> None:

--- a/vyper/venom/settings.py
+++ b/vyper/venom/settings.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from vyper.compiler.settings import OptimizationLevel, Settings
+
+
+@dataclass
+class VenomSettings:
+    optimize: Optional[OptimizationLevel] = None
+    evm_version: Optional[str] = None
+    debug: Optional[bool] = None
+
+    @classmethod
+    def from_vyper_settings(cls, settings: Settings):
+        return cls(
+            optimize=settings.optimize, evm_version=settings.evm_version, debug=settings.debug
+        )
+
+    @classmethod
+    def from_optimization_level(cls, optimize: OptimizationLevel):
+        return cls(optimize=optimize, debug=False)

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from vyper.compiler.settings import OptimizationLevel
 from vyper.exceptions import CompilerPanic, StackTooDeep
 from vyper.ir.compile_ir import (
     PUSH,
@@ -26,6 +27,7 @@ from vyper.venom.basicblock import (
 )
 from vyper.venom.context import IRContext
 from vyper.venom.passes import NormalizationPass
+from vyper.venom.settings import VenomSettings
 from vyper.venom.stack_model import StackModel
 
 DEBUG_SHOW_COST = False
@@ -141,14 +143,16 @@ class VenomCompiler:
     visited_instructions: OrderedSet  # {IRInstruction}
     visited_basicblocks: OrderedSet  # {IRBasicBlock}
     liveness_analysis: LivenessAnalysis
+    settings: VenomSettings
 
-    def __init__(self, ctxs: list[IRContext]):
+    def __init__(self, ctxs: list[IRContext], settings: VenomSettings):
         self.ctxs = ctxs
         self.label_counter = 0
         self.visited_instructions = OrderedSet()
         self.visited_basicblocks = OrderedSet()
+        self.settings = settings
 
-    def generate_evm(self, no_optimize: bool = False) -> list[str]:
+    def generate_evm(self) -> list[str]:
         self.visited_instructions = OrderedSet()
         self.visited_basicblocks = OrderedSet()
         self.label_counter = 0
@@ -202,7 +206,7 @@ class VenomCompiler:
 
                 asm.append(asm_data_section)
 
-        if no_optimize is False:
+        if self.settings.optimize != OptimizationLevel.NONE:
             optimize_assembly(top_asm)
 
         return top_asm


### PR DESCRIPTION
### What I did

Until now Venom was only accepting a single boolean optimization flag, which is no longer adequate. I updated that to a venom settings dataclass, that will accommodate for the upcoming special to venom settings

### How I did it

### How to verify it

### Commit message

```
Add the `VenomSettings` dataclass and update the code to use it.
Until now Venom was only accepting an single boolean optimization flag, which is no 
longer adequate. The updated venom settings dataclass will accommodate for the 
upcoming special to venom settings and the more specific optimization selection.
```

### Description for the changelog

### Cute Animal Picture

![33687185-bec4-4959-98fd-11d4a373b09d](https://github.com/user-attachments/assets/db0872ea-106e-4ec8-9a6f-0c91b13fbd09)

