### PR TITLE
Fix Typos in Comments Across Venom Modules

### DIFF
--- a/vyper/venom/analysis/available_expression.py
+++ b/vyper/venom/analysis/available_expression.py
@@ -262,7 +262,7 @@ class AvailableExpressionAnalysis(IRAnalysis):
             if self._handle_bb(bb):
                 worklist.extend(self.cfg.cfg_out(bb))
 
-    # msize effect should be only necessery
+    # msize effect should be only necessary
     # to be handled when there is a possibility
     # of msize read otherwise it should not make difference
     # for this analysis
@@ -317,7 +317,7 @@ class AvailableExpressionAnalysis(IRAnalysis):
 
         if bb not in self.bb_outs or available_exprs != self.bb_outs[bb]:
             self.bb_outs[bb] = available_exprs
-            # change is only necessery when the output of the
+            # change is only necessary when the output of the
             # basic block is changed (otherwise it wont affect rest)
             change |= True
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -60,7 +60,7 @@ class AlgebraicOptimizationPass(IRPass):
                     opcode = use_inst.opcode
 
                     if opcode == "iszero":
-                        # We keep iszero instuctions as is
+                        # We keep iszero instructions as is
                         continue
                     if opcode in ("jnz", "assert"):
                         # instructions that accept a truthy value as input:

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -407,7 +407,7 @@ class VenomCompiler:
             operands = [offset]
 
         # iload and istore are special cases because they can take a literal
-        # that is handled specialy with the _OFST macro. Look below, after the
+        # that is handled specially with the _OFST macro. Look below, after the
         # stack reordering.
         elif opcode == "iload":
             addr = inst.operands[0]


### PR DESCRIPTION


---



**Description:**  
This pull request corrects several typographical errors in comments across the Venom analysis, optimization, and assembly modules.  
- Fixed spelling of "necessary", "instructions", and "specially" in relevant files.


---

