### PR TITLE
feat[lang]: remove `@external` decorator from builtin interfaces

### DIFF
--- a/vyper/builtins/interfaces/IERC165.vyi
+++ b/vyper/builtins/interfaces/IERC165.vyi
@@ -1,4 +1,3 @@
 @view
-@external
 def supportsInterface(interface_id: bytes4) -> bool:
     ...

--- a/vyper/builtins/interfaces/IERC20.vyi
+++ b/vyper/builtins/interfaces/IERC20.vyi
@@ -11,28 +11,22 @@ event Approval:
 
 # Functions
 @view
-@external
 def totalSupply() -> uint256:
     ...
 
 @view
-@external
 def balanceOf(_owner: address) -> uint256:
     ...
 
 @view
-@external
 def allowance(_owner: address, _spender: address) -> uint256:
     ...
 
-@external
 def transfer(_to: address, _value: uint256) -> bool:
     ...
 
-@external
 def transferFrom(_from: address, _to: address, _value: uint256) -> bool:
     ...
 
-@external
 def approve(_spender: address, _value: uint256) -> bool:
     ...

--- a/vyper/builtins/interfaces/IERC20Detailed.vyi
+++ b/vyper/builtins/interfaces/IERC20Detailed.vyi
@@ -3,16 +3,13 @@
 #    uses a value n >= 1. Regardless this is fine as one can't do String[0] where n == 0.
 
 @view
-@external
 def name() -> String[1]:
     ...
 
 @view
-@external
 def symbol() -> String[1]:
     ...
 
 @view
-@external
 def decimals() -> uint8:
     ...

--- a/vyper/builtins/interfaces/IERC4626.vyi
+++ b/vyper/builtins/interfaces/IERC4626.vyi
@@ -14,77 +14,61 @@ event Withdraw:
 
 # Functions
 @view
-@external
 def asset() -> address:
     ...
 
 @view
-@external
 def totalAssets() -> uint256:
     ...
 
 @view
-@external
 def convertToShares(assetAmount: uint256) -> uint256:
     ...
 
 @view
-@external
 def convertToAssets(shareAmount: uint256) -> uint256:
     ...
 
 @view
-@external
 def maxDeposit(owner: address) -> uint256:
     ...
 
 @view
-@external
 def previewDeposit(assets: uint256) -> uint256:
     ...
 
-@external
 def deposit(assets: uint256, receiver: address) -> uint256:
     ...
 
 @view
-@external
 def maxMint(owner: address) -> uint256:
     ...
 
 @view
-@external
 def previewMint(shares: uint256) -> uint256:
     ...
 
-@external
 def mint(shares: uint256, receiver: address) -> uint256:
     ...
 
 @view
-@external
 def maxWithdraw(owner: address) -> uint256:
     ...
 
 @view
-@external
 def previewWithdraw(assets: uint256) -> uint256:
     ...
 
-@external
 def withdraw(assets: uint256, receiver: address, owner: address) -> uint256:
     ...
 
 @view
-@external
 def maxRedeem(owner: address) -> uint256:
     ...
 
 @view
-@external
 def previewRedeem(shares: uint256) -> uint256:
     ...
 
-@external
 def redeem(shares: uint256, receiver: address, owner: address) -> uint256:
     ...

--- a/vyper/builtins/interfaces/IERC721.vyi
+++ b/vyper/builtins/interfaces/IERC721.vyi
@@ -18,45 +18,36 @@ event ApprovalForAll:
 # Functions
 
 @view
-@external
 def supportsInterface(interface_id: bytes4) -> bool:
     ...
 
 @view
-@external
 def balanceOf(_owner: address) -> uint256:
     ...
 
 @view
-@external
 def ownerOf(_tokenId: uint256) -> address:
     ...
 
 @view
-@external
 def getApproved(_tokenId: uint256) -> address:
     ...
 
 @view
-@external
 def isApprovedForAll(_owner: address, _operator: address) -> bool:
     ...
 
-@external
 @payable
 def transferFrom(_from: address, _to: address, _tokenId: uint256):
     ...
 
-@external
 @payable
 def safeTransferFrom(_from: address, _to: address, _tokenId: uint256, _data: Bytes[1024] = b""):
     ...
 
-@external
 @payable
 def approve(_approved: address, _tokenId: uint256):
     ...
 
-@external
 def setApprovalForAll(_operator: address, _approved: bool):
     ...


### PR DESCRIPTION
in interfaces, `@external` is already implicit. also, in error messages, not having the extra line helps with context

particularly in the context of https://github.com/vyperlang/vyper/pull/4359, the `@view` decorator gets cut off without this PR.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
