### PR TITLE
fix[lang]: disallow `@raw_return` in interfaces

### DIFF
--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -340,6 +340,11 @@ class ContractFunctionT(VyperType):
         # guaranteed by parse_decorators and disallowing nonreentrant pragma
         assert decorators.reentrant_node is None  # sanity check
 
+        if decorators.raw_return_node is not None:
+            raise FunctionDeclarationException(
+                "`@raw_return` not allowed in interfaces", decorators.raw_return_node
+            )
+
         # it's redundant to specify visibility in vyi - always should be external
         function_visibility = decorators.visibility
         if function_visibility is None:


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
this commit disallows `@raw_return` in `.vyi` files, as the decorator
doesn't have much semantic information for interfaces.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
