### PR TITLE
refactor[venom]: don't do load elimination in memmerge pass

### DIFF
--- a/tests/unit/compiler/venom/test_memmerging.py
+++ b/tests/unit/compiler/venom/test_memmerging.py
@@ -253,6 +253,8 @@ def test_memmerging_partial_msize():
 
     post = """
     _global:
+        %1 = mload 0   ; was not removed due to presence of msize
+        %2 = mload 32  ; was not removed due to presence of msize
         %3 = mload 64
         mcopy 1000, 0, 64
         %4 = msize

--- a/vyper/venom/passes/memmerging.py
+++ b/vyper/venom/passes/memmerging.py
@@ -123,7 +123,6 @@ class MemMergePass(IRPass):
         for copy in copies:
             copy.insts.sort(key=bb.instructions.index)
 
-            pin_inst = None
             inst = copy.insts[-1]
             if copy.length != 32 or load_opcode == "dload":
                 ops: list[IROperand] = [
@@ -135,10 +134,7 @@ class MemMergePass(IRPass):
             elif inst.opcode == "mstore":
                 # we already have a load which is the val for this mstore;
                 # leave it in place.
-                var, _ = inst.operands
-                assert isinstance(var, IRVariable)  # help mypy
-                pin_inst = self.dfg.get_producing_instruction(var)
-                assert pin_inst is not None  # help mypy
+                pass
 
             else:
                 # we are converting an mcopy into an mload+mstore (mload+mstore
@@ -151,16 +147,7 @@ class MemMergePass(IRPass):
 
             for inst in copy.insts[:-1]:
                 if inst.opcode == load_opcode:
-                    if inst is pin_inst:
-                        continue
-
-                    # if the load is used by any instructions besides the ones
-                    # we are removing, we can't delete it. (in the future this
-                    # may be handled by "remove unused effects" pass).
-                    assert isinstance(inst.output, IRVariable)  # help mypy
-                    uses = self.dfg.get_uses(inst.output)
-                    if not all(use in copy.insts for use in uses):
-                        continue
+                    continue
 
                 to_nop.append(inst)
 


### PR DESCRIPTION
the load elimination makes the memmerging pass more complex, and as of 3b0ee7804fda6fb, load elimination is also handled (more correctly) in the `RemoveUnusedVariables` pass.

this incidentally fixes a bug -- the memmerging pass was removing `mload`s incorrectly in the case that they reach an `msize` instruction.

after this commit, the removal of `mload` is blocked by the presence of a reachable `msize` -- see the changed test.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
