### PR TITLE
refactor[venom]: add dom walk property

### DIFF
--- a/vyper/venom/analysis/dominators.py
+++ b/vyper/venom/analysis/dominators.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import Iterator
 
 from vyper.exceptions import CompilerPanic
@@ -34,6 +33,8 @@ class DominatorTreeAnalysis(IRAnalysis):
         self.dominator_frontiers = {}
 
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
+        self.cfg_post_walk = list(self.cfg.dfs_post_walk)
+        self.cfg_post_order = {bb: idx for idx, bb in enumerate(self.cfg_post_walk)}
 
         self._compute_dominators()
         self._compute_idoms()
@@ -55,7 +56,7 @@ class DominatorTreeAnalysis(IRAnalysis):
         """
         Compute dominators
         """
-        basic_blocks = list(self._dfs_post_order.keys())
+        basic_blocks = self.cfg_post_walk
         self.dominators = {bb: OrderedSet(basic_blocks) for bb in basic_blocks}
         self.dominators[self.entry_block] = OrderedSet([self.entry_block])
         changed = True
@@ -81,15 +82,15 @@ class DominatorTreeAnalysis(IRAnalysis):
         """
         Compute immediate dominators
         """
-        self.immediate_dominators = {bb: None for bb in self._dfs_post_order.keys()}
+        self.immediate_dominators = {bb: None for bb in self.cfg_post_walk}
         self.immediate_dominators[self.entry_block] = self.entry_block
-        for bb in self._dfs_post_walk:
+        for bb in self.cfg_post_walk:
             if bb == self.entry_block:
                 continue
-            doms = sorted(self.dominators[bb], key=lambda x: self._dfs_post_order[x])
+            doms = sorted(self.dominators[bb], key=lambda x: self.cfg_post_order[x])
             self.immediate_dominators[bb] = doms[1]
 
-        self.dominated = {bb: OrderedSet() for bb in self._dfs_post_walk}
+        self.dominated = {bb: OrderedSet() for bb in self.cfg_post_walk}
         for dom, target in self.immediate_dominators.items():
             self.dominated[target].add(dom)
 
@@ -97,10 +98,10 @@ class DominatorTreeAnalysis(IRAnalysis):
         """
         Compute dominance frontier
         """
-        basic_blocks = self._dfs_post_walk
+        basic_blocks = self.cfg_post_walk
         self.dominator_frontiers = {bb: OrderedSet() for bb in basic_blocks}
 
-        for bb in self._dfs_post_walk:
+        for bb in self.cfg_post_walk:
             if len(bb.cfg_in) > 1:
                 for pred in bb.cfg_in:
                     runner = pred
@@ -121,7 +122,7 @@ class DominatorTreeAnalysis(IRAnalysis):
         """
         Find the nearest common dominator of two basic blocks.
         """
-        dfs_order = self.dfs_order
+        dfs_order = self.cfg_post_order
         while bb1 != bb2:
             while dfs_order[bb1] < dfs_order[bb2]:
                 bb1 = self.immediate_dominators[bb1]
@@ -145,14 +146,6 @@ class DominatorTreeAnalysis(IRAnalysis):
             yield bb
 
         return visit(self.entry_block)
-
-    @cached_property
-    def _dfs_post_walk(self) -> list[IRBasicBlock]:
-        return list(self.cfg.dfs_post_walk)
-
-    @cached_property
-    def _dfs_post_order(self) -> dict[IRBasicBlock, int]:
-        return {bb: idx for idx, bb in enumerate(self._dfs_post_walk)}
 
     def as_graph(self) -> str:
         """

--- a/vyper/venom/passes/make_ssa.py
+++ b/vyper/venom/passes/make_ssa.py
@@ -35,8 +35,8 @@ class MakeSSA(IRPass):
         Add phi nodes to the function.
         """
         self._compute_defs()
-        work = {bb: 0 for bb in self.dom.dfs_post_walk}
-        has_already = {bb: 0 for bb in self.dom.dfs_post_walk}
+        work = {bb: 0 for bb in self.dom.dom_post_order()}
+        has_already = {bb: 0 for bb in self.dom.dom_post_order()}
         i = 0
 
         # Iterate over all variables
@@ -152,7 +152,7 @@ class MakeSSA(IRPass):
         Compute the definition points of variables in the function.
         """
         self.defs = {}
-        for bb in self.dom.dfs_post_walk:
+        for bb in self.dom.dom_post_order():
             assignments = bb.get_assignments()
             for var in assignments:
                 if var not in self.defs:

--- a/vyper/venom/passes/make_ssa.py
+++ b/vyper/venom/passes/make_ssa.py
@@ -35,8 +35,8 @@ class MakeSSA(IRPass):
         Add phi nodes to the function.
         """
         self._compute_defs()
-        work = {bb: 0 for bb in self.dom.dom_post_order()}
-        has_already = {bb: 0 for bb in self.dom.dom_post_order()}
+        work = {bb: 0 for bb in self.dom.dom_post_order}
+        has_already = {bb: 0 for bb in self.dom.dom_post_order}
         i = 0
 
         # Iterate over all variables
@@ -152,7 +152,7 @@ class MakeSSA(IRPass):
         Compute the definition points of variables in the function.
         """
         self.defs = {}
-        for bb in self.dom.dom_post_order():
+        for bb in self.dom.dom_post_order:
             assignments = bb.get_assignments()
             for var in assignments:
                 if var not in self.defs:


### PR DESCRIPTION
### What I did

Refactored `DominatorTreeAnalysis` to be more clear. Added a dominator post-order traversal property.

### How I did it

### How to verify it

### Commit message

```
Refactor `DominatorTreeAnalysis` to be more clear regarding cfg walk
usage. Add a dominator post-order traversal property.

The `MakeSSA` pass is refactored to use dom tree walk instead of CFG
post walk. Traversing based on the dominator tree is not technically
mandatory but it aligns with the algorithm's reliance on dominance and
simplifies the renaming phase.
```

### Description for the changelog

### Cute Animal Picture

![image-14](https://github.com/user-attachments/assets/57b7785f-6805-4a3a-a841-c8492ce1a5f4)

