### PR TITLE
fix[tool]: fix invalid quotes in `-f cfg` output

### DIFF
--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -439,7 +439,7 @@ def call_foo(amount: uint256, account: address) -> uint256:
     }
     output_json = compile_json(code)
     venom = output_json["contracts"]["foo.vy"]["foo"]["venom"]
-    assert 'subgraph "\\"internal 0 _foo(uint256,address)_runtime\\""' in venom["cfg_runtime"]
+    assert 'subgraph "internal 0 _foo(uint256,address)_runtime"' in venom["cfg_runtime"]
 
 
 def test_compile_json_without_experimental_codegen():

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -403,7 +403,7 @@ def test_compile_json_with_experimental_codegen():
     assert venom["cfg_runtime"] == expected["cfg_runtime"]
 
 
-def test_compile_json_escapes_subgraph_label():
+def test_compile_json_subgraph_label():
     foo_code = """
 a: uint256
 b: address
@@ -432,7 +432,7 @@ def call_foo(amount: uint256, account: address) -> uint256:
         "settings": {
             "evmVersion": "cancun",
             "optimize": "gas",
-            "venom": True,
+            "venomExperimental": True,
             "search_paths": ["."],
             "outputSelection": {"*": ["cfg_runtime"]},
         },

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -439,6 +439,7 @@ def call_foo(amount: uint256, account: address) -> uint256:
     }
     output_json = compile_json(code)
     venom = output_json["contracts"]["foo.vy"]["foo"]["venom"]
+    # ensure that quotes are formatted properly in the output
     assert 'subgraph "internal 0 _foo(uint256,address)_runtime"' in venom["cfg_runtime"]
 
 

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import textwrap
+import json
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, Optional
@@ -192,7 +193,7 @@ class IRFunction:
 
         if not only_subgraph:
             ret.append("digraph G {{")
-        ret.append(f'subgraph "{self.name}" {{')
+        ret.append(f"subgraph {json.dumps(repr(self.name))} {{")
 
         for bb in self.get_basic_blocks():
             for out_bb in bb.out_bbs:

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import textwrap
-import json
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, Optional
@@ -193,7 +192,7 @@ class IRFunction:
 
         if not only_subgraph:
             ret.append("digraph G {{")
-        ret.append(f"subgraph {json.dumps(repr(self.name))} {{")
+        ret.append(f"subgraph {repr(self.name)} {{")
 
         for bb in self.get_basic_blocks():
             for out_bb in bb.out_bbs:


### PR DESCRIPTION
### What I did
The subgraph labels of the IR contain duplicate double quotes `""` for the internal nodes which create a syntax error when parsing the generated output with graphviz. As a fix, I removed the duplicates so that the output only contains `"` now and can be used with graphviz again.

### How I did it
Changed the string interpolation of the subgraph label

### How to verify it
Run tests or manually pipe the compiler output `cfg_runtime` format into `dot`:

```
$ vyper -f cfg_runtime --venom test.vy | dot 
```

### Commit message
```
the subgraph labels of the `-f cfg` and `-f cfg_runtime` output contain
duplicate double quotes `""` for some inlined functions, which create a
syntax error when parsing the generated output with graphviz.

this commit escapes quotes in the labels by serializing with `repr`.
```

### Description for the changelog
Remove duplicate quotes in subgraph labels which created a syntax error in the dot output

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
