### PR TITLE
fix[test]: add missing keywords to reserved list

### DIFF
--- a/vyper/ast/identifiers.py
+++ b/vyper/ast/identifiers.py
@@ -64,6 +64,8 @@ RESERVED_KEYWORDS = _PYTHON_RESERVED_KEYWORDS | {
     "internal",
     "payable",
     "nonreentrant",
+    "staticcall",
+    "extcall",
     # "class" keywords
     "interface",
     "struct",


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
fixes fuzz failure in `test_call_graph_stability.py` which relies on
`RESERVED_KEYWORDS` to filter invalid programs.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
