### PR TITLE
fix[codegen]: fix gas usage of iterators

### DIFF
--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -425,8 +425,6 @@ class IRnode:
 
     @property
     def is_pointer(self) -> bool:
-        # not used yet but should help refactor/clarify downstream code
-        # eventually
         return self.location is not None
 
     @property  # probably could be cached_property but be paranoid

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -257,8 +257,8 @@ class Stmt:
 
         ret = ["seq"]
 
-        # list literal, force it to memory first
-        if iter_list.is_literal:
+        # if it's a list literal, force it to memory first
+        if not iter_list.is_pointer:
             tmp_list = self.context.new_internal_variable(iter_list.typ)
             ret.append(make_setter(tmp_list, iter_list))
             iter_list = tmp_list


### PR DESCRIPTION
cd318676a0b7bcb (#4462) introduces a gas regression, which is that `IRnode.is_literal` evaluates to true even for pointers (which are not source-level literals). this commit changes the condition to be `not .is_pointer`, which should be the correct condition for needing to strictify into memory.

thanks to @pcaversaccio for spotting!

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
