### PR TITLE
chore[ci]: bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
 
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: dist/vyper.*
 
@@ -81,7 +81,7 @@ jobs:
           ./make.cmd freeze
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: dist/vyper.*
 
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
+          name: vyper-${{ matrix.runs-on }}
           path: dist/vyper.*
 
   windows-build:
@@ -83,6 +84,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
+          name: vyper-${{ runner.os }}
           path: dist/vyper.*
 
   publish-release-assets:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/
+          pattern: vyper-*
           merge-multiple: true
 
       - name: Upload assets
@@ -104,6 +105,7 @@ jobs:
         # TODO: this needs to be tested when upgrading to upload-artifact v4
         working-directory: artifacts
         run: |
+
           set -Eeuxo pipefail
           for BIN_NAME in $(ls)
           do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload assets
         # fun - artifacts are downloaded into "artifact/".
         # TODO: this needs to be tested when upgrading to upload-artifact v4
-        working-directory: artifacts/artifact
+        working-directory: artifacts
         run: |
           set -Eeuxo pipefail
           for BIN_NAME in $(ls)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/
+          merge-multiple: true
 
       - name: Upload assets
         # fun - artifacts are downloaded into "artifact/".

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   unix-build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ runner.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
           set -Eeuxo pipefail
           for BIN_NAME in $(ls)
           do
+            ls -L "${BIN_NAME}"
             curl -L \
               --no-progress-meter \
               -X POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: vyper-${{ matrix.runs-on }}
+          name: vyper-${{ matrix.os }}
           path: dist/vyper.*
 
   windows-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/
-          pattern: vyper-*
           merge-multiple: true
 
       - name: Upload assets
@@ -105,11 +104,9 @@ jobs:
         # TODO: this needs to be tested when upgrading to upload-artifact v4
         working-directory: artifacts
         run: |
-
           set -Eeuxo pipefail
           for BIN_NAME in $(ls)
           do
-            ls -L "${BIN_NAME}"
             curl -L \
               --no-progress-meter \
               -X POST \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   unix-build:
-    runs-on: ${{ runner.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest]
@@ -51,7 +51,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: vyper-${{ matrix.os }}
+          name: vyper-${{ runner.os }}
           path: dist/vyper.*
 
   windows-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,6 @@ jobs:
           merge-multiple: true
 
       - name: Upload assets
-        # fun - artifacts are downloaded into "artifact/".
-        # TODO: this needs to be tested when upgrading to upload-artifact v4
         working-directory: artifacts
         run: |
           set -Eeuxo pipefail


### PR DESCRIPTION
### What I did

Fix #4441.

### How I did it

### How to verify it

### Commit message

```
This commit bumps the upload-artifact action to v4 because
v3 will be deprecated on 30 Jan 2025.
```

### Description for the changelog

Bump upload-artifact action to v4

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.gettyimages.com/id/1266039701/photo/sleepy-koala-in-a-eucalyptus-tree-on-a-sunny-morning.jpg?s=612x612&w=gi&k=20&c=6hHQttZLQC4mePkcLSx5n0EUU_4eEcroUrF_yK7BH8Y=)
