### PR TITLE
fix[venom]: revert-to-assert should invalidate dfg

### DIFF
--- a/vyper/venom/passes/revert_to_assert.py
+++ b/vyper/venom/passes/revert_to_assert.py
@@ -1,4 +1,4 @@
-from vyper.venom.analysis import CFGAnalysis
+from vyper.venom.analysis import CFGAnalysis, DFGAnalysis
 from vyper.venom.basicblock import IRInstruction, IRLiteral
 from vyper.venom.passes.base_pass import IRPass
 

--- a/vyper/venom/passes/revert_to_assert.py
+++ b/vyper/venom/passes/revert_to_assert.py
@@ -26,6 +26,7 @@ class RevertToAssert(IRPass):
                 self._rewrite_jnz(pred, bb)
 
         self.analyses_cache.invalidate_analysis(CFGAnalysis)
+        self.analyses_cache.invalidate_analysis(DFGAnalysis)
 
     def _rewrite_jnz(self, pred, revert_bb):
         term = pred.instructions[-1]


### PR DESCRIPTION
the revert-to-assert pass should invalidate the dfg. since cfg invalidation already invalidates the dfg, this commit is just for hygiene.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
