### PR TITLE
refactor[venom]: rename `store` instruction to `iden`

### DIFF
--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -357,10 +357,10 @@ def test_phis():
         IRVariable("%11:4"),
         ret=IRVariable("11:3"),
     )
-    expect_bb.append_instruction("store", IRVariable("11:3"), ret=IRVariable("%35"))
-    expect_bb.append_instruction("store", IRLiteral(9), ret=IRVariable("%36"))
+    expect_bb.append_instruction("iden", IRVariable("11:3"), ret=IRVariable("%35"))
+    expect_bb.append_instruction("iden", IRLiteral(9), ret=IRVariable("%36"))
     expect_bb.append_instruction("xor", IRVariable("%35"), IRVariable("%36"), ret=IRVariable("%15"))
-    expect_bb.append_instruction("store", IRVariable("%15"), ret=IRVariable("%37"))
+    expect_bb.append_instruction("iden", IRVariable("%15"), ret=IRVariable("%37"))
     expect_bb.append_instruction("jnz", IRVariable("%37"), IRLabel("5_body"), IRLabel("7_exit"))
     # other basic blocks omitted for brevity
 

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -222,9 +222,9 @@ def test_offsets():
         %1 = offset @main, 0
 
         ; TODO fix this, should be `offset @main, 0`
-        ; (also, the `store` opcode is used directly because
+        ; (also, the `iden` opcode is used directly because
         ; the parser does not see the label as literal)
-        %2 = store @main
+        %2 = iden @main
         %3 = add %par, @main
         sink %1, %2, %3
     """

--- a/tests/unit/compiler/venom/test_duplicate_operands.py
+++ b/tests/unit/compiler/venom/test_duplicate_operands.py
@@ -20,7 +20,7 @@ def test_duplicate_operands():
     ctx = IRContext()
     fn = ctx.create_function("test")
     bb = fn.get_basic_block()
-    op = bb.append_instruction("store", 10)
+    op = bb.append_instruction("iden", 10)
     sum_ = bb.append_instruction("add", op, op)
     bb.append_instruction("mul", sum_, op)
     bb.append_instruction("stop")

--- a/tests/unit/compiler/venom/test_multi_entry_block.py
+++ b/tests/unit/compiler/venom/test_multi_entry_block.py
@@ -13,14 +13,14 @@ def test_multi_entry_block_1():
     block_1_label = IRLabel("block_1", fn)
 
     bb = fn.get_basic_block()
-    op = bb.append_instruction("store", 10)
+    op = bb.append_instruction("iden", 10)
     acc = bb.append_instruction("add", op, op)
     bb.append_instruction("jnz", acc, finish_label, block_1_label)
 
     block_1 = IRBasicBlock(block_1_label, fn)
     fn.append_basic_block(block_1)
     acc = block_1.append_instruction("add", acc, op)
-    op = block_1.append_instruction("store", 10)
+    op = block_1.append_instruction("iden", 10)
     block_1.append_instruction("mstore", acc, op)
     block_1.append_instruction("jnz", acc, finish_label, target_label)
 
@@ -60,21 +60,21 @@ def test_multi_entry_block_2():
     block_2_label = IRLabel("block_2", fn)
 
     bb = fn.get_basic_block()
-    op = bb.append_instruction("store", 10)
+    op = bb.append_instruction("iden", 10)
     acc = bb.append_instruction("add", op, op)
     bb.append_instruction("jnz", acc, finish_label, block_1_label)
 
     block_1 = IRBasicBlock(block_1_label, fn)
     fn.append_basic_block(block_1)
     acc = block_1.append_instruction("add", acc, op)
-    op = block_1.append_instruction("store", 10)
+    op = block_1.append_instruction("iden", 10)
     block_1.append_instruction("mstore", acc, op)
     block_1.append_instruction("jnz", acc, target_label, finish_label)
 
     block_2 = IRBasicBlock(block_2_label, fn)
     fn.append_basic_block(block_2)
     acc = block_2.append_instruction("add", acc, op)
-    op = block_2.append_instruction("store", 10)
+    op = block_2.append_instruction("iden", 10)
     block_2.append_instruction("mstore", acc, op)
     # switch the order of the labels, for fun and profit
     block_2.append_instruction("jnz", acc, finish_label, target_label)
@@ -113,14 +113,14 @@ def test_multi_entry_block_with_dynamic_jump():
     block_1_label = IRLabel("block_1", fn)
 
     bb = fn.get_basic_block()
-    op = bb.append_instruction("store", 10)
+    op = bb.append_instruction("iden", 10)
     acc = bb.append_instruction("add", op, op)
     bb.append_instruction("djmp", acc, finish_label, block_1_label)
 
     block_1 = IRBasicBlock(block_1_label, fn)
     fn.append_basic_block(block_1)
     acc = block_1.append_instruction("add", acc, op)
-    op = block_1.append_instruction("store", 10)
+    op = block_1.append_instruction("iden", 10)
     block_1.append_instruction("mstore", acc, op)
     block_1.append_instruction("jnz", acc, finish_label, target_label)
 

--- a/tests/unit/compiler/venom/test_stack_cleanup.py
+++ b/tests/unit/compiler/venom/test_stack_cleanup.py
@@ -8,8 +8,8 @@ def test_cleanup_stack():
     fn = ctx.create_function("test")
     bb = fn.get_basic_block()
     ret_val = bb.append_instruction("param")
-    op = bb.append_instruction("store", 10)
-    op2 = bb.append_instruction("store", op)
+    op = bb.append_instruction("iden", 10)
+    op2 = bb.append_instruction("iden", op)
     bb.append_instruction("add", op, op2)
     bb.append_instruction("ret", ret_val)
 

--- a/vyper/venom/analysis/available_expression.py
+++ b/vyper/venom/analysis/available_expression.py
@@ -105,7 +105,7 @@ class _Expression:
         return same_ops(self.operands, other.operands)
 
     def __repr__(self) -> str:
-        if self.opcode == "store":
+        if self.opcode == "iden":
             assert len(self.operands) == 1, "wrong store"
             return repr(self.operands[0])
         res = self.opcode + "("
@@ -286,7 +286,7 @@ class AvailableExpressionAnalysis(IRAnalysis):
 
         change = False
         for inst in bb.instructions:
-            if inst.opcode == "store" or inst.is_pseudo or inst.is_bb_terminator:
+            if inst.opcode == "iden" or inst.is_pseudo or inst.is_bb_terminator:
                 continue
 
             if (
@@ -334,7 +334,7 @@ class AvailableExpressionAnalysis(IRAnalysis):
         # create dataflow loop
         if inst.opcode == "phi":
             return op
-        if inst.opcode == "store":
+        if inst.opcode == "iden":
             return self._get_operand(inst.operands[0], available_exprs)
         if inst.opcode == "param":
             return op

--- a/vyper/venom/analysis/dfg.py
+++ b/vyper/venom/analysis/dfg.py
@@ -52,15 +52,15 @@ class DFGAnalysis(IRAnalysis):
             return True
 
         if isinstance(var1, IRVariable) and isinstance(var2, IRVariable):
-            var1 = self._traverse_store_chain(var1)
-            var2 = self._traverse_store_chain(var2)
+            var1 = self._traverse_assign_chain(var1)
+            var2 = self._traverse_assign_chain(var2)
 
         return var1 == var2
 
-    def _traverse_store_chain(self, var: IRVariable) -> IRVariable:
+    def _traverse_assign_chain(self, var: IRVariable) -> IRVariable:
         while True:
             inst = self.get_producing_instruction(var)
-            if inst is None or inst.opcode != "store":
+            if inst is None or inst.opcode != "iden":
                 return var
             var = inst.operands[0]  # type: ignore
 

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -388,7 +388,7 @@ class IRInstruction:
     def code_size_cost(self) -> int:
         if self.opcode in ("ret", "param"):
             return 0
-        if self.opcode in ("store", "palloca", "alloca", "calloca"):
+        if self.opcode in ("iden", "palloca", "alloca", "calloca"):
             return 1
         return 2
 
@@ -412,7 +412,7 @@ class IRInstruction:
         s = ""
         if self.output:
             s += f"{self.output} = "
-        opcode = f"{self.opcode} " if self.opcode != "store" else ""
+        opcode = f"{self.opcode} " if self.opcode != "iden" else ""
         s += opcode
         operands = self.operands
         if opcode not in ["jmp", "jnz", "djmp", "invoke"]:
@@ -424,7 +424,7 @@ class IRInstruction:
         s = ""
         if self.output:
             s += f"{self.output} = "
-        opcode = f"{self.opcode} " if self.opcode != "store" else ""
+        opcode = f"{self.opcode} " if self.opcode != "iden" else ""
         s += opcode
         operands = self.operands
         if self.opcode == "invoke":

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -170,8 +170,8 @@ def _append_return_args(fn: IRFunction, ofst: int = 0, size: int = 0):
         fn.append_basic_block(bb)
     ret_ofst = IRVariable("ret_ofst")
     ret_size = IRVariable("ret_size")
-    bb.append_instruction("store", ofst, ret=ret_ofst)
-    bb.append_instruction("store", size, ret=ret_size)
+    bb.append_instruction("iden", ofst, ret=ret_ofst)
+    bb.append_instruction("iden", size, ret=ret_size)
 
 
 # func_t: ContractFunctionT
@@ -463,7 +463,7 @@ def _convert_ir_bb(fn, ir, symbols):
         fn.append_basic_block(then_block)
         then_ret_val = _convert_ir_bb(fn, ir.args[1], cond_symbols)
         if isinstance(then_ret_val, IRLiteral):
-            then_ret_val = fn.get_basic_block().append_instruction("store", then_ret_val)
+            then_ret_val = fn.get_basic_block().append_instruction("iden", then_ret_val)
 
         then_block_finish = fn.get_basic_block()
 
@@ -475,7 +475,7 @@ def _convert_ir_bb(fn, ir, symbols):
             else_ret_val = _convert_ir_bb(fn, ir.args[2], cond_symbols)
             if isinstance(else_ret_val, IRLiteral):
                 assert isinstance(else_ret_val.value, int)  # help mypy
-                else_ret_val = fn.get_basic_block().append_instruction("store", else_ret_val)
+                else_ret_val = fn.get_basic_block().append_instruction("iden", else_ret_val)
 
         else_block_finish = fn.get_basic_block()
 
@@ -488,8 +488,8 @@ def _convert_ir_bb(fn, ir, symbols):
 
         if_ret = fn.get_next_variable()
         if then_ret_val is not None and else_ret_val is not None:
-            then_block_finish.append_instruction("store", then_ret_val, ret=if_ret)
-            else_block_finish.append_instruction("store", else_ret_val, ret=if_ret)
+            then_block_finish.append_instruction("iden", then_ret_val, ret=if_ret)
+            else_block_finish.append_instruction("iden", else_ret_val, ret=if_ret)
 
         if not else_block_finish.is_terminated:
             else_block_finish.append_instruction("jmp", exit_bb.label)
@@ -502,7 +502,7 @@ def _convert_ir_bb(fn, ir, symbols):
     elif ir.value == "with":
         ret = _convert_ir_bb(fn, ir.args[1], symbols)  # initialization
 
-        ret = fn.get_basic_block().append_instruction("store", ret)
+        ret = fn.get_basic_block().append_instruction("iden", ret)
 
         sym = ir.args[0]
         with_symbols = symbols.copy()
@@ -521,7 +521,7 @@ def _convert_ir_bb(fn, ir, symbols):
     elif ir.value == "set":
         sym = ir.args[0]
         arg_1 = _convert_ir_bb(fn, ir.args[1], symbols)
-        fn.get_basic_block().append_instruction("store", arg_1, ret=symbols[sym.value])
+        fn.get_basic_block().append_instruction("iden", arg_1, ret=symbols[sym.value])
     elif ir.value == "symbol":
         return IRLabel(ir.args[0].value, True)
     elif ir.value == "data":
@@ -622,7 +622,7 @@ def _convert_ir_bb(fn, ir, symbols):
         bb.append_instruction("jmp", entry_block.label)
         fn.append_basic_block(entry_block)
 
-        counter_var = entry_block.append_instruction("store", start)
+        counter_var = entry_block.append_instruction("iden", start)
         symbols[sym.value] = counter_var
 
         if bound is not None:

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -212,7 +212,7 @@ class VenomTransformer(Transformer):
             value.output = to
             return value
         if isinstance(value, (IRLiteral, IRVariable, IRLabel)):
-            return IRInstruction("store", [value], output=to)
+            return IRInstruction("iden", [value], output=to)
         raise TypeError(f"Unexpected value {value} of type {type(value)}")
 
     def expr(self, children) -> IRInstruction | IROperand:

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -127,7 +127,7 @@ class AlgebraicOptimizationPass(IRPass):
             return
         if inst.is_volatile:
             return
-        if inst.opcode == "store":
+        if inst.opcode == "iden":
             return
         if inst.is_pseudo:
             return
@@ -150,7 +150,7 @@ class AlgebraicOptimizationPass(IRPass):
         if inst.opcode in {"shl", "shr", "sar"}:
             # (x >> 0) == (x << 0) == x
             if lit_eq(operands[1], 0):
-                self.updater.store(inst, operands[0])
+                self.updater.mk_iden(inst, operands[0])
                 return
             # no more cases for these instructions
             return
@@ -158,12 +158,12 @@ class AlgebraicOptimizationPass(IRPass):
         if inst.opcode == "exp":
             # x ** 0 -> 1
             if lit_eq(operands[0], 0):
-                self.updater.store(inst, IRLiteral(1))
+                self.updater.mk_iden(inst, IRLiteral(1))
                 return
 
             # 1 ** x -> 1
             if lit_eq(operands[1], 1):
-                self.updater.store(inst, IRLiteral(1))
+                self.updater.mk_iden(inst, IRLiteral(1))
                 return
 
             # 0 ** x -> iszero x
@@ -173,7 +173,7 @@ class AlgebraicOptimizationPass(IRPass):
 
             # x ** 1 -> x
             if lit_eq(operands[0], 1):
-                self.updater.store(inst, operands[1])
+                self.updater.mk_iden(inst, operands[1])
                 return
 
             # no more cases for this instruction
@@ -182,14 +182,14 @@ class AlgebraicOptimizationPass(IRPass):
         if inst.opcode in {"add", "sub", "xor"}:
             # (x - x) == (x ^ x) == 0
             if inst.opcode in ("xor", "sub") and operands[0] == operands[1]:
-                self.updater.store(inst, IRLiteral(0))
+                self.updater.mk_iden(inst, IRLiteral(0))
                 return
 
             # (x + 0) == (0 + x)  -> x
             # x - 0 -> x
             # (x ^ 0) == (0 ^ x)  -> x
             if lit_eq(operands[0], 0):
-                self.updater.store(inst, operands[1])
+                self.updater.mk_iden(inst, operands[1])
                 return
 
             # (-1) - x -> ~x
@@ -207,24 +207,24 @@ class AlgebraicOptimizationPass(IRPass):
 
         # x & 0xFF..FF -> x
         if inst.opcode == "and" and lit_eq(operands[0], -1):
-            self.updater.store(inst, operands[1])
+            self.updater.mk_iden(inst, operands[1])
             return
 
         if inst.opcode in ("mul", "and", "div", "sdiv", "mod", "smod"):
             # (x * 0) == (x & 0) == (x // 0) == (x % 0) -> 0
             if any(lit_eq(op, 0) for op in operands):
-                self.updater.store(inst, IRLiteral(0))
+                self.updater.mk_iden(inst, IRLiteral(0))
                 return
 
         if inst.opcode in {"mul", "div", "sdiv", "mod", "smod"}:
             if inst.opcode in ("mod", "smod") and lit_eq(operands[0], 1):
                 # x % 1 -> 0
-                self.updater.store(inst, IRLiteral(0))
+                self.updater.mk_iden(inst, IRLiteral(0))
                 return
 
             # (x * 1) == (1 * x) == (x // 1)  -> x
             if inst.opcode in ("mul", "div", "sdiv") and lit_eq(operands[0], 1):
-                self.updater.store(inst, operands[1])
+                self.updater.mk_iden(inst, operands[1])
                 return
 
             if self._is_lit(operands[0]) and is_power_of_two(operands[0].value):
@@ -256,23 +256,23 @@ class AlgebraicOptimizationPass(IRPass):
         if inst.opcode == "or":
             # x | 0xff..ff == 0xff..ff
             if any(lit_eq(op, SizeLimits.MAX_UINT256) for op in operands):
-                self.updater.store(inst, IRLiteral(SizeLimits.MAX_UINT256))
+                self.updater.mk_iden(inst, IRLiteral(SizeLimits.MAX_UINT256))
                 return
 
             # x | n -> 1 in truthy positions (if n is non zero)
             if is_truthy and self._is_lit(operands[0]) and operands[0].value != 0:
-                self.updater.store(inst, IRLiteral(1))
+                self.updater.mk_iden(inst, IRLiteral(1))
                 return
 
             # x | 0 -> x
             if lit_eq(operands[0], 0):
-                self.updater.store(inst, operands[1])
+                self.updater.mk_iden(inst, operands[1])
                 return
 
         if inst.opcode == "eq":
             # x == x -> 1
             if operands[0] == operands[1]:
-                self.updater.store(inst, IRLiteral(1))
+                self.updater.mk_iden(inst, IRLiteral(1))
                 return
 
             # x == 0 -> iszero x
@@ -306,7 +306,7 @@ class AlgebraicOptimizationPass(IRPass):
 
         # (x > x) == (x < x) -> 0
         if operands[0] == operands[1]:
-            self.updater.store(inst, IRLiteral(0))
+            self.updater.mk_iden(inst, IRLiteral(0))
             return
 
         is_gt = "g" in opcode
@@ -333,7 +333,7 @@ class AlgebraicOptimizationPass(IRPass):
             almost_never = lo + 1
 
         if lit_eq(operands[0], never):
-            self.updater.store(inst, IRLiteral(0))
+            self.updater.mk_iden(inst, IRLiteral(0))
             return
 
         if lit_eq(operands[0], almost_never):
@@ -408,4 +408,4 @@ class AlgebraicOptimizationPass(IRPass):
         else:
             # remove the iszero!
             assert len(after.operands) == 1, after
-            self.updater.update(after, "store", after.operands)
+            self.updater.update(after, "iden", after.operands)

--- a/vyper/venom/passes/assign_elimination.py
+++ b/vyper/venom/passes/assign_elimination.py
@@ -18,7 +18,7 @@ class AssignElimination(IRPass):
         self.updater = InstUpdater(self.dfg)
 
         for var, inst in self.dfg.outputs.copy().items():
-            if inst.opcode != "store":
+            if inst.opcode != "iden":
                 continue
             self._process_store(inst, var, inst.operands[0])
 

--- a/vyper/venom/passes/common_subexpression_elimination.py
+++ b/vyper/venom/passes/common_subexpression_elimination.py
@@ -14,7 +14,7 @@ UNINTERESTING_OPCODES = frozenset(
         "gaslimit",
         "address",
         "codesize",
-        "store",
+        "iden",
         "phi",
         "param",
         "source",
@@ -96,7 +96,7 @@ class CSE(IRPass):
 
     def _replace_inst(self, orig_inst: IRInstruction, to_inst: IRInstruction):
         if orig_inst.output is not None:
-            orig_inst.opcode = "store"
+            orig_inst.opcode = "iden"
             assert isinstance(to_inst.output, IRVariable), f"not var {to_inst}"
             orig_inst.operands = [to_inst.output]
         else:

--- a/vyper/venom/passes/function_inliner.py
+++ b/vyper/venom/passes/function_inliner.py
@@ -116,7 +116,7 @@ class FunctionInlinerPass(IRGlobalPass):
                             # and both b and c get inlined.
                             calloca_inst = callocas[alloca_id]
                             assert calloca_inst.output is not None
-                            inst.opcode = "store"
+                            inst.opcode = "iden"
                             inst.operands = [calloca_inst.output]
                         else:
                             callocas[alloca_id] = inst
@@ -129,7 +129,7 @@ class FunctionInlinerPass(IRGlobalPass):
                             # this is our own palloca, not one that got
                             # inlined
                             continue
-                        inst.opcode = "store"
+                        inst.opcode = "iden"
                         calloca_inst = callocas[alloca_id]
                         assert calloca_inst.output is not None  # help mypy
                         inst.operands = [calloca_inst.output]
@@ -180,7 +180,7 @@ class FunctionInlinerPass(IRGlobalPass):
             for inst in bb.instructions:
                 if inst.opcode == "param":
                     # NOTE: one of these params is the return pc.
-                    inst.opcode = "store"
+                    inst.opcode = "iden"
                     # handle return pc specially - it's at top of stack.
                     ops = call_site.operands[1:] + [call_site.operands[0]]
                     val = ops[param_idx]
@@ -195,7 +195,7 @@ class FunctionInlinerPass(IRGlobalPass):
                         assert ENABLE_NEW_CALL_CONV
                         ret_value = inst.operands[0]
                         bb.insert_instruction(
-                            IRInstruction("store", [ret_value], call_site.output), -1
+                            IRInstruction("iden", [ret_value], call_site.output), -1
                         )
                     inst.opcode = "jmp"
                     inst.operands = [call_site_return.label]

--- a/vyper/venom/passes/literals_codesize.py
+++ b/vyper/venom/passes/literals_codesize.py
@@ -18,7 +18,7 @@ class ReduceLiteralsCodesize(IRPass):
 
     def _process_bb(self, bb):
         for inst in bb.instructions:
-            if inst.opcode != "store":
+            if inst.opcode != "iden":
                 continue
 
             (op,) = inst.operands

--- a/vyper/venom/passes/load_elimination.py
+++ b/vyper/venom/passes/load_elimination.py
@@ -71,7 +71,7 @@ class LoadElimination(IRPass):
         self._lattice[ptr] = inst.output
 
         if existing_value is not None:
-            self.updater.store(inst, existing_value)
+            self.updater.mk_iden(inst, existing_value)
 
     def _handle_store(self, inst, store_opcode):
         # mstore [val, ptr]

--- a/vyper/venom/passes/machinery/inst_updater.py
+++ b/vyper/venom/passes/machinery/inst_updater.py
@@ -102,8 +102,8 @@ class InstUpdater:
         self.nop(inst)  # for dfg updates and checks
         inst.parent.remove_instruction(inst)
 
-    def store(self, inst: IRInstruction, op: IROperand, new_output: Optional[IRVariable] = None):
-        self.update(inst, "store", [op], new_output=new_output)
+    def mk_iden(self, inst: IRInstruction, op: IROperand, new_output: Optional[IRVariable] = None):
+        self.update(inst, "iden", [op], new_output=new_output)
 
     def add_before(
         self, inst: IRInstruction, opcode: str, args: list[IROperand]

--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -49,9 +49,9 @@ class Mem2Var(IRPass):
         var = IRVariable(var_name)
         for inst in uses.copy():
             if inst.opcode == "mstore":
-                self.updater.store(inst, inst.operands[0], new_output=var)
+                self.updater.mk_iden(inst, inst.operands[0], new_output=var)
             elif inst.opcode == "mload":
-                self.updater.store(inst, var)
+                self.updater.mk_iden(inst, var)
             elif inst.opcode == "return":
                 self.updater.add_before(inst, "mstore", [var, inst.operands[1]])
 
@@ -77,13 +77,13 @@ class Mem2Var(IRPass):
             if param is None:
                 self.updater.update(palloca_inst, "mload", [ofst], new_output=var)
             else:
-                self.updater.update(palloca_inst, "store", [param.func_var], new_output=var)
+                self.updater.update(palloca_inst, "iden", [param.func_var], new_output=var)
         else:
             # otherwise, it comes from memory, convert to an mload.
             self.updater.update(palloca_inst, "mload", [ofst], new_output=var)
 
         for inst in uses.copy():
             if inst.opcode == "mstore":
-                self.updater.store(inst, inst.operands[0], new_output=var)
+                self.updater.mk_iden(inst, inst.operands[0], new_output=var)
             elif inst.opcode == "mload":
-                self.updater.store(inst, var)
+                self.updater.mk_iden(inst, var)

--- a/vyper/venom/passes/phi_elimination.py
+++ b/vyper/venom/passes/phi_elimination.py
@@ -30,7 +30,7 @@ class PhiEliminationPass(IRPass):
             if src == inst:
                 return
             assert src.output is not None
-            self.updater.store(inst, src.output)
+            self.updater.mk_iden(inst, src.output)
 
     def _calculate_phi_origins(self):
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
@@ -86,12 +86,12 @@ class PhiEliminationPass(IRPass):
                 return set([inst])
             return res
 
-        if inst.opcode == "store" and isinstance(inst.operands[0], IRVariable):
-            # traverse store chain
+        if inst.opcode == "iden" and isinstance(inst.operands[0], IRVariable):
+            # traverse assignment chain
             var = inst.operands[0]
             next_inst = self.dfg.get_producing_instruction(var)
             assert next_inst is not None
             return self._get_phi_origins_r(next_inst, visited)
 
-        # root of the phi/store chain
+        # root of the phi/assignment chain
         return set([inst])

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -180,7 +180,7 @@ class SCCP(IRPass):
     def _visit_expr(self, inst: IRInstruction):
         opcode = inst.opcode
 
-        store_opcodes: tuple[str, ...] = ("store",)
+        store_opcodes: tuple[str, ...] = ("iden",)
         if self.remove_allocas:
             store_opcodes += ("alloca", "palloca", "calloca")
 

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -132,7 +132,7 @@ class SimplifyCFGPass(IRPass):
 
             op_len = len(inst.operands)
             if op_len == 2:
-                inst.opcode = "store"
+                inst.opcode = "iden"
                 inst.operands = [inst.operands[1]]
             elif op_len == 0:
                 inst.make_nop()

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -31,7 +31,7 @@ class SingleUseExpansion(IRPass):
         i = 0
         while i < len(bb.instructions):
             inst = bb.instructions[i]
-            if inst.opcode in ("store", "offset", "phi", "param"):
+            if inst.opcode in ("iden", "offset", "phi", "param"):
                 i += 1
                 continue
 
@@ -52,7 +52,7 @@ class SingleUseExpansion(IRPass):
                     continue
 
                 var = self.function.get_next_variable()
-                to_insert = IRInstruction("store", [op], var)
+                to_insert = IRInstruction("iden", [op], var)
                 bb.insert_instruction(to_insert, index=i)
                 inst.operands[j] = var
                 i += 1

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -509,7 +509,7 @@ class VenomCompiler:
             pass
         elif opcode == "param":
             pass
-        elif opcode == "store":
+        elif opcode == "iden":
             pass
         elif opcode == "dbname":
             pass


### PR DESCRIPTION
the `store` instruction name was misleading - it suggests memory storage operations when it's actually an identity operation that copies a value to a new variable name.

renamed to `iden` (identity) because:
- accurately represents the semantic: `f(x) = x`
- doesn't imply memory operations like `mstore`/`sstore`
- makes optimization passes clearer when forwarding values

also renamed the `InstUpdater.store()` method to `mk_iden()` for consistency with the new instruction name.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
