### PR TITLE
fix[codegen]: relax the filter for augassign oob check

### DIFF
--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -1,5 +1,6 @@
 import pytest
 
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import CodegenPanic, ImmutableViolation, InvalidType, TypeMismatch
 
 
@@ -240,9 +241,11 @@ def entry() -> DynArray[uint256, 2]:
     """,
     ],
 )
-@pytest.mark.requires_evm_version("cancun")
 @pytest.mark.xfail(strict=True, raises=CodegenPanic)
 def test_augassign_rhs_references_lhs_transient2(get_contract, tx_failed, source):
+    if not version_check(begin="cancun"):
+        # no transient available before cancun
+        pytest.skip()
     # xfail here (with panic):
     c = get_contract(source)
 

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -209,7 +209,7 @@ def entry() -> DynArray[uint256, 2]:
     """
     c = get_contract(source)
 
-    assert c.entry() == [3, 2]
+    assert c.entry() == [2, 3]
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -163,7 +163,6 @@ def foo() -> uint256:
 @external
 def entry() -> DynArray[uint256, 2]:
     self.a = [1, 1]
-    # panics due to staticcall
     self.a[1] += staticcall Foo(self).foo()
     return self.a
     """,

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -132,6 +132,25 @@ def entry() -> DynArray[uint256, 2]:
     return self.a
     """,
         """
+interface Foo:
+    def foo() -> uint256: nonpayable
+
+def get_foo() -> uint256:
+    return extcall Foo(self).foo()
+
+@external
+def foo() -> uint256:
+    return 1
+
+@external
+def entry() -> DynArray[uint256, 2]:
+    # memory variable, can't be overwritten by extcall
+    a: DynArray[uint256, 2] = [1, 1]
+    # extcall hidden inside internal function
+    a[1] += self.get_foo()
+    return a
+    """,
+        """
 a: public(DynArray[uint256, 2])
 
 interface Foo:

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -103,36 +103,6 @@ def test_augassign_oob(get_contract, tx_failed, source):
     "source",
     [
         """
-a: public(DynArray[uint256, 2])
-
-interface Foo:
-    def foo() -> uint256: view
-
-@external
-def foo() -> uint256:
-    return self.a[1]
-
-@external
-def entry() -> DynArray[uint256, 2]:
-    self.a = [1, 1]
-    # panics due to staticcall
-    self.a[1] += staticcall Foo(self).foo()
-    return self.a
-    """
-    ],
-)
-@pytest.mark.xfail(strict=True, raises=CodegenPanic)
-def test_augassign_rhs_references_lhs(get_contract, tx_failed, source):
-    # xfail here (with panic):
-    c = get_contract(source)
-
-    assert c.entry() == [1, 2]
-
-
-@pytest.mark.parametrize(
-    "source",
-    [
-        """
 @external
 def entry() -> DynArray[uint256, 2]:
     a: DynArray[uint256, 2] = [1, 1]
@@ -159,6 +129,23 @@ def read() -> uint256:
 def entry() -> DynArray[uint256, 2]:
     self.a = [1, 1]
     self.a[1] += self.read()
+    return self.a
+    """,
+        """
+a: public(DynArray[uint256, 2])
+
+interface Foo:
+    def foo() -> uint256: view
+
+@external
+def foo() -> uint256:
+    return self.a[1]
+
+@external
+def entry() -> DynArray[uint256, 2]:
+    self.a = [1, 1]
+    # panics due to staticcall
+    self.a[1] += staticcall Foo(self).foo()
     return self.a
     """,
     ],

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -201,8 +201,10 @@ def read() -> uint256:
 @external
 def entry() -> DynArray[uint256, 2]:
     self.x = [1, 1]
-    self.x[1] += self.read()
-    self.x[0] += self.x[1]
+    # test augassign with state read hidden behind function call
+    self.x[0] += self.read()
+    # augassign with direct state read
+    self.x[1] += self.x[0]
     return self.x
     """
     c = get_contract(source)
@@ -222,6 +224,7 @@ def write() -> uint256:
 @external
 def entry() -> DynArray[uint256, 2]:
     self.x = [1, 1]
+    # hide state write behind function call
     self.x[1] += self.write()
     return self.x
     """,
@@ -231,6 +234,7 @@ x: transient(DynArray[uint256, 2])
 @external
 def entry() -> DynArray[uint256, 2]:
     self.x = [1, 1]
+    # direct state write
     self.x[1] += self.x.pop()
     return self.x
     """,

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -135,6 +135,22 @@ def entry() -> DynArray[uint256, 2]:
 interface Foo:
     def foo() -> uint256: nonpayable
 
+@external
+def foo() -> uint256:
+    return 1
+
+@external
+def entry() -> DynArray[uint256, 2]:
+    # memory variable, can't be overwritten by extcall, so there
+    # is no panic
+    a: DynArray[uint256, 2] = [1, 1]
+    a[1] += extcall Foo(self).foo()
+    return a
+    """,
+        """
+interface Foo:
+    def foo() -> uint256: nonpayable
+
 def get_foo() -> uint256:
     return extcall Foo(self).foo()
 
@@ -144,7 +160,8 @@ def foo() -> uint256:
 
 @external
 def entry() -> DynArray[uint256, 2]:
-    # memory variable, can't be overwritten by extcall
+    # memory variable, can't be overwritten by extcall, so there
+    # is no panic
     a: DynArray[uint256, 2] = [1, 1]
     # extcall hidden inside internal function
     a[1] += self.get_foo()

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -246,6 +246,7 @@ def test_augassign_rhs_references_lhs_transient2(get_contract, tx_failed, source
     if not version_check(begin="cancun"):
         # no transient available before cancun
         pytest.skip()
+
     # xfail here (with panic):
     c = get_contract(source)
 

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -499,6 +499,18 @@ class IRnode:
         return ret
 
     @cached_property
+    def contains_writeable_call(self):
+        ret = self.value in ("call", "delegatecall", "create", "create2")
+
+        for arg in self.args:
+            ret |= arg.contains_writeable_call
+
+        if getattr(self, "is_self_call", False):
+            ret |= self.invoked_function_ir.func_ir.contains_writeable_call
+
+        return ret
+
+    @cached_property
     def contains_self_call(self):
         return getattr(self, "is_self_call", False) or any(x.contains_self_call for x in self.args)
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -289,6 +289,13 @@ class Stmt:
             # single word load/stores are atomic.
             raise TypeCheckFailure("unreachable")
 
+        for var in target.referenced_variables:
+            if var.typ._is_prim_word:
+                continue
+            # oob - GHSA-4w26-8p97-f4jp
+            if var in right.variable_writes or right.contains_risky_call:
+                raise CodegenPanic("unreachable")
+
         with target.cache_when_complex("_loc") as (b, target):
             left = IRnode.from_list(LOAD(target), typ=target.typ)
             new_val = Expr.handle_binop(self.stmt.op, left, right, self.context)

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -293,7 +293,9 @@ class Stmt:
             if var.typ._is_prim_word:
                 continue
             # oob - GHSA-4w26-8p97-f4jp
-            if var in right.variable_writes or right.contains_risky_call:
+            if var in right.variable_writes or (
+                var.is_state_variable() and right.contains_writeable_call
+            ):
                 raise CodegenPanic("unreachable")
 
         with target.cache_when_complex("_loc") as (b, target):

--- a/vyper/semantics/analysis/base.py
+++ b/vyper/semantics/analysis/base.py
@@ -205,6 +205,7 @@ class VarInfo:
         assert isinstance(position, VarOffset)  # sanity check
         self.position = position
 
+    # TODO: convert to property
     def is_state_variable(self):
         non_state_locations = (DataLocation.UNSET, DataLocation.MEMORY, DataLocation.CALLDATA)
         # `self` gets a VarInfo, but it is not considered a state


### PR DESCRIPTION
### What I did
relax the filter in #4487

### How I did it

### How to verify it

### Commit message

```
this commit relaxes the filter introduced in dd5a3d9e0f1e8685. the
filter was valid, but blocked too many user programs. this commit
updates the filter so that the external call check is only applied if
there is a state variable on the lhs. it also updates the external call
check to only consider state-modifying calls, since staticcalls cannot
modify the lhs.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
