### PR TITLE
feat[venom]: rewrite grammar to LALR(1)

### DIFF
--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from lark import Lark, Transformer
 
@@ -14,7 +15,6 @@ from vyper.venom.context import DataItem, DataSection, IRContext
 from vyper.venom.function import IRFunction
 
 VENOM_GRAMMAR = """
-    %import common.CNAME
     %import common.DIGIT
     %import common.HEXDIGIT
     %import common.LETTER
@@ -22,53 +22,61 @@ VENOM_GRAMMAR = """
     %import common.INT
     %import common.SIGNED_INT
     %import common.ESCAPED_STRING
+    %import common.NEWLINE
 
     # Allow multiple comment styles
     COMMENT: ";" /[^\\n]*/ | "//" /[^\\n]*/ | "#" /[^\\n]*/
 
     start: function* data_segment?
 
-    # TODO: consider making entry block implicit, e.g.
-    # `"{" instruction+ block* "}"`
-    function: "function" LABEL_IDENT "{" block* "}"
+    # Function contains lines, each line is terminated by NEWLINE or EOF
+    function: "function" func_name "{" line* "}"
 
-    data_segment: "data" "readonly" "{" data_section* "}"
-    data_section: "dbsection" LABEL_IDENT ":" data_item+
-    data_item: "db" (HEXSTR | LABEL)
+    # A line can contain a label declaration, a statement, or be empty
+    line: label_decl NEWLINE* | statement NEWLINE* | NEWLINE
 
-    block: LABEL_IDENT ":" "\\n" statement*
+    # Label declaration is IDENT or ESCAPED_STRING followed by ":"
+    label_decl: (IDENT | ESCAPED_STRING) ":"
 
-    statement: (instruction | assignment) "\\n"
+    # Statements are either assignments or instructions
+    statement: assignment | instruction
     assignment: VAR_IDENT "=" expr
     expr: instruction | operand
-    instruction: OPCODE operands_list?
+
+    # Instructions are IDENT followed by optional operands
+    instruction: IDENT operands_list?
 
     operands_list: operand ("," operand)*
 
-    operand: VAR_IDENT | CONST | LABEL
+    operand: VAR_IDENT | CONST | label_ref
 
     CONST: SIGNED_INT | "0x" HEXDIGIT+
-    OPCODE: CNAME
     VAR_IDENT: "%" (DIGIT|LETTER|"_"|":")+
 
-    # handy for identifier to be an escaped string sometimes
-    # (especially for machine-generated labels)
-    LABEL_IDENT: (NAME | ESCAPED_STRING)
-    LABEL: "@" LABEL_IDENT
+    # Non-terminal rules for different contexts
+    func_name: IDENT | ESCAPED_STRING
+    label_name: IDENT | ESCAPED_STRING
+    label_ref: "@" (IDENT | ESCAPED_STRING)
+
+    # Data segment rules remain the same
+    data_segment: "data" "readonly" "{" data_section* "}"
+    data_section: "dbsection" label_name ":" data_item+
+    data_item: "db" (HEXSTR | label_ref) NEWLINE*
 
     DOUBLE_QUOTE: "\\""
-    NAME: (DIGIT|LETTER|"_")+
+    IDENT: (DIGIT|LETTER|"_")+
     HEXSTR: "x" DOUBLE_QUOTE (HEXDIGIT|"_")+ DOUBLE_QUOTE
 
     %ignore WS
     %ignore COMMENT
     """
 
-VENOM_PARSER = Lark(VENOM_GRAMMAR)
+# Use LALR parser without contextual lexer since grammar is now unambiguous
+VENOM_PARSER = Lark(VENOM_GRAMMAR, parser="lalr")
 
 
-def _set_last_var(fn: IRFunction):
-    for bb in fn.get_basic_blocks():
+def _set_last_var(function: IRFunction) -> None:
+    for bb in function.get_basic_blocks():
         for inst in bb.instructions:
             if inst.output is None:
                 continue
@@ -76,19 +84,19 @@ def _set_last_var(fn: IRFunction):
             assert value.startswith("%")
             varname = value[1:]
             if varname.isdigit():
-                fn.last_variable = max(fn.last_variable, int(varname))
+                function.last_variable = max(function.last_variable, int(varname))
 
 
-def _set_last_label(ctx: IRContext):
-    for fn in ctx.functions.values():
-        for bb in fn.get_basic_blocks():
+def _set_last_label(ctx: IRContext) -> None:
+    for function in ctx.functions.values():
+        for bb in function.get_basic_blocks():
             label = bb.label.value
             label_head, *_ = label.split("_", maxsplit=1)
             if label_head.isdigit():
                 ctx.last_label = max(int(label_head), ctx.last_label)
 
 
-def _unescape(s: str):
+def _unescape(s: str) -> str:
     """
     Unescape the escaped string. This is the inverse of `IRLabel.__repr__()`.
     """
@@ -98,12 +106,23 @@ def _unescape(s: str):
 
 
 class _TypedItem:
-    def __init__(self, children):
+    """Base class for typed items in the parse tree."""
+
+    def __init__(self, children: list) -> None:
         self.children = children
 
 
 class _DataSegment(_TypedItem):
+    """Represents a data segment in the parse tree."""
+
     pass
+
+
+class _LabelDecl:
+    """Represents a label declaration in the parse tree."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
 
 
 class VenomTransformer(Transformer):
@@ -113,12 +132,36 @@ class VenomTransformer(Transformer):
             ctx.data_segment = children.pop().children
 
         funcs = children
-        for fn_name, blocks in funcs:
+        for fn_name, lines in funcs:
             fn = ctx.create_function(fn_name)
             if ctx.entry_function is None:
                 ctx.entry_function = fn
             fn._basic_block_dict.clear()
 
+            # Process lines to reconstruct blocks
+            current_block_label: Optional[str] = None
+            current_block_instructions: list[IRInstruction] = []
+            blocks: list[tuple[str, list[IRInstruction]]] = []
+
+            for item in lines:
+                if isinstance(item, _LabelDecl):
+                    # Save previous block if exists
+                    if current_block_label is not None:
+                        blocks.append((current_block_label, current_block_instructions))
+                    # Start new block
+                    current_block_label = item.label
+                    current_block_instructions = []
+                elif isinstance(item, IRInstruction):
+                    # Add instruction to current block
+                    if current_block_label is None:
+                        raise ValueError("Instruction found before any label declaration")
+                    current_block_instructions.append(item)
+
+            # Save last block
+            if current_block_label is not None:
+                blocks.append((current_block_label, current_block_instructions))
+
+            # Create basic blocks
             for block_name, instructions in blocks:
                 bb = IRBasicBlock(IRLabel(block_name, True), fn)
                 fn.append_basic_block(bb)
@@ -132,35 +175,49 @@ class VenomTransformer(Transformer):
 
         return ctx
 
-    def function(self, children) -> tuple[str, list[tuple[str, list[IRInstruction]]]]:
-        name, *blocks = children
-        return name, blocks
+    def function(self, children) -> tuple[str, list]:
+        name = children[0]
+        lines = []
+        # Filter out None values from empty lines
+        for child in children[1:]:
+            if child is not None:
+                lines.append(child)
+        return name, lines
 
-    def statement(self, children):
+    def line(self, children) -> Optional[_LabelDecl | IRInstruction]:
+        # A line might have just a NEWLINE (empty line) which we skip
+        if len(children) == 0 or (len(children) == 1 and children[0].type == "NEWLINE"):
+            return None
+        # Otherwise return the label_decl or statement
         return children[0]
 
-    def data_segment(self, children):
+    def label_decl(self, children) -> _LabelDecl:
+        label = _unescape(str(children[0]))
+        return _LabelDecl(label)
+
+    def statement(self, children) -> IRInstruction:
+        return children[0]
+
+    def data_segment(self, children) -> _DataSegment:
         return _DataSegment(children)
 
-    def data_section(self, children):
+    def data_section(self, children) -> DataSection:
         label = IRLabel(children[0], True)
         data_items = children[1:]
         assert all(isinstance(item, DataItem) for item in data_items)
         return DataSection(label, data_items)
 
-    def data_item(self, children):
+    def data_item(self, children) -> DataItem:
         item = children[0]
         if isinstance(item, IRLabel):
             return DataItem(item)
+        # Handle HEXSTR
+        assert isinstance(item, str)
         assert item.startswith('x"')
         assert item.endswith('"')
         item = item.removeprefix('x"').removesuffix('"')
         item = item.replace("_", "")
         return DataItem(bytes.fromhex(item))
-
-    def block(self, children) -> tuple[str, list[IRInstruction]]:
-        label, *instructions = children
-        return label, instructions
 
     def assignment(self, children) -> IRInstruction:
         to, value = children
@@ -171,16 +228,19 @@ class VenomTransformer(Transformer):
             return IRInstruction("store", [value], output=to)
         raise TypeError(f"Unexpected value {value} of type {type(value)}")
 
-    def expr(self, children):
+    def expr(self, children) -> IRInstruction | IROperand:
         return children[0]
 
     def instruction(self, children) -> IRInstruction:
         if len(children) == 1:
-            opcode = children[0]
+            # Just the opcode (IDENT)
+            opcode = str(children[0])
             operands = []
         else:
             assert len(children) == 2
-            opcode, operands = children
+            # IDENT and operands_list
+            opcode = str(children[0])
+            operands = children[1]
 
         # reverse operands, venom internally represents top of stack
         # as rightmost operand
@@ -199,14 +259,19 @@ class VenomTransformer(Transformer):
     def operand(self, children) -> IROperand:
         return children[0]
 
-    def OPCODE(self, token):
-        return token.value
+    def func_name(self, children) -> str:
+        # func_name can be IDENT or ESCAPED_STRING
+        return _unescape(str(children[0]))
 
-    def LABEL_IDENT(self, label) -> str:
-        return _unescape(label)
+    def label_name(self, children) -> str:
+        # label_name can be IDENT or ESCAPED_STRING
+        return _unescape(str(children[0]))
 
-    def LABEL(self, label) -> IRLabel:
-        label = _unescape(label[1:])
+    def label_ref(self, children) -> IRLabel:
+        # label_ref is "@" followed by IDENT or ESCAPED_STRING
+        label = _unescape(str(children[0]))
+        if label.startswith("@"):
+            label = label[1:]
         return IRLabel(label, True)
 
     def VAR_IDENT(self, var_ident) -> IRVariable:
@@ -217,10 +282,10 @@ class VenomTransformer(Transformer):
             return IRLiteral(int(val, 16))
         return IRLiteral(int(val))
 
-    def CNAME(self, val) -> str:
+    def IDENT(self, val) -> str:
         return val.value
 
-    def NAME(self, val) -> str:
+    def HEXSTR(self, val) -> str:
         return val.value
 
 


### PR DESCRIPTION
### What I did
fixes https://github.com/vyperlang/vyper/issues/4417

### How I did it

### How to verify it

### Commit message

```
this commit updates the venom parser to use the LALR(1) algorithm,
which is O(n) rather than the O(n^3) earley algorithm.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
