### PR TITLE
fix[ux]: typechecking for loop annotation of list variable

### DIFF
--- a/tests/functional/codegen/features/iteration/test_for_in_list.py
+++ b/tests/functional/codegen/features/iteration/test_for_in_list.py
@@ -847,6 +847,38 @@ def foo():
     """,
         UnknownType,
     ),
+    # Mismatch between iterator and iterable types: struct
+    (
+        """
+struct Tx1:
+    x: uint256
+    y: address
+
+struct Tx2:
+    x: uint256
+    y: address
+
+@external
+def test():
+    txs: Tx1[20] = empty(Tx1[20])
+
+    for txx: Tx2 in txs:  # should be `txx: Tx1`
+        pass
+    """,
+        TypeMismatch,
+    ),
+    # Mismatch between iterator and iterable types: primitive
+    (
+        """
+@external
+def test():
+    txs: uint256[20] = empty(uint256[20])
+
+    for txx: uint248 in txs:
+        pass
+    """,
+        TypeMismatch,
+    ),
 ]
 
 BAD_CODE = [code if isinstance(code, tuple) else (code, StructureException) for code in BAD_CODE]

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -531,7 +531,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         for arg in (*args, *kwargs):
             self.expr_visitor.visit(arg, target_type)
 
-    def _analyse_list_iter(self, iter_node, target_node, target_type):
+    def _analyse_list_iter(self, target_node, iter_node, target_type):
         # iteration over a variable or literal list
         iter_val = iter_node.reduced()
 
@@ -574,7 +574,8 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             # sanity check the postcondition of analyse_range_iter
             assert isinstance(target_type, IntegerT)
         else:
-            iter_var = self._analyse_list_iter(node.iter, node.target.target, target_type)
+            # note: using `node.target` here results in bad source location.
+            iter_var = self._analyse_list_iter(node.target.target, node.iter, target_type)
 
         with self.namespace.enter_scope(), self.enter_for_loop(iter_var):
             target_name = node.target.target.id

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -543,13 +543,21 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         else:
             try:
                 iter_type = get_exact_type_from_node(iter_node)
+
+                # CMC 2024-02-09 TODO: use validate_expected_type once we have DArrays
+                # with generic length.
+                if not isinstance(iter_type, (DArrayT, SArrayT)):
+                    raise InvalidType("Not an iterable type", iter_node)
+
+                if not target_type.compare_type(iter_type.value_type):
+                    raise TypeMismatch(
+                        f"Iterator has a type of {target_type} but "
+                        f"iterable has a type of {iter_type}",
+                        iter_node,
+                    )
+
             except (InvalidType, StructureException):
                 raise InvalidType("Not an iterable type", iter_node)
-
-        # CMC 2024-02-09 TODO: use validate_expected_type once we have DArrays
-        # with generic length.
-        if not isinstance(iter_type, (DArrayT, SArrayT)):
-            raise InvalidType("Not an iterable type", iter_node)
 
         self.expr_visitor.visit(iter_node, iter_type)
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -531,7 +531,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         for arg in (*args, *kwargs):
             self.expr_visitor.visit(arg, target_type)
 
-    def _analyse_list_iter(self, iter_node, target_type):
+    def _analyse_list_iter(self, iter_node, target_node, target_type):
         # iteration over a variable or literal list
         iter_val = iter_node.reduced()
 
@@ -553,10 +553,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             raise InvalidType("Not an iterable type", iter_node)
 
         if not target_type.compare_type(iter_type.value_type):
-            raise TypeMismatch(
-                f"Iterator has a type of {target_type} but iterable has a type of {iter_type}",
-                iter_node,
-            )
+            raise TypeMismatch(f"Expected type of {iter_type.value_type}", target_node)
 
         self.expr_visitor.visit(iter_node, iter_type)
 
@@ -577,7 +574,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             # sanity check the postcondition of analyse_range_iter
             assert isinstance(target_type, IntegerT)
         else:
-            iter_var = self._analyse_list_iter(node.iter, target_type)
+            iter_var = self._analyse_list_iter(node.iter, node.target.target, target_type)
 
         with self.namespace.enter_scope(), self.enter_for_loop(iter_var):
             target_name = node.target.target.id

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -544,20 +544,19 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             try:
                 iter_type = get_exact_type_from_node(iter_node)
 
-                # CMC 2024-02-09 TODO: use validate_expected_type once we have DArrays
-                # with generic length.
-                if not isinstance(iter_type, (DArrayT, SArrayT)):
-                    raise InvalidType("Not an iterable type", iter_node)
-
-                if not target_type.compare_type(iter_type.value_type):
-                    raise TypeMismatch(
-                        f"Iterator has a type of {target_type} but "
-                        f"iterable has a type of {iter_type}",
-                        iter_node,
-                    )
-
             except (InvalidType, StructureException):
                 raise InvalidType("Not an iterable type", iter_node)
+
+        # CMC 2024-02-09 TODO: use validate_expected_type once we have DArrays
+        # with generic length.
+        if not isinstance(iter_type, (DArrayT, SArrayT)):
+            raise InvalidType("Not an iterable type", iter_node)
+
+        if not target_type.compare_type(iter_type.value_type):
+            raise TypeMismatch(
+                f"Iterator has a type of {target_type} but iterable has a type of {iter_type}",
+                iter_node,
+            )
 
         self.expr_visitor.visit(iter_node, iter_type)
 


### PR DESCRIPTION
### What I did

Fix #4549

### How I did it

Add a check that the type derived for a variable list matches the iterator type specified in the for loop annotation.

### How to verify it

See new tests.

### Commit message

```
This commit fixes a compiler panic for `for` loops by properly catching
type mismatch between the iterator and target during semantic analysis
```

### Description for the changelog

Typechecking for loop annotation of variable list

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://flatout.com.au/wp-content/uploads/2023/02/yellow-octopus-koala-australia.jpg)
