### PR TITLE
chore[ci]: separate codecov upload into separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,7 +264,7 @@ jobs:
         coverage report --fail-under=90
         coverage xml
 
-    - name: Upload coverage artifact
+    - name: Upload coverage sqlite artifact
       # upload coverage sqlite db for debugging
       uses: actions/upload-artifact@v4
       with:
@@ -273,7 +273,7 @@ jobs:
         path: .coverage
         if-no-files-found: error
 
-    - name: Upload coverage artifact
+    - name: Upload coverage.xml
       uses: actions/upload-artifact@v4
       with:
         name: coverage-xml
@@ -283,7 +283,7 @@ jobs:
   upload-coverage:
     # upload coverage to the codecov app
     runs-on: ubuntu-latest
-    needs: [tests, fuzzing]
+    needs: [consolidate-coverage]
 
     steps:
     - uses: actions/checkout@v4
@@ -296,4 +296,4 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage-xml/coverage.xml
+        file: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,8 +262,8 @@ jobs:
         coverage combine coverage-files/**/.coverage
 
     - name: Coverage report
+      # coverage report and fail if coverage is too low
       run: |
-        # coverage report and fail if coverage is too low
         coverage report --fail-under=90
 
     - name: Generate coverage.xml
@@ -293,7 +293,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
     - uses: actions/download-artifact@v4
       with:
         name: coverage-xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,7 +290,7 @@ jobs:
   upload-coverage:
     # upload coverage to the codecov app
     runs-on: ubuntu-latest
-    needs: [consolidate-coverage]
+    needs: [coverage-report]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,8 +260,14 @@ jobs:
     - name: Combine coverage
       run: |
         coverage combine coverage-files/**/.coverage
+
+    - name: Coverage report
+      run: |
         # coverage report and fail if coverage is too low
         coverage report --fail-under=90
+
+    - name: Generate coverage.xml
+      run: |
         coverage xml
 
     - name: Upload coverage sqlite artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,8 +234,9 @@ jobs:
         if: ${{ needs.fuzzing.result != 'success' }}
         run: exit 1
 
-  consolidate-coverage:
-    # Consolidate code coverage using `coverage combine`
+  coverage-report:
+    # Consolidate code coverage using `coverage combine` and
+    # call coverage report with fail-under=90
     runs-on: ubuntu-latest
     needs: [tests, fuzzing]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,8 +235,7 @@ jobs:
         run: exit 1
 
   consolidate-coverage:
-    # Consolidate code coverage using `coverage combine` and upload
-    # to the codecov app
+    # Consolidate code coverage using `coverage combine`
     runs-on: ubuntu-latest
     needs: [tests, fuzzing]
 
@@ -261,10 +260,40 @@ jobs:
     - name: Combine coverage
       run: |
         coverage combine coverage-files/**/.coverage
+        # coverage report and fail if coverage is too low
+        coverage report --fail-under=90
         coverage xml
+
+    - name: Upload coverage artifact
+      # upload coverage sqlite db for debugging
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-sqlite
+        include-hidden-files: true
+        path: .coverage
+        if-no-files-found: error
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-xml
+        path: coverage.xml
+        if-no-files-found: error
+
+  upload-coverage:
+    # upload coverage to the codecov app
+    runs-on: ubuntu-latest
+    needs: [tests, fuzzing]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: coverage-xml
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        file: coverage-xml/coverage.xml


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
this commit separates `coverage combine` (the local tool) and codecov
upload (upload to 3rd party app) into separate steps. it also uploads
the coverage report artifacts. this makes the actions more transparent
since we can download the coverage database to inspect it if there is
an issue, and allows us to set the `coverage report` as a required CI
check, which does not depend on a 3rd party service. (if it depended on
a 3rd party service, we might then be unable to merge PRs if there is
an issue on the 3rd party service's side).
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
