### PR TITLE
fix[venom]: fix sccp resolution of truthy `jnz`

### DIFF
--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -195,6 +195,7 @@ class SCCP(IRPass):
                 self.work_list.append(FlowWorkItem(inst.parent, target))
             else:
                 # jnz True branch (any nonzero condition)
+                assert isinstance(lat, IRLiteral) and lat.value != 0  # for clarity
                 target = self.fn.get_basic_block(inst.operands[1].name)
                 self.work_list.append(FlowWorkItem(inst.parent, target))
         elif opcode == "djmp":

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -189,14 +189,14 @@ class SCCP(IRPass):
             if lat == LatticeEnum.BOTTOM:
                 for out_bb in inst.parent.cfg_out:
                     self.work_list.append(FlowWorkItem(inst.parent, out_bb))
-            elif lat == IRLiteral(0):
-                # jnz False branch
-                target = self.fn.get_basic_block(inst.operands[2].name)
-                self.work_list.append(FlowWorkItem(inst.parent, target))
             else:
-                # jnz True branch (any nonzero condition)
-                assert isinstance(lat, IRLiteral) and lat.value != 0  # for clarity
-                target = self.fn.get_basic_block(inst.operands[1].name)
+                assert isinstance(lat, IRLiteral)  # sanity
+                if lat.value == 0:
+                    # jnz False branch
+                    target = self.fn.get_basic_block(inst.operands[2].name)
+                else:
+                    # jnz True branch (any nonzero condition)
+                    target = self.fn.get_basic_block(inst.operands[1].name)
                 self.work_list.append(FlowWorkItem(inst.parent, target))
         elif opcode == "djmp":
             lat = self._eval_from_lattice(inst.operands[0])


### PR DESCRIPTION
### What I did
see commit message

### How I did it

### How to verify it
see the unit tests

### Commit message

```
this commit fixes SCCP traversal - when a jnz has a truthy condition
that is not equal to 1, it gets transformed to a `jmp`, however, during
lattice construction, both branches are explored and therefore some
phis are suboptimally resolved to BOTTOM, even though they can
theoretically be resolved to a proper value since one of the input bbs
will actually be pruned from the CFG.

this issue is *not* visible in the regular pipeline, since SCCP is run
multiple times and thus the phis get resolved after the second SCCP run.
however, it is visible in tests, and would be visible in the regular
pipeline if SCCP were only run one time.

this commit also removes a `FlowWorkItem` addition, which is redundant
since all the cfg altering instructions are already handled in
`_visit_expr`.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
