### PR TITLE
refactor[codegen]: refactor get_type_for_exact_size

### DIFF
--- a/vyper/codegen/memory_allocator.py
+++ b/vyper/codegen/memory_allocator.py
@@ -90,6 +90,9 @@ class MemoryAllocator:
         """
         if size % 32 != 0:
             raise CompilerPanic(f"tried to allocate {size} bytes, only multiples of 32 supported.")
+        if size < 0:
+            # sanity check
+            raise CompilerPanic(f"tried to allocate {size} bytes")
 
         # check for deallocated memory prior to expanding
         for i, free_memory in enumerate(self.deallocated_mem):

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -171,7 +171,7 @@ class VyperType:
         """
         raise CompilerPanic("Method must be implemented by the inherited class")
 
-    def get_size_in(self, location: DataLocation):
+    def get_size_in(self, location: DataLocation) -> int:
         if location in (DataLocation.STORAGE, DataLocation.TRANSIENT):
             return self.storage_size_in_words
         if location == DataLocation.MEMORY:


### PR DESCRIPTION
previously, `get_type_for_exact_size` returned a `BytesT`. for cleanliness and hygiene, create a dedicated type to return from `get_type_for_exact_size`. add additional sanity checks in the allocator.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
