### PR TITLE
fix[lang]: disable nonreentrant behavior of immutable and constant getters

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -186,7 +186,7 @@ You can view where the nonreentrant key is physically laid out in storage by usi
 The nonreentrant pragma
 -----------------------
 
-Beginning in 0.4.2, the ``#pragma nonreentrancy on`` pragma is available, and it enables nonreentrancy on all external functions and public getters (except for ``constants`` and ``immutables``)  in the file. This is to prepare for a future release, probably in the 0.5.x series, where nonreentrant locks will be enabled by default language-wide.
+Beginning in 0.4.2, the ``#pragma nonreentrancy on`` pragma is available, and it enables nonreentrancy on all external functions and public getters (except for ``constants`` and ``immutables``) in the file. This is to prepare for a future release, probably in the 0.5.x series, where nonreentrant locks will be enabled by default language-wide.
 
 When the pragma is on, to re-enable reentrancy for a specific function, add the ``@reentrant`` decorator. For getters, add the ``reentrant()`` modifier. Here is an example:
 
@@ -231,7 +231,7 @@ Internal functions, ``__init__`` function and getters for ``constants`` and ``im
    The ``nonreentrancy on/off`` pragma is scoped to the current file. If you import a file without the ``nonreentrancy on`` pragma, the functions in that file will behave as the author intended, that is, they will be reentrant unless marked otherwise.
 
 .. note::
-    The ``constant`` and ``imutable`` state variable getters don't check the lock because the value of the variables can't change.
+    The ``constant`` and ``immutable`` state variable getters don't check the lock because the value of the variables can't change.
 
 
 The ``__default__`` Function

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -219,7 +219,7 @@ Note that the same caveats about nonreentrancy on ``__default__()`` as mentioned
 
 With the pragma on, internal functions remain unlocked by default but can still use the ``@nonreentrant`` decorator. External ``view`` functions are protected by default (as before, checking the lock upon entry but only reading its state). External ``pure`` functions do not interact with the lock.
 
-Internal functions, ``__init__`` function and getters for ``constants`` and ``immutables`` can be marked ``reentrant``. Reentrant behavior is the default for these structure anyway, and this feature can be used to explicitly highlight the fact.
+Internal functions, ``__init__`` function and getters for ``constants`` and ``immutables`` can be marked ``reentrant``. Reentrant behavior is the default for these structures anyway, and this feature can be used to explicitly highlight the fact.
 
 .. note::
    All the protected functions share the same, global lock.

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -186,7 +186,7 @@ You can view where the nonreentrant key is physically laid out in storage by usi
 The nonreentrant pragma
 -----------------------
 
-Beginning in 0.4.2, the ``#pragma nonreentrancy on`` pragma is available, and it enables nonreentrancy on all external functions and public getters in the file. This is to prepare for a future release, probably in the 0.5.x series, where nonreentrant locks will be enabled by default language-wide.
+Beginning in 0.4.2, the ``#pragma nonreentrancy on`` pragma is available, and it enables nonreentrancy on all external functions and public getters (except for ``constants`` and ``immutables``)  in the file. This is to prepare for a future release, probably in the 0.5.x series, where nonreentrant locks will be enabled by default language-wide.
 
 When the pragma is on, to re-enable reentrancy for a specific function, add the ``@reentrant`` decorator. For getters, add the ``reentrant()`` modifier. Here is an example:
 
@@ -219,6 +219,8 @@ Note that the same caveats about nonreentrancy on ``__default__()`` as mentioned
 
 With the pragma on, internal functions remain unlocked by default but can still use the ``@nonreentrant`` decorator. External ``view`` functions are protected by default (as before, checking the lock upon entry but only reading its state). External ``pure`` functions do not interact with the lock.
 
+Internal functions, ``__init__`` function and getters for ``constants`` and ``immutables`` can be marked ``reentrant``. Reentrant behavior is the default for these structure anyway, and this feature can be used to explicitly highlight the fact.
+
 .. note::
    All the protected functions share the same, global lock.
 
@@ -227,6 +229,9 @@ With the pragma on, internal functions remain unlocked by default but can still 
 
 .. note::
    The ``nonreentrancy on/off`` pragma is scoped to the current file. If you import a file without the ``nonreentrancy on`` pragma, the functions in that file will behave as the author intended, that is, they will be reentrant unless marked otherwise.
+
+.. note::
+    The ``constant`` and ``imutable`` state variable getters don't check the lock because the value of the variables can't change.
 
 
 The ``__default__`` Function

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,9 @@ ensure_newline_before_comments = True
 line_length = 100
 
 [tool:pytest]
-addopts = --strict-markers
+addopts = -n auto
+	--dist worksteal
+	--strict-markers
 python_files = test_*.py
 testpaths = tests
 xfail_strict = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,7 @@ ensure_newline_before_comments = True
 line_length = 100
 
 [tool:pytest]
-addopts = -n auto
-	--dist worksteal
-	--strict-markers
+addopts = --strict-markers
 python_files = test_*.py
 testpaths = tests
 xfail_strict = true

--- a/tests/functional/codegen/features/decorators/test_nonreentrant.py
+++ b/tests/functional/codegen/features/decorators/test_nonreentrant.py
@@ -561,7 +561,8 @@ def foo():
 
 
 # there's no reason to protect immutable and constant variable
-# getters, they should be reentrant
+# getters, they should be reentrant.
+# this test also tests the behavior inside of a submodule
 def test_pragma_with_immutables_and_constants(make_input_bundle, get_contract, tx_failed):
     lib1 = """
 # pragma nonreentrancy on

--- a/tests/functional/codegen/features/decorators/test_nonreentrant.py
+++ b/tests/functional/codegen/features/decorators/test_nonreentrant.py
@@ -560,6 +560,51 @@ def foo():
         c.foo()
 
 
+# there's no reason to protect immutable and constant variable
+# getters, they should be reentrant
+def test_pragma_with_immutables_and_constants(make_input_bundle, get_contract, tx_failed):
+    lib1 = """
+# pragma nonreentrancy on
+
+a: public(constant(uint256)) = 333
+b: public(immutable(uint256))
+
+@deploy
+def __init__():
+    b = 666
+
+    """
+    main = """
+# pragma nonreentrancy on
+
+import lib1
+initializes: lib1
+
+interface Self:
+    def a() -> uint256: nonpayable
+    def b() -> uint256: nonpayable
+
+exports: lib1.a
+exports: lib1.b
+
+@deploy
+def __init__():
+    lib1.__init__()
+
+@external
+def foo():
+    res: uint256 = extcall Self(self).a()
+    assert res == 333
+    res = extcall Self(self).b()
+    assert res == 666
+    """
+    input_bundle = make_input_bundle({"lib1.vy": lib1})
+
+    c = get_contract(main, input_bundle=input_bundle)
+
+    c.foo()
+
+
 # foo in main module has reentrancy on, bar in lib1 off because
 # that's the default for internal functions
 # call bar from foo via extcall and ensure it succeeds

--- a/vyper/semantics/analysis/getters.py
+++ b/vyper/semantics/analysis/getters.py
@@ -65,7 +65,11 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         decorators = [vy_ast.Name(id="external"), vy_ast.Name(id="view")]
         settings = node.module_node.settings
-        if settings.nonreentrancy_by_default and node.is_reentrant:
+        # immutable and constant variables can't change, and thus
+        # can't lead to read-only-reentrancy
+        if settings.nonreentrancy_by_default and (
+            node.is_reentrant or node.is_constant or node.is_immutable
+        ):
             decorators.append(vy_ast.Name(id="reentrant"))
 
         # join everything together as a new `FunctionDef` node

--- a/vyper/semantics/analysis/getters.py
+++ b/vyper/semantics/analysis/getters.py
@@ -65,12 +65,11 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
 
         decorators = [vy_ast.Name(id="external"), vy_ast.Name(id="view")]
         settings = node.module_node.settings
-        # immutable and constant variables can't change, and thus
-        # can't lead to read-only-reentrancy
-        if settings.nonreentrancy_by_default and (
-            node.is_reentrant or node.is_constant or node.is_immutable
-        ):
-            decorators.append(vy_ast.Name(id="reentrant"))
+        if settings.nonreentrancy_by_default:
+            # immutable and constant variables can't change, and thus
+            # can't lead to read-only-reentrancy
+            if node.is_reentrant or node.is_constant or node.is_immutable:
+                decorators.append(vy_ast.Name(id="reentrant"))
 
         # join everything together as a new `FunctionDef` node
         expanded = vy_ast.FunctionDef(


### PR DESCRIPTION
### What I did

### How I did it

### Commit message

```
the nonreentrancy pragma enables reentrancy protection for all
public entrypoints, including immutable and constant getters. however
`immutable` and `constant` variables can't change after deployment, and
thus can't lead to issues due to read-only-reentrancy. thus, checking
the lock is undesirable (in other words, the getters should behave more
similarly to `pure` functions than `view` functions).
```

### How to verify it
- added relevant tests


