### PR TITLE
feat[tool]: add venom callconv info to metadata output

### DIFF
--- a/vyper/compiler/output.py
+++ b/vyper/compiler/output.py
@@ -16,6 +16,7 @@ from vyper.semantics.types.function import ContractFunctionT, FunctionVisibility
 from vyper.semantics.types.module import InterfaceT
 from vyper.typing import StorageLayout
 from vyper.utils import safe_relpath
+from vyper.venom.ir_node_to_venom import _pass_via_stack
 from vyper.warnings import ContractSizeLimit, vyper_warn
 
 
@@ -258,6 +259,13 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
         ret["source_id"] = func_t.decl_node.module_node.source_id
         ret["function_id"] = func_t._function_id
 
+        if func_t.is_internal:
+            pass_via_stack = _pass_via_stack(func_t)
+            pass_via_stack_list = [
+                arg for (arg, is_stack_arg) in pass_via_stack.items() if is_stack_arg
+            ]
+            ret["venom_via_stack"] = pass_via_stack_list
+
         keep_keys = {
             "name",
             "return_type",
@@ -272,6 +280,7 @@ def build_metadata_output(compiler_data: CompilerData) -> dict:
             "module_path",
             "source_id",
             "function_id",
+            "venom_via_stack",
         }
         ret = {k: v for k, v in ret.items() if k in keep_keys}
         return ret

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -177,7 +177,7 @@ def _append_return_args(fn: IRFunction, ofst: int = 0, size: int = 0):
 # func_t: ContractFunctionT
 @functools.lru_cache(maxsize=1024)
 def _pass_via_stack(func_t) -> dict[str, bool]:
-    # returns a dict which returns True if a given argument (referered to
+    # returns a dict which returns True if a given argument (referred to
     # by name) should be passed via the stack
     if not ENABLE_NEW_CALL_CONV:
         return {arg.name: False for arg in func_t.arguments}


### PR DESCRIPTION
this commit adds info about the venom calling convention to the `-f metadata` output, specifically, which args are passed via stack for internal functions.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
