### PR TITLE
fix[lang]: block modules in structs

### DIFF
--- a/tests/functional/syntax/modules/test_module_instantiation.py
+++ b/tests/functional/syntax/modules/test_module_instantiation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from vyper.compiler import compile_code
+from vyper.exceptions import InstantiationException, StructureException
+
+fail_list = [
+    (
+        """
+import lib1
+h: HashMap[uint256, lib1]
+""",
+        InstantiationException,
+        ".*is not instantiable in storage",
+    ),
+    (
+        """
+import lib1
+
+struct S:
+    l: lib1
+    """,
+        StructureException,
+        ".*not a valid struct member",
+    ),
+    (
+        """
+import lib1
+
+d: DynArray[lib1, 10]
+    """,
+        StructureException,
+        ".*Arrays of.*are not allowed",
+    ),
+]
+
+
+@pytest.mark.parametrize("bad_code,exc,match_regex", fail_list)
+def test_module_instantiation(make_input_bundle, bad_code, exc, match_regex):
+    lib1 = """
+foo: uint256
+        """
+
+    input_bundle = make_input_bundle({"lib1.vy": lib1})
+
+    with pytest.raises(exc, match=match_regex):
+        compile_code(bad_code, input_bundle=input_bundle)

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -50,6 +50,10 @@ class VyperType:
         The name of the type.
     _as_array: bool, optional
         If `True`, this type can be used as the base member for an array.
+    _as_hashmap_key: bool, optional
+        If `True`, this type can be used as a hashmap key
+    _as_tuple_member: bool, optional
+        If `True`, this type can be used as a tuple member
     _valid_literal : Tuple
         A tuple of Vyper ast classes that may be assigned this type.
     _invalid_locations : Tuple
@@ -78,6 +82,8 @@ class VyperType:
 
     _as_array: bool = False  # rename to something like can_be_array_member
     _as_hashmap_key: bool = False
+    _as_tuple_member: bool = True  # can be a tuple member
+
 
     _supports_external_calls: bool = False
     _attribute_in_annotation: bool = False

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -84,7 +84,6 @@ class VyperType:
     _as_hashmap_key: bool = False
     _as_tuple_member: bool = True  # can be a tuple member
 
-
     _supports_external_calls: bool = False
     _attribute_in_annotation: bool = False
 

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -288,6 +288,9 @@ class ModuleT(VyperType):
     typeclass = "module"
 
     _attribute_in_annotation = True
+    _as_array = False
+    _as_hashmap_key = False
+    _as_tuple_member = False
     _invalid_locations = (
         DataLocation.STORAGE,
         DataLocation.CALLDATA,

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -330,6 +330,9 @@ class TupleT(VyperType):
 
     def __init__(self, member_types: Tuple[VyperType, ...]) -> None:
         super().__init__()
+        for mt in member_types:
+            if not mt._as_tuple_member:
+                raise StructureException(f"not a valid tuple member: {mt}")
         self.member_types = member_types
         self.key_type = UINT256_T  # API Compatibility
 

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -337,6 +337,10 @@ class StructT(_UserType):
     def __init__(self, _id, members, ast_def=None):
         super().__init__(members)
 
+        for mt in members.values():
+            if not mt._as_tuple_member:
+                raise StructureException(f"not a valid struct member: {mt}")
+
         self._id = _id
 
         self.ast_def = ast_def


### PR DESCRIPTION
### What I did
modules could have been instantiated
```
import lib1

struct A:
    a: lib1

h: DynArray[A, 5]
```

a further question is whether to refactor location validation - a module can't be instantiated in storage, yet it's possible as shown in the example above. the location check should  also recurse on the subtypes. i'm for refactor as it will help prevent potential future bugs

### Commit Message

````
prior to this commit, modules could be added as a struct member,
as below:

```vyper
import lib1

struct A:
    a: lib1

h: DynArray[A, 5]
```

this commit blocks the behavior.
````