### PR TITLE
fix[tool]: fix layout export with nonreentrancy pragma on

### DIFF
--- a/tests/unit/cli/storage_layout/test_storage_layout_overrides.py
+++ b/tests/unit/cli/storage_layout/test_storage_layout_overrides.py
@@ -451,4 +451,5 @@ a: public(uint256)
             "$.nonreentrant_key": {"type": "nonreentrant lock", "n_slots": 1, "slot": 20},
         }
 
+    # note: compile_code checks roundtrip of the override
     compile_code(code, storage_layout_override=override)

--- a/tests/unit/cli/storage_layout/test_storage_layout_overrides.py
+++ b/tests/unit/cli/storage_layout/test_storage_layout_overrides.py
@@ -435,3 +435,20 @@ initializes: lib1
             input_bundle=input_bundle,
             storage_layout_override=override,
         )
+
+
+def test_override_with_nonreentrant_pragma(make_input_bundle):
+    code = """
+# pragma nonreentrancy on
+a: public(uint256)
+    """
+
+    if version_check(begin="cancun"):
+        override = {"a": {"type": "uint256", "n_slots": 1, "slot": 0}}
+    else:
+        override = {
+            "a": {"type": "uint256", "n_slots": 1, "slot": 0},
+            "$.nonreentrant_key": {"type": "nonreentrant lock", "n_slots": 1, "slot": 20},
+        }
+
+    compile_code(code, storage_layout_override=override)

--- a/vyper/semantics/analysis/data_positions.py
+++ b/vyper/semantics/analysis/data_positions.py
@@ -182,6 +182,17 @@ def _allocate_with_overrides(vyper_module: vy_ast.Module, layout: StorageLayout)
     _allocate_with_overrides_r(vyper_module, layout, allocator, nonreentrant_slot, [])
 
 
+def _get_func_defs(vyper_module: vy_ast.Module):
+    funcdefs = vyper_module.get_children(vy_ast.FunctionDef)
+    for vardecl in vyper_module.get_children(vy_ast.VariableDecl):
+        if not vardecl.is_public:
+            # no getter
+            continue
+        funcdefs.append(vardecl._expanded_getter)
+
+    return funcdefs
+
+
 def _allocate_with_overrides_r(
     vyper_module: vy_ast.Module,
     layout: StorageLayout,
@@ -190,12 +201,7 @@ def _allocate_with_overrides_r(
     path: list[str],
 ):
     # Search through function definitions to find non-reentrant functions
-    funcdefs = vyper_module.get_children(vy_ast.FunctionDef)
-    for vardecl in vyper_module.get_children(vy_ast.VariableDecl):
-        if not vardecl.is_public:
-            # no getter
-            continue
-        funcdefs.append(vardecl._expanded_getter)
+    funcdefs = _get_func_defs(vyper_module)
 
     for node in funcdefs:
         fn_t = node._metadata["func_type"]
@@ -391,7 +397,8 @@ def _generate_layout_export_r(vyper_module):
             raise CompilerPanic("unreachable")
         ret[layout_key][node.target.id] = item
 
-    for fn in vyper_module.get_children(vy_ast.FunctionDef):
+    funcdefs = _get_func_defs(vyper_module)
+    for fn in funcdefs:
         fn_t = fn._metadata["func_type"]
         if not fn_t.nonreentrant:
             continue


### PR DESCRIPTION
### What I did
- address https://github.com/vyperlang/vyper/issues/4612

### How I did it
- included also getter definitions when iterating over functions during exports

### Commit message

```
this commit fixes storage layout exports when pragma nonreentrancy is
on for getters (which were not being included in the layout).
```

### How to verify it
- added relevant tests

