### PR TITLE
Fix inconsistent clamp_basetype handling in make_setter function

### DIFF
--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1053,8 +1053,11 @@ def make_setter(left, right, hi=None):
         right = unwrap_location(right)
         # TODO rethink/streamline the clamp_basetype logic
         if needs_clamp(right.typ, enc):
-            right = clamp_basetype(right)
-
+            with right.cache_when_complex("prim_val") as (b, right):
+                clamped = clamp_basetype(right)
+                ret = b.resolve(["seq", clamped, STORE(left, right)])
+                return IRnode.from_list(ret)
+        
         return STORE(left, right)
 
     # Byte arrays


### PR DESCRIPTION
## Description
This PR addresses an inconsistency in the `make_setter` function in `vyper/codegen/core.py`. The function was handling `clamp_basetype` differently for primitive word types compared to other data types (like bytestrings and dynamic arrays).

For other data types, the function properly:
1. Caches complex values with `cache_when_complex`
2. Creates a sequence operation with proper IR node construction
3. Wraps the result in an `IRnode.from_list()` call

However, for primitive word types, it was directly assigning the result of `clamp_basetype(right)` back to `right`, which could lead to potential issues with complex values and IR node construction.

### Changes
- Modified the `clamp_basetype` handling for primitive word types to use the same pattern as other data types
- Added proper caching and sequence construction for clamping operations
- Ensured consistent IR node construction across all data type handlers
