### PR TITLE
feat[docs]: update verbiage around reference types

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -29,6 +29,7 @@ You can optionally declare a function's visibility by using a :ref:`decorator <f
     * ``@internal`` (default): can be invoked only from within this contract. Not available to external callers
     * ``@deploy``: constructor code. This is code which is invoked once in the lifetime of a contract, upon its deploy. It is not available at runtime to either external callers or internal call invocations. At this time, only the :ref:`__init__() function <init-function>` may be marked as ``@deploy``.
 
+.. _structure-functions-external:
 
 External Functions
 ******************

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -9,11 +9,13 @@ Vyper is a statically typed language. The type of each variable (state and local
 
 In addition, types can interact with each other in expressions containing operators.
 
-Unlike in some other languages, there are no sub-categories of types. Values are always copied when assigned to a variable, or when passed to a function (also known as call-by-value). That means that, a calling function never needs to worry about a callee modifying the data of a passed structure.
+Unlike in some other languages, there are no sub-categories of types. Values are always copied, both when assigned to a variable and when passed to a function (also known as call-by-value). This means a calling function never needs to worry about a callee modifying the data of a passed structure.
 
 .. note::
 
-    However neither values nor variables are immutable. Variables can be reassigned to values of the same type. And values of some types (for example arrays and structs) have operations that modify them in place, usually by assigning to their members directly: `my_array[0] = 42`.
+    However neither parameters of :ref:`structure-functions-internal` nor variables are immutable. They can be reassigned to values of the same type. Furthermore, some types (for example arrays and structs) have operations that modify them in place, usually by assigning to their members directly (for example ``my_array[0] = 42``).
+
+    Parameters of :ref:`structure-functions-external` are immutable. They can neither be reassigned nor modified in place.
 
 .. index:: ! bool, ! true, ! false
 


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
previous "value types" section hinted at reference types being passed by
reference which is incorrect. taking this fact into account it seems the
main reason to split types into value types and reference-types
disappears.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.saymedia-content.com/.image/t_share/MTkxOTg2MzI5MDM3MzgzMTEx/6-beautiful-beetles.png)
