### PR TITLE
feat[ci]: use `coverage combine` to reduce codecov uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,17 +256,6 @@ jobs:
         pattern: coverage-files-*
         path: coverage-files
 
-    - name: Create coveragerc
-      run: |
-        echo > .coveragerc <<EOF
-[paths]
-source =
-    /home/runner/work/vyper/vyper
-    /Users/runner/work/vyper/vyper
-    D:\a\vyper\vyper
-        EOF
-
-
     - name: Debug directory
       run: |
         ls -la .
@@ -274,7 +263,7 @@ source =
 
     - name: Combine coverage
       run: |
-        coverage combine --debug=pathmap coverage-files/**/.coverage
+        coverage combine coverage-files/**/.coverage
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch
-        --cov-report xml:coverage-${{ github.job }}-${{ strategy.job-index }}.xml
+        --cov-report=
         --cov=vyper
         tests/
 
@@ -210,7 +210,7 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-branch \
-          --cov-report xml:coverage-${{ github.job }}-${{ strategy.job-index }}.xml \
+          --cov-report= \
           --cov=vyper \
           tests/
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,12 @@ jobs:
         --cov-append
         tests/
 
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-${{ strategy.job-index }}
+        path: .coverage.xml.${{ strategy.job-index }}
+
   core-tests-success:
     if: always()
     # summary result from test matrix.
@@ -209,6 +215,12 @@ jobs:
           --cov=vyper \
           --cov-append \
           tests/
+      
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-${{ strategy.job-index }}
+        path: .coverage.xml.${{ strategy.job-index }}
 
   slow-tests-success:
     if: always()
@@ -224,7 +236,7 @@ jobs:
 
   code-coverage:
     runs-on: ubuntu-latest
-    needs: [core-tests-success, slow-tests-success]
+    needs: [tests, fuzzing]
 
     steps:
     - uses: actions/checkout@v4
@@ -235,11 +247,21 @@ jobs:
         python-version: "3.11"
         cache: "pip"
   
-    - name: Install dependencies
-      run: pip install .[test]
+    - name: Install coverage
+      run: pip install coverage
+
+    - name: Download coverage artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: coverage-files
+
+    - name: Combine coverage
+      run: |
+        coverage combine coverage-files/.coverage.*
+        coverage xml
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        file: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        path: coverage-${{ github.job }}-${{ strategy.job-index }}.xml
+        path: coverage*
 
   core-tests-success:
     if: always()
@@ -218,7 +218,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        path: coverage-${{ github.job }}-${{ strategy.job-index }}.xml
+        path: coverage*
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
       run: >
         coverage run 
         --rcfile=setup.cfg
-        pytest
+        -m pytest
         -m "not fuzzing"
         --optimize ${{ matrix.opt-mode || 'gas' }}
         --evm-version ${{ matrix.evm-version || 'cancun' }}
@@ -207,7 +207,7 @@ jobs:
       run: |
         coverage run \
           --rcfile=setup.cfg \
-          pytest \
+          -m pytest \
           -m "fuzzing" \
           --splits 120 \
           --group ${{ matrix.group }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
         --cov-report xml:coverage.xml
         --cov=vyper
         --cov-append
-        tests
+        tests/
 
   core-tests-success:
     if: always()
@@ -207,8 +207,8 @@ jobs:
           --cov-branch \
           --cov-report xml:coverage.xml \
           --cov=vyper \
-          --cov-append
-          tests
+          --cov-append \
+          tests/
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,6 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-config=setup.cfg
-        --cov=vyper
         tests/
 
     - name: Upload coverage artifact
@@ -211,7 +210,6 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-config=setup.cfg \
-          --cov=vyper \
           tests/
 
     - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,8 +141,6 @@ jobs:
       run: pip freeze
 
     - name: Run tests
-      env:
-        COVERAGE_PARALLEL: True
       run: >
         pytest
         -m "not fuzzing"
@@ -206,8 +204,6 @@ jobs:
       run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/master/test_durations" -o .test_durations
 
     - name: Run tests
-      env:
-        COVERAGE_PARALLEL: True
       run: |
         pytest \
           -m "fuzzing" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,11 +257,12 @@ jobs:
 
     - name: Debug directory
       run: |
-        ls -la coverage-files/
+        ls -la .
+        ls -la coverage-files*/
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/**/.coverage
+        coverage combine coverage-files**/.coverage
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-branch \
-          --cov-report xml:coverage.xml \
+          --cov-report xml:coverage.xml.${{ strategy.job-index }} \
           --cov=vyper \
           --cov-append \
           tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,13 +152,8 @@ jobs:
         --cov-branch
         --cov-report xml:coverage.xml
         --cov=vyper
+        --cov-append
         tests/
-
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
 
   core-tests-success:
     if: always()
@@ -212,13 +207,8 @@ jobs:
           --cov-branch \
           --cov-report xml:coverage.xml \
           --cov=vyper \
+          --cov-append
           tests/
-
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
 
   slow-tests-success:
     if: always()
@@ -231,3 +221,13 @@ jobs:
       - name: Check slow tests all succeeded
         if: ${{ needs.fuzzing.result != 'success' }}
         run: exit 1
+
+  code-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
+        include-hidden-files: true
         path: .coverage*
 
   core-tests-success:
@@ -218,6 +219,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
+        include-hidden-files: true
         path: .coverage*
 
   slow-tests-success:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,6 +224,7 @@ jobs:
 
   code-coverage:
     runs-on: ubuntu-latest
+    needs: [core-tests-success, slow-tests-success]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
 
     - name: Run tests
       run: >
-        coverage run -m pytest
+        pytest
         -m "not fuzzing"
         --optimize ${{ matrix.opt-mode || 'gas' }}
         --evm-version ${{ matrix.evm-version || 'cancun' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch
-        --cov-report xml:coverage.xml.${{ strategy.job-index }}
+        --cov-report xml:coverage.xml.${{ github.job }}-${{ strategy.job-index }}
         --cov=vyper
         tests/
 
@@ -210,7 +210,7 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-branch \
-          --cov-report xml:coverage.xml.${{ strategy.job-index }} \
+          --cov-report xml:coverage.xml.${{ github.job }}-${{ strategy.job-index }} \
           --cov=vyper \
           tests/
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,17 +142,13 @@ jobs:
 
     - name: Run tests
       run: >
-        pytest
+        coverage run -m pytest
         -m "not fuzzing"
         --optimize ${{ matrix.opt-mode || 'gas' }}
         --evm-version ${{ matrix.evm-version || 'cancun' }}
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
-        --cov-config=setup.cfg
-        --cov-branch
-        --cov-report=
-        --cov=vyper
         tests/
 
     - name: Upload coverage artifact
@@ -206,15 +202,11 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest \
+        coverage run -m pytest \
           -m "fuzzing" \
           --splits 120 \
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
-          --cov-config=setup.cfg \
-          --cov-branch \
-          --cov-report= \
-          --cov=vyper \
           tests/
       
     - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         path: coverage-files
+        merge-multiple: true
 
     - name: Combine coverage
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
 
     - name: Debug directory
       run: |
-        ls coverage-files/
+        ls -la coverage-files/
 
     - name: Combine coverage
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,8 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch
-        --cov-report xml:coverage.xml
+        --cov-report xml:coverage.xml.${{ strategy.job-index }}
         --cov=vyper
-        --cov-append
         tests/
 
     - name: Upload coverage artifact
@@ -213,7 +212,6 @@ jobs:
           --cov-branch \
           --cov-report xml:coverage.xml.${{ strategy.job-index }} \
           --cov=vyper \
-          --cov-append \
           tests/
       
     - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,8 @@ jobs:
 
     - name: Run tests
       run: >
+        coverage run 
+        --rcfile=setup.cfg
         pytest
         -m "not fuzzing"
         --optimize ${{ matrix.opt-mode || 'gas' }}
@@ -149,8 +151,6 @@ jobs:
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
-        --cov-config=setup.cfg
-        --cov=vyper
         tests/
 
     - name: Upload coverage artifact
@@ -205,13 +205,13 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest \
+        coverage run \
+          --rcfile=setup.cfg \
+          pytest \
           -m "fuzzing" \
           --splits 120 \
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
-          --cov-config=setup.cfg \
-          --cov=vyper \
           tests/
 
     - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,8 +142,6 @@ jobs:
 
     - name: Run tests
       run: >
-        coverage run 
-        --rcfile=setup.cfg
         pytest
         -m "not fuzzing"
         --optimize ${{ matrix.opt-mode || 'gas' }}
@@ -151,6 +149,8 @@ jobs:
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
+        --cov-config=setup.cfg
+        --cov=vyper
         tests/
 
     - name: Upload coverage artifact
@@ -205,13 +205,13 @@ jobs:
 
     - name: Run tests
       run: |
-        coverage run \
-          --rcfile=setup.cfg \
-          pytest \
+        pytest \
           -m "fuzzing" \
           --splits 120 \
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
+          --cov-config=setup.cfg \
+          --cov=vyper \
           tests/
 
     - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
         tests/
 
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ strategy.job-index }}
         path: coverage.xml.${{ strategy.job-index }}
@@ -215,7 +215,7 @@ jobs:
           tests/
       
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ strategy.job-index }}
         path: coverage.xml.${{ strategy.job-index }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,17 @@ jobs:
         pattern: coverage-files-*
         path: coverage-files
 
+    - name: Create coveragerc
+      run: |
+        echo > .coveragerc <<EOF
+[paths]
+source =
+    /home/runner/work/vyper/vyper
+    /Users/runner/work/vyper/vyper
+    D:\a\vyper\vyper
+        EOF
+
+
     - name: Debug directory
       run: |
         ls -la .
@@ -263,7 +274,7 @@ jobs:
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/**/.coverage
+        coverage combine --debug=pathmap coverage-files/**/.coverage
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-branch \
-          --cov-report xml:coverage-${{ github.job }}-${{ strategy.job-index }}.xml
+          --cov-report xml:coverage-${{ github.job }}-${{ strategy.job-index }}.xml \
           --cov=vyper \
           tests/
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,9 +235,10 @@ jobs:
         run: exit 1
 
   consolidate-coverage:
+    # Consolidate code coverage using `coverage combine` and upload
+    # to the codecov app
     runs-on: ubuntu-latest
     needs: [tests, fuzzing]
-    description: Consolidate code coverage using `coverage combine` and upload to the codecov app
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
         --cov-report xml:coverage.xml
         --cov=vyper
         --cov-append
-        tests/
+        tests
 
   core-tests-success:
     if: always()
@@ -208,7 +208,7 @@ jobs:
           --cov-report xml:coverage.xml \
           --cov=vyper \
           --cov-append
-          tests/
+          tests
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,11 +256,6 @@ jobs:
         pattern: coverage-files-*
         path: coverage-files
 
-    - name: Debug directory
-      run: |
-        ls -la .
-        ls -la coverage-files/
-
     - name: Combine coverage
       run: |
         coverage combine coverage-files/**/.coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,14 +149,16 @@ jobs:
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
+        --cov-branch
+        --cov-report xml:coverage.xml
+        --cov=vyper
         tests/
 
-    - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v5
       with:
-        name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        include-hidden-files: true
-        path: .coverage*
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
 
   core-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,16 +253,17 @@ jobs:
     - name: Download coverage artifacts
       uses: actions/download-artifact@v4
       with:
-        path: coverage-files-*
+        pattern: coverage-files-*
+        path: coverage-files
 
     - name: Debug directory
       run: |
         ls -la .
-        ls -la coverage-files*/
+        ls -la coverage-files/
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files**/.coverage
+        coverage combine coverage-files/**/.coverage
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,8 +157,8 @@ jobs:
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ strategy.job-index }}
-        path: coverage.xml.${{ strategy.job-index }}
+        name: coverage-${{ github.job }}-${{ strategy.job-index }}
+        path: coverage.xml.${{ github.job }}-${{ strategy.job-index }}
 
   core-tests-success:
     if: always()
@@ -217,8 +217,8 @@ jobs:
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ strategy.job-index }}
-        path: coverage.xml.${{ strategy.job-index }}
+        name: coverage-${{ github.job }}-${{ strategy.job-index }}
+        path: coverage.xml.${{ github.job }}-${{ strategy.job-index }}
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,10 @@ jobs:
         path: coverage-files
         merge-multiple: true
 
+    - name: Debug directory
+      run: |
+        ls coverage-files/
+
     - name: Combine coverage
       run: |
         coverage combine coverage-files/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       with:
         name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
-        path: .coverage*
+        path: .coverage
         if-no-files-found: error
 
   core-tests-success:
@@ -219,7 +219,7 @@ jobs:
       with:
         name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
-        path: .coverage*
+        path: .coverage
         if-no-files-found: error
 
   slow-tests-success:
@@ -263,7 +263,7 @@ jobs:
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/**/.coverage*
+        coverage combine coverage-files/**/.coverage
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/coverage.*
+        coverage combine coverage-files/
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
       run: >
         coverage run 
         --rcfile=setup.cfg
-        -m pytest
+        pytest
         -m "not fuzzing"
         --optimize ${{ matrix.opt-mode || 'gas' }}
         --evm-version ${{ matrix.evm-version || 'cancun' }}
@@ -207,7 +207,7 @@ jobs:
       run: |
         coverage run \
           --rcfile=setup.cfg \
-          -m pytest \
+          pytest \
           -m "fuzzing" \
           --splits 120 \
           --group ${{ matrix.group }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,7 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-config=setup.cfg
+        --cov=vyper
         tests/
 
     - name: Upload coverage artifact
@@ -210,6 +211,7 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-config=setup.cfg \
+          --cov=vyper \
           tests/
 
     - name: Upload coverage artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/.coverage.*
+        coverage combine coverage-files/coverage.*
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        path: coverage*
+        path: .coverage*
 
   core-tests-success:
     if: always()
@@ -218,7 +218,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        path: coverage*
+        path: .coverage*
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,4 +267,4 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: coverage.xml
+        file: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,6 +226,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: "pip"
+  
+    - name: Install dependencies
+      run: pip install .[test]
+
     - name: Upload Coverage
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,9 +234,10 @@ jobs:
         if: ${{ needs.fuzzing.result != 'success' }}
         run: exit 1
 
-  code-coverage:
+  consolidate-coverage:
     runs-on: ubuntu-latest
     needs: [tests, fuzzing]
+    description: Consolidate code coverage using `coverage combine` and upload to the codecov app
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch
-        --cov-report xml:coverage.xml.${{ github.job }}-${{ strategy.job-index }}
+        --cov-report xml:coverage-${{ github.job }}-${{ strategy.job-index }}.xml
         --cov=vyper
         tests/
 
@@ -158,7 +158,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        path: coverage.xml.${{ github.job }}-${{ strategy.job-index }}
+        path: coverage-${{ github.job }}-${{ strategy.job-index }}.xml
 
   core-tests-success:
     if: always()
@@ -210,7 +210,7 @@ jobs:
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
           --cov-branch \
-          --cov-report xml:coverage.xml.${{ github.job }}-${{ strategy.job-index }} \
+          --cov-report xml:coverage-${{ github.job }}-${{ strategy.job-index }}.xml
           --cov=vyper \
           tests/
       
@@ -218,7 +218,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}
-        path: coverage.xml.${{ github.job }}-${{ strategy.job-index }}
+        path: coverage-${{ github.job }}-${{ strategy.job-index }}.xml
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,8 @@ jobs:
       run: pip freeze
 
     - name: Run tests
+      env:
+        COVERAGE_PARALLEL: True
       run: >
         pytest
         -m "not fuzzing"
@@ -204,6 +206,8 @@ jobs:
       run: curl --location "https://raw.githubusercontent.com/vyperlang/vyper-test-durations/master/test_durations" -o .test_durations
 
     - name: Run tests
+      env:
+        COVERAGE_PARALLEL: True
       run: |
         pytest \
           -m "fuzzing" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,15 +150,16 @@ jobs:
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
         --cov-branch
-        --cov-report xml:coverage.xml
         --cov=vyper
         tests/
 
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v5
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
+        include-hidden-files: true
+        path: .coverage*
+        if-no-files-found: error
 
   core-tests-success:
     if: always()
@@ -216,9 +217,10 @@ jobs:
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ github.job }}-${{ strategy.job-index }}
+        name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
         path: .coverage*
+        if-no-files-found: error
 
   slow-tests-success:
     if: always()
@@ -251,8 +253,7 @@ jobs:
     - name: Download coverage artifacts
       uses: actions/download-artifact@v4
       with:
-        path: coverage-files
-        merge-multiple: true
+        path: coverage-files-*
 
     - name: Debug directory
       run: |
@@ -260,7 +261,7 @@ jobs:
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/
+        coverage combine coverage-files/**/.coverage
         coverage xml
 
     - name: Upload Coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: coverage-${{ strategy.job-index }}
-        path: .coverage.xml.${{ strategy.job-index }}
+        path: coverage.xml.${{ strategy.job-index }}
 
   core-tests-success:
     if: always()
@@ -218,7 +218,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: coverage-${{ strategy.job-index }}
-        path: .coverage.xml.${{ strategy.job-index }}
+        path: coverage.xml.${{ strategy.job-index }}
 
   slow-tests-success:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       with:
         name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
-        path: .coverage*
+        path: .coverage
         if-no-files-found: error
 
   core-tests-success:
@@ -219,7 +219,7 @@ jobs:
       with:
         name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
-        path: .coverage*
+        path: .coverage
         if-no-files-found: error
 
   slow-tests-success:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,13 +204,15 @@ jobs:
 
     - name: Run tests
       run: |
-        coverage run -m pytest \
+        pytest \
           -m "fuzzing" \
           --splits 120 \
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
+          --cov-branch \
+          --cov=vyper \
           tests/
-      
+
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
-        --cov-branch
+        --cov-config=setup.cfg
         --cov=vyper
         tests/
 
@@ -210,7 +210,7 @@ jobs:
           --splits 120 \
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
-          --cov-branch \
+          --cov-config=setup.cfg \
           --cov=vyper \
           tests/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,7 @@ jobs:
       run: pip install coverage
 
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: coverage-files
         merge-multiple: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,4 +265,4 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        files: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,7 @@ jobs:
         --evm-backend ${{ matrix.evm-backend || 'revm' }}
         ${{ matrix.debug && '--enable-compiler-debug-mode' || '' }}
         ${{ matrix.experimental-codegen && '--experimental-codegen' || '' }}
+        --cov-config=setup.cfg
         --cov-branch
         --cov-report=
         --cov=vyper
@@ -210,6 +211,7 @@ jobs:
           --splits 120 \
           --group ${{ matrix.group }} \
           --splitting-algorithm least_duration \
+          --cov-config=setup.cfg \
           --cov-branch \
           --cov-report= \
           --cov=vyper \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
       with:
         name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
-        path: .coverage
+        path: .coverage*
         if-no-files-found: error
 
   core-tests-success:
@@ -219,7 +219,7 @@ jobs:
       with:
         name: coverage-files-${{ github.job }}-${{ strategy.job-index }}
         include-hidden-files: true
-        path: .coverage
+        path: .coverage*
         if-no-files-found: error
 
   slow-tests-success:
@@ -263,7 +263,7 @@ jobs:
 
     - name: Combine coverage
       run: |
-        coverage combine coverage-files/**/.coverage
+        coverage combine coverage-files/**/.coverage*
         coverage xml
 
     - name: Upload Coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,11 +33,3 @@ markers =
 	fuzzing: Run Hypothesis fuzz test suite (deselect with '-m "not fuzzing"')
 	requires_evm_version(version): Mark tests that require at least a specific EVM version and would throw `EvmVersionException` otherwise
 	venom_xfail: mark a test case as a regression (expected to fail) under the venom pipeline
-
-[coverage:run]
-branch = True
-parallel = True
-source = vyper
-
-[coverage:paths]
-source = vyper/

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ parallel = True
 source = vyper
 
 [coverage:paths]
-source = vyper/
+source = vyper
 
 [coverage:report]
 ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,5 +44,5 @@ relative_files = True
 [coverage:paths]
 source = vyper/
 
-[report]
+[coverage:report]
 ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,13 @@ markers =
 	fuzzing: Run Hypothesis fuzz test suite (deselect with '-m "not fuzzing"')
 	requires_evm_version(version): Mark tests that require at least a specific EVM version and would throw `EvmVersionException` otherwise
 	venom_xfail: mark a test case as a regression (expected to fail) under the venom pipeline
+
+
+[coverage:run]
+branch = True
+parallel = True
+source = vyper
+relative_files = True
+
+[coverage:paths]
+source = vyper/

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ markers =
 branch = True
 parallel = True
 source = vyper
-relative_files = True
 
 [coverage:paths]
 source = vyper/

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,3 @@ markers =
 
 [coverage:run]
 branch = True
-
-[coverage:report]
-ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,5 @@ markers =
 
 [coverage:run]
 branch = True
+source = vyper
+relative_files = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,4 +35,6 @@ markers =
 	venom_xfail: mark a test case as a regression (expected to fail) under the venom pipeline
 
 [coverage:run]
+branch = True
 parallel = True
+include = vyper

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,4 @@ markers =
 [coverage:run]
 branch = True
 parallel = True
-include = vyper
-
-[coverage:report]
-include = vyper
+source = vyper

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,11 +37,6 @@ markers =
 
 [coverage:run]
 branch = True
-parallel = True
-source = vyper
-
-[coverage:paths]
-source = vyper
 
 [coverage:report]
 ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,6 @@ markers =
 	fuzzing: Run Hypothesis fuzz test suite (deselect with '-m "not fuzzing"')
 	requires_evm_version(version): Mark tests that require at least a specific EVM version and would throw `EvmVersionException` otherwise
 	venom_xfail: mark a test case as a regression (expected to fail) under the venom pipeline
+
+[coverage:run]
+parallel = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,6 @@ markers =
 branch = True
 parallel = True
 source = vyper
+
+[coverage:paths]
+source = vyper/

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,6 @@ markers =
 branch = True
 parallel = True
 include = vyper
+
+[coverage:report]
+include = vyper

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,5 @@ markers =
 [coverage:run]
 branch = True
 source = vyper
+omit = vyper/version.py
 relative_files = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,5 +38,10 @@ markers =
 [coverage:run]
 branch = True
 source = vyper
+
+# this is not available on the CI step that performs `coverage combine`
 omit = vyper/version.py
+
+# allow `coverage combine` to combine reports from heterogeneous OSes.
+# (mainly important for consolidating coverage reports in the CI).
 relative_files = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,6 @@ relative_files = True
 
 [coverage:paths]
 source = vyper/
+
+[report]
+ignore_errors = True


### PR DESCRIPTION
### What I did

Consolidate code coverage files and upload it once.

### How I did it

### How to verify it

### Commit message

```
This commit updates the CI to combine code coverage to a single file
and perform just a single upload after all tests finish (rather than
each test run uploading its own coverage report). This should reduce
failures / rate limiting on the codecov app, and also prevent the
codecov app from producing an inaccurate coverage report before all
the tests finish.

references:
- https://coverage.readthedocs.io/en/7.6.10/cmd.html#cmd-combine
- https://coverage.readthedocs.io/en/7.6.10/cmd.html#re-mapping-paths
- https://coverage.readthedocs.io/en/7.6.10/config.html#config-run-relative-files
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRgJ3cioNlT_vjx1iffqo3KrCBWwys_hC-D9w&s)
