### PR TITLE
feat[tool]!: rename `--venom` to `--venom-experimental`

### DIFF
--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -62,7 +62,7 @@ The new experimental code generation feature can be activated using the followin
 
    #pragma experimental-codegen
 
-Alternatively, you can use the alias ``"venom"`` instead of ``"experimental-codegen"``  to enable this feature.
+Alternatively, you can use the alias ``"venom-experimental"`` instead of ``"experimental-codegen"``  to enable this feature.
 
 Imports
 =======

--- a/tests/unit/ast/test_pre_parser.py
+++ b/tests/unit/ast/test_pre_parser.py
@@ -214,7 +214,7 @@ def test_parse_pragmas(code, pre_parse_settings, compiler_data_settings, mock_ve
 
 pragma_venom = [
     """
-    #pragma venom
+    #pragma venom-experimental
     """,
     """
     #pragma experimental-codegen
@@ -261,12 +261,12 @@ invalid_pragmas = [
     """,
     # duplicate setting of venom
     """
-    #pragma venom
+    #pragma venom-experimental
     #pragma experimental-codegen
     """,
     """
-    #pragma venom
-    #pragma venom
+    #pragma venom-experimental
+    #pragma venom-experimental
     """,
 ]
 

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -375,7 +375,7 @@ def test_compile_json_with_experimental_codegen():
         "settings": {
             "evmVersion": "cancun",
             "optimize": "gas",
-            "venom": True,
+            "venomExperimental": True,
             "search_paths": [],
             "outputSelection": {"*": ["ast"]},
         },
@@ -393,11 +393,11 @@ def test_compile_json_with_both_venom_aliases():
             "evmVersion": "cancun",
             "optimize": "gas",
             "experimentalCodegen": False,
-            "venom": False,
+            "venomExperimental": False,
             "search_paths": [],
             "outputSelection": {"*": ["ast"]},
         },
     }
     with pytest.raises(JSONError) as e:
         get_settings(code)
-    assert e.value.args[0] == "both experimentalCodegen and venom cannot be set"
+    assert e.value.args[0] == "both experimentalCodegen and venomExperimental cannot be set"

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -79,7 +79,7 @@ def _parse_pragma(comment_contents, settings, is_interface, code, start):
         settings.evm_version = evm_version
         return
 
-    if pragma in ("experimental-codegen", "venom"):
+    if pragma in ("experimental-codegen", "venom-experimental"):
         if settings.experimental_codegen is not None:
             raise PragmaException("pragma experimental-codegen/venom specified twice!", *location)
         settings.experimental_codegen = True

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -81,7 +81,9 @@ def _parse_pragma(comment_contents, settings, is_interface, code, start):
 
     if pragma in ("experimental-codegen", "venom-experimental"):
         if settings.experimental_codegen is not None:
-            raise PragmaException("pragma experimental-codegen/venom specified twice!", *location)
+            raise PragmaException(
+                "pragma experimental-codegen/venom-experimental specified twice!", *location
+            )
         settings.experimental_codegen = True
         return
 

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -179,7 +179,7 @@ def _parse_args(argv):
     parser.add_argument("-o", help="Set the output path", dest="output_path")
     parser.add_argument(
         "--experimental-codegen",
-        "--venom",
+        "--venom-experimental",
         help="The compiler uses the new IR codegen. This is an experimental feature.",
         action="store_true",
         dest="experimental_codegen",

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -271,9 +271,9 @@ def get_settings(input_dict: dict) -> Settings:
 
     experimental_codegen = input_dict["settings"].get("experimentalCodegen")
     if experimental_codegen is None:
-        experimental_codegen = input_dict["settings"].get("venom")
-    elif input_dict["settings"].get("venom") is not None:
-        raise JSONError("both experimentalCodegen and venom cannot be set")
+        experimental_codegen = input_dict["settings"].get("venomExperimental")
+    elif input_dict["settings"].get("venomExperimental") is not None:
+        raise JSONError("both experimentalCodegen and venomExperimental cannot be set")
 
     if isinstance(optimize, bool):
         # bool optimization level for backwards compatibility

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -85,7 +85,7 @@ class Settings:
         if self.optimize is not None:
             ret.append(" --optimize " + str(self.optimize))
         if self.experimental_codegen is True:
-            ret.append(" --venom")
+            ret.append(" --venom-experimental")
         if self.evm_version is not None:
             ret.append(" --evm-version " + self.evm_version)
         if self.debug is True:


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
`--venom` was added as an alias for `--experimental-codegen` in
471a556f617e550a7. however, users might mistake that as meaning venom
is stable, which it is not (yet).

this commit renames the `--venom` CLI/pragma flag to
`--venom-experimental`, to better communicate that it is still not
stable.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
