### PR TITLE
chore[ci]: improve coverage jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,4 +297,4 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        files: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,7 +275,7 @@ jobs:
       # upload coverage sqlite db for debugging
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-sqlite
+        name: coverage-artifacts
         include-hidden-files: true
         path: |
           .coverage
@@ -291,7 +291,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        name: coverage-xml
+        name: coverage-artifacts
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,20 +271,15 @@ jobs:
       run: |
         coverage xml
 
-    - name: Upload coverage sqlite artifact
+    - name: Upload coverage sqlite artifact and report
       # upload coverage sqlite db for debugging
       uses: actions/upload-artifact@v4
       with:
         name: coverage-sqlite
         include-hidden-files: true
-        path: .coverage
-        if-no-files-found: error
-
-    - name: Upload coverage.xml
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-xml
-        path: coverage.xml
+        path: |
+          .coverage
+          coverage.xml
         if-no-files-found: error
 
   upload-coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,8 +271,9 @@ jobs:
       run: |
         coverage xml
 
-    - name: Upload coverage sqlite artifact and report
+    - name: Upload coverage artifacts
       # upload coverage sqlite db for debugging
+      # upload coverage.xml artifact for downstream codecov upload action
       uses: actions/upload-artifact@v4
       with:
         name: coverage-artifacts


### PR DESCRIPTION
### What I did

Minor improvements to coverage CI:
1. Consolidate upload of coverage artifacts into a single step
2. Change `file` to `files` for `codecov-action@v5`

### How I did it

### How to verify it

### Commit message

```
This commit makes minor improvements to the coverage CI:
1. Consolidate upload of coverage artifacts into a single step
2. Change `file` field to `files` for `codecov-action@v5`

references:
- https://github.com/codecov/codecov-action?tab=readme-ov-file#migration-guide
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ-jGZb01Nnt7Tfqgs1Vo07UFbvPu0t6HArBA&s)
