### PR TITLE
refactor[venom]: replace `bb.mark_for_removal` with `make_nop`

### DIFF
--- a/tests/unit/compiler/venom/test_memmerging.py
+++ b/tests/unit/compiler/venom/test_memmerging.py
@@ -3,7 +3,7 @@ import pytest
 from tests.venom_utils import assert_ctx_eq, parse_from_basic_block, parse_venom
 from vyper.evm.opcodes import version_check
 from vyper.venom.analysis import IRAnalysesCache
-from vyper.venom.passes import SCCP, MemMergePass
+from vyper.venom.passes import SCCP, MemMergePass, RemoveUnusedVariablesPass
 
 
 def _check_pre_post(pre, post):
@@ -11,6 +11,7 @@ def _check_pre_post(pre, post):
     for fn in ctx.functions.values():
         ac = IRAnalysesCache(fn)
         MemMergePass(ac, fn).run_pass()
+        RemoveUnusedVariablesPass(ac, fn).run_pass()
     assert_ctx_eq(ctx, parse_from_basic_block(post))
 
 
@@ -853,8 +854,6 @@ def test_memzeroing_2():
 
     post = """
     _global:
-        %1 = calldatasize
-        %2 = calldatasize
         %3 = calldatasize
         calldatacopy 64, %3, 256
         stop
@@ -881,8 +880,6 @@ def test_memzeroing_3():
 
     post = """
     _global:
-        %1 = calldatasize
-        %2 = calldatasize
         %3 = calldatasize
         calldatacopy 0, %3, 264
         stop
@@ -905,7 +902,6 @@ def test_memzeroing_small_calldatacopy():
 
     post = """
     _global:
-        %1 = calldatasize
         mstore 0, 0
         stop
     """
@@ -935,13 +931,8 @@ def test_memzeroing_smaller_calldatacopy():
 
     post = """
     _global:
-        %1 = calldatasize
-        %2 = calldatasize
         %6 = calldatasize
         calldatacopy 0, %6, 24
-        %3 = calldatasize
-        %4 = calldatasize
-        %5 = calldatasize
         mstore 100, 0
         stop
     """
@@ -966,7 +957,6 @@ def test_memzeroing_overlap():
 
     post = """
     _global:
-        %1 = calldatasize
         %2 = calldatasize
         calldatacopy 100, %2, 64
         stop

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -469,8 +469,6 @@ class IRBasicBlock:
         self.out_vars = OrderedSet()
         self.is_reachable = False
 
-        self._garbage_instructions: set[IRInstruction] = set()
-
     def add_cfg_in(self, bb: "IRBasicBlock") -> None:
         self.cfg_in.add(bb)
 
@@ -544,16 +542,6 @@ class IRBasicBlock:
         instruction.ast_source = self.parent.ast_source
         instruction.error_msg = self.parent.error_msg
         self.instructions.insert(index, instruction)
-
-    def mark_for_removal(self, instruction: IRInstruction) -> None:
-        self._garbage_instructions.add(instruction)
-
-    def clear_dead_instructions(self) -> None:
-        if len(self._garbage_instructions) > 0:
-            self.instructions = [
-                inst for inst in self.instructions if inst not in self._garbage_instructions
-            ]
-            self._garbage_instructions.clear()
 
     def remove_instruction(self, instruction: IRInstruction) -> None:
         assert isinstance(instruction, IRInstruction), "instruction must be an IRInstruction"

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -543,6 +543,10 @@ class IRBasicBlock:
         instruction.error_msg = self.parent.error_msg
         self.instructions.insert(index, instruction)
 
+    def clear_nops(self) -> None:
+        if any(inst.opcode == "nop" for inst in self.instructions):
+            self.instructions = [inst for inst in self.instructions if inst.opcode != "nop"]
+
     def remove_instruction(self, instruction: IRInstruction) -> None:
         assert isinstance(instruction, IRInstruction), "instruction must be an IRInstruction"
         self.instructions.remove(instruction)

--- a/vyper/venom/passes/memmerging.py
+++ b/vyper/venom/passes/memmerging.py
@@ -155,7 +155,7 @@ class MemMergePass(IRPass):
                     if not all(use in copy.insts for use in uses):
                         continue
 
-                bb.mark_for_removal(inst)
+                inst.make_nop()
 
         self._copies.clear()
         self._loads.clear()
@@ -285,7 +285,6 @@ class MemMergePass(IRPass):
                 _barrier()
 
         _barrier()
-        bb.clear_dead_instructions()
 
     # optimize memzeroing operations
     def _optimize_memzero(self, bb: IRBasicBlock):
@@ -304,7 +303,7 @@ class MemMergePass(IRPass):
                 inst.operands = [IRLiteral(copy.length), calldatasize, IRLiteral(copy.dst)]
 
             for inst in copy.insts[:-1]:
-                bb.mark_for_removal(inst)
+                inst.make_nop()
 
         self._copies.clear()
         self._loads.clear()
@@ -350,7 +349,6 @@ class MemMergePass(IRPass):
                 continue
 
         _barrier()
-        bb.clear_dead_instructions()
 
 
 def _volatile_memory(inst):

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -25,6 +25,9 @@ class RemoveUnusedVariablesPass(IRPass):
             inst = work_list.pop()
             self._process_instruction(inst)
 
+        for bb in self.function.get_basic_blocks():
+            bb.clear_nops()
+
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
         self.analyses_cache.invalidate_analysis(DFGAnalysis)
 


### PR DESCRIPTION
this is slightly cleaner, since we don't need to remember to call `bb.clear_dead_instructions()` after `mark_for_removal()`, instead they will all be removed in one go whenever `RemoveUnusedVariablesPass` runs.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
