### PR TITLE
feat[venom]: parse hex literals in text format 

### DIFF
--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -22,11 +22,13 @@ def test_single_bb():
 
     assert_ctx_eq(parsed_ctx, expected_ctx)
 
+
 def test_hex_literal():
     source = """
     function main {
         main:
-            mstore 0x1, 0x01
+            mstore 0, 0x7  ; test odd-length literal
+            mstore 1, 0x03
     }
     """
 
@@ -35,7 +37,8 @@ def test_hex_literal():
     expected_ctx = IRContext()
     expected_ctx.add_function(main_fn := IRFunction(IRLabel("main")))
     main_bb = main_fn.get_basic_block("main")
-    main_bb.append_instruction("mstore", IRLiteral(1), IRLiteral(1))
+    main_bb.append_instruction("mstore", IRLiteral(0), IRLiteral(7))
+    main_bb.append_instruction("mstore", IRLiteral(1), IRLiteral(3))
 
     assert_ctx_eq(parsed_ctx, expected_ctx)
 

--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -37,8 +37,8 @@ def test_hex_literal():
     expected_ctx = IRContext()
     expected_ctx.add_function(main_fn := IRFunction(IRLabel("main")))
     main_bb = main_fn.get_basic_block("main")
-    main_bb.append_instruction("mstore", IRLiteral(0), IRLiteral(7))
-    main_bb.append_instruction("mstore", IRLiteral(1), IRLiteral(3))
+    main_bb.append_instruction("mstore", IRLiteral(7), IRLiteral(0))
+    main_bb.append_instruction("mstore", IRLiteral(3), IRLiteral(1))
 
     assert_ctx_eq(parsed_ctx, expected_ctx)
 

--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -22,6 +22,23 @@ def test_single_bb():
 
     assert_ctx_eq(parsed_ctx, expected_ctx)
 
+def test_hex_literal():
+    source = """
+    function main {
+        main:
+            mstore 0x1, 0x01
+    }
+    """
+
+    parsed_ctx = parse_venom(source)
+
+    expected_ctx = IRContext()
+    expected_ctx.add_function(main_fn := IRFunction(IRLabel("main")))
+    main_bb = main_fn.get_basic_block("main")
+    main_bb.append_instruction("mstore", IRLiteral(1), IRLiteral(1))
+
+    assert_ctx_eq(parsed_ctx, expected_ctx)
+
 
 def test_multi_bb_single_fn():
     source = """

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -213,7 +213,7 @@ class VenomTransformer(Transformer):
         return IRVariable(var_ident[1:])
 
     def CONST(self, val) -> IRLiteral:
-        if str(val).startswith('0x'):
+        if str(val).startswith("0x"):
             return IRLiteral(int(val, 16))
         return IRLiteral(int(val))
 

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -47,7 +47,7 @@ VENOM_GRAMMAR = """
 
     operand: VAR_IDENT | CONST | LABEL
 
-    CONST: SIGNED_INT
+    CONST: SIGNED_INT | "0x" HEXDIGIT+
     OPCODE: CNAME
     VAR_IDENT: "%" (DIGIT|LETTER|"_"|":")+
 
@@ -213,6 +213,8 @@ class VenomTransformer(Transformer):
         return IRVariable(var_ident[1:])
 
     def CONST(self, val) -> IRLiteral:
+        if str(val).startswith('0x'):
+            return IRLiteral(int(val, 16))
         return IRLiteral(int(val))
 
     def CNAME(self, val) -> str:


### PR DESCRIPTION
### What I did

Added hex parsing support to the venom text format parser

### How I did it

### How to verify it

### Commit message

```
This commit adds hex parsing support to the venom text format parser
```

### Description for the changelog

