### PR TITLE
refactor[venom]: strengthen an assumption in venom lowering

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -9,6 +9,7 @@ from vyper.evm.address_space import MEMORY, STORAGE, TRANSIENT
 from vyper.exceptions import CompilerPanic
 from vyper.venom.analysis import MemSSA
 from vyper.venom.analysis.analysis import IRAnalysesCache
+from vyper.venom.check_venom import check_venom_fn
 from vyper.venom.context import IRContext
 from vyper.venom.function import IRFunction
 from vyper.venom.ir_node_to_venom import ir_node_to_venom

--- a/vyper/venom/check_venom.py
+++ b/vyper/venom/check_venom.py
@@ -77,6 +77,13 @@ def find_semantic_errors(context: IRContext) -> list[VenomError]:
     return errors
 
 
+def check_venom_fn(fn: IRFunction):
+    errors = find_semantic_errors_fn(fn)
+
+    if errors:
+        raise ExceptionGroup("venom semantic errors", errors)
+
+
 def check_venom_ctx(context: IRContext):
     errors = find_semantic_errors(context)
 

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -36,6 +36,11 @@ class SimplifyCFGPass(IRPass):
         jump_inst = a.instructions[-1]
         assert b.label in jump_inst.operands, f"{b.label} {jump_inst.operands}"
         jump_inst.operands[jump_inst.operands.index(b.label)] = next_bb.label
+        for inst in next_bb.instructions:
+            # assume phi instructions are at beginning of bb
+            if inst.opcode != "phi":
+                break
+            inst.operands[inst.operands.index(b.label)] = a.label
 
         self._schedule_label_replacement(b.label, next_bb.label)
 

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -69,7 +69,7 @@ class SingleUseExpansion(IRPass):
     def _process_phi(self, inst: IRInstruction):
         assert inst.opcode == "phi"
 
-        new_vars: list[IRVariable] = []
+        replacements: dict[IRVariable, IRVariable] = {}
         for label, var in inst.phi_operands:
             assert isinstance(var, IRVariable)
             bb = self.function.get_basic_block(label.name)
@@ -77,8 +77,6 @@ class SingleUseExpansion(IRPass):
             assert term.is_bb_terminator
             new_var = self.updater.add_before(term, "assign", [var])
             assert new_var is not None
-            new_vars.append(new_var)
+            replacements[var] = new_var
 
-        for index, new_var in enumerate(new_vars):
-            i = 2 * index + 1
-            inst.operands[i] = new_var
+        inst.replace_operands(replacements)

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -58,9 +58,10 @@ class SingleUseExpansion(IRPass):
                     # skip them for now.
                     continue
 
-                var = self.function.get_next_variable()
-                to_insert = IRInstruction("assign", [op], var)
-                bb.insert_instruction(to_insert, index=i)
+                #var = self.function.get_next_variable()
+                #to_insert = IRInstruction("assign", [op], var)
+                #bb.insert_instruction(to_insert, index=i)
+                var = self.updater.add_before(inst, "assign", [op])
                 inst.operands[j] = var
                 i += 1
 

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -90,13 +90,14 @@ class SingleUseExpansion(IRPass):
             #   bb2:
             #       %phi = phi @bb1, %origin, @someother, %somevar
             #       ...
-            uses = [
-                use
-                for use in self.dfg.get_uses(var)
-                if not (
-                    use.opcode == "assign" or (use.opcode == "phi" and use.parent != inst.parent)
-                )
-            ]
+
+            # if the only other use would be in assigns then the variable
+            # does not have to be moved out to the new assign
+            uses = [use for use in self.dfg.get_uses(var) if use.opcode != "assign"]
+
+            # if the only other use would be in phi node in the some other block then
+            # the same rule applies
+            uses = [use for use in uses if use.opcode != "phi" or use.parent == inst.parent]
             if len(uses) <= 1:
                 continue
             bb = self.function.get_basic_block(label.name)

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -79,6 +79,6 @@ class SingleUseExpansion(IRPass):
             assert new_var is not None
             new_vars.append(new_var)
 
-        for index, var in enumerate(new_vars):
+        for index, new_var in enumerate(new_vars):
             i = 2 * index + 1
-            inst.operands[i] = var
+            inst.operands[i] = new_var

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -77,6 +77,19 @@ class SingleUseExpansion(IRPass):
         replacements: dict[IROperand, IROperand] = {}
         for label, var in inst.phi_operands:
             assert isinstance(var, IRVariable)
+            # you only care about the cases which would be not correct
+            # as an output of this pass
+            # example
+            #
+            #   bb1:
+            #       ...
+            #       ; it does not matter that the %origin is here for the phi instruction
+            #       %var = %origin
+            #       ...
+            #       jmp @bb2
+            #   bb2:
+            #       %phi = phi @bb1, %origin, @someother, %somevar
+            #       ...
             uses = [
                 use
                 for use in self.dfg.get_uses(var) 

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -74,8 +74,12 @@ class SingleUseExpansion(IRPass):
         replacements: dict[IRVariable, IRVariable] = {}
         for label, var in inst.phi_operands:
             assert isinstance(var, IRVariable)
-            uses = [inst for inst in self.dfg.get_uses(var) if inst.opcode != "assign"]
-            if len(uses) == 1:
+            uses = [
+                use
+                for use in self.dfg.get_uses(var) 
+                if not use.opcode == "assign"
+            ]
+            if len(uses) <= 1:
                 continue
             bb = self.function.get_basic_block(label.name)
             term = bb.instructions[-1]

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -1,5 +1,5 @@
 from vyper.venom.analysis import DFGAnalysis, LivenessAnalysis
-from vyper.venom.basicblock import IRInstruction, IRLiteral, IRVariable, IROperand
+from vyper.venom.basicblock import IRInstruction, IRLiteral, IROperand, IRVariable
 from vyper.venom.passes.base_pass import IRPass
 from vyper.venom.passes.machinery.inst_updater import InstUpdater
 
@@ -66,7 +66,7 @@ class SingleUseExpansion(IRPass):
                 assert var is not None
                 ops = inst.operands.copy()
                 ops[j] = var
-                self.updater.update(inst, inst.opcode, ops) 
+                self.updater.update(inst, inst.opcode, ops)
                 i += 1
 
             i += 1
@@ -92,8 +92,10 @@ class SingleUseExpansion(IRPass):
             #       ...
             uses = [
                 use
-                for use in self.dfg.get_uses(var) 
-                if not (use.opcode == "assign" or (use.opcode == "phi" and use.parent != inst.parent))
+                for use in self.dfg.get_uses(var)
+                if not (
+                    use.opcode == "assign" or (use.opcode == "phi" and use.parent != inst.parent)
+                )
             ]
             if len(uses) <= 1:
                 continue
@@ -104,4 +106,4 @@ class SingleUseExpansion(IRPass):
             assert new_var is not None
             replacements[var] = new_var
 
-        self.updater.update_operands(inst, replacements) 
+        self.updater.update_operands(inst, replacements)

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -73,6 +73,9 @@ class SingleUseExpansion(IRPass):
         replacements: dict[IRVariable, IRVariable] = {}
         for label, var in inst.phi_operands:
             assert isinstance(var, IRVariable)
+            uses = self.dfg.get_uses(var)
+            if len(uses) == 1:
+                continue
             bb = self.function.get_basic_block(label.name)
             term = bb.instructions[-1]
             assert term.is_bb_terminator

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -62,9 +62,6 @@ class SingleUseExpansion(IRPass):
                     # skip them for now.
                     continue
 
-                #var = self.function.get_next_variable()
-                #to_insert = IRInstruction("assign", [op], var)
-                #bb.insert_instruction(to_insert, index=i)
                 var = self.updater.add_before(inst, "assign", [op])
                 inst.operands[j] = var
                 i += 1

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -77,7 +77,7 @@ class SingleUseExpansion(IRPass):
             uses = [
                 use
                 for use in self.dfg.get_uses(var) 
-                if not use.opcode == "assign"
+                if not (use.opcode == "assign" or (use.opcode == "phi" and inst.parent != use.parent))
             ]
             if len(uses) <= 1:
                 continue

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -77,7 +77,7 @@ class SingleUseExpansion(IRPass):
         replacements: dict[IRVariable, IRVariable] = {}
         for label, var in inst.phi_operands:
             assert isinstance(var, IRVariable)
-            uses = self.dfg.get_uses(var)
+            uses = [inst for inst in self.dfg.get_uses(var) if inst.opcode != "assign"]
             if len(uses) == 1:
                 continue
             bb = self.function.get_basic_block(label.name)

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -84,10 +84,15 @@ class SingleUseExpansion(IRPass):
             #   bb1:
             #       ...
             #       ; it does not matter that the %origin is here for the phi instruction
+            #       ; since if this is the only place where the origin is used
+            #       ; other then the phi node then the phi node does not have to add
+            #       ; additional store for it as and input to phi
             #       %var = %origin
             #       ...
             #       jmp @bb2
             #   bb2:
+            #       ; the %origin does not have to be extracted to new varible
+            #       ; since the only place where it is used is assign instruction
             #       %phi = phi @bb1, %origin, @someother, %somevar
             #       ...
 

--- a/vyper/venom/passes/single_use_expansion.py
+++ b/vyper/venom/passes/single_use_expansion.py
@@ -23,8 +23,12 @@ class SingleUseExpansion(IRPass):
     def run_pass(self):
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
         self.updater = InstUpdater(self.dfg)
+        self.phis: list[IRInstruction] = []
         for bb in self.function.get_basic_blocks():
             self._process_bb(bb)
+
+        for inst in self.phis:
+            self._process_phi(inst)
 
         self.analyses_cache.invalidate_analysis(DFGAnalysis)
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
@@ -38,7 +42,7 @@ class SingleUseExpansion(IRPass):
                 continue
 
             if inst.opcode == "phi":
-                self._process_phi(inst)
+                self.phis.append(inst)
                 i += 1
                 continue
 

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -436,13 +436,9 @@ class VenomCompiler:
             # example, for `%56 = %label1 %13 %label2 %14`, we will
             # find an instance of %13 *or* %14 in the stack and replace it with %56.
             to_be_replaced = stack.peek(depth)
-            if to_be_replaced in next_liveness:
-                # this branch seems unreachable (maybe due to make_ssa)
-                # %13/%14 is still live(!), so we make a copy of it
-                self.dup(assembly, stack, depth)
-                stack.poke(0, ret)
-            else:
-                stack.poke(depth, ret)
+            # precondition from SSA
+            assert to_be_replaced not in next_liveness
+            stack.poke(depth, ret)
             return apply_line_numbers(inst, assembly)
 
         if opcode == "offset":


### PR DESCRIPTION
this commit strengthens an assumption in venom_to_assembly. due to SSA form, the arguments to phi must be in the predecessor blocks. this means that the def does not reach any use from both branches, except in the case that the use is a phi.

### What I did

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
