### PR TITLE
fix: add `socl_json` output selection to translate map for standard JSON

### DIFF
--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -33,6 +33,7 @@ TRANSLATE_MAP = {
     "metadata": "metadata",
     "layout": "layout",
     "userdoc": "userdoc",
+    "solc_json": "solc_json",
 }
 
 


### PR DESCRIPTION
### What I did

add `socl_json` output selection to translate map for standard JSON

### How I did it

add it to the map.

### How to verify it

include solc_json in an output selection in some std json and run it through the compiler

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
