### PR TITLE
fix[lang]: update comparison operation handling and improve value expression parsing #4444

### DIFF
--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -570,7 +570,7 @@ class Expr:
             if left.typ == right.typ and right.typ == UINT256_T:
                 # signed comparison ops work for any integer
                 # type BESIDES uint256
-                op = self._signed_to_unsigned_comparison_op(op)
+                op = Expr._signed_to_unsigned_comparison_op(op)
 
         elif left.typ._is_prim_word and right.typ._is_prim_word:
             if op not in ("eq", "ne"):
@@ -810,7 +810,11 @@ class Expr:
     # Parse an expression that results in a value
     @classmethod
     def parse_value_expr(cls, expr, context):
-        return unwrap_location(cls(expr, context).ir_node)
+        ir_node = cls(expr, context).ir_node
+        # Don't unwrap Bytes or String constants as they're already properly initialized
+        if ir_node.location is not None and isinstance(ir_node.typ, (_BytestringT)):
+            return ir_node
+        return unwrap_location(ir_node)
 
     # Parse an expression that represents a pointer to memory/calldata or storage.
     @classmethod


### PR DESCRIPTION
# fix[lang]: update comparison operation handling and improve value expression parsing

This commit modifies the handling of signed to unsigned comparison operations by making the method call static. Additionally, it enhances the `parse_value_expr` method to prevent unwrapping of `Bytes` or `String` constants, ensuring they remain properly initialized.

### What I did
- Fixed a bug where Bytes and String constants were incorrectly unwrapped, causing compiler panics
- Made the `_signed_to_unsigned_comparison_op` method a static class method for proper usage

### How I did it
- Added a check in `parse_value_expr` to prevent unwrapping IR nodes with bytestring types and a location
- Changed the method call from instance-based to class-based for the comparison operation conversion

### How to verify it
- Run the compiler on code with constant Bytes/String variables, especially when those constants are used in expressions or derived from struct fields
- Test comparisons with integer types to ensure the static method works correctly

### Commit message
fix(codegen): prevent compiler panic on Bytes/String constants

This commit fixes an issue where constant Bytes and String variables would cause
compiler panics during code generation. The problem occurred when trying to unwrap
bytestring values that already had a proper memory structure.

Also fixed the `_signed_to_unsigned_comparison_op` method to properly use the
static class method.

### Description for the changelog
- Fixed compiler panic when using constant Bytes or String variables

### #4444