### PR TITLE
refactor[venom]: change `has_outputs` to property

### DIFF
--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -335,6 +335,7 @@ class IRInstruction:
         assert len(self._outputs) == 1, f"expected single output for {self}"
         return self._outputs[0]
 
+    @property
     def has_outputs(self) -> bool:
         """
         Check whether this instruction produces any outputs.

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -118,7 +118,7 @@ class IRFunction:
         varmap: dict[IRVariable, IRVariable] = defaultdict(self.get_next_variable)
         for bb in self.get_basic_blocks():
             for inst in bb.instructions:
-                if inst.has_outputs():
+                if inst.has_outputs:
                     inst.set_outputs([varmap[o] for o in inst.get_outputs()])
 
                 for i, op in enumerate(inst.operands):

--- a/vyper/venom/passes/common_subexpression_elimination.py
+++ b/vyper/venom/passes/common_subexpression_elimination.py
@@ -107,7 +107,7 @@ class CSE(IRPass):
             self._replace_inst(orig, to)
 
     def _replace_inst(self, orig_inst: IRInstruction, to_inst: IRInstruction):
-        if orig_inst.has_outputs():
+        if orig_inst.has_outputs:
             orig_inst.opcode = "assign"
             orig_inst.operands = [to_inst.output]
         else:


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
use property access for `IRInstruction.has_outputs`
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
