### PR TITLE
refactor[parser]: remove `asttokens` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
     py_modules=["vyper"],
     install_requires=[
         "cbor2>=5.4.6,<6",
-        "asttokens>=2.0.5,<4",
         "pycryptodome>=3.5.1,<4",
         "packaging>=23.1",
         "lark>=1.0.0,<2",

--- a/vyper/ast/natspec.py
+++ b/vyper/ast/natspec.py
@@ -2,10 +2,8 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-# NOTE: this is our only use of asttokens -- consider vendoring in the implementation.
-from asttokens import LineNumbers
-
 from vyper.ast import nodes as vy_ast
+from vyper.ast.utils import LineNumbers
 from vyper.exceptions import NatSpecSyntaxException
 
 SINGLE_FIELDS = ("title", "author", "license", "notice", "dev")

--- a/vyper/ast/utils.py
+++ b/vyper/ast/utils.py
@@ -1,7 +1,32 @@
-from typing import Dict, List, Union
+import bisect
+import re
+from typing import Dict, List, Tuple, Union
 
 from vyper.ast import nodes as vy_ast
 from vyper.exceptions import CompilerPanic
+
+
+class LineNumbers:
+    """
+    Class to convert between character offsets in a text string, and pairs (line, column) of 1-based
+    line and 0-based column numbers.
+
+    Vendored from asttokens.
+    """
+
+    def __init__(self, text: str) -> None:
+        # a list of character offsets of each line's first character
+        self._line_offsets = [m.start(0) for m in re.finditer(r"^", text, re.M)]
+        self._text_len = len(text)
+
+    def offset_to_line(self, offset: int) -> Tuple[int, int]:
+        """
+        Converts 0-based character offset to pair (line, col) of 1-based line and 0-based column
+        numbers.
+        """
+        offset = max(0, min(self._text_len, offset))
+        line_index = bisect.bisect_right(self._line_offsets, offset) - 1
+        return (line_index + 1, offset - self._line_offsets[line_index])
 
 
 def ast_to_dict(ast_struct: Union[vy_ast.VyperNode, List]) -> Union[Dict, List]:


### PR DESCRIPTION
vendor in the single function that we use, `offset_to_line()`.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
