### PR TITLE
fix: raise better error when source content unexpected

### DIFF
--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -376,7 +376,8 @@ def compile_files(
         # rare, strange race conditions if the file changes in between
         # the two reads).
         file = input_bundle.load_file(file_path)
-        assert isinstance(file, FileInput)  # mypy hint
+        if not isinstance(file, FileInput):
+            raise ValueError(f"Invalid Vyper content: '{file_path}'")
 
         storage_layout_override = None
         if storage_layout_paths:


### PR DESCRIPTION
### What I did

fixes: #4523 

### How I did it

Insteat of a mypy assert, raise a more helpful ValueError

### How to verify it

Compile a Vyper file with ABI json for the content.
Notice error improvement.

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

improve error message when a `.vy.` source file content is ABI JSON

### Cute Animal Picture

◡̈
