### PR TITLE
fix[codegen]: fix iteration over constant literals

### DIFF
--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -214,6 +214,21 @@ def data() -> int128:
         assert c.data() == sum(xs)
 
 
+def test_constant_list_iter(get_contract):
+    code = """
+X: constant(uint24[4]) = [1, 2, 3, 4]
+
+@external
+def foo() -> uint24:
+    x: uint24 = 0
+    for s: uint24 in X:
+        x += s
+    return x
+    """
+    c = get_contract(code)
+    assert c.foo() == sum([1, 2, 3, 4])
+
+
 def test_basic_for_list_storage_address(get_contract):
     code = """
 addresses: address[3]

--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -216,12 +216,12 @@ def data() -> int128:
 
 def test_constant_list_iter(get_contract):
     code = """
-X: constant(uint24[4]) = [1, 2, 3, 4]
+MY_LIST: constant(uint24[4]) = [1, 2, 3, 4]
 
 @external
 def foo() -> uint24:
     x: uint24 = 0
-    for s: uint24 in X:
+    for s: uint24 in MY_LIST:
         x += s
     return x
     """

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -560,7 +560,7 @@ def _get_element_ptr_array(parent, key, array_bounds_check):
         return IRnode.from_list("~empty", subtype)
 
     if parent.value == "multi":
-        assert isinstance(key.value, int)
+        assert isinstance(key.value, int), key
         return parent.args[key.value]
 
     ix = unwrap_location(key)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -258,7 +258,7 @@ class Stmt:
         ret = ["seq"]
 
         # list literal, force it to memory first
-        if isinstance(self.stmt.iter, vy_ast.List):
+        if iter_list.is_literal:
             tmp_list = self.context.new_internal_variable(iter_list.typ)
             ret.append(make_setter(tmp_list, iter_list))
             iter_list = tmp_list


### PR DESCRIPTION
### What I did
fix #4461 

### How I did it

### How to verify it

### Commit message

```
the check in `_parse_For_list` is wrong when the iter is a constant
(since the check is syntactic). the fix is to check the `is_literal`
property on the generated IR.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
