### PR TITLE
fix[docs]: fix venom examples

### DIFF
--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -361,7 +361,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   - Translates to `label JUMP`.
 - `jnz`
    - ```
-     jnz op, @label1, @label2
+     jnz %op, @label1, @label2
      ```
   - A conditional jump depending on the value of `op`.
   - Jumps to `label2` when `op` is not zero, otherwise jumps to `label1`.

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -38,16 +38,16 @@ function global {
     selector_bucket_0:
         %3 = xor %2, 1579456981
         %4 = iszero %3
-        jnz %4, @1, @2
+        jnz %4, @true, @false
 
-    1:
+    false:
         jmp @fallback
 
-    2:
+    true:
         %5 = callvalue
         %6 = calldatasize
-        %7 = lt %6, 164
-        %8 = or %5, %7
+        %7 = lt 164, %6
+        %8 = or %7, %5
         %9 = iszero %8
         assert %9
         stop

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -38,7 +38,7 @@ function global {
     selector_bucket_0:
         %3 = xor %2, 1579456981
         %4 = iszero %3
-        jnz @1, @2, %4
+        jnz %4, @1, @2
 
     1:
         jmp @fallback
@@ -55,8 +55,6 @@ function global {
     fallback:
         revert 0, 0
 }
-
-[data]
 ```
 
 ### Grammar

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -361,7 +361,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   - Translates to `label JUMP`.
 - `jnz`
    - ```
-     jnz %op, @label1, @label2
+     jnz op, @label1, @label2
      ```
   - A conditional jump depending on the value of `op`.
   - Jumps to `label2` when `op` is not zero, otherwise jumps to `label1`.

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -373,7 +373,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
     could translate to: `PUSH1 15 label2 JUMPI label1 JUMP`.
 - `djmp`
   - ```
-    djmp @label1, @label2, ..., @labeln, %var
+    djmp %var, @label1, @label2, ..., @labeln
     ```
   - Dynamic jump to an address specified by the variable operand, constrained to the provided labels.
   - Accepts a variable number of labels.

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -233,7 +233,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
      `PUSH1 12 PUSH1 24 _mem_deploy_end ADD MSTORE`.
 - `phi`
   - ```
-    out = phi %var_a, label_a, %var_b, label_b
+    out = phi label_a, %var_a, label_b, %var_b
     ```
   - Because in SSA form each variable is assigned just once, it is tricky to handle that variables may be assigned to something different based on which program path was taken.
   - Therefore, we use `phi` instructions. They are are magic instructions, used in basic blocks where the control flow path merges.

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -191,7 +191,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   - Effectively translates to `JUMP`, and marks the call site as a valid return destination (for callee to jump back to) by `JUMPDEST`.
 - `alloca`
   - ```
-    out = alloca size, offset, id
+    %out = alloca size, offset, id
     ```
   - Allocates memory of a given `size` at a given `offset` in memory.
   - The `id` argument is there to help debugging translation into venom
@@ -200,12 +200,12 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   
 - `palloca`
   - ```
-    out = palloca size, offset, id
+    %out = palloca size, offset, id
     ```
   - Like the `alloca` instruction but only used for parameters of internal functions which are passed by memory.
 - `iload`
   - ```
-    out = iload offset
+    %out = iload offset
     ```
   - Loads value at an immutable section of memory denoted by `offset` into `out` variable.
   - The operand can be either a literal, which is a statically computed offset, or a variable.
@@ -231,27 +231,27 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
      `PUSH1 12 PUSH1 24 _mem_deploy_end ADD MSTORE`.
 - `phi`
   - ```
-    out = phi label_a, %var_a, label_b, %var_b
+    %out = phi @label_a, %var_a, @label_b, %var_b
     ```
   - Because in SSA form each variable is assigned just once, it is tricky to handle that variables may be assigned to something different based on which program path was taken.
   - Therefore, we use `phi` instructions. They are are magic instructions, used in basic blocks where the control flow path merges.
-  - In this example, essentially the `out` variable is set to `%var_a` if the program entered the current block from `label_a` or to `%var_b` when it went through `label_b`.
+  - In this example, essentially the `%out` variable is set to `%var_a` if the program entered the current block from `label_a` or to `%var_b` when it went through `label_b`.
 - `offset`
   - ```
-    ret = offset label, op
+    %ret = offset label, op
     ```
   - Statically compute offset before compiling into bytecode. Useful for `mstore`, `mload` and such.
   - Basically `label` + `op`.
   - The `asm` output could show something like `_OFST _sym_<op> label`.
 - `param`
   - ```
-    out = param
+    %out = param
     ```
   - The `param` instruction is used to represent function arguments passed by the stack.
   - We assume the argument is on the stack and the `param` instruction is used to ensure we represent the argument by the `out` variable.
 - `store`
   - ```
-    out = op
+    %out = op
     ```
   - Store variable value or literal into `out` variable.
 - `dbname`
@@ -282,7 +282,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   - Might translate to something like  `_sym__ctor_exit JUMP`.
 - `sha3_64`
   - ```
-    out = sha3_64 x y
+    %out = sha3_64 x y
     ```
   - Shortcut to access the `SHA3` EVM opcode where `out` is the result.
   - Essentially translates to
@@ -371,7 +371,7 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
     could translate to: `PUSH1 15 label2 JUMPI label1 JUMP`.
 - `djmp`
   - ```
-    djmp %var, label1, label2, label3, ...
+    djmp %var, @label1, @label2, @label3, ...
     ```
   - Dynamic jump to an address specified by the variable operand, constrained to the provided labels.
   - Accepts a variable number of labels.

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -361,14 +361,14 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   - Translates to `label JUMP`.
 - `jnz`
    - ```
-     jnz label1, label2, op
+     jnz op, label1, label2
      ```
   - A conditional jump depending on the value of `op`.
   - Jumps to `label2` when `op` is not zero, otherwise jumps to `label1`.
   - For example
     ```
     %op = 15
-    jnz label1, label2, %op
+    jnz %op, @label1, @label2
     ```
     could translate to: `PUSH1 15 label2 JUMPI label1 JUMP`.
 - `djmp`


### PR DESCRIPTION
### What I did
I was playing around with the venom IR parser and ran into issues when using some of the instructions per the README. The current docs has swapped the usage of labels and the vars a few places.

### How I did it
I got a error message which hinted at the issue
```
  File "/Users/brage/Downloads/vyper/vyper/venom/analysis/liveness.py", line 90, in input_vars_from
    for label, var in inst.phi_operands:
  File "/Users/brage/Downloads/vyper/vyper/venom/basicblock.py", line 374, in phi_operands
    assert isinstance(label, IRLabel), "phi operand must be a label"
AssertionError: phi operand must be a label
```

Then I ran the following on a Vyper file which would use the phi function to find a reference
```bash
 vyper --experimental-codegen -f bb_runtime 
```

It gave out
```
%ret_size:3 = phi @8_then, %ret_size:5, @9_else, %ret_size:4
```

### How to verify it
Per the docs, this should compile, but it doesn't 
```
function global {
  global:
    jnz 1, @1_then, @2_then
  1_then:
    %1 = 1
    jmp @3_phi
  2_then:
    %2 = 2
    jmp @3_phi
  3_phi:
    %3 = phi %1, @1_then, %2, @2_then
    return 0,%3
}
```

With my suggested fix it does compile
```
function global {
  global:
    jnz 1, @1_then, @2_then
  1_then:
    %1 = 1
    jmp @3_phi
  2_then:
    %2 = 2
    jmp @3_phi
  3_phi:
    %3 = phi %1, @1_then, %2, @2_then
    return 0,%3
}
```

Using `python3 -m vyper.cli.venom_main [file]` to verify. Same is true for `jnz` and the example code.

### Commit message

```
Fix operands order and clarify opcodes in README for Venom IR

The README incorrectly swapped the arguments for the some of the
opcodes example. This change fixes that and clarifies some of the
opcode usages.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.sanity.io/images/5vm5yn1d/pro/e8901b37029ada974f945ce569a5643b511fb4a9-1499x1000.jpg?fm=webp&q=80)
