### PR TITLE
feat: add venom keys into the compiled output json

### DIFF
--- a/tests/unit/cli/vyper_json/test_output_selection.py
+++ b/tests/unit/cli/vyper_json/test_output_selection.py
@@ -33,6 +33,17 @@ def test_translate_map(output):
         "sources": {"foo.vy": ""},
         "settings": {"outputSelection": {"foo.vy": [output[0]]}},
     }
+    if output[0] in ["bb", "bb_runtime", "cfg", "cfg_runtime"]:
+        assert get_output_formats(input_json) == {PurePath("foo.vy"): []}
+    else:
+        assert get_output_formats(input_json) == {PurePath("foo.vy"): [output[1]]}
+
+@pytest.mark.parametrize("output", TRANSLATE_MAP.items())
+def test_translate_map_with_venom_flag(output):
+    input_json = {
+        "sources": {"foo.vy": ""},
+        "settings": {"venom": True, "outputSelection": {"foo.vy": [output[0]]}},
+    }
     assert get_output_formats(input_json) == {PurePath("foo.vy"): [output[1]]}
 
 
@@ -41,7 +52,23 @@ def test_star():
         "sources": {"foo.vy": "", "bar.vy": ""},
         "settings": {"outputSelection": {"*": ["*"]}},
     }
-    expected = sorted(set(TRANSLATE_MAP.values()))
+    translate_map = set(TRANSLATE_MAP.values())
+    # if the venom flag is not present
+    translate_map.remove("bb")
+    translate_map.remove("bb_runtime")
+    translate_map.remove("cfg")
+    translate_map.remove("cfg_runtime")
+    expected = sorted(translate_map)
+    result = get_output_formats(input_json)
+    assert result == {PurePath("foo.vy"): expected, PurePath("bar.vy"): expected}
+
+def test_star_with_venom_flag():
+    input_json = {
+        "sources": {"foo.vy": "", "bar.vy": ""},
+        "settings": {"venom": True, "outputSelection": {"*": ["*"]}},
+    }
+    translate_map = set(TRANSLATE_MAP.values())
+    expected = sorted(translate_map)
     result = get_output_formats(input_json)
     assert result == {PurePath("foo.vy"): expected, PurePath("bar.vy"): expected}
 

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -34,6 +34,10 @@ TRANSLATE_MAP = {
     "metadata": "metadata",
     "layout": "layout",
     "userdoc": "userdoc",
+    "bb": "bb",
+    "bb_runtime": "bb_runtime",
+    "cfg": "cfg",
+    "cfg_runtime": "cfg_runtime",
 }
 
 
@@ -245,6 +249,10 @@ def get_output_formats(input_dict: dict) -> dict[PurePath, list[str]]:
                 raise JSONError(f"Invalid outputSelection - {e}")
 
         outputs = sorted(list(outputs))
+        if not input_dict["settings"].get("venom") and not input_dict["settings"].get("experimentalCodegen"):
+            for key in ["bb", "bb_runtime", "cfg", "cfg_runtime"]:
+                if key in outputs:
+                    outputs.remove(key)
 
         if path == "*":
             output_paths = [PurePath(path) for path in input_dict["sources"].keys()]
@@ -400,6 +408,18 @@ def format_to_output_dict(compiler_data: dict) -> dict:
                 evm["opcodes"] = data["opcodes_runtime"]
             if "source_map_runtime" in data:
                 evm["sourceMap"] = data["source_map_runtime"]
+
+        venom_keys = ("bb", "bb_runtime", "cfg", "cfg_runtime",)
+        if any(i in data for i in venom_keys):
+            venom = output_contracts.setdefault("venom", {})
+            if "bb" in data:
+                venom["bb"] = repr(data["bb"])
+            if "bb_runtime" in data:
+                venom["bb_runtime"] = repr(data["bb_runtime"])
+            if "cfg" in data:
+                venom["cfg"] = data["cfg"]
+            if "cfg_runtime" in data:
+                venom["cfg_runtime"] = data["cfg_runtime"]
 
     return output_dict
 


### PR DESCRIPTION
### What I did
I added the venom optimizer keys `['bb', 'bb_runtime', 'cfg', 'cfg_runtime']` into the compiled output when calling `compile_json()`
### How I did it
Adapted the translate map and guarded it with the `venom` flag
### How to verify it
Added tests inside `test_comile_json.py` 
### Commit message
```feat: add venom optimizer keys ['bb', 'bb_runtime', 'cfg', 'cfg_runtime'] into the compiled output when calling compile_json()```

### Description for the changelog
- compile_json output contains venom optimizer keys `['bb', 'bb_runtime', 'cfg', 'cfg_runtime']`
### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](
![image](https://github.com/user-attachments/assets/75b6464f-14c2-453e-b0bd-9aee9bb1287c)
)
