### PR TITLE
fix[tool]: roll back OS used to build binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os:
+          # the binary will not work for users with an older libc than what
+          # is available on the ubuntu that the binary was built with.
+          # therefore, use the oldest available ubuntu.
+          - ubuntu-22.04
+          - macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
per ae6ab0d3dc58167cc6, the OS image used to build vyper binaries was
updated. however, this can break users who don't have a compatible libc
(i.e., at least as recent as the latest ubuntu). roll back to an older
ubuntu for those users.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
