### PR TITLE
feat[tool]: add `-Werror` and `-Wnone` options

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -198,6 +198,23 @@ The following is a list of supported EVM versions, and changes in the compiler i
    - Functions marked with ``@nonreentrant`` are protected with TLOAD/TSTORE instead of SLOAD/SSTORE
    - The ``MCOPY`` opcode will be generated automatically by the compiler for most memory operations.
 
+
+.. _warnings:
+
+Controlling Warnings
+====================
+
+Vyper allows suppression of warnings via the CLI flag ``-Wnone``, or promotion of (all) warnings to errors via the ``-Werror`` flag.
+
+.. code:: shell
+
+    $ vyper -Wnone foo.vy   # suppress warnings
+
+.. code:: shell
+
+    $ vyper -Werror foo.vy   # promote warnings to errors
+
+
 .. _integrity-hash:
 
 Integrity Hash

--- a/tests/unit/ast/test_tokenizer.py
+++ b/tests/unit/ast/test_tokenizer.py
@@ -1,0 +1,94 @@
+"""
+Tests that the tokenizer / parser are passing correct source location
+info to the AST
+"""
+import pytest
+
+from vyper.ast.parse import parse_to_ast
+from vyper.compiler import compile_code
+from vyper.exceptions import UndeclaredDefinition
+
+
+def test_log_token_aligned():
+    # GH issue 3430
+    code = """
+event A:
+    b: uint256
+
+@external
+def f():
+    log A(b=d)
+    """
+    with pytest.raises(UndeclaredDefinition) as e:
+        compile_code(code)
+
+    expected = """
+ 'd' has not been declared.
+
+  function "f", line 7:12 
+       6 def f():
+  ---> 7     log A(b=d)
+  -------------------^
+       8
+    """  # noqa: W291
+    assert expected.strip() == str(e.value).strip()
+
+
+def test_log_token_aligned2():
+    # GH issue 3059
+    code = """
+interface Contract:
+    def foo(): nonpayable
+
+event MyEvent:
+    a: address
+
+@external
+def foo(c: Contract):
+    log MyEvent(a=c.address)
+    """
+    compile_code(code)
+
+
+def test_log_token_aligned3():
+    # https://github.com/vyperlang/vyper/pull/3808#pullrequestreview-1900570163
+    code = """
+import ITest
+
+implements: ITest
+
+event Foo:
+    a: address
+
+@external
+def foo(u: uint256):
+    log Foo(empty(address))
+    log i.Foo(empty(address))
+    """
+    # not semantically valid code, check we can at least parse it
+    assert parse_to_ast(code) is not None
+
+
+def test_log_token_aligned4():
+    # GH issue 4139
+    code = """
+b: public(uint256)
+
+event Transfer:
+    random: indexed(uint256)
+    shi: uint256
+
+@external
+def transfer():
+    log Transfer(T(self).b(), 10)
+    return
+    """
+    # not semantically valid code, check we can at least parse it
+    assert parse_to_ast(code) is not None
+
+
+def test_long_string_non_coding_token():
+    # GH issue 2258
+    code = '\r[[]]\ndef _(e:[],l:[]):\n    """"""""""""""""""""""""""""""""""""""""""""""""""""""\n    f.n()'  # noqa: E501
+    # not valid code, but should at least parse
+    assert parse_to_ast(code) is not None

--- a/tests/unit/cli/vyper_compile/test_parse_args.py
+++ b/tests/unit/cli/vyper_compile/test_parse_args.py
@@ -1,10 +1,10 @@
 import os
-from vyper.warnings import VyperWarning
 import warnings
 
 import pytest
 
 from vyper.cli.vyper_compile import _parse_args
+from vyper.warnings import VyperWarning
 
 
 @pytest.fixture
@@ -29,6 +29,7 @@ def foo() -> bool:
 
     _parse_args([str(bar_path)])  # absolute path, subfolder of cwd
     _parse_args([str(bar_path.relative_to(chdir_path.parent))])  # relative path
+
 
 def test_warnings(make_file):
     """

--- a/tests/unit/cli/vyper_compile/test_parse_args.py
+++ b/tests/unit/cli/vyper_compile/test_parse_args.py
@@ -37,22 +37,16 @@ def test_warnings(make_file):
     """
     # test code which emits warnings
     code = """
-@external
-def foo():
-    breakpoint()
+x: public(uint256[2**64])
     """
     path = make_file("foo.vy", code)
     path_str = str(path)
 
-    # (1)
-    # test promote warnings to error
-    # doesn't work if it runs after (2)!
-    with pytest.raises(VyperWarning) as e:
-        _parse_args([path_str, "-Werror"])
-
-    # (2)
     with warnings.catch_warnings(record=True) as w:
         _parse_args([str(path)])
+
+    with pytest.raises(VyperWarning) as e:
+        _parse_args([path_str, "-Werror"])
 
     assert len(w) == 1
     warning_message = w[0].message.message

--- a/tests/unit/compiler/test_compile_code.py
+++ b/tests/unit/compiler/test_compile_code.py
@@ -19,7 +19,7 @@ def a() -> bool:
     q: Bytes[24577] = {huge_bytestring}
     return True
 """
-    with pytest.warns(vyper.warnings.ContractSizeLimitWarning):
+    with pytest.warns(vyper.warnings.ContractSizeLimit):
         vyper.compile_code(code, output_formats=["bytecode_runtime"])
 
 

--- a/vyper/ast/natspec.py
+++ b/vyper/ast/natspec.py
@@ -2,6 +2,7 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+# NOTE: this is our only use of asttokens -- consider vendoring in the implementation.
 from asttokens import LineNumbers
 
 from vyper.ast import nodes as vy_ast

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -7,7 +7,6 @@ import math
 import operator
 import pickle
 import sys
-import warnings
 from typing import Any, Optional, Union
 
 from vyper.ast.metadata import NodeMetadata
@@ -23,7 +22,6 @@ from vyper.exceptions import (
     TypeMismatch,
     UnfoldableNode,
     VariableDeclarationException,
-    VyperException,
     ZeroDivisionException,
 )
 from vyper.utils import (
@@ -34,6 +32,7 @@ from vyper.utils import (
     quantize,
     sha256sum,
 )
+from vyper.warnings import EnumUsage, vyper_warn
 
 NODE_BASE_ATTRIBUTES = (
     "_children",
@@ -133,13 +132,9 @@ def get_node(
 
     node = vy_class(parent=parent, **ast_struct)
 
-    # TODO: Putting this after node creation to pretty print, remove after enum deprecation
     if enum_warn:
-        # TODO: hack to pretty print, logic should be factored out of exception
-        pretty_printed_node = str(VyperException("", node))
-        warnings.warn(
-            f"enum will be deprecated in a future release, use flag instead. {pretty_printed_node}",
-            stacklevel=2,
+        vyper_warn(
+            EnumUsage("enum will be deprecated in a future release, use flag instead.", node)
         )
 
     node.validate()

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -435,14 +435,14 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         return node
 
     def visit_Call(self, node):
-        self.generic_visit(node)
-
         # Convert structs declared as `Dict` node for vyper < 0.4.0 to kwargs
         if len(node.args) == 1 and isinstance(node.args[0], python_ast.Dict):
             msg = "Instantiating a struct using a dictionary is deprecated "
             msg += "as of v0.4.0 and will be disallowed in a future release. "
             msg += "Use kwargs instead e.g. Foo(a=1, b=2)"
 
+            # add full_source_code so that str(VyperException(msg, node)) works
+            node.full_source_code = self._source_code
             vyper_warn(Deprecation(msg, node))
 
             dict_ = node.args[0]
@@ -458,6 +458,8 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
             node.args = []
             node.keywords = kw_list
+
+        self.generic_visit(node)
 
         return node
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -1,9 +1,9 @@
 import ast as python_ast
+import pickle
 import tokenize
 from decimal import Decimal
+from functools import cached_property
 from typing import Any, Dict, List, Optional, Union
-
-import asttokens
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.pre_parser import PreParser
@@ -80,12 +80,16 @@ def _parse_to_ast_with_settings(
     try:
         py_ast = python_ast.parse(pre_parser.reformatted_code)
     except SyntaxError as e:
-        # TODO: Ensure 1-to-1 match of source_code:reformatted_code SyntaxErrors
         offset = e.offset
         if offset is not None:
             # SyntaxError offset is 1-based, not 0-based (see:
             # https://docs.python.org/3/library/exceptions.html#SyntaxError.offset)
             offset -= 1
+
+            # adjust the column of the error if it was modified by the pre-parser
+            if e.lineno is not None:  # help mypy
+                offset += pre_parser.adjustments.get((e.lineno, offset), 0)
+
         new_e = SyntaxException(str(e), vyper_source, e.lineno, offset)
 
         likely_errors = ("staticall", "staticcal")
@@ -96,6 +100,11 @@ def _parse_to_ast_with_settings(
                 break
 
         raise new_e from None
+
+    # some python AST node instances are singletons and are reused between
+    # parse() invocations. copy the python AST so that we are using fresh
+    # objects.
+    py_ast = _deepcopy_ast(py_ast)
 
     # Add dummy function node to ensure local variables are treated as `AnnAssign`
     # instead of state variables (`VariableDecl`)
@@ -129,6 +138,9 @@ def _parse_to_ast_with_settings(
     return pre_parser.settings, module
 
 
+LINE_INFO_FIELDS = ("lineno", "col_offset", "end_lineno", "end_col_offset")
+
+
 def ast_to_dict(ast_struct: Union[vy_ast.VyperNode, List]) -> Union[Dict, List]:
     """
     Converts a Vyper AST node, or list of nodes, into a dictionary suitable for
@@ -155,7 +167,7 @@ def dict_to_ast(ast_struct: Union[Dict, List]) -> Union[vy_ast.VyperNode, List]:
 
 
 def annotate_python_ast(
-    parsed_ast: python_ast.AST,
+    parsed_ast: python_ast.Module,
     vyper_source: str,
     pre_parser: PreParser,
     source_id: int = 0,
@@ -178,20 +190,17 @@ def annotate_python_ast(
     -------
         The annotated and optimized AST.
     """
-    tokens = asttokens.ASTTokens(vyper_source)
-    assert isinstance(parsed_ast, python_ast.Module)  # help mypy
-    tokens.mark_tokens(parsed_ast)
     visitor = AnnotatingVisitor(
-        vyper_source,
-        pre_parser,
-        tokens,
-        source_id,
-        module_path=module_path,
-        resolved_path=resolved_path,
+        vyper_source, pre_parser, source_id, module_path=module_path, resolved_path=resolved_path
     )
-    visitor.visit(parsed_ast)
+    visitor.start(parsed_ast)
 
     return parsed_ast
+
+
+def _deepcopy_ast(ast_node: python_ast.AST):
+    # pickle roundtrip is faster than copy.deepcopy() here.
+    return pickle.loads(pickle.dumps(ast_node))
 
 
 class AnnotatingVisitor(python_ast.NodeTransformer):
@@ -202,12 +211,10 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         self,
         source_code: str,
         pre_parser: PreParser,
-        tokens: asttokens.ASTTokens,
         source_id: int,
         module_path: Optional[str] = None,
         resolved_path: Optional[str] = None,
     ):
-        self._tokens = tokens
         self._source_id = source_id
         self._module_path = module_path
         self._resolved_path = resolved_path
@@ -216,6 +223,58 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         self.counter: int = 0
 
+    @cached_property
+    def source_lines(self):
+        return self._source_code.splitlines(keepends=True)
+
+    @cached_property
+    def line_offsets(self):
+        ofst = 0
+        # ensure line_offsets has at least 1 entry for 0-line source
+        ret = {1: ofst}
+        for lineno, line in enumerate(self.source_lines):
+            ret[lineno + 1] = ofst
+            ofst += len(line)
+        return ret
+
+    def start(self, node: python_ast.Module):
+        self._fix_missing_locations(node)
+        self.visit(node)
+
+    def _fix_missing_locations(self, ast_node: python_ast.Module):
+        """
+        adapted from cpython Lib/ast.py. adds line/col info to ast,
+        but unlike Lib/ast.py, adjusts *all* ast nodes, not just the
+        one that python defines to have line/col info.
+        https://github.com/python/cpython/blob/62729d79206014886f5d/Lib/ast.py#L228
+        """
+        assert isinstance(ast_node, python_ast.Module)
+        ast_node.lineno = 1
+        ast_node.col_offset = 0
+        ast_node.end_lineno = max(1, len(self.source_lines))
+
+        if len(self.source_lines) > 0:
+            ast_node.end_col_offset = len(self.source_lines[-1])
+        else:
+            ast_node.end_col_offset = 0
+
+        def _fix(node, parent=None):
+            for field in LINE_INFO_FIELDS:
+                if parent is not None:
+                    val = getattr(node, field, None)
+                    # special case for USub - heisenbug when coverage is
+                    # enabled in the test suite.
+                    if val is None or isinstance(node, python_ast.USub):
+                        val = getattr(parent, field)
+                    setattr(node, field, val)
+                else:
+                    assert hasattr(node, field), node
+
+            for child in python_ast.iter_child_nodes(node):
+                _fix(child, node)
+
+        _fix(ast_node)
+
     def generic_visit(self, node):
         """
         Annotate a node with information that simplifies Vyper node generation.
@@ -223,38 +282,28 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         # Decorate every node with the original source code to allow pretty-printing errors
         node.full_source_code = self._source_code
         node.node_id = self.counter
-        node.ast_type = node.__class__.__name__
         self.counter += 1
+        node.ast_type = node.__class__.__name__
 
-        # Decorate every node with source end offsets
-        start = (None, None)
-        if hasattr(node, "first_token"):
-            start = node.first_token.start
-        end = (None, None)
-        if hasattr(node, "last_token"):
-            end = node.last_token.end
-            if node.last_token.type == 4:
-                # token type 4 is a `\n`, some nodes include a trailing newline
-                # here we ignore it when building the node offsets
-                end = (end[0], end[1] - 1)
+        adjustments = self._pre_parser.adjustments
 
-        node.lineno = start[0]
-        node.col_offset = start[1]
-        node.end_lineno = end[0]
-        node.end_col_offset = end[1]
+        # Load and Store behave differently inside of fix_missing_locations;
+        # we don't use them in the vyper AST so just skip adjusting the line
+        # info.
+        if isinstance(node, (python_ast.Load, python_ast.Store)):
+            return super().generic_visit(node)
 
-        # TODO: adjust end_lineno and end_col_offset when this node is in
-        # modification_offsets
+        adj = adjustments.get((node.lineno, node.col_offset), 0)
+        node.col_offset += adj
 
-        if hasattr(node, "last_token"):
-            start_pos = node.first_token.startpos
-            end_pos = node.last_token.endpos
+        adj = adjustments.get((node.end_lineno, node.end_col_offset), 0)
+        node.end_col_offset += adj
 
-            if node.last_token.type == 4:
-                # ignore trailing newline once more
-                end_pos -= 1
-            node.src = f"{start_pos}:{end_pos-start_pos}:{self._source_id}"
-            node.node_source_code = self._source_code[start_pos:end_pos]
+        start_pos = self.line_offsets[node.lineno] + node.col_offset
+        end_pos = self.line_offsets[node.end_lineno] + node.end_col_offset
+
+        node.src = f"{start_pos}:{end_pos-start_pos}:{self._source_id}"
+        node.node_source_code = self._source_code[start_pos:end_pos]
 
         return super().generic_visit(node)
 
@@ -288,12 +337,6 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         return self._visit_docstring(node)
 
     def visit_FunctionDef(self, node):
-        if node.decorator_list:
-            # start the source highlight at `def` to improve annotation readability
-            decorator_token = node.decorator_list[-1].last_token
-            def_token = self._tokens.find_token(decorator_token, tokenize.NAME, tok_str="def")
-            node.first_token = def_token
-
         return self._visit_docstring(node)
 
     def visit_ClassDef(self, node):
@@ -306,7 +349,7 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         """
         self.generic_visit(node)
 
-        node.ast_type = self._pre_parser.modification_offsets[(node.lineno, node.col_offset)]
+        node.ast_type = self._pre_parser.keyword_translations[(node.lineno, node.col_offset)]
         return node
 
     def visit_For(self, node):
@@ -349,15 +392,12 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         try:
             fake_node = python_ast.parse(annotation_str).body[0]
+            # do we need to fix location info here?
+            fake_node = _deepcopy_ast(fake_node)
         except SyntaxError as e:
             raise SyntaxException(
                 "invalid type annotation", self._source_code, node.lineno, node.col_offset
             ) from e
-
-        # fill in with asttokens info. note we can use `self._tokens` because
-        # it is indented to exactly the same position where it appeared
-        # in the original source!
-        self._tokens.mark_tokens(fake_node)
 
         # replace the dummy target name with the real target name.
         fake_node.target = node.target
@@ -383,14 +423,14 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
             # CMC 2024-03-03 consider unremoving this from the enclosing Expr
             node = node.value
             key = (node.lineno, node.col_offset)
-            node.ast_type = self._pre_parser.modification_offsets[key]
+            node.ast_type = self._pre_parser.keyword_translations[key]
 
         return node
 
     def visit_Await(self, node):
-        start_pos = node.lineno, node.col_offset  # grab these before generic_visit modifies them
+        start_pos = node.lineno, node.col_offset
         self.generic_visit(node)
-        node.ast_type = self._pre_parser.modification_offsets[start_pos]
+        node.ast_type = self._pre_parser.keyword_translations[start_pos]
         return node
 
     def visit_Call(self, node):
@@ -410,6 +450,9 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
             assert len(dict_.keys) == len(dict_.values)
             for key, value in zip(dict_.keys, dict_.values):
                 replacement_kw_node = python_ast.keyword(key.id, value)
+                # set locations
+                for attr in LINE_INFO_FIELDS:
+                    setattr(replacement_kw_node, attr, getattr(key, attr))
                 kw_list.append(replacement_kw_node)
 
             node.args = []

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -96,8 +96,8 @@ from vyper.utils import (
     keccak256,
     method_id,
     method_id_int,
-    vyper_warn,
 )
+from vyper.warnings import vyper_warn
 
 from ._convert import convert
 from ._signatures import BuiltinFunctionT, process_inputs

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -15,7 +15,7 @@ from vyper.cli.compile_archive import NotZipInput, compile_from_zip
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle
 from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel, Settings
 from vyper.typing import ContractPath, OutputFormats
-from vyper.warnings import VyperWarning
+from vyper.warnings import set_warnings_filter
 
 T = TypeVar("T")
 
@@ -204,18 +204,6 @@ def _parse_args(argv):
         # an error occurred in a Vyper source file.
         sys.tracebacklimit = 0
 
-    if args.warnings_control == "error":
-        warnings_filter = "error"
-    elif args.warnings_control == "none":
-        warnings_filter = "ignore"
-    else:
-        assert args.warnings_control is None  # sanity
-        warnings_filter = "default"
-
-    # NOTE: in the future we can do more fine-grained control by setting
-    # category to specific warning types
-    warnings.simplefilter(warnings_filter, category=VyperWarning)
-
     if args.hex_ir:
         ir_node.AS_HEX_DEFAULT = True
 
@@ -263,6 +251,7 @@ def _parse_args(argv):
         settings,
         args.storage_layout,
         args.no_bytecode_metadata,
+        args.warnings_control,
     )
 
     mode = "w"
@@ -329,7 +318,10 @@ def compile_files(
     settings: Optional[Settings] = None,
     storage_layout_paths: list[str] = None,
     no_bytecode_metadata: bool = False,
+    warnings_control: Optional[str] = None,
 ) -> dict:
+    set_warnings_filter(warnings_control)
+
     search_paths = get_search_paths(paths, include_sys_path)
     input_bundle = FilesystemInputBundle(search_paths)
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -212,6 +212,8 @@ def _parse_args(argv):
         assert args.warnings_control is None  # sanity
         warnings_filter = "default"
 
+    # NOTE: in the future we can do more fine-grained control by setting
+    # category to specific warning types
     warnings.simplefilter(warnings_filter, category=VyperWarning)
 
     if args.hex_ir:

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -99,8 +99,6 @@ def _cli_helper(f, output_formats, compiled):
 
 
 def _parse_args(argv):
-    warnings.simplefilter("always")
-
     if "--standard-json" in argv:
         argv.remove("--standard-json")
         vyper_json._parse_args(argv)

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -235,9 +235,6 @@ def _parse_args(argv):
     if args.enable_decimals:
         settings.enable_decimals = args.enable_decimals
 
-    if args.warnings_control:
-        settings.warnings_control = args.warnings_control
-
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import functools
+import inspect
 import json
 import os
 import sys
@@ -297,7 +298,11 @@ def get_search_paths(paths: list[str] = None, include_sys_path=True) -> list[Pat
 def _apply_warnings_filter(func):
     @functools.wraps(func)
     def inner(*args, **kwargs):
-        warnings_control = args[-1]
+        # find "warnings_control" argument
+        ba = inspect.signature(func).bind(*args, **kwargs)
+        ba.apply_defaults()
+
+        warnings_control = ba.arguments["warnings_control"]
         with warnings_filter(warnings_control):
             return func(*args, **kwargs)
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -3,7 +3,6 @@ import argparse
 import json
 import os
 import sys
-import warnings
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional, Set, TypeVar
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -235,6 +235,9 @@ def _parse_args(argv):
     if args.enable_decimals:
         settings.enable_decimals = args.enable_decimals
 
+    if args.warnings_control:
+        settings.warnings_control = args.warnings_control
+
     if args.verbose:
         print(f"cli specified: `{settings}`", file=sys.stderr)
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -15,6 +15,7 @@ from vyper.cli.compile_archive import NotZipInput, compile_from_zip
 from vyper.compiler.input_bundle import FileInput, FilesystemInputBundle
 from vyper.compiler.settings import VYPER_TRACEBACK_LIMIT, OptimizationLevel, Settings
 from vyper.typing import ContractPath, OutputFormats
+from vyper.warnings import VyperWarning
 
 T = TypeVar("T")
 
@@ -187,6 +188,10 @@ def _parse_args(argv):
     )
     parser.add_argument("--enable-decimals", help="Enable decimals", action="store_true")
 
+    parser.add_argument(
+        "-W", help="Control warnings", dest="warnings_control", choices=["error", "none"]
+    )
+
     args = parser.parse_args(argv)
 
     if args.traceback_limit is not None:
@@ -200,6 +205,16 @@ def _parse_args(argv):
         # setting of zero so error printouts only include information about where
         # an error occurred in a Vyper source file.
         sys.tracebacklimit = 0
+
+    if args.warnings_control == "error":
+        warnings_filter = "error"
+    elif args.warnings_control == "none":
+        warnings_filter = "ignore"
+    else:
+        assert args.warnings_control is None  # sanity
+        warnings_filter = "default"
+
+    warnings.simplefilter(warnings_filter, category=VyperWarning)
 
     if args.hex_ir:
         ir_node.AS_HEX_DEFAULT = True

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -14,6 +14,7 @@ from vyper.evm.opcodes import EVM_VERSIONS
 from vyper.exceptions import JSONError
 from vyper.typing import StorageLayout
 from vyper.utils import OrderedSet, keccak256
+from vyper.warnings import Deprecation, vyper_warn
 
 TRANSLATE_MAP = {
     "abi": "abi",
@@ -276,9 +277,10 @@ def get_settings(input_dict: dict) -> Settings:
 
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility
-        warnings.warn(
-            "optimize: <bool> is deprecated! please use one of 'gas', 'codesize', 'none'.",
-            stacklevel=2,
+        vyper_warn(
+            Deprecation(
+                "optimize: <bool> is deprecated! please use one of 'gas', 'codesize', 'none'."
+            )
         )
         optimize = OptimizationLevel.default() if optimize else OptimizationLevel.NONE
     elif isinstance(optimize, str):

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -267,14 +267,12 @@ def get_search_paths(input_dict: dict) -> list[PurePath]:
 def get_settings(input_dict: dict) -> Settings:
     evm_version = get_evm_version(input_dict)
 
-    settings_dict = input_dict["settings"]
+    optimize = input_dict["settings"].get("optimize")
 
-    optimize = settings_dict.get("optimize")
-
-    experimental_codegen = settings_dict.get("experimentalCodegen")
+    experimental_codegen = input_dict["settings"].get("experimentalCodegen")
     if experimental_codegen is None:
         experimental_codegen = input_dict["settings"].get("venom")
-    elif settings_dict.get("venom") is not None:
+    elif input_dict["settings"].get("venom") is not None:
         raise JSONError("both experimentalCodegen and venom cannot be set")
 
     if isinstance(optimize, bool):
@@ -290,12 +288,10 @@ def get_settings(input_dict: dict) -> Settings:
     else:
         assert optimize is None
 
-    debug = settings_dict.get("debug", None)
+    debug = input_dict["settings"].get("debug", None)
 
     # TODO: maybe change these to camelCase for consistency
-    enable_decimals = settings_dict.get("enable_decimals", None)
-
-    warnings_control = settings_dict.get("warnings_control", None)
+    enable_decimals = input_dict["settings"].get("enable_decimals", None)
 
     return Settings(
         evm_version=evm_version,
@@ -303,7 +299,6 @@ def get_settings(input_dict: dict) -> Settings:
         experimental_codegen=experimental_codegen,
         debug=debug,
         enable_decimals=enable_decimals,
-        warnings_control=warnings_control,
     )
 
 

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -267,12 +267,14 @@ def get_search_paths(input_dict: dict) -> list[PurePath]:
 def get_settings(input_dict: dict) -> Settings:
     evm_version = get_evm_version(input_dict)
 
-    optimize = input_dict["settings"].get("optimize")
+    settings_dict = input_dict["settings"]
 
-    experimental_codegen = input_dict["settings"].get("experimentalCodegen")
+    optimize = settings_dict.get("optimize")
+
+    experimental_codegen = settings_dict.get("experimentalCodegen")
     if experimental_codegen is None:
         experimental_codegen = input_dict["settings"].get("venom")
-    elif input_dict["settings"].get("venom") is not None:
+    elif settings_dict.get("venom") is not None:
         raise JSONError("both experimentalCodegen and venom cannot be set")
 
     if isinstance(optimize, bool):
@@ -288,10 +290,12 @@ def get_settings(input_dict: dict) -> Settings:
     else:
         assert optimize is None
 
-    debug = input_dict["settings"].get("debug", None)
+    debug = settings_dict.get("debug", None)
 
     # TODO: maybe change these to camelCase for consistency
-    enable_decimals = input_dict["settings"].get("enable_decimals", None)
+    enable_decimals = settings_dict.get("enable_decimals", None)
+
+    warnings_control = settings_dict.get("warnings_control", None)
 
     return Settings(
         evm_version=evm_version,
@@ -299,6 +303,7 @@ def get_settings(input_dict: dict) -> Settings:
         experimental_codegen=experimental_codegen,
         debug=debug,
         enable_decimals=enable_decimals,
+        warnings_control=warnings_control,
     )
 
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -61,7 +61,8 @@ from vyper.semantics.types import (
 from vyper.semantics.types.bytestrings import _BytestringT
 from vyper.semantics.types.function import ContractFunctionT, MemberFunctionT
 from vyper.semantics.types.shortcuts import BYTES32_T, UINT256_T
-from vyper.utils import DECIMAL_DIVISOR, bytes_to_int, is_checksum_encoded, vyper_warn
+from vyper.utils import DECIMAL_DIVISOR, bytes_to_int, is_checksum_encoded
+from vyper.warnings import VyperWarning, vyper_warn
 
 ENVIRONMENT_VARIABLES = {"block", "msg", "tx", "chain"}
 
@@ -274,13 +275,13 @@ class Expr:
                 if not version_check(begin="paris"):
                     warning = "tried to use block.prevrandao in pre-Paris "
                     warning += "environment! Suggest using block.difficulty instead."
-                    vyper_warn(warning, self.expr)
+                    vyper_warn(VyperWarning(warning, self.expr))
                 return IRnode.from_list(["prevrandao"], typ=BYTES32_T)
             elif key == "block.difficulty":
                 if version_check(begin="paris"):
                     warning = "tried to use block.difficulty in post-Paris "
                     warning += "environment! Suggest using block.prevrandao instead."
-                    vyper_warn(warning, self.expr)
+                    vyper_warn(VyperWarning(warning, self.expr))
                 return IRnode.from_list(["difficulty"], typ=UINT256_T)
             elif key == "block.timestamp":
                 return IRnode.from_list(["timestamp"], typ=UINT256_T)

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -439,6 +439,7 @@ EIP170_CONTRACT_SIZE_LIMIT: int = 2**14 + 2**13
 
 def build_bytecode_runtime_output(compiler_data: CompilerData) -> str:
     compiled_bytecode_runtime_length = len(compiler_data.bytecode_runtime)
+    # NOTE: we should actually add the size of the immutables section to this.
     if compiled_bytecode_runtime_length > EIP170_CONTRACT_SIZE_LIMIT:
         vyper_warn(
             ContractSizeLimit(

--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -1,5 +1,4 @@
 import base64
-import warnings
 from collections import deque
 from pathlib import PurePath
 
@@ -16,8 +15,8 @@ from vyper.semantics.analysis.base import ModuleInfo
 from vyper.semantics.types.function import ContractFunctionT, FunctionVisibility, StateMutability
 from vyper.semantics.types.module import InterfaceT
 from vyper.typing import StorageLayout
-from vyper.utils import safe_relpath, vyper_warn
-from vyper.warnings import ContractSizeLimitWarning
+from vyper.utils import safe_relpath
+from vyper.warnings import ContractSizeLimit, vyper_warn
 
 
 def build_ast_dict(compiler_data: CompilerData) -> dict:
@@ -441,12 +440,12 @@ EIP170_CONTRACT_SIZE_LIMIT: int = 2**14 + 2**13
 def build_bytecode_runtime_output(compiler_data: CompilerData) -> str:
     compiled_bytecode_runtime_length = len(compiler_data.bytecode_runtime)
     if compiled_bytecode_runtime_length > EIP170_CONTRACT_SIZE_LIMIT:
-        warnings.warn(
-            f"Length of compiled bytecode is bigger than Ethereum contract size limit "
-            "(see EIP-170: https://eips.ethereum.org/EIPS/eip-170): "
-            f"{compiled_bytecode_runtime_length}b > {EIP170_CONTRACT_SIZE_LIMIT}b",
-            ContractSizeLimitWarning,
-            stacklevel=2,
+        vyper_warn(
+            ContractSizeLimit(
+                f"Length of compiled bytecode is bigger than Ethereum contract size limit "
+                "(see EIP-170: https://eips.ethereum.org/EIPS/eip-170): "
+                f"{compiled_bytecode_runtime_length}b > {EIP170_CONTRACT_SIZE_LIMIT}b"
+            )
         )
     return f"0x{compiler_data.bytecode_runtime.hex()}"
 

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import warnings
 from functools import cached_property
 from pathlib import Path, PurePath
 from typing import Any, Optional
@@ -20,8 +19,9 @@ from vyper.semantics.analysis.imports import resolve_imports
 from vyper.semantics.types.function import ContractFunctionT
 from vyper.semantics.types.module import ModuleT
 from vyper.typing import StorageLayout
-from vyper.utils import ERC5202_PREFIX, sha256sum, vyper_warn
+from vyper.utils import ERC5202_PREFIX, sha256sum
 from vyper.venom import generate_assembly_experimental, generate_ir
+from vyper.warnings import VyperWarning, vyper_warn
 
 DEFAULT_CONTRACT_PATH = PurePath("VyperContract.vy")
 
@@ -352,10 +352,11 @@ def generate_assembly(ir_nodes: IRnode, optimize: Optional[OptimizationLevel] = 
     assembly = compile_ir.compile_to_assembly(ir_nodes, optimize=optimize)
 
     if _find_nested_opcode(assembly, "DEBUG"):
-        warnings.warn(
-            "This code contains DEBUG opcodes! The DEBUG opcode will only work in "
-            "a supported EVM! It will FAIL on all other nodes!",
-            stacklevel=2,
+        vyper_warn(
+            VyperWarning(
+                "This code contains DEBUG opcodes! The DEBUG opcode will only work in "
+                "a supported EVM! It will FAIL on all other nodes!"
+            )
         )
     return assembly
 

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -54,6 +54,7 @@ class Settings:
     experimental_codegen: Optional[bool] = None
     debug: Optional[bool] = None
     enable_decimals: Optional[bool] = None
+    warnings_control: Optional[str] = None
 
     def __post_init__(self):
         # sanity check inputs
@@ -65,6 +66,8 @@ class Settings:
             assert isinstance(self.debug, bool)
         if self.enable_decimals is not None:
             assert isinstance(self.enable_decimals, bool)
+        if self.warnings_control is not None:
+            assert isinstance(self.warnings_control, str)
 
     # CMC 2024-04-10 consider hiding the `enable_decimals` member altogether
     def get_enable_decimals(self) -> bool:
@@ -84,6 +87,8 @@ class Settings:
             ret.append(" --debug")
         if self.enable_decimals is True:
             ret.append(" --enable-decimals")
+        if self.warnings_control is not None:
+            ret.append(" -W" + self.warnings_control)
 
         return "".join(ret)
 

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -54,7 +54,6 @@ class Settings:
     experimental_codegen: Optional[bool] = None
     debug: Optional[bool] = None
     enable_decimals: Optional[bool] = None
-    warnings_control: Optional[str] = None
 
     def __post_init__(self):
         # sanity check inputs
@@ -66,8 +65,6 @@ class Settings:
             assert isinstance(self.debug, bool)
         if self.enable_decimals is not None:
             assert isinstance(self.enable_decimals, bool)
-        if self.warnings_control is not None:
-            assert isinstance(self.warnings_control, str)
 
     # CMC 2024-04-10 consider hiding the `enable_decimals` member altogether
     def get_enable_decimals(self) -> bool:
@@ -87,8 +84,6 @@ class Settings:
             ret.append(" --debug")
         if self.enable_decimals is True:
             ret.append(" --enable-decimals")
-        if self.warnings_control is not None:
-            ret.append(" -W" + self.warnings_control)
 
         return "".join(ret)
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Dict, List, Optional, Tuple
@@ -766,13 +765,6 @@ def _parse_decorators(
                 state_mutability = StateMutability(decorator.id)
 
             else:
-                if decorator.id == "constant":
-                    warnings.warn(
-                        "'@constant' decorator has been removed (see VIP2040). "
-                        "Use `@view` instead.",
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
                 raise FunctionDeclarationException(f"Unknown decorator: {decorator.id}", decorator)
 
         else:

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Any, Dict, Optional, Tuple
 
 from vyper import ast as vy_ast
@@ -9,6 +8,7 @@ from vyper.semantics.types.base import VyperType
 from vyper.semantics.types.primitives import IntegerT
 from vyper.semantics.types.shortcuts import UINT256_T
 from vyper.semantics.types.utils import get_index_value, type_from_annotation
+from vyper.warnings import VyperWarning, vyper_warn
 
 
 class _SubscriptableT(VyperType):
@@ -113,7 +113,7 @@ class _SequenceT(_SubscriptableT):
             raise InvalidType("Array length is invalid")
 
         if length >= 2**64:
-            warnings.warn("Use of large arrays can be unsafe!", stacklevel=2)
+            vyper_warn(VyperWarning("Use of large arrays can be unsafe!"))
 
         super().__init__(UINT256_T, value_type)
         self.length = length

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -23,7 +23,8 @@ from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.types.base import VyperType
 from vyper.semantics.types.subscriptable import HashMapT
 from vyper.semantics.types.utils import type_from_abi, type_from_annotation
-from vyper.utils import keccak256, vyper_warn
+from vyper.utils import keccak256
+from vyper.warnings import Deprecation, vyper_warn
 
 
 # user defined type
@@ -303,7 +304,7 @@ class EventT(_UserType):
         msg += "in a future release. Use kwargs instead eg. "
         msg += "Foo(a=1, b=2)"
 
-        vyper_warn(msg, node)
+        vyper_warn(Deprecation(msg, node))
 
         validate_call_args(node, len(self.arguments))
         for arg, expected in zip(node.args, self.arguments.values()):

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -11,7 +11,7 @@ import traceback
 import warnings
 from typing import Generic, List, TypeVar, Union
 
-from vyper.exceptions import CompilerPanic, DecimalOverrideException, VyperException
+from vyper.exceptions import CompilerPanic, DecimalOverrideException
 
 _T = TypeVar("_T")
 
@@ -282,14 +282,6 @@ def trace(n=5, out=sys.stderr):
     for x in list(traceback.format_stack())[-n:]:
         print(x.strip(), file=out)
     print("END TRACE", file=out)
-
-
-# print a warning
-def vyper_warn(msg, node=None):
-    if node is not None:
-        # use VyperException for its formatting abilities
-        msg = str(VyperException(msg, node))
-    warnings.warn(msg, stacklevel=2)
 
 
 # converts a signature like Func(bool,uint256,address) to its 4 byte method ID

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -518,7 +518,7 @@ def timeit(msg):  # pragma: nocover
     yield
     end_time = time.perf_counter()
     total_time = end_time - start_time
-    print(f"{msg}: Took {total_time:.4f} seconds", file=sys.stderr)
+    print(f"{msg}: Took {total_time:.6f} seconds", file=sys.stderr)
 
 
 _CUMTIMES = None
@@ -527,7 +527,7 @@ _CUMTIMES = None
 def _dump_cumtime():  # pragma: nocover
     global _CUMTIMES
     for msg, total_time in _CUMTIMES.items():
-        print(f"{msg}: Cumulative time {total_time:.4f} seconds", file=sys.stderr)
+        print(f"{msg}: Cumulative time {total_time:.3f} seconds", file=sys.stderr)
 
 
 @contextlib.contextmanager

--- a/vyper/warnings.py
+++ b/vyper/warnings.py
@@ -1,3 +1,4 @@
+import contextlib
 import warnings
 from typing import Optional
 
@@ -13,6 +14,13 @@ def vyper_warn(warning: VyperWarning | str, node=None):
     if isinstance(warning, str):
         warning = VyperWarning(warning, node)
     warnings.warn(warning, stacklevel=2)
+
+
+@contextlib.contextmanager
+def warnings_filter(warnings_control: Optional[str]):
+    with warnings.catch_warnings():
+        set_warnings_filter(warnings_control)
+        yield
 
 
 def set_warnings_filter(warnings_control: Optional[str]):

--- a/vyper/warnings.py
+++ b/vyper/warnings.py
@@ -14,6 +14,7 @@ def vyper_warn(warning: VyperWarning | str, node=None):
         warning = VyperWarning(warning, node)
     warnings.warn(warning, stacklevel=2)
 
+
 def set_warnings_filter(warnings_control: Optional[str]):
     if warnings_control == "error":
         warnings_filter = "error"
@@ -30,7 +31,7 @@ def set_warnings_filter(warnings_control: Optional[str]):
 
     # NOTE: in the future we can do more fine-grained control by setting
     # category to specific warning types
-    warnings.simplefilter(warnings_filter, category=VyperWarning)
+    warnings.simplefilter(warnings_filter, category=VyperWarning)  # type: ignore[arg-type]
 
 
 class ContractSizeLimit(VyperWarning):

--- a/vyper/warnings.py
+++ b/vyper/warnings.py
@@ -1,3 +1,38 @@
-# TODO: Create VyperWarning class similarly to what is being done with exceptinos?
-class ContractSizeLimitWarning(Warning):
+import warnings
+
+from vyper.exceptions import _BaseVyperException
+
+
+class VyperWarning(_BaseVyperException, Warning):
+    pass
+
+
+# print a warning
+def vyper_warn(warning: VyperWarning | str, node=None):
+    if isinstance(warning, str):
+        warning = VyperWarning(warning, node)
+    warnings.warn(warning, stacklevel=2)
+
+
+class ContractSizeLimit(VyperWarning):
+    """
+    Warn if past the EIP-170 size limit
+    """
+
+    pass
+
+
+class EnumUsage(VyperWarning):
+    """
+    Warn about using `enum` instead of `flag
+    """
+
+    pass
+
+
+class Deprecation(VyperWarning):
+    """
+    General deprecation warning
+    """
+
     pass

--- a/vyper/warnings.py
+++ b/vyper/warnings.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Optional
 
 from vyper.exceptions import _BaseVyperException
 
@@ -12,6 +13,24 @@ def vyper_warn(warning: VyperWarning | str, node=None):
     if isinstance(warning, str):
         warning = VyperWarning(warning, node)
     warnings.warn(warning, stacklevel=2)
+
+def set_warnings_filter(warnings_control: Optional[str]):
+    if warnings_control == "error":
+        warnings_filter = "error"
+    elif warnings_control == "none":
+        warnings_filter = "ignore"
+    else:
+        assert warnings_control is None  # sanity
+        warnings_filter = "default"
+
+    if warnings_control is not None:
+        # warnings.simplefilter only adds to the warnings filters,
+        # so we should clear warnings filter between calls to simplefilter()
+        warnings.resetwarnings()
+
+    # NOTE: in the future we can do more fine-grained control by setting
+    # category to specific warning types
+    warnings.simplefilter(warnings_filter, category=VyperWarning)
 
 
 class ContractSizeLimit(VyperWarning):

--- a/vyper/warnings.py
+++ b/vyper/warnings.py
@@ -18,6 +18,8 @@ def vyper_warn(warning: VyperWarning | str, node=None):
 
 @contextlib.contextmanager
 def warnings_filter(warnings_control: Optional[str]):
+    # note: using warnings.catch_warnings() since it saves and restores
+    # the warnings filter
     with warnings.catch_warnings():
         set_warnings_filter(warnings_control)
         yield


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
this commit adds `-Werror` and `-Wnone` CLI flags which promote
warnings to errors and ignore them, respectively.

also adds some small refactoring for warning handling to simplify the
implementation (allow us to use warnings.simplefilter). this provides
a way moving forward to do fine-grained warnings control, since the
warnings filter allows us to use the exception class in the filter.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
