### PR TITLE
feat[lang]: improve error message for namespace collision

### DIFF
--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -93,7 +93,18 @@ class Namespace(dict):
             prev_decl = getattr(prev, "decl_node", None)
             msg = f"'{attr}' has already been declared"
             if prev_decl is None:
-                msg += f" as a {prev}"
+                # attempt to print a hint for namespace collision
+                alias = getattr(prev, "alias", None)
+
+                if alias:
+                    hint = f" via import (alias=`{alias}`)"
+                else:
+                    short_name = getattr(prev, "name", None)
+                    type_name = type(prev).__name__
+
+                    hint = f" as {type_name} '{short_name}'" if short_name else f" as {type_name}"
+
+                msg += hint + f".\n\n Suggested fix: rename or remove the previous declaration (e.g. use `import {attr} as ...` to avoid collisions)"
             raise NamespaceCollision(msg, prev_decl=prev_decl)
 
 


### PR DESCRIPTION
### Added improved error message for namespace collisions in imports

resolves #4579

New error message looks like:
```
Error compiling: _test.vy
vyper.exceptions.NamespaceCollision: 'math' has already been declared via import (alias=`math`).

 Suggested fix: rename or remove the previous declaration (e.g. use `import math as ...` to avoid collisions)

  contract "_test.vy:2", line 2:0 
       1 from snekmate.utils import math
  ---> 2 import math
  -------^
```

### Commit message:

feat[lang]: improve error message for namespace collision

### Description for the changelog

Added a block in which it attempts to provide an easier to read hint for the user.

### Cute Animal Picture
![car](https://github.com/user-attachments/assets/af4025f2-f233-48aa-9381-af38643deabd)