### PR TITLE
chore[lang]: remove `sha3` and `importlib_metadata` imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         "pycryptodome>=3.5.1,<4",
         "packaging>=23.1,<24",
         "lark>=1.0.0,<2",
-        "importlib-metadata",
         "wheel",
     ],
     setup_requires=["setuptools_scm>=7.1.0,<8.0.0"],

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -12,10 +12,13 @@ if _commit_hash_file.exists():
 else:
     __commit__ = "unknown"
 
+__version__: str
 try:
     __version__ = _version(__name__)
 except PackageNotFoundError:
-    from vyper.version import version as __version__  # type: ignore[no-redef]
+    from vyper.version import version
+
+    __version__ = version
 
 # pep440 version with commit hash
 __long_version__ = f"{__version__}+commit.{__commit__}"

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -6,6 +6,8 @@ try:
     from importlib.metadata import PackageNotFoundError  # type: ignore
     from importlib.metadata import version as _version  # type: ignore
 except ModuleNotFoundError:
+    # TODO: which versions are these backported for? can we remove
+    # the backport?
     from importlib_metadata import PackageNotFoundError  # type: ignore
     from importlib_metadata import version as _version  # type: ignore
 

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -2,14 +2,8 @@ from pathlib import Path as _Path
 
 from vyper.compiler import compile_code, compile_from_file_input
 
-try:
-    from importlib.metadata import PackageNotFoundError  # type: ignore
-    from importlib.metadata import version as _version  # type: ignore
-except ModuleNotFoundError:
-    # TODO: which versions are these backported for? can we remove
-    # the backport?
-    from importlib_metadata import PackageNotFoundError  # type: ignore
-    from importlib_metadata import version as _version  # type: ignore
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
 
 _commit_hash_file = _Path(__file__).parent.joinpath("vyper_git_commithash.txt")
 

--- a/vyper/__init__.py
+++ b/vyper/__init__.py
@@ -1,9 +1,8 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
 from pathlib import Path as _Path
 
 from vyper.compiler import compile_code, compile_from_file_input
-
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _version
 
 _commit_hash_file = _Path(__file__).parent.joinpath("vyper_git_commithash.txt")
 
@@ -16,7 +15,7 @@ else:
 try:
     __version__ = _version(__name__)
 except PackageNotFoundError:
-    from vyper.version import version as __version__
+    from vyper.version import version as __version__  # type: ignore[no-redef]
 
 # pep440 version with commit hash
 __long_version__ = f"{__version__}+commit.{__commit__}"

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -11,6 +11,8 @@ import traceback
 import warnings
 from typing import Generic, Iterable, Iterator, List, Set, TypeVar, Union
 
+from Crypto.Hash import keccak
+
 from vyper.exceptions import CompilerPanic, DecimalOverrideException
 
 _T = TypeVar("_T")
@@ -217,14 +219,8 @@ class DecimalContextOverride(decimal.Context):
 decimal.setcontext(DecimalContextOverride(prec=78))
 
 
-try:
-    from Crypto.Hash import keccak  # type: ignore
-
-    keccak256 = lambda x: keccak.new(digest_bits=256, data=x).digest()  # noqa: E731
-except ImportError:
-    import sha3 as _sha3
-
-    keccak256 = lambda x: _sha3.sha3_256(x).digest()  # noqa: E731
+def keccak256(x):
+    return keccak.new(digest_bits=256, data=x).digest()
 
 
 @functools.lru_cache(maxsize=512)


### PR DESCRIPTION
since we have `pycryptodome` as a requirement, the sha3 import is dead. additionally, pysha3 is no longer maintained.

### What I did

### How I did it

### How to verify it

### Commit message

```
since we have `pycryptodome` as a requirement, the `sha3` import is
dead.  additionally, `pysha3` is no longer maintained.

`importlib.metadata` is no longer provisional as of Python3.10, so we
can remove the backported version.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
