### PR TITLE
feat[venom]: remove `dload` from list of volatile instructions

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -83,10 +83,13 @@ def _run_passes(fn: IRFunction, optimize: OptimizationLevel, ac: IRAnalysesCache
 
     SimplifyCFGPass(ac, fn).run_pass()
     MemMergePass(ac, fn).run_pass()
+    RemoveUnusedVariablesPass(ac, fn).run_pass()
+
     DeadStoreElimination(ac, fn).run_pass(addr_space=MEMORY)
     DeadStoreElimination(ac, fn).run_pass(addr_space=STORAGE)
     DeadStoreElimination(ac, fn).run_pass(addr_space=TRANSIENT)
     LowerDloadPass(ac, fn).run_pass()
+
     BranchOptimizationPass(ac, fn).run_pass()
 
     AlgebraicOptimizationPass(ac, fn).run_pass()

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -37,7 +37,6 @@ VOLATILE_INSTRUCTIONS = frozenset(
         "returndatacopy",
         "codecopy",
         "dloadbytes",
-        "dload",  # is this volatile?
         "return",
         "ret",
         "sink",


### PR DESCRIPTION
this allows it to be removed by the `RemoveUnusedVariables` pass.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
