### PR TITLE
feat[venom]: allow SCCP to run without removing allocas

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -63,13 +63,16 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
 
     MakeSSA(ac, fn).run_pass()
     PhiEliminationPass(ac, fn).run_pass()
-    # run algebraic opts before mem2var to reduce some pointer arithmetic
+
+    # run constant folding before mem2var to reduce some pointer arithmetic
     AlgebraicOptimizationPass(ac, fn).run_pass()
+    SCCP(ac, fn, remove_allocas=False).run_pass()
     AssignElimination(ac, fn).run_pass()
     Mem2Var(ac, fn).run_pass()
+    SimplifyCFGPass(ac, fn).run_pass()
+
     MakeSSA(ac, fn).run_pass()
     PhiEliminationPass(ac, fn).run_pass()
-    SCCP(ac, fn).run_pass()
 
     SimplifyCFGPass(ac, fn).run_pass()
     AssignElimination(ac, fn).run_pass()

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -68,12 +68,13 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
     # run constant folding before mem2var to reduce some pointer arithmetic
     AlgebraicOptimizationPass(ac, fn).run_pass()
     SCCP(ac, fn, remove_allocas=False).run_pass()
-    AssignElimination(ac, fn).run_pass()
-    Mem2Var(ac, fn).run_pass()
     SimplifyCFGPass(ac, fn).run_pass()
 
+    AssignElimination(ac, fn).run_pass()
+    Mem2Var(ac, fn).run_pass()
     MakeSSA(ac, fn).run_pass()
     PhiEliminationPass(ac, fn).run_pass()
+    SCCP(ac, fn).run_pass()
 
     SimplifyCFGPass(ac, fn).run_pass()
     AssignElimination(ac, fn).run_pass()

--- a/vyper/venom/passes/sccp/eval.py
+++ b/vyper/venom/passes/sccp/eval.py
@@ -122,7 +122,6 @@ ARITHMETIC_OPS: dict[str, Callable[[list[IRLiteral]], int]] = {
     "shr": _wrap_binop(_evm_shr),
     "shl": _wrap_binop(_evm_shl),
     "sar": _wrap_signed_binop(_evm_sar),
-    "store": _wrap_unop(lambda ops: ops[0].value),
 }
 
 

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -58,7 +58,9 @@ class SCCP(IRPass):
 
     cfg_dirty: bool
 
-    def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction, /, remove_allocas=True):
+    def __init__(
+        self, analyses_cache: IRAnalysesCache, function: IRFunction, /, remove_allocas=True
+    ):
         super().__init__(analyses_cache, function)
         self.remove_allocas = remove_allocas
 
@@ -178,7 +180,7 @@ class SCCP(IRPass):
     def _visit_expr(self, inst: IRInstruction):
         opcode = inst.opcode
 
-        store_opcodes = ("store",)
+        store_opcodes: tuple[str, ...] = ("store",)
         if self.remove_allocas:
             store_opcodes += ("alloca", "palloca", "calloca")
 

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -58,8 +58,10 @@ class SCCP(IRPass):
 
     cfg_dirty: bool
 
-    def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction):
+    def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction, /, remove_allocas=True):
         super().__init__(analyses_cache, function)
+        self.remove_allocas = remove_allocas
+
         self.lattice = {}
         self.work_list: list[WorkListItem] = []
 
@@ -175,7 +177,12 @@ class SCCP(IRPass):
 
     def _visit_expr(self, inst: IRInstruction):
         opcode = inst.opcode
-        if opcode in ("store", "alloca", "palloca", "calloca"):
+
+        store_opcodes = ("store",)
+        if self.remove_allocas:
+            store_opcodes += ("alloca", "palloca", "calloca")
+
+        if opcode in store_opcodes:
             assert inst.output is not None, inst
             out = self._eval_from_lattice(inst.operands[0])
             self._set_lattice(inst.output, out)


### PR DESCRIPTION
this allows us to run it before mem2var, and in the future, will allow us to keep allocas around longer for alias analysis.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
