### PR TITLE
fix[ux]: don't print full path as interface name in output

### DIFF
--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -621,3 +621,15 @@ def bar():
     # TODO make the exception more precise once fixed
     with pytest.raises(Exception):  # noqa: B017
         compiler.compile_code(main, input_bundle=input_bundle)
+
+
+def test_interface_name_in_output_is_short(make_input_bundle):
+    code = """
+from ethereum.ercs import IERC20
+@external
+def test(input: IERC20):
+    pass
+        """
+    out = compiler.compile_code(code, output_formats=["interface"])
+
+    assert "def test(input: IERC20):" in out["interface"]

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from vyper import ast as vy_ast
@@ -79,7 +80,7 @@ class InterfaceT(_UserType):
         return ABI_Address()
 
     def __str__(self):
-        return self._id
+        return Path(self._id).stem
 
     def __repr__(self):
         return f"interface {self._id}"


### PR DESCRIPTION
### What I did
Instead of the full path as the interface print just the name of the interface as per https://github.com/vyperlang/vyper/issues/4299. 
### How I did it
Use only a part of _id as the interface's string representation and use it when printing signature.

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
