### PR TITLE
feat[venom]: algebraic optimizations

### DIFF
--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -202,6 +202,98 @@ def test_interleaved_case(interleave_point):
     _check_pre_post(pre, post)
 
 
+def test_fold_add_chain():
+    """add(add(x, 3), 5) => add(x, 8)"""
+    pre = """
+    main:
+        %x = source
+        %tmp = add 3, %x
+        %out = add 5, %tmp
+        sink %out
+    """
+    post = """
+    main:
+        %x = source
+        %out = add 8, %x
+        sink %out
+    """
+    _check_pre_post(pre, post)
+
+
+def test_fold_sub_lit_chain():
+    """(x + 10) - 3 => x + 7 (sub with var - lit)"""
+    pre = """
+    main:
+        %x = source
+        %tmp = add 10, %x
+        %out = sub %tmp, 3
+        sink %out
+    """
+    post = """
+    main:
+        %x = source
+        %out = add 7, %x
+        sink %out
+    """
+    _check_pre_post(pre, post)
+
+
+def test_fold_add_chain_cancels_to_zero():
+    """(x + 5) - 5 => x (constants cancel)"""
+    pre = """
+    main:
+        %x = source
+        %tmp = add 5, %x
+        %out = sub %tmp, 5
+        sink %out
+    """
+    post = """
+    main:
+        %x = source
+        %out = assign %x
+        sink %out
+    """
+    _check_pre_post(pre, post)
+
+
+def test_fold_add_chain_multi_use_stops():
+    """Don't fold through intermediates with multiple uses."""
+    pre = """
+    main:
+        %x = source
+        %tmp = add 3, %x
+        %out = add 5, %tmp
+        sink %out, %tmp
+    """
+    post = """
+    main:
+        %x = source
+        %tmp = add 3, %x
+        %out = add 5, %tmp
+        sink %out, %tmp
+    """
+    _check_pre_post(pre, post)
+
+
+def test_fold_add_chain_three_deep():
+    """add(add(add(x, 1), 2), 3) => add(x, 6)"""
+    pre = """
+    main:
+        %x = source
+        %t1 = add 1, %x
+        %t2 = add 2, %t1
+        %out = add 3, %t2
+        sink %out
+    """
+    post = """
+    main:
+        %x = source
+        %out = add 6, %x
+        sink %out
+    """
+    _check_pre_post(pre, post)
+
+
 def test_offsets():
     """
     Test of addition to offset rewrites

--- a/vyper/venom/analysis/dfg.py
+++ b/vyper/venom/analysis/dfg.py
@@ -21,6 +21,9 @@ class DFGAnalysis(IRAnalysis):
     def get_uses(self, op: IRVariable) -> OrderedSet[IRInstruction]:
         return self._dfg_inputs.get(op, OrderedSet())
 
+    def is_single_use(self, output: IRVariable) -> bool:
+        return len(self.get_uses(output)) == 1
+
     def get_uses_in_bb(self, op: IRVariable, bb: IRBasicBlock):
         """
         Get uses of a given variable in a specific basic block.

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -12,12 +12,23 @@ from vyper.venom.basicblock import (
     flip_comparison_opcode,
 )
 from vyper.venom.passes.base_pass import InstUpdater, IRPass
+from vyper.venom.passes.sccp.eval import eval_arith
 
 TRUTHY_INSTRUCTIONS = ("iszero", "jnz", "assert", "assert_unreachable")
 
 
 def lit_eq(op: IROperand, val: int) -> bool:
     return isinstance(op, IRLiteral) and wrap256(op.value) == wrap256(val)
+
+
+def lit_add(op: IROperand, val: int) -> int:
+    assert isinstance(op, IRLiteral)
+    return eval_arith("add", [op, IRLiteral(val)])
+
+
+def lit_sub(val: int, op: IROperand) -> int:
+    assert isinstance(op, IRLiteral)
+    return eval_arith("sub", [op, IRLiteral(val)])
 
 
 class AlgebraicOptimizationPass(IRPass):
@@ -108,6 +119,89 @@ class AlgebraicOptimizationPass(IRPass):
 
     def _is_lit(self, operand: IROperand) -> bool:
         return isinstance(operand, IRLiteral)
+
+    def _extract_value_and_literal_operands(
+        self, inst: IRInstruction
+    ) -> tuple[IROperand | None, IRLiteral | None]:
+        value_op = None
+        literal_op = None
+        for op in inst.operands:
+            if self._is_lit(op):
+                if literal_op is not None:
+                    return None, None
+                literal_op = op
+            else:
+                value_op = op
+        assert isinstance(literal_op, IRLiteral) or literal_op is None  # help mypy
+        return value_op, literal_op
+
+    def _fold_add_chain(self, inst: IRInstruction) -> bool:
+        if inst.opcode not in {"add", "sub"}:
+            return False
+
+        op0, op1 = inst.operands
+        base_operand: IROperand | None = None
+        total = 0
+
+        if inst.opcode == "add":
+            base_operand, literal = self._extract_value_and_literal_operands(inst)
+            if literal is None or base_operand is None:
+                return False
+            total = lit_add(literal, total)
+        else:  # sub
+            if self._is_lit(op0) and not self._is_lit(op1):
+                total = lit_sub(total, op0)
+                base_operand = op1
+            else:
+                return False
+
+        base_operand, traced = self._trace_add_chain(base_operand)
+        total += traced
+
+        if total == 0:
+            self.updater.mk_assign(inst, base_operand)
+            return True
+
+        self.updater.update(inst, "add", [base_operand, IRLiteral(total)])
+        return True
+
+    def _trace_add_chain(self, operand: IROperand) -> tuple[IROperand, int]:
+        total = 0
+        current = operand
+
+        while isinstance(current, IRVariable):
+            producer = self.dfg.get_producing_instruction(current)
+            if producer is None:
+                break
+
+            if producer.opcode == "add":
+                assert producer.output is not None  # help mypy
+                if not self.dfg.is_single_use(producer.output):
+                    break
+
+                value_op, literal = self._extract_value_and_literal_operands(producer)
+                if literal is None or value_op is None:
+                    break
+
+                assert isinstance(literal, IRLiteral)  # help mypy
+                total = lit_add(literal, total)
+                current = value_op
+                continue
+
+            if producer.opcode == "sub":
+                assert producer.output is not None  # help mypy
+                if not self.dfg.is_single_use(producer.output):
+                    break
+                op0, op1 = producer.operands
+                if self._is_lit(op0) and not self._is_lit(op1):
+                    total = lit_sub(total, op0)
+                    current = op1
+                    continue
+                break
+
+            break
+
+        return current, total
 
     def _algebraic_opt(self):
         self._algebraic_opt_pass()
@@ -265,6 +359,10 @@ class AlgebraicOptimizationPass(IRPass):
             if inst.opcode == "xor" and lit_eq(operands[0], -1):
                 self.updater.update(inst, "not", [operands[1]])
                 return
+
+            if inst.opcode in {"add", "sub"}:
+                if self._fold_add_chain(inst):
+                    return
 
             return
 


### PR DESCRIPTION
### What I did

Improve optimizations performed by algebraic optimization pass. Specifically, optimize add/sub chains.

### How I did it

### How to verify it

### Commit message

```
Implements constant folding and chain optimization for add/sub operations in the Venom IR:
  - Adds `_fold_add_chain()` to collapse chains of add/sub operations into single operations
  - Adds `_trace_add_chain()` to trace through add/sub chains and compute total offsets
  - Adds `is_single_use()` helper to DFG analysis for checking variable usage
  - Optimize patterns like `add(add(x, c1), c2)` to `add(x, c1+c2)`
  - Handle sub operations in chains
  - Add foundation for shifted add chain optimization (currently disabled)
``` 

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
