### PR TITLE
feat[venom]: allow labels to be assigned to variables

### DIFF
--- a/tests/functional/venom/test_venom_label_variables.py
+++ b/tests/functional/venom/test_venom_label_variables.py
@@ -1,0 +1,90 @@
+    
+import vyper
+import vyper.evm.opcodes as evm
+from vyper.compiler.phases import generate_bytecode
+from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings
+from vyper.venom import generate_assembly_experimental, run_passes_on
+from vyper.venom.check_venom import check_venom_ctx
+from vyper.venom.parser import parse_venom
+ 
+
+
+def test_labels_as_variables():
+    code = """
+    function global {
+      global:
+        mstore 64, 128
+        %2 = callvalue
+        %3 = iszero %2
+        jnz %3, @block_0xe, @block_0xb
+      block_0xe:
+        %6 = calldatasize
+        %7 = lt %6, 4
+        jnz %7, @block_0x2f, @block_0x17
+      block_0xb:
+        revert 0, 0
+      block_0x2f:
+        revert 0, 0
+      block_0x17:
+        %12 = calldataload 0
+        %14 = shr 224, %12
+        %16 = eq 10773267, %14
+        jnz %16, @block_0x33, @block_0x25
+      block_0x33:
+        %block_57 = @block_0x39
+        jmp @block_0x67
+      block_0x25:
+        %21 = eq 4171824493, %14
+        jnz %21, @block_0x4d, @block_0x2f
+      block_0x67:
+        %phi0 = phi @block_0x33, %block_57, @block_0x6f, %block_118
+        djmp %phi0, @block_0x76, @block_0x39
+      block_0x4d:
+        jmp @block_0x6f
+      block_0x39:
+        %28 = mload 64
+        %block_68 = @block_0x44
+        jmp @block_0x91
+      block_0x6f:
+        %block_118 = @block_0x76
+        jmp @block_0x67
+      block_0x91:
+        %phi1 = phi @block_0x39, %28, @block_0x53, %45
+        %phi2 = phi @block_0x39, %28, @block_0x53, %45
+        %phi3 = phi @block_0x39, %block_68, @block_0x53, %block_94
+        %36 = add %phi1, 32
+        %39 = add %phi2, 0
+        jmp @block_0x84
+      block_0x84:
+        jmp @block_0x7b
+      block_0x76:
+        jmp @block_0x53
+      block_0x7b:
+        jmp @block_0x8b
+      block_0x53:
+        %45 = mload 64
+        %block_94 = @block_0x5e
+        jmp @block_0x91
+      block_0x8b:
+        mstore %39, 1
+        jmp @block_0xa2
+      block_0xa2:
+        djmp %phi3, @block_0x5e, @block_0x44
+      block_0x44:
+        %49 = mload 64
+        %50 = sub %36, %49
+        return %49, %50
+      block_0x5e:
+        %52 = mload 64
+        %53 = sub %36, %52
+        return %52, %53
+    }
+    """
+    ctx = parse_venom(code)
+
+    check_venom_ctx(ctx)
+
+    run_passes_on(ctx, OptimizationLevel.default())
+    asm = generate_assembly_experimental(ctx)
+    bytecode = generate_bytecode(asm, compiler_metadata=None)
+

--- a/tests/functional/venom/test_venom_label_variables.py
+++ b/tests/functional/venom/test_venom_label_variables.py
@@ -1,12 +1,8 @@
-    
-import vyper
-import vyper.evm.opcodes as evm
 from vyper.compiler.phases import generate_bytecode
-from vyper.compiler.settings import OptimizationLevel, Settings, set_global_settings
+from vyper.compiler.settings import OptimizationLevel
 from vyper.venom import generate_assembly_experimental, run_passes_on
 from vyper.venom.check_venom import check_venom_ctx
 from vyper.venom.parser import parse_venom
- 
 
 
 def test_labels_as_variables():
@@ -86,5 +82,4 @@ def test_labels_as_variables():
 
     run_passes_on(ctx, OptimizationLevel.default())
     asm = generate_assembly_experimental(ctx)
-    bytecode = generate_bytecode(asm, compiler_metadata=None)
-
+    generate_bytecode(asm, compiler_metadata=None)

--- a/vyper/cli/venom_main.py
+++ b/vyper/cli/venom_main.py
@@ -57,7 +57,7 @@ def _parse_args(argv: list[str]):
 
     ctx = parse_venom(venom_source)
 
-    # check_venom_ctx(ctx)
+    check_venom_ctx(ctx)
 
     run_passes_on(ctx, OptimizationLevel.default())
     asm = generate_assembly_experimental(ctx)

--- a/vyper/cli/venom_main.py
+++ b/vyper/cli/venom_main.py
@@ -57,7 +57,7 @@ def _parse_args(argv: list[str]):
 
     ctx = parse_venom(venom_source)
 
-    check_venom_ctx(ctx)
+    # check_venom_ctx(ctx)
 
     run_passes_on(ctx, OptimizationLevel.default())
     asm = generate_assembly_experimental(ctx)

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -429,7 +429,7 @@ class IRInstruction:
         opcode = f"{self.opcode} " if self.opcode != "store" else ""
         s += opcode
         operands = self.operands
-        if opcode not in ["jmp", "jnz", "invoke"]:
+        if opcode not in ["jmp", "jnz", "djmp", "invoke"]:
             operands = list(reversed(operands))
         s += ", ".join([(f"@{op}" if isinstance(op, IRLabel) else str(op)) for op in operands])
         return s
@@ -443,7 +443,7 @@ class IRInstruction:
         operands = self.operands
         if self.opcode == "invoke":
             operands = [operands[0]] + list(reversed(operands[1:]))
-        elif self.opcode not in ("jmp", "jnz", "phi"):
+        elif self.opcode not in ("jmp", "jnz", "djmp", "phi"):
             operands = reversed(operands)  # type: ignore
         s += ", ".join([(f"@{op}" if isinstance(op, IRLabel) else str(op)) for op in operands])
 

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -386,10 +386,8 @@ class IRInstruction:
         for i in range(0, len(self.operands), 2):
             label = self.operands[i]
             var = self.operands[i + 1]
-            assert isinstance(label, IRLabel), "phi operand must be a label"
-            assert isinstance(
-                var, (IRVariable, IRLiteral)
-            ), "phi operand must be a variable or literal"
+            assert isinstance(label, IRLabel), f"not a label: {label} (at `{self}`)"
+            assert isinstance(var, IRVariable), f"not a variable: {var} (at `{self}`)"
             yield label, var
 
     def remove_phi_operand(self, label: IRLabel) -> None:

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -200,7 +200,7 @@ class VenomTransformer(Transformer):
             # invoke <target> <stack arguments>
             operands = [operands[0]] + list(reversed(operands[1:]))
         # special cases: operands with labels look better un-reversed
-        elif opcode not in ("jmp", "jnz", "phi"):
+        elif opcode not in ("jmp", "jnz", "djmp", "phi"):
             operands.reverse()
         return IRInstruction(opcode, operands)
 

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -178,7 +178,7 @@ class VenomTransformer(Transformer):
         if isinstance(value, IRInstruction):
             value.output = to
             return value
-        if isinstance(value, (IRLiteral, IRVariable)):
+        if isinstance(value, (IRLiteral, IRVariable, IRLabel)):
             return IRInstruction("store", [value], output=to)
         raise TypeError(f"Unexpected value {value} of type {type(value)}")
 

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -37,8 +37,8 @@ class FlowWorkItem:
 
 WorkListItem = Union[FlowWorkItem, SSAWorkListItem]
 LatticeItem = Union[LatticeEnum, IRLiteral]
-Lattice = dict[IRVariable, LatticeItem]
-
+LatticeKey = Union[IRVariable, IRLabel]
+Lattice = dict[LatticeKey, LatticeItem]
 
 class SCCP(IRPass):
     """
@@ -96,6 +96,9 @@ class SCCP(IRPass):
         for v in self.dfg._dfg_outputs:
             self.lattice[v] = LatticeEnum.TOP
 
+        for bb in self.fn.get_basic_blocks():
+            self.lattice[bb.label] = LatticeEnum.TOP
+
         # Iterate over the work list until it is empty
         # Items in the work list can be either FlowWorkItem or SSAWorkListItem
         while len(self.work_list) > 0:
@@ -141,19 +144,20 @@ class SCCP(IRPass):
             self._visit_expr(work_item.inst)
 
     def _lookup_from_lattice(self, op: IROperand) -> LatticeItem:
-        assert isinstance(op, IRVariable), f"Can't get lattice for non-variable ({op})"
+        assert isinstance(op, LatticeKey), f"Can't get lattice for non-variable ({op})"
         lat = self.lattice[op]
         assert lat is not None, f"Got undefined var {op}"
         return lat
 
     def _set_lattice(self, op: IROperand, value: LatticeItem):
-        assert isinstance(op, IRVariable), "Can't set lattice for non-variable"
+        assert isinstance(op, LatticeKey), "Can't set lattice for non-variable"
         self.lattice[op] = value
 
     def _eval_from_lattice(self, op: IROperand) -> IRLiteral | LatticeEnum:
         if isinstance(op, IRLiteral):
             return op
 
+        assert isinstance(op, LatticeKey), f"Can't get lattice for non-variable or non-label ({op})"
         return self._lookup_from_lattice(op)
 
     def _visit_phi(self, inst: IRInstruction):
@@ -200,11 +204,13 @@ class SCCP(IRPass):
                 self.work_list.append(FlowWorkItem(inst.parent, target))
         elif opcode == "djmp":
             lat = self._eval_from_lattice(inst.operands[0])
-            assert lat != LatticeEnum.TOP, f"Got undefined var at jmp at {inst.parent}"
+            # assert lat != LatticeEnum.TOP, f"Got undefined var at jmp at {inst.parent}"
             if lat == LatticeEnum.BOTTOM:
                 for op in inst.operands[1:]:
                     target = self.fn.get_basic_block(op.name)
                     self.work_list.append(FlowWorkItem(inst.parent, target))
+            elif lat == LatticeEnum.TOP:
+                pass
             elif isinstance(lat, IRLiteral):
                 raise CompilerPanic("Unimplemented djmp with literal")
 
@@ -241,7 +247,7 @@ class SCCP(IRPass):
             # Evaluate the operand according to the lattice
             if isinstance(op, IRLabel):
                 return finalize(LatticeEnum.BOTTOM)
-            elif isinstance(op, IRVariable):
+            elif isinstance(op, LatticeKey):
                 eval_result = self.lattice[op]
             else:
                 eval_result = op

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -36,8 +36,9 @@ class FlowWorkItem:
 
 
 WorkListItem = Union[FlowWorkItem, SSAWorkListItem]
-LatticeItem = Union[LatticeEnum, IRLiteral]
+LatticeItem = Union[LatticeEnum, IRLiteral, IRLabel]
 Lattice = dict[IRVariable, LatticeItem]
+
 
 class SCCP(IRPass):
     """
@@ -149,7 +150,7 @@ class SCCP(IRPass):
         assert isinstance(op, IRVariable), f"Not a variable: {op}"
         self.lattice[op] = value
 
-    def _eval_from_lattice(self, op: IROperand) -> IRLiteral | LatticeEnum:
+    def _eval_from_lattice(self, op: IROperand) -> LatticeItem:
         if isinstance(op, (IRLiteral, IRLabel)):
             return op
 

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -36,6 +36,8 @@ class SimplifyCFGPass(IRPass):
         assert b.label in jump_inst.operands, f"{b.label} {jump_inst.operands}"
         jump_inst.operands[jump_inst.operands.index(b.label)] = next_bb.label
 
+        self._replace_label(b.label, next_bb.label)
+
         # Update CFG
         a.remove_cfg_out(b)
         a.add_cfg_out(next_bb)
@@ -104,17 +106,18 @@ class SimplifyCFGPass(IRPass):
                 replaced_label, replacement_label = replacement_label, replaced_label
                 next_bb.label = replacement_label
 
-            for bb2 in fn.get_basic_blocks():
-                for inst in bb2.instructions:
-                    for op in inst.operands:
-                        if isinstance(op, IRLabel) and op.value == replaced_label.value:
-                            op.value = replacement_label.value
+            self._replace_label(replaced_label, replacement_label)
 
             fn.remove_basic_block(bb)
             i -= 1
             count += 1
 
         return count
+
+    def _replace_label(self, original_label: IRLabel, replacement_label: IRLabel):
+        for bb in self.function.get_basic_blocks():
+            for inst in bb.instructions:
+                inst.replace_operands({original_label: replacement_label})
 
     def run_pass(self):
         fn = self.function

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -86,6 +86,8 @@ class SimplifyCFGPass(IRPass):
         """
         Remove empty basic blocks.
         """
+        # NOTE CMC 2025-03-12 this function is a no-op!
+
         fn = self.function
         worklist = list(fn.get_basic_blocks())
         i = count = 0


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
this commit allows labels to be assigned to variables. it updates
assumptions in `SCCP` and the venom parser which blocked that behavior.

it also updates the text format for `djmp` to be like `jnz` (condition
is first). it also fixes a bug in SimplifyCFG where `merge_jump` did
not rename label operands.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
