### PR TITLE
refactor[parser]: put settings on Module AST node

### DIFF
--- a/vyper/ast/__init__.py
+++ b/vyper/ast/__init__.py
@@ -7,7 +7,7 @@ from . import nodes, validation
 from .natspec import parse_natspec
 from .nodes import as_tuple
 from .utils import ast_to_dict
-from .parse import parse_to_ast, parse_to_ast_with_settings
+from .parse import parse_to_ast
 
 # adds vyper.ast.nodes classes into the local namespace
 for name, obj in (

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -617,7 +617,11 @@ class TopLevel(VyperNode):
 
 class Module(TopLevel):
     # metadata
-    __slots__ = ("path", "resolved_path", "source_id", "is_interface")
+    __slots__ = ("path", "resolved_path", "source_id", "is_interface", "settings")
+    """
+    settings: Settings
+        settings result from parsing the compiler pragmas in the file.
+    """
 
     def to_dict(self):
         return dict(source_sha256sum=self.source_sha256sum, **super().to_dict())

--- a/vyper/ast/nodes.pyi
+++ b/vyper/ast/nodes.pyi
@@ -1,9 +1,10 @@
 import ast as python_ast
 from typing import Any, Optional, Sequence, Type, Union
 
+from vyper.compiler.settings import Settings
+
 from .natspec import parse_natspec as parse_natspec
 from .parse import parse_to_ast as parse_to_ast
-from .parse import parse_to_ast_with_settings as parse_to_ast_with_settings
 from .utils import ast_to_dict as ast_to_dict
 
 NODE_BASE_ATTRIBUTES: Any
@@ -72,6 +73,7 @@ class Module(TopLevel):
     resolved_path: str = ...
     source_id: int = ...
     is_interface: bool = ...
+    settings: Settings = ...
     def namespace(self) -> Any: ...  # context manager
 
 class FunctionDef(TopLevel):

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -3,31 +3,25 @@ import pickle
 import tokenize
 from decimal import Decimal
 from functools import cached_property
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.pre_parser import PreParser
-from vyper.compiler.settings import Settings
 from vyper.exceptions import CompilerPanic, ParserException, SyntaxException
 from vyper.utils import sha256sum
 from vyper.warnings import Deprecation, vyper_warn
 
 
-def parse_to_ast(*args: Any, **kwargs: Any) -> vy_ast.Module:
-    _settings, ast = parse_to_ast_with_settings(*args, **kwargs)
-    return ast
-
-
-def parse_to_ast_with_settings(
+def parse_to_ast(
     vyper_source: str,
     source_id: int = 0,
     module_path: Optional[str] = None,
     resolved_path: Optional[str] = None,
     add_fn_node: Optional[str] = None,
     is_interface: bool = False,
-) -> tuple[Settings, vy_ast.Module]:
+) -> vy_ast.Module:
     try:
-        return _parse_to_ast_with_settings(
+        return _parse_to_ast(
             vyper_source, source_id, module_path, resolved_path, add_fn_node, is_interface
         )
     except SyntaxException as e:
@@ -35,14 +29,14 @@ def parse_to_ast_with_settings(
         raise e
 
 
-def _parse_to_ast_with_settings(
+def _parse_to_ast(
     vyper_source: str,
     source_id: int = 0,
     module_path: Optional[str] = None,
     resolved_path: Optional[str] = None,
     add_fn_node: Optional[str] = None,
     is_interface: bool = False,
-) -> tuple[Settings, vy_ast.Module]:
+) -> vy_ast.Module:
     """
     Parses a Vyper source string and generates basic Vyper AST nodes.
 
@@ -136,7 +130,9 @@ def _parse_to_ast_with_settings(
     assert isinstance(module, vy_ast.Module)  # mypy hint
     module.is_interface = is_interface
 
-    return pre_parser.settings, module
+    module.settings = pre_parser.settings
+
+    return module
 
 
 LINE_INFO_FIELDS = ("lineno", "col_offset", "end_lineno", "end_col_offset")

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -114,16 +114,22 @@ class CompilerData:
         return self.file_input.path
 
     @cached_property
-    def _generate_ast(self):
+    def vyper_module(self):
         is_vyi = self.contract_path.suffix == ".vyi"
 
-        settings, ast = vy_ast.parse_to_ast_with_settings(
+        ast = vy_ast.parse_to_ast(
             self.source_code,
             self.source_id,
             module_path=self.contract_path.as_posix(),
             resolved_path=self.file_input.resolved_path.as_posix(),
             is_interface=is_vyi,
         )
+
+        return ast
+
+    @cached_property
+    def settings(self):
+        settings = self.vyper_module.settings
 
         if self.original_settings:
             og_settings = self.original_settings
@@ -140,17 +146,7 @@ class CompilerData:
         if settings.experimental_codegen is None:
             settings.experimental_codegen = False
 
-        return settings, ast
-
-    @cached_property
-    def settings(self):
-        settings, _ = self._generate_ast
         return settings
-
-    @cached_property
-    def vyper_module(self):
-        _, ast = self._generate_ast
-        return ast
 
     def _compute_integrity_sum(self, imports_integrity_sum: str) -> str:
         if self.storage_layout_override is not None:


### PR DESCRIPTION
remove `parse_to_ast_with_settings`, and replace it with directly putting the settings parsed from the pragmas on the AST. this allows us to respect pragmas on a file-by-file basis if needed.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
