### PR TITLE
feat[venom]: tune function inliner

### DIFF
--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -402,6 +402,8 @@ class IRInstruction:
 
     @property
     def code_size_cost(self) -> int:
+        if self.opcode in ("ret", "param"):
+            return 0
         if self.opcode == "store":
             return 1
         return 2


### PR DESCRIPTION
this commit tunes the function inliner by assigning `param` and `ret` instructions a cost of 0 (in fact, they should probably have negative cost, since those only have cost in the call convention overhead, but when inlined, they disappear).

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
