### PR TITLE
fix[venom]: inliner phi invalidation

### DIFF
--- a/tests/unit/compiler/venom/test_inliner.py
+++ b/tests/unit/compiler/venom/test_inliner.py
@@ -1,8 +1,9 @@
 from tests.venom_utils import parse_venom
-from vyper.venom.check_venom import check_venom_ctx
-from vyper.venom.passes import FunctionInlinerPass, SimplifyCFGPass, MakeSSA
+from vyper.compiler.settings import OptimizationLevel
 from vyper.venom.analysis.analysis import IRAnalysesCache
-from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.venom.check_venom import check_venom_ctx
+from vyper.venom.passes import FunctionInlinerPass, SimplifyCFGPass
+
 
 def test_inliner():
     pre = """

--- a/tests/unit/compiler/venom/test_inliner.py
+++ b/tests/unit/compiler/venom/test_inliner.py
@@ -1,0 +1,48 @@
+from tests.venom_utils import parse_venom
+from vyper.venom.check_venom import check_venom_ctx
+from vyper.venom.passes import FunctionInlinerPass, SimplifyCFGPass, MakeSSA
+from vyper.venom.analysis.analysis import IRAnalysesCache
+from vyper.compiler.settings import OptimizationLevel, Settings
+
+def test_inliner():
+    pre = """
+    function main {
+    main:
+        %p = param
+        %1 = invoke @f, %p
+        %2 = 0
+        jmp @cond
+    cond:
+        %2:1 = phi @main, %2, @body, %2:2
+        %cond = iszero %2:1
+        jnz %cond, @body, @join
+    body:
+        %2:2 = add %2:1, 1
+        jmp @cond
+    join:
+        sink %2:1
+    }
+
+    function f {
+    main:
+        %p = param
+        %1 = add %p, 1
+        ret %1
+    }
+    """
+
+    ctx = parse_venom(pre)
+
+    ir_analyses = {}
+    for fn in ctx.functions.values():
+        ir_analyses[fn] = IRAnalysesCache(fn)
+
+    FunctionInlinerPass(ir_analyses, ctx, OptimizationLevel.CODESIZE).run_pass()
+
+    for fn in ctx.get_functions():
+        ac = IRAnalysesCache(fn)
+        SimplifyCFGPass(ac, fn).run_pass()
+
+    print(ctx)
+
+    check_venom_ctx(ctx)


### PR DESCRIPTION
### What I did
Fix the issue which invalidated `phi` instruction in function inlining, that later resulted in removal of the `phi` in `SimplifyCFGPass`

### How I did it
implemented fixing of `phi`s in relevant place in inliner

### How to verify it
created test that reproduces the original issue

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
