### PR TITLE
fix[venom]: fix inliner return items

### DIFF
--- a/vyper/venom/passes/function_inliner.py
+++ b/vyper/venom/passes/function_inliner.py
@@ -141,6 +141,17 @@ class FunctionInlinerPass(IRGlobalPass):
                     inst.opcode = "store"
                     inst.operands = [inst.operands[0]]
                 elif inst.opcode == "ret":
+                    if call_site.output is not None:
+                        # only handle 1 output from invoke.. the other
+                        # is the return pc. if there are more in the future,
+                        # we need to loop, 1 store for every output.
+                        assert len(inst.operands) == 2, inst
+                        return_value = inst.operands[0]
+                        set_output_inst = IRInstruction(
+                            "store", [return_value], output=call_site.output
+                        )
+                        call_site_return.insert_instruction(set_output_inst, index=0)
+
                     inst.opcode = "jmp"
                     inst.operands = [call_site_return.label]
 

--- a/vyper/venom/passes/machinery/inst_updater.py
+++ b/vyper/venom/passes/machinery/inst_updater.py
@@ -43,7 +43,7 @@ class InstUpdater:
             if isinstance(op, IRVariable):
                 self.dfg.add_use(op, inst)
 
-        if opcode in NO_OUTPUT_INSTRUCTIONS:
+        if opcode in NO_OUTPUT_INSTRUCTIONS and opcode != "invoke":
             if inst.output is not None:
                 assert new_output is None
                 assert len(uses := self.dfg.get_uses(inst.output)) == 0, (inst, uses)


### PR DESCRIPTION
this fixes the function inliner returning items. currently in vyper, functions do not return stack items, so there was an assumption that `ret` had no arguments besides the return pc. this commit adds the store instructions so that the return items are set properly.

it also fixes a bug in InstUpdater, which is that invoke can have no outputs.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
