### PR TITLE
feat[venom]: add assert optimizer

### DIFF
--- a/tests/unit/compiler/test_source_map.py
+++ b/tests/unit/compiler/test_source_map.py
@@ -96,7 +96,7 @@ def test_pos_map_offsets():
             )
 
 
-def test_error_map():
+def test_error_map(experimental_codegen):
     code = """
 foo: uint256
 
@@ -106,7 +106,12 @@ def update_foo():
     """
     error_map = compile_code(code, output_formats=["source_map"])["source_map"]["error_map"]
     assert "safeadd" in error_map.values()
-    assert "fallback function" in error_map.values()
+
+    if experimental_codegen:
+        # fallback function gets turned into an assertion
+        pass
+    else:
+        assert "fallback function" in error_map.values()
 
 
 def test_error_map_with_user_error():

--- a/tests/unit/compiler/venom/test_revert_to_assert.py
+++ b/tests/unit/compiler/venom/test_revert_to_assert.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests.venom_utils import PrePostChecker
+from vyper.venom.passes import RevertToAssert, SimplifyCFGPass
+
+pytestmark = pytest.mark.hevm
+
+_check_pre_post = PrePostChecker(passes=[RevertToAssert, SimplifyCFGPass])
+
+
+def _check_no_change(pre):
+    _check_pre_post(pre, pre, hevm=False)
+
+
+def test_revert_to_assert():
+    pre = """
+    main:
+        %cond = param
+        jnz %cond, @revert_block, @else
+    revert_block:
+        revert 0, 0
+    else:
+        stop
+    """
+    post = """
+    main:
+        %cond = param
+        %1 = iszero %cond
+        assert %1
+        stop
+    """
+    _check_pre_post(pre, post)
+
+
+# same test but with branches flipped
+def test_revert_to_assert2():
+    pre = """
+    main:
+        %cond = param
+        jnz %cond, @then, @revert_block
+    then:
+        stop
+    revert_block:
+        revert 0, 0
+    """
+    post = """
+    main:
+        %cond = param
+        assert %cond
+        stop
+    """
+    _check_pre_post(pre, post)

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -24,6 +24,7 @@ from vyper.venom.passes import (
     MemMergePass,
     ReduceLiteralsCodesize,
     RemoveUnusedVariablesPass,
+    RevertToAssert,
     SimplifyCFGPass,
     StoreElimination,
     StoreExpansionPass,
@@ -70,6 +71,7 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
     LoadElimination(ac, fn).run_pass()
     SCCP(ac, fn).run_pass()
     StoreElimination(ac, fn).run_pass()
+    RevertToAssert(ac, fn).run_pass()
 
     SimplifyCFGPass(ac, fn).run_pass()
     MemMergePass(ac, fn).run_pass()

--- a/vyper/venom/passes/__init__.py
+++ b/vyper/venom/passes/__init__.py
@@ -11,6 +11,7 @@ from .mem2var import Mem2Var
 from .memmerging import MemMergePass
 from .normalization import NormalizationPass
 from .remove_unused_variables import RemoveUnusedVariablesPass
+from .revert_to_assert import RevertToAssert
 from .sccp import SCCP
 from .simplify_cfg import SimplifyCFGPass
 from .store_elimination import StoreElimination

--- a/vyper/venom/passes/revert_to_assert.py
+++ b/vyper/venom/passes/revert_to_assert.py
@@ -1,0 +1,49 @@
+from vyper.venom.analysis import CFGAnalysis
+from vyper.venom.basicblock import IRInstruction, IRLiteral
+from vyper.venom.passes.base_pass import IRPass
+
+# convert:
+# - jnz cond revert_block else to assert (iszero cond); jmp else
+# - jnz cond then revert_block to assert cond; jmp then
+
+
+class RevertToAssert(IRPass):
+    def run_pass(self):
+        self.analyses_cache.request_analysis(CFGAnalysis)
+        fn = self.function
+
+        for bb in fn.get_basic_blocks():
+            if len(bb.instructions) != 1:
+                continue
+            term = bb.instructions[0]
+            if term.opcode != "revert" or any(op != IRLiteral(0) for op in term.operands):
+                continue
+
+            for pred in bb.cfg_in:
+                if pred.instructions[-1].opcode != "jnz":
+                    continue
+
+                self._rewrite_jnz(pred, bb)
+
+        self.analyses_cache.invalidate_analysis(CFGAnalysis)
+
+    def _rewrite_jnz(self, pred, revert_bb):
+        term = pred.instructions[-1]
+        cond, then_label, else_label = term.operands
+        if then_label == revert_bb.label:
+            new_cond = self.function.get_next_variable()
+            iszero_inst = IRInstruction("iszero", [cond], output=new_cond)
+            assert_inst = IRInstruction("assert", [iszero_inst.output])
+            pred.insert_instruction(iszero_inst, index=-1)
+            pred.insert_instruction(assert_inst, index=-1)
+            # rewrite the jnz into a jmp
+            term.opcode = "jmp"
+            term.operands = [else_label]
+            return
+
+        if else_label == revert_bb.label:
+            assert_inst = IRInstruction("assert", [cond])
+            pred.insert_instruction(assert_inst, index=-1)
+            term.opcode = "jmp"
+            term.operands = [then_label]
+            return


### PR DESCRIPTION
this pass adds a revert-to-assert pass, which detects patterns where we `jnz` into a block which simply does `revert 0, 0`, and optimizes that into an `assert`, which is better for instruction reordering.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
