### PR TITLE
fix[lang]: disallow duplicate getter annotations

### DIFF
--- a/tests/functional/syntax/test_getters.py
+++ b/tests/functional/syntax/test_getters.py
@@ -4,23 +4,26 @@ from vyper.compiler import compile_code
 from vyper.exceptions import SyntaxException
 
 
-def test_duplicate_public_annotation():
-    code = """
-a: public(public(uint256))
+@pytest.mark.parametrize("annotation", ("public", "reentrant"))
+def test_duplicate_getter_annotation(annotation):
+    code = f"""
+a: {annotation}({annotation}(uint256))
     """
 
     with pytest.raises(SyntaxException) as e:
         compile_code(code)
 
-    assert e.value.message == "Used variable annotation `public` multiple times"
+    assert e.value.message == f"Used variable annotation `{annotation}` multiple times"
 
 
-def test_duplicate_reentrant_annotation():
-    code = """
-a: reentrant(reentrant(uint256))
+@pytest.mark.parametrize("annotation", ("constant", "transient", "immutable"))
+def test_duplicate_location_annotation(annotation):
+    code = f"""
+a: {annotation}({annotation}(uint256))
     """
 
     with pytest.raises(SyntaxException) as e:
         compile_code(code)
 
-    assert e.value.message == "Used variable annotation `reentrant` multiple times"
+    # TODO: improve this error message
+    assert e.value.message == "Invalid scope for variable declaration"

--- a/tests/functional/syntax/test_getters.py
+++ b/tests/functional/syntax/test_getters.py
@@ -1,0 +1,26 @@
+import pytest
+
+from vyper.compiler import compile_code
+from vyper.exceptions import SyntaxException
+
+
+def test_duplicate_public_annotation():
+    code = """
+a: public(public(uint256))
+    """
+
+    with pytest.raises(SyntaxException) as e:
+        compile_code(code)
+
+    assert e.value.message == "Used variable annotation `public` multiple times"
+
+
+def test_duplicate_reentrant_annotation():
+    code = """
+a: reentrant(reentrant(uint256))
+    """
+
+    with pytest.raises(SyntaxException) as e:
+        compile_code(code)
+
+    assert e.value.message == "Used variable annotation `reentrant` multiple times"

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1405,13 +1405,19 @@ class VariableDecl(VyperNode):
         # TYPE | PUBLIC "(" TYPE | ((IMMUTABLE | CONSTANT) "(" TYPE ")") ")"
 
         # unwrap reentrant and public. they can be in any order
+        seen = []
         for _ in range(2):
             func_id = self.annotation.get("func.id")
+            if func_id in seen:
+                _raise_syntax_exc(
+                    f"Used variable annotation `{func_id}` multiple times", self.annotation
+                )
             if func_id not in ("public", "reentrant"):
                 break
             _check_args(self.annotation, func_id)
             setattr(self, f"is_{func_id}", True)
             # unwrap one layer
+            seen.append(func_id)
             self.annotation = self.annotation.args[0]
 
         func_id = self.annotation.get("func.id")


### PR DESCRIPTION
### What I did
- address: https://github.com/vyperlang/vyper/issues/4610

### Commit message

```
state variables with getters can currently compile with
duplicate `public` or `reentrant` annotations, e.g.
`x: public(public(uint256))`. this commit blocks the behavior.

it also adds test cases for this behavior, as well as analogous test
cases for `immutable` and the other location annotations (which are
correctly blocked, but good to have the tests as well).
```

### How to verify it
- added tests

