### PR TITLE
chore[tool]: widen version bounds for `packaging`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "cbor2>=5.4.6,<6",
         "asttokens>=2.0.5,<3",
         "pycryptodome>=3.5.1,<4",
-        "packaging>=23.1,<24",
+        "packaging>=23.1,<26",
         "lark>=1.0.0,<2",
         "importlib-metadata",
         "wheel",

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "cbor2>=5.4.6,<6",
         "asttokens>=2.0.5,<3",
         "pycryptodome>=3.5.1,<4",
-        "packaging>=23.1,<26",
+        "packaging>=23.1",
         "lark>=1.0.0,<2",
         "importlib-metadata",
         "wheel",


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
`poetry` depends on a higher version of `packaging`. relax the version
bounds

remove upper bound since packaging uses calendar versioning
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
