### PR TITLE
refactor[venom]: rename "store"-related passes

### DIFF
--- a/tests/hevm.py
+++ b/tests/hevm.py
@@ -5,7 +5,7 @@ import pytest
 
 from tests.venom_utils import parse_from_basic_block
 from vyper.ir.compile_ir import assembly_to_evm
-from vyper.venom import LowerDloadPass, SimplifyCFGPass, StoreExpansionPass, VenomCompiler
+from vyper.venom import LowerDloadPass, SimplifyCFGPass, SingleUseExpansion, VenomCompiler
 from vyper.venom.analysis import IRAnalysesCache
 from vyper.venom.basicblock import IRInstruction, IRLiteral
 
@@ -64,7 +64,7 @@ def _prep_hevm_venom_ctx(ctx, verbose=False):
 
         # requirements for venom_to_assembly
         LowerDloadPass(ac, fn).run_pass()
-        StoreExpansionPass(ac, fn).run_pass()
+        SingleUseExpansion(ac, fn).run_pass()
 
     compiler = VenomCompiler([ctx])
     asm = compiler.generate_evm(no_optimize=False)

--- a/tests/unit/compiler/venom/test_algebraic_binopt.py
+++ b/tests/unit/compiler/venom/test_algebraic_binopt.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tests.venom_utils import PrePostChecker
-from vyper.venom.passes import AlgebraicOptimizationPass, StoreElimination
+from vyper.venom.passes import AlgebraicOptimizationPass, AssignElimination
 
 """
 Test abstract binop+unop optimizations in algebraic optimizations pass
@@ -9,7 +9,7 @@ Test abstract binop+unop optimizations in algebraic optimizations pass
 
 pytestmark = pytest.mark.hevm
 
-_check_pre_post = PrePostChecker([StoreElimination, AlgebraicOptimizationPass, StoreElimination])
+_check_pre_post = PrePostChecker([AssignElimination, AlgebraicOptimizationPass, AssignElimination])
 
 
 def test_sccp_algebraic_opt_sub_xor():

--- a/tests/unit/compiler/venom/test_duplicate_operands.py
+++ b/tests/unit/compiler/venom/test_duplicate_operands.py
@@ -2,7 +2,7 @@ from vyper.compiler.settings import OptimizationLevel
 from vyper.venom import generate_assembly_experimental
 from vyper.venom.analysis import IRAnalysesCache
 from vyper.venom.context import IRContext
-from vyper.venom.passes import StoreExpansionPass
+from vyper.venom.passes import SingleUseExpansion
 
 
 def test_duplicate_operands():
@@ -26,7 +26,7 @@ def test_duplicate_operands():
     bb.append_instruction("stop")
 
     ac = IRAnalysesCache(fn)
-    StoreExpansionPass(ac, fn).run_pass()
+    SingleUseExpansion(ac, fn).run_pass()
 
     optimize = OptimizationLevel.GAS
     asm = generate_assembly_experimental(ctx, optimize=optimize)

--- a/tests/unit/compiler/venom/test_load_elimination.py
+++ b/tests/unit/compiler/venom/test_load_elimination.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.venom_utils import PrePostChecker
 from vyper.evm.address_space import CALLDATA, DATA, MEMORY, STORAGE, TRANSIENT
-from vyper.venom.passes import LoadElimination, StoreElimination
+from vyper.venom.passes import AssignElimination, LoadElimination
 
 pytestmark = pytest.mark.hevm
 
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.hevm
 # and the second/in post is needed to create
 # easier equivalence in the test for pre and post
 _check_pre_post = PrePostChecker(
-    passes=[StoreElimination, LoadElimination, StoreElimination], post=[StoreElimination]
+    passes=[AssignElimination, LoadElimination, AssignElimination], post=[AssignElimination]
 )
 
 

--- a/tests/unit/compiler/venom/test_single_use_expansion.py
+++ b/tests/unit/compiler/venom/test_single_use_expansion.py
@@ -3,17 +3,17 @@ import pytest
 from tests.venom_utils import parse_from_basic_block
 from vyper.venom import generate_assembly_experimental
 from vyper.venom.analysis import IRAnalysesCache
-from vyper.venom.passes import StoreExpansionPass
+from vyper.venom.passes import SingleUseExpansion
 
 
-def test_store_expansion():
+def test_single_use_Expansion():
     """
     Test to was created from the example in the
     issue https://github.com/vyperlang/vyper/issues/4215
-    it issue is handled by StoreExpansionPass
+    it issue is handled by the SingleUseExpansion pass
 
     Originally it was handled by different reorder algorithm
-    which is not necessary with store expansion
+    which is not necessary with single-use expansion
     """
 
     code = """
@@ -43,6 +43,6 @@ def test_store_expansion():
 
     for fn in ctx.functions.values():
         ac = IRAnalysesCache(fn)
-        StoreExpansionPass(ac, fn).run_pass()
+        SingleUseExpansion(ac, fn).run_pass()
 
     generate_assembly_experimental(ctx)

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -14,6 +14,7 @@ from vyper.venom.passes import (
     CSE,
     SCCP,
     AlgebraicOptimizationPass,
+    AssignElimination,
     BranchOptimizationPass,
     DFTPass,
     FloatAllocas,
@@ -27,7 +28,6 @@ from vyper.venom.passes import (
     RemoveUnusedVariablesPass,
     RevertToAssert,
     SimplifyCFGPass,
-    StoreElimination,
     StoreExpansionPass,
 )
 from vyper.venom.venom_to_assembly import VenomCompiler
@@ -61,17 +61,17 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
     MakeSSA(ac, fn).run_pass()
     # run algebraic opts before mem2var to reduce some pointer arithmetic
     AlgebraicOptimizationPass(ac, fn).run_pass()
-    StoreElimination(ac, fn).run_pass()
+    AssignElimination(ac, fn).run_pass()
     Mem2Var(ac, fn).run_pass()
     MakeSSA(ac, fn).run_pass()
     SCCP(ac, fn).run_pass()
 
     SimplifyCFGPass(ac, fn).run_pass()
-    StoreElimination(ac, fn).run_pass()
+    AssignElimination(ac, fn).run_pass()
     AlgebraicOptimizationPass(ac, fn).run_pass()
     LoadElimination(ac, fn).run_pass()
     SCCP(ac, fn).run_pass()
-    StoreElimination(ac, fn).run_pass()
+    AssignElimination(ac, fn).run_pass()
     RevertToAssert(ac, fn).run_pass()
 
     SimplifyCFGPass(ac, fn).run_pass()
@@ -85,9 +85,9 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
     # This improves the performance of cse
     RemoveUnusedVariablesPass(ac, fn).run_pass()
 
-    StoreElimination(ac, fn).run_pass()
+    AssignElimination(ac, fn).run_pass()
     CSE(ac, fn).run_pass()
-    StoreElimination(ac, fn).run_pass()
+    AssignElimination(ac, fn).run_pass()
     RemoveUnusedVariablesPass(ac, fn).run_pass()
     StoreExpansionPass(ac, fn).run_pass()
 

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -28,7 +28,7 @@ from vyper.venom.passes import (
     RemoveUnusedVariablesPass,
     RevertToAssert,
     SimplifyCFGPass,
-    StoreExpansionPass,
+    SingleUseExpansion,
 )
 from vyper.venom.venom_to_assembly import VenomCompiler
 
@@ -89,7 +89,7 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
     CSE(ac, fn).run_pass()
     AssignElimination(ac, fn).run_pass()
     RemoveUnusedVariablesPass(ac, fn).run_pass()
-    StoreExpansionPass(ac, fn).run_pass()
+    SingleUseExpansion(ac, fn).run_pass()
 
     if optimize == OptimizationLevel.CODESIZE:
         ReduceLiteralsCodesize(ac, fn).run_pass()

--- a/vyper/venom/passes/__init__.py
+++ b/vyper/venom/passes/__init__.py
@@ -1,4 +1,5 @@
 from .algebraic_optimization import AlgebraicOptimizationPass
+from .assign_elimination import AssignElimination
 from .branch_optimization import BranchOptimizationPass
 from .common_subexpression_elimination import CSE
 from .dft import DFTPass
@@ -15,5 +16,4 @@ from .remove_unused_variables import RemoveUnusedVariablesPass
 from .revert_to_assert import RevertToAssert
 from .sccp import SCCP
 from .simplify_cfg import SimplifyCFGPass
-from .store_elimination import StoreElimination
 from .store_expansion import StoreExpansionPass

--- a/vyper/venom/passes/__init__.py
+++ b/vyper/venom/passes/__init__.py
@@ -16,4 +16,4 @@ from .remove_unused_variables import RemoveUnusedVariablesPass
 from .revert_to_assert import RevertToAssert
 from .sccp import SCCP
 from .simplify_cfg import SimplifyCFGPass
-from .store_expansion import StoreExpansionPass
+from .single_use_expansion import SingleUseExpansion

--- a/vyper/venom/passes/assign_elimination.py
+++ b/vyper/venom/passes/assign_elimination.py
@@ -3,10 +3,11 @@ from vyper.venom.basicblock import IRVariable
 from vyper.venom.passes.base_pass import InstUpdater, IRPass
 
 
-class StoreElimination(IRPass):
+class AssignElimination(IRPass):
     """
     This pass forwards variables to their uses though `store` instructions,
-    and removes the `store` instruction.
+    and removes the `store` instruction. In the future we will probably rename
+    the `store` instruction to `"assign"`.
     """
 
     # TODO: consider renaming `store` instruction, since it is confusing

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -3,10 +3,15 @@ from vyper.venom.basicblock import IRInstruction, IRLiteral, IRVariable
 from vyper.venom.passes.base_pass import IRPass
 
 
-class StoreExpansionPass(IRPass):
+class SingleUseExpansion(IRPass):
     """
     This pass extracts literals and variables so that they can be
-    reordered by the DFT pass
+    reordered by the DFT pass. It creates an invariant which is that
+    each variable is used at most once (by any opcode besides a simple
+    assignment), which is helpful for DFT, and *required* by
+    venom_to_assembly.py.
+
+    This pass is in some sense the "inverse" of AssignElimination.
     """
 
     def run_pass(self):

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -5,11 +5,16 @@ from vyper.venom.passes.base_pass import IRPass
 
 class SingleUseExpansion(IRPass):
     """
-    This pass extracts literals and variables so that they can be
-    reordered by the DFT pass. It creates an invariant which is that
-    each variable is used at most once (by any opcode besides a simple
-    assignment), which is helpful for DFT, and *required* by
-    venom_to_assembly.py.
+    This pass transforms venom IR to "single use" form. It extracts literals
+    and variables so that they can be reordered by the DFT pass. It creates
+    two invariants:
+    - each variable is used at most once (by any opcode besides a simple
+      assignment)
+    - operands to all instructions (besides assignment instructions) must
+      be variables.
+
+    these two properties are helpful for DFT and venom_to_assembly.py, and
+    in fact the first invariant is *required* by venom_to_assembly.py.
 
     This pass is in some sense the "inverse" of AssignElimination.
     """


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
the "store" opcode is confusingly named. in the future, we plan to
rename to "assign" or similar. that currently might produce merge
conflicts, so in the meantime we just rename the `StoreElimination` and
`StoreExpansion` pass names to be less confusing.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
