### PR TITLE
fix[lang]: define rounding mode for sqrt

### DIFF
--- a/docs/built-in-functions.rst
+++ b/docs/built-in-functions.rst
@@ -711,7 +711,7 @@ Math
 
 .. py:function:: sqrt(d: decimal) -> decimal
 
-    Return the square root of the provided decimal number, using the Babylonian square root algorithm.
+    Return the square root of the provided decimal number, using the Babylonian square root algorithm. The rounding mode is to round down to the nearest epsilon. For instance, ``sqrt(0.9999999998) == 0.9999999998``.
 
     .. code-block:: vyper
 

--- a/tests/functional/codegen/types/numbers/test_sqrt.py
+++ b/tests/functional/codegen/types/numbers/test_sqrt.py
@@ -146,6 +146,7 @@ def test_sqrt_bounds(sqrt_contract, value):
 )
 @hypothesis.example(value=Decimal(SizeLimits.MAX_INT128))
 @hypothesis.example(value=Decimal(0))
+# cf. GHSA-2p94-8669-xg86 for the following three examples:
 @hypothesis.example(value=Decimal("0.9999999998"))
 @hypothesis.example(value=Decimal("0.9999999997"))
 @hypothesis.example(value=Decimal("1.1000000000"))

--- a/tests/functional/codegen/types/numbers/test_sqrt.py
+++ b/tests/functional/codegen/types/numbers/test_sqrt.py
@@ -146,6 +146,9 @@ def test_sqrt_bounds(sqrt_contract, value):
 )
 @hypothesis.example(value=Decimal(SizeLimits.MAX_INT128))
 @hypothesis.example(value=Decimal(0))
+@hypothesis.example(value=Decimal("0.9999999998"))
+@hypothesis.example(value=Decimal("0.9999999997"))
+@hypothesis.example(value=Decimal("1.1000000000"))
 def test_sqrt_valid_range(sqrt_contract, value):
     vyper_sqrt = sqrt_contract.test(decimal_to_int(value))
     actual_sqrt = decimal_sqrt(value)

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2145,6 +2145,9 @@ else:
             break
         y = z
         z = (x / z + z) / 2.0
+
+    if y < z:
+        z = y
             """
 
             x_type = DecimalT()


### PR DESCRIPTION
### What I did
fix for https://github.com/vyperlang/vyper/security/advisories/GHSA-2p94-8669-xg86

prior to this PR, the rounding mode for `sqrt()` is undefined. this PR ensures the result is rounded down.

### How I did it

### How to verify it

### Commit message

```
prior to this commit, the rounding mode for `sqrt()` is undefined,
which could be an issue for applications which use `sqrt()` to
determine boundary conditions. this commit ensures the result is
rounded down.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
