### PR TITLE
fix[codegen]: fix assertions for certain precompiles

### DIFF
--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -105,9 +105,9 @@ def do_ecrecover(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
     v, r, s = sig.v, sig.r, sig.s
 
     assert c.do_ecrecover(h, v, r, s) == local_account.address
-    gas_used = env.last_result.gas_used
 
-    with tx_failed(EvmError):
+    gas_used = env.last_result.gas_used
+    with tx_failed():
         # provide enough spare gas for the top-level call to not oog but
         # not enough for ecrecover to succeed
-        c.do_ecrecover(h, v, r, s, gas=gas_used - 1)
+        c.do_ecrecover(h, v, r, s, gas=gas_used)

--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -1,7 +1,10 @@
+import contextlib
+
 from eth_account import Account
 from eth_account._utils.signing import to_bytes32
 
 from tests.utils import ZERO_ADDRESS
+from vyper.compiler.settings import OptimizationLevel
 
 
 def test_ecrecover_test(get_contract):
@@ -88,7 +91,7 @@ def test_ecrecover() -> bool:
     assert c.test_ecrecover() is True
 
 
-def test_ecrecover_oog_handling(env, get_contract, tx_failed):
+def test_ecrecover_oog_handling(env, get_contract, tx_failed, optimize):
     # GHSA-vgf2-gvx8-xwc3
     code = """
 @external
@@ -106,7 +109,18 @@ def do_ecrecover(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
     assert c.do_ecrecover(h, v, r, s) == local_account.address
 
     gas_used = env.last_result.gas_used
-    with tx_failed():
+
+    if optimize == OptimizationLevel.NONE:
+        # if optimizations are off, enough gas is used by the contract
+        # that the gas provided to ecrecover (63/64ths rule) is enough
+        # for it to succeed
+        ctx = contextlib.nullcontext
+    else:
+        # in other cases, the gas forwarded is small enough for ecrecover
+        # to fail with oog, which we handle by reverting.
+        ctx = tx_failed
+
+    with ctx():
         # provide enough spare gas for the top-level call to not oog but
         # not enough for ecrecover to succeed
         c.do_ecrecover(h, v, r, s, gas=gas_used)

--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -91,7 +91,7 @@ def test_ecrecover() -> bool:
     assert c.test_ecrecover() is True
 
 
-def test_ecrecover_oog_handling(env, get_contract, tx_failed, optimize):
+def test_ecrecover_oog_handling(env, get_contract, tx_failed, optimize, experimental_codegen):
     # GHSA-vgf2-gvx8-xwc3
     code = """
 @external
@@ -110,7 +110,7 @@ def do_ecrecover(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
 
     gas_used = env.last_result.gas_used
 
-    if optimize == OptimizationLevel.NONE:
+    if optimize == OptimizationLevel.NONE and not experimental_codegen:
         # if optimizations are off, enough gas is used by the contract
         # that the gas provided to ecrecover (63/64ths rule) is enough
         # for it to succeed

--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -1,6 +1,7 @@
 from eth_account import Account
 from eth_account._utils.signing import to_bytes32
 
+from tests.evm_backends.base_env import EvmError
 from tests.utils import ZERO_ADDRESS
 
 
@@ -106,7 +107,7 @@ def do_ecrecover(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
     assert c.do_ecrecover(h, v, r, s) == local_account.address
     gas_used = env.last_result.gas_used
 
-    with tx_failed():
+    with tx_failed(EvmError):
         # provide enough spare gas for the top-level call to not oog but
         # not enough for ecrecover to succeed
         c.do_ecrecover(h, v, r, s, gas=gas_used - 1)

--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -3,7 +3,7 @@ import contextlib
 from eth_account import Account
 from eth_account._utils.signing import to_bytes32
 
-from tests.utils import ZERO_ADDRESS
+from tests.utils import ZERO_ADDRESS, check_precompile_asserts
 from vyper.compiler.settings import OptimizationLevel
 
 
@@ -99,6 +99,8 @@ def test_ecrecover_oog_handling(env, get_contract, tx_failed, optimize, experime
 def do_ecrecover(hash: bytes32, v: uint256, r:uint256, s:uint256) -> address:
     return ecrecover(hash, v, r, s)
     """
+    check_precompile_asserts(code)
+
     c = get_contract(code)
 
     h = b"\x35" * 32

--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -1,7 +1,6 @@
 from eth_account import Account
 from eth_account._utils.signing import to_bytes32
 
-from tests.evm_backends.base_env import EvmError
 from tests.utils import ZERO_ADDRESS
 
 

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -4,7 +4,7 @@ from typing import Any, Callable
 
 import pytest
 
-from tests.utils import decimal_to_int
+from tests.utils import check_precompile_asserts, decimal_to_int
 from vyper.compiler import compile_code
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
@@ -1914,6 +1914,8 @@ def foo(a: DynArray[uint256, 4000]) -> uint256:
     b: DynArray[uint256, 4000] = a
     return b[0]
     """
+    check_precompile_asserts(code)
+
     c = get_contract(code)
     dynarray = [2] * 4000
     assert c.foo(dynarray) == 2
@@ -1940,6 +1942,7 @@ def foo(x: String[1000000], y: String[1000000]) -> DynArray[String[1000000], 2]:
     # Some code
     return z
     """
+    check_precompile_asserts(code)
 
     c = get_contract(code)
     calldata0 = "a" * 10

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -1,13 +1,12 @@
-import itertools
-from vyper.evm.opcodes import version_check
 import contextlib
+import itertools
 from typing import Any, Callable
 
 import pytest
 
-from tests.evm_backends.base_env import EvmError
 from tests.utils import decimal_to_int
 from vyper.compiler import compile_code
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
     ArgumentException,
     ArrayIndexException,

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -1918,6 +1918,7 @@ def foo(a: DynArray[uint256, 4000]) -> uint256:
     assert c.foo(dynarray) == 2
     gas_used = env.last_result.gas_used
     with tx_failed(EvmError):  # catch reverts *and* exceptional halt from oog
+        # should fail pre-cancun due to identity precompile returning 0
         c.foo(dynarray, gas=gas_used - 1)
 
 
@@ -1938,4 +1939,5 @@ def foo(x: String[1000000], y: String[1000000]) -> DynArray[String[1000000], 2]:
     assert c.foo(calldata0, calldata1) == [calldata0, calldata1]
     gas_used = env.last_result.gas_used
     with tx_failed(EvmError):  # catch reverts *and* exceptional halt from oog
+        # should fail pre-cancun due to identity precompile returning 0
         c.foo(calldata0, calldata1, gas=gas_used - 1)

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -3,6 +3,7 @@ import itertools
 
 import pytest
 
+from tests.evm_backends.base_env import EvmError
 from tests.utils import check_precompile_asserts, decimal_to_int
 from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import version_check
@@ -869,8 +870,10 @@ def foo(x: uint256[3000]) -> uint256:
     check_precompile_asserts(code)
 
     if optimize == OptimizationLevel.NONE and not experimental_codegen:
-        # fails in get_contract due to code too large
-        request.node.add_marker(pytest.mark.xfail(strict=True))
+        # fails in bytecode generation due to jumpdests too large
+        with pytest.raises(AssertionError):
+            get_contract(code)
+        return
 
     c = get_contract(code)
     array = [2] * 3000
@@ -900,8 +903,10 @@ def foo(x: uint256[2500]) -> uint256:
     check_precompile_asserts(code)
 
     if optimize == OptimizationLevel.NONE and not experimental_codegen:
-        # fails in get_contract due to code too large
-        request.node.add_marker(pytest.mark.xfail(strict=True))
+        # fails in creating contract due to code too large
+        with tx_failed(EvmError):
+            get_contract(code)
+        return
 
     c = get_contract(code)
     array = [2] * 2500

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -3,7 +3,7 @@ import itertools
 
 import pytest
 
-from tests.utils import decimal_to_int
+from tests.utils import check_precompile_asserts, decimal_to_int
 from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import ArrayIndexException, OverflowException, TypeMismatch
@@ -866,6 +866,8 @@ def foo(x: uint256[3000]) -> uint256:
     s: uint256[3000] = self.bar(x)
     return s[0]
     """
+    check_precompile_asserts(code)
+
     if optimize == OptimizationLevel.NONE and not experimental_codegen:
         # fails in get_contract due to code too large
         request.node.add_marker(pytest.mark.xfail(strict=True))
@@ -895,6 +897,8 @@ def foo(x: uint256[2500]) -> uint256:
     t: uint256[2500] = s
     return t[0]
     """
+    check_precompile_asserts(code)
+
     if optimize == OptimizationLevel.NONE and not experimental_codegen:
         # fails in get_contract due to code too large
         request.node.add_marker(pytest.mark.xfail(strict=True))

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -1,12 +1,11 @@
-import itertools
 import contextlib
-from vyper.evm.opcodes import version_check
+import itertools
 
 import pytest
 
-from tests.evm_backends.base_env import EvmError
 from tests.utils import decimal_to_int
 from vyper.compiler.settings import OptimizationLevel
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import ArrayIndexException, OverflowException, TypeMismatch
 
 
@@ -877,7 +876,7 @@ def foo(x: uint256[3000]) -> uint256:
 
     # get the minimum gas for the contract complete execution
     gas_used = env.last_result.gas_used
-    if version_check(begin= "cancun"):
+    if version_check(begin="cancun"):
         ctx = contextlib.nullcontext
     else:
         ctx = tx_failed
@@ -906,7 +905,7 @@ def foo(x: uint256[2500]) -> uint256:
 
     # get the minimum gas for the contract complete execution
     gas_used = env.last_result.gas_used
-    if version_check(begin= "cancun"):
+    if version_check(begin="cancun"):
         ctx = contextlib.nullcontext
     else:
         ctx = tx_failed

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -852,7 +852,7 @@ def foo() -> {return_type}:
     assert_compile_failed(lambda: get_contract(code), TypeMismatch)
 
 
-def test_array_copy_oog(env, get_contract, tx_failed, optimize, request):
+def test_array_copy_oog(env, get_contract, tx_failed, optimize, experimental_codegen, request):
     # GHSA-vgf2-gvx8-xwc3
     code = """
 @internal
@@ -865,7 +865,7 @@ def foo(x: uint256[3000]) -> uint256:
     s: uint256[3000] = self.bar(x)
     return s[0]
     """
-    if optimize == OptimizationLevel.NONE:
+    if optimize == OptimizationLevel.NONE and not experimental_codegen:
         # fails in get_contract due to code too large
         request.node.add_marker(pytest.mark.xfail(strict=True))
 
@@ -877,7 +877,7 @@ def foo(x: uint256[3000]) -> uint256:
         c.foo(array, gas=gas_used - 1)
 
 
-def test_array_copy_oog2(env, get_contract, tx_failed, optimize, request):
+def test_array_copy_oog2(env, get_contract, tx_failed, optimize, experimental_codegen, request):
     # GHSA-vgf2-gvx8-xwc3
     code = """
 @external
@@ -886,7 +886,7 @@ def foo(x: uint256[2500]) -> uint256:
     t: uint256[2500] = s
     return t[0]
     """
-    if optimize == OptimizationLevel.NONE:
+    if optimize == OptimizationLevel.NONE and not experimental_codegen:
         # fails in get_contract due to code too large
         request.node.add_marker(pytest.mark.xfail(strict=True))
 

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -874,6 +874,8 @@ def foo(x: uint256[3000]) -> uint256:
     assert c.foo(array) == array[0]
     gas_used = env.last_result.gas_used
     with tx_failed(EvmError):  # catch reverts *and* exceptional halt from oog
+        # depends on EVM version. pre-cancun, will revert due to checking
+        # success flag from identity precompile.
         c.foo(array, gas=gas_used - 1)
 
 
@@ -895,4 +897,6 @@ def foo(x: uint256[2500]) -> uint256:
     assert c.foo(array) == array[0]
     gas_used = env.last_result.gas_used
     with tx_failed(EvmError):  # catch reverts *and* exceptional halt from oog
+        # depends on EVM version. pre-cancun, will revert due to checking
+        # success flag from identity precompile.
         c.foo(array, gas=gas_used - 1)

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -395,7 +395,8 @@ def test_string_copy_oog2(env, get_contract, tx_failed):
 @external
 @view
 def foo(x: String[1000000]) -> uint256:
-    return len(x)
+    y: String[1000000] = x
+    return len(y)
     """
     c = get_contract(code)
     calldata = "a" * 1000000

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -2,6 +2,7 @@ import contextlib
 
 import pytest
 
+from tests.utils import check_precompile_asserts
 from vyper.evm.opcodes import version_check
 
 
@@ -373,6 +374,8 @@ def test_string_copy_oog(env, get_contract, tx_failed):
 def foo(x: String[1000000]) -> String[1000000]:
     return x
     """
+    check_precompile_asserts(code)
+
     c = get_contract(code)
     calldata = "a" * 1000000
     assert c.foo(calldata) == calldata
@@ -398,6 +401,8 @@ def foo(x: String[1000000]) -> uint256:
     y: String[1000000] = x
     return len(y)
     """
+    check_precompile_asserts(code)
+
     c = get_contract(code)
     calldata = "a" * 1000000
     assert c.foo(calldata) == len(calldata)

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -374,11 +374,17 @@ def foo(x: String[1000000]) -> String[1000000]:
     c = get_contract(code)
     calldata = "a" * 1000000
     assert c.foo(calldata) == calldata
-    gas_used = env.last_result.gas_used - 1
-    # note: EvmError catches both reverts and exceptional halts (oog).
-    # this is dependent on the target evm version.
-    with tx_failed(EvmError):
-        c.foo(calldata, gas=gas_used - 1)
+
+    gas_used = env.last_result.gas_used
+    if version_check(begin="cancun"):
+        ctx = contextlib.nullcontext
+    else:
+        ctx = tx_failed
+
+    with ctx():
+        # depends on EVM version. pre-cancun, will revert due to checking
+        # success flag from identity precompile.
+        c.foo(calldata, gas=gas_used)
 
 
 def test_string_copy_oog2(env, get_contract, tx_failed):
@@ -392,8 +398,14 @@ def foo(x: String[1000000]) -> uint256:
     c = get_contract(code)
     calldata = "a" * 1000000
     assert c.foo(calldata) == len(calldata)
-    gas_used = env.last_result.gas_used - 1
-    # note: EvmError catches both reverts and exceptional halts (oog).
-    # this is dependent on the target evm version.
-    with tx_failed(EvmError):
-        c.foo(calldata, gas=gas_used - 1)
+
+    gas_used = env.last_result.gas_used
+    if version_check(begin="cancun"):
+        ctx = contextlib.nullcontext
+    else:
+        ctx = tx_failed
+
+    with ctx():
+        # depends on EVM version. pre-cancun, will revert due to checking
+        # success flag from identity precompile.
+        c.foo(calldata, gas=gas_used)

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -1,6 +1,8 @@
+import contextlib
+
 import pytest
 
-from tests.evm_backends.base_env import EvmError
+from vyper.evm.opcodes import version_check
 
 
 def test_string_return(get_contract):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,10 @@ def decimal_to_int(*args):
 
 
 def check_precompile_asserts(source_code):
-    # check deploy IR (which contains runtime IR)
+    # common sanity check for some tests, that calls to precompiles
+    # are correctly wrapped in an assert.
+
+    # check the deploy IR (which contains runtime IR)
     ir_node = CompilerData(source_code).ir_nodes
 
     def _check(ir_node, parent=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,8 +35,9 @@ def check_precompile_asserts(source_code):
     # common sanity check for some tests, that calls to precompiles
     # are correctly wrapped in an assert.
 
-    # check the deploy IR (which contains runtime IR)
-    ir_node = CompilerData(source_code).ir_nodes
+    compiler_data = CompilerData(source_code)
+    deploy_ir = compiler_data.ir_nodes
+    runtime_ir = compiler_data.ir_runtime
 
     def _check(ir_node, parent=None):
         if ir_node.value == "staticcall":
@@ -46,4 +47,6 @@ def check_precompile_asserts(source_code):
         for arg in ir_node.args:
             _check(arg, ir_node)
 
-    _check(ir_node)
+    _check(deploy_ir)
+    # technically runtime_ir is contained in deploy_ir, but check it anyways.
+    _check(runtime_ir)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -781,7 +781,7 @@ class ECRecover(BuiltinFunctionT):
                 ["mstore", add_ofst(input_buf, 32), args[1]],
                 ["mstore", add_ofst(input_buf, 64), args[2]],
                 ["mstore", add_ofst(input_buf, 96), args[3]],
-                ["staticcall", "gas", 1, input_buf, 128, output_buf, 32],
+                ["assert", ["staticcall", "gas", 1, input_buf, 128, output_buf, 32]],
                 ["mload", output_buf],
             ],
             typ=AddressT(),

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -326,7 +326,7 @@ def copy_bytes(dst, src, length, length_bound):
                     copy_op = ["mcopy", dst, src, length]
                     gas_bound = _mcopy_gas_bound(length_bound)
                 else:
-                    copy_op = ["staticcall", "gas", 4, src, length, dst, length]
+                    copy_op = ["assert", ["staticcall", "gas", 4, src, length, dst, length]]
                     gas_bound = _identity_gas_bound(length_bound)
             elif src.location == CALLDATA:
                 copy_op = ["calldatacopy", dst, src, length]


### PR DESCRIPTION
### What I did
fix for https://github.com/vyperlang/vyper/security/advisories/GHSA-vgf2-gvx8-xwc3

### How I did it

### How to verify it

### Commit message

```
this commit fixes a flaw in code generation for certain
precompiles. specifically, some calls to the ecrecover (0x01) and
identity (0x04) precompiles were not checked for success.

in 93a957947af1088addc, the assert for memory copying calls to the
identity precompile was optimized out; the reasoning being that if the
identity precompile fails due to OOG, the contract would also likely
fail with OOG. however, due to the 63/64ths rule, there are cases where
just enough gas was supplied to the current call context so that the
subcall to the precompile could fail with OOG, but the contract has
enough gas to continue execution after it shouldn't (which is undefined
behavior) and then successfully return out of the call context.

(note that even prior to 93a957947af1088addc, some calls to the
identity precompile did not check the success flag. cf. commit
cf03d27be6a74c0c33de. the call to ecrecover was unchecked since
inception - db44cde626919ed8bebf).

note also that since cancun, memory copies are implemented using
the `mcopy` instruction, so the bug as it pertains to the identity
precompile only affects pre-cancun compilation targets.

this commit fixes the flaw by converting the relevant unchecked calls
to checked calls.

it also adds tests that trigger the behavior by running the call, and
then performing the exact same call again but providing `gas_used` back
to the contract, which is the minimum amount of gas for the call to the
contract to finish execution. the specific amount of gas left at the
point of the subcall is small enough to cause the subcall to fail (and
the check around the subcall success to revert, which is what is tested
for in the new tests). in these tests, it also adds a static check
that the IR is well-formed (that all relevant calls to precompiles are
appropriately checked).

references:
- https://github.com/vyperlang/vyper/security/advisories/GHSA-vgf2-gvx8-xwc3
```

### Description for the changelog

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/c25a3083-ad5f-450b-a090-c93fdd707c31)
