### PR TITLE
chore[tool]: widen version bounds for `asttokens`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     py_modules=["vyper"],
     install_requires=[
         "cbor2>=5.4.6,<6",
-        "asttokens>=2.0.5,<3",
+        "asttokens>=2.0.5,<4",
         "pycryptodome>=3.5.1,<4",
         "packaging>=23.1",
         "lark>=1.0.0,<2",


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
Allow using asttokens 3.0.0 which was released last year.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
