### PR TITLE
feat[test]: add bytesM tests for extract32

### DIFF
--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -848,7 +848,7 @@ class Extract32(BuiltinFunctionT):
             output_type = type_from_annotation(node.keywords[0].value)
             if not isinstance(output_type, (AddressT, BytesM_T, IntegerT)):
                 raise InvalidType(
-                    "Output type must be one of integer, bytes32 or address", node.keywords[0].value
+                    "Output type must be one of integer, bytesM or address", node.keywords[0].value
                 )
             output_typedef = TYPE_T(output_type)
             node.keywords[0].value._metadata["type"] = output_typedef


### PR DESCRIPTION
### What I did


### How I did it

### How to verify it

### Commit message
Added `bytesM` fuzz tests for `extract32` builtin. Tests all available `m` and tests with both valid and invalid tail bytes to verify the output is properly clamped. Also, changes the type-checker error message to reflect that `bytesM` are supported as output type of the builtin.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
