### PR TITLE
feat[docs]: document order of evalution of arguments of `log` 

### DIFF
--- a/docs/statements.rst
+++ b/docs/statements.rst
@@ -77,6 +77,9 @@ The event must have been previously declared.
 
 See :ref:`Event Logging<event-logging>` for more information on events.
 
+.. warning::
+    The evaluation order of arguments passed to ``log`` is undefined. The compiler may evaluate them in any order. Therefore, arguments with side effects should be evaluated in separate statements before the ``log`` call to ensure predictable behavior.
+
 Assertions and Exceptions
 =========================
 


### PR DESCRIPTION
### What I did
- address: https://github.com/vyperlang/vyper/issues/4464#issuecomment-2607668271


