### PR TITLE
fix[lang]: only reserve builtins at the top level

### DIFF
--- a/tests/functional/codegen/modules/test_stateless_functions.py
+++ b/tests/functional/codegen/modules/test_stateless_functions.py
@@ -1,8 +1,8 @@
 import hypothesis.strategies as st
-from tests.utils import working_directory
 import pytest
 from hypothesis import given, settings
 
+from tests.utils import working_directory
 from vyper import compiler
 from vyper.exceptions import (
     CallViolation,

--- a/vyper/compiler/input_bundle.py
+++ b/vyper/compiler/input_bundle.py
@@ -15,6 +15,9 @@ PathLike = Path | PurePath
 if TYPE_CHECKING:
     from zipfile import ZipFile
 
+# hacky sentinel to indicate that a file came from InputBundle for builtins
+BUILTIN = -2
+
 
 @dataclass(frozen=True)
 class CompilerInput:
@@ -31,6 +34,10 @@ class CompilerInput:
     @cached_property
     def sha256sum(self):
         return sha256sum(self.contents)
+
+    @property
+    def from_builtin(self):
+        return self.source_id == BUILTIN
 
 
 @dataclass(frozen=True)

--- a/vyper/compiler/output_bundle.py
+++ b/vyper/compiler/output_bundle.py
@@ -56,7 +56,7 @@ class OutputBundle:
     @cached_property
     def compiler_inputs(self) -> dict[str, CompilerInput]:
         inputs: list[CompilerInput] = [
-            t.compiler_input for t in self._imports if not _is_builtin(t.qualified_module_name)
+            t.compiler_input for t in self._imports if not _is_builtin(0, t.qualified_module_name)
         ]
         inputs.append(self.compiler_data.file_input)
 

--- a/vyper/compiler/output_bundle.py
+++ b/vyper/compiler/output_bundle.py
@@ -11,7 +11,6 @@ from vyper.compiler.input_bundle import CompilerInput, _NotFound
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import Settings
 from vyper.exceptions import CompilerPanic
-from vyper.semantics.analysis.imports import _is_builtin
 from vyper.typing import StorageLayout
 from vyper.utils import get_long_version, safe_relpath
 
@@ -56,7 +55,7 @@ class OutputBundle:
     @cached_property
     def compiler_inputs(self) -> dict[str, CompilerInput]:
         inputs: list[CompilerInput] = [
-            t.compiler_input for t in self._imports if not _is_builtin(0, t.qualified_module_name)
+            t.compiler_input for t in self._imports if not t.from_builtin
         ]
         inputs.append(self.compiler_data.file_input)
 

--- a/vyper/compiler/output_bundle.py
+++ b/vyper/compiler/output_bundle.py
@@ -55,7 +55,7 @@ class OutputBundle:
     @cached_property
     def compiler_inputs(self) -> dict[str, CompilerInput]:
         inputs: list[CompilerInput] = [
-            t.compiler_input for t in self._imports if not t.from_builtin
+            t.compiler_input for t in self._imports if not t.compiler_input.from_builtin
         ]
         inputs.append(self.compiler_data.file_input)
 

--- a/vyper/semantics/analysis/imports.py
+++ b/vyper/semantics/analysis/imports.py
@@ -1,5 +1,6 @@
 import contextlib
-from dataclasses import dataclass, field
+import dataclasses as dc
+from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any, Iterator, Optional
 
@@ -7,6 +8,7 @@ import vyper.builtins.interfaces
 import vyper.builtins.stdlib
 from vyper import ast as vy_ast
 from vyper.compiler.input_bundle import (
+    BUILTIN,
     ABIInput,
     CompilerInput,
     FileInput,
@@ -35,11 +37,11 @@ segregate the I/O portion of semantic analysis into its own pass.
 @dataclass
 class _ImportGraph:
     # the current path in the import graph traversal
-    _path: list[vy_ast.Module] = field(default_factory=list)
+    _path: list[vy_ast.Module] = dc.field(default_factory=list)
 
     # stack of dicts, each item in the stack is a dict keeping
     # track of imports in the current module
-    _imports: list[dict] = field(default_factory=list)
+    _imports: list[dict] = dc.field(default_factory=list)
 
     @property
     def imported_modules(self):
@@ -324,6 +326,8 @@ def _load_builtin_import(level: int, module_str: str) -> tuple[CompilerInput, vy
 
     try:
         file = input_bundle.load_file(path)
+        # set source_id to builtin sentinel value
+        file = dc.replace(file, source_id=BUILTIN)
         assert isinstance(file, FileInput)  # mypy hint
     except FileNotFoundError as e:
         hint = None

--- a/vyper/semantics/analysis/imports.py
+++ b/vyper/semantics/analysis/imports.py
@@ -159,7 +159,7 @@ class ImportAnalyzer:
     def _load_import(
         self, node: vy_ast.VyperNode, level: int, module_str: str, alias: str
     ) -> tuple[CompilerInput, Any]:
-        if level == 0 and _is_builtin(module_str):
+        if _is_builtin(level, module_str):
             return _load_builtin_import(level, module_str)
 
         path = _import_to_path(level, module_str)
@@ -288,8 +288,8 @@ def _get_builtin_prefix(module_str: str):
     return None
 
 
-def _is_builtin(module_str):
-    return _get_builtin_prefix(module_str) is not None
+def _is_builtin(level, module_str):
+    return level == 0 and _get_builtin_prefix(module_str) is not None
 
 
 def _load_builtin_import(level: int, module_str: str) -> tuple[CompilerInput, vy_ast.Module]:

--- a/vyper/semantics/analysis/imports.py
+++ b/vyper/semantics/analysis/imports.py
@@ -1,7 +1,7 @@
 import contextlib
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from typing import Any, Iterator
+from typing import Any, Iterator, Optional
 
 import vyper.builtins.interfaces
 import vyper.builtins.stdlib
@@ -281,14 +281,14 @@ BUILTIN_MODULE_RULES = {
 
 
 # TODO: could move this to analysis/common.py or something
-def _get_builtin_prefix(module_str: str):
+def _get_builtin_prefix(module_str: str) -> Optional[str]:
     for prefix in BUILTIN_MODULE_RULES.keys():
         if module_str.startswith(prefix):
             return prefix
     return None
 
 
-def _is_builtin(level, module_str):
+def _is_builtin(level: int, module_str: str) -> bool:
     return level == 0 and _get_builtin_prefix(module_str) is not None
 
 

--- a/vyper/semantics/analysis/imports.py
+++ b/vyper/semantics/analysis/imports.py
@@ -159,7 +159,7 @@ class ImportAnalyzer:
     def _load_import(
         self, node: vy_ast.VyperNode, level: int, module_str: str, alias: str
     ) -> tuple[CompilerInput, Any]:
-        if _is_builtin(module_str):
+        if level == 0 and _is_builtin(module_str):
             return _load_builtin_import(level, module_str)
 
         path = _import_to_path(level, module_str)


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
commit 1591a1229cf837ccca introduced a regression in snekmate, which is
that imports of the form `from .. import math` are rejected, due to the
assertion that `level == 0` on L299 inside of _load_builtin_import.

this was already a latent bug for several versions, but was not
previously tripped, since the only builtin namespace was `ethereum.ercs`
(and users presumably didn't have modules named `ethereum`).

this commit fixes builtin detection by protecting the builtin check with
an additional requirement that `level == 0` (indicating an absolute
import).

misc/refactor:
- add `from_builtin` property on FileInputs that come from the builtin
  loader
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
