### PR TITLE
docs: fix non working link to `installing-vyper.rst` 

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,7 +5,7 @@ Contributing
 
 Help is always appreciated!
 
-To get started, you can try `installing Vyper <installing-vyper.html>`_ in order to familiarize
+To get started, you can try `installing Vyper <installing-vyper.rst>`_ in order to familiarize
 yourself with the components of Vyper and the build process. Also, it may be
 useful to become well-versed at writing smart-contracts in Vyper.
 


### PR DESCRIPTION
### What I did
changed file's extension (format)
### How I did it

### How to verify it

### Commit message

### Description for the changelog
docs: fix non working link to `installing-vyper.rst` 
### Cute Animal Picture

![photo_2025-04-27_11-36-23](https://github.com/user-attachments/assets/41b46532-ca35-45aa-bbe1-95a22aabd51a)

