### PR TITLE
fix[venom]: fix deploy immutables layout and ctor memory accounting

### DIFF
--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -24,7 +24,7 @@ from vyper.semantics.types.function import ContractFunctionT
 from vyper.semantics.types.module import ModuleT
 from vyper.typing import StorageLayout
 from vyper.utils import ERC5202_PREFIX, sha256sum
-from vyper.venom import generate_assembly_experimental, generate_venom
+from vyper.venom import DeployInfo, generate_assembly_experimental, generate_venom
 from vyper.warnings import VyperWarning, vyper_warn
 
 DEFAULT_CONTRACT_PATH = PurePath("VyperContract.vy")
@@ -264,14 +264,13 @@ class CompilerData:
         if self.bytecode_metadata is not None:
             data_sections["cbor_metadata"] = self.bytecode_metadata
 
-        constants = {
-            "runtime_codesize": len(self.bytecode_runtime),
-            "immutables_len": self.compilation_target._metadata["type"].immutable_section_bytes,
-        }
-
-        venom_ctx = generate_venom(
-            self.ir_nodes, self.settings, constants=constants, data_sections=data_sections
+        deploy_info = DeployInfo(
+            runtime_codesize=len(self.bytecode_runtime),
+            immutables_len=self.compilation_target._metadata["type"].immutable_section_bytes,
+            data_sections=data_sections,
         )
+
+        venom_ctx = generate_venom(self.ir_nodes, self.settings, deploy=deploy_info)
         return venom_ctx
 
     @cached_property

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -191,8 +191,10 @@ def generate_venom(
         ctx.mem_allocator.allocate(IRAbstractMemLoc.FREE_VAR1)
         ctx.mem_allocator.allocate(IRAbstractMemLoc.FREE_VAR2)
 
-        # Pin deploy_mem at offset 0 so it doesn't inflate ctor allocations;
-        # offsets for codecopy/iload/istore are absolute via runtime_code_start.
+        # Pre-seed deploy_mem at offset 0 because codecopy/iload/istore 
+        # use runtime_code_start for absolute offsets. Restore eom so ctor scratch
+        # allocations start from the normal baseline 
+        # (deploy_mem shouldn't bump the ctor watermark).
         if ctx.deploy_mem is not None:
             old_eom = ctx.mem_allocator.eom
             ctx.mem_allocator.allocate_fixed_at(ctx.deploy_mem, 0)

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -226,6 +226,20 @@ def generate_venom(
                 continue
             peak = max(peak, ptr + size)
 
-        return _build_ctx(peak)
+        final_ctx = _build_ctx(peak)
+
+        # sanity: ensure final peak does not exceed initial peak
+        final_peak = 0
+        if final_ctx.deploy_mem is not None:
+            skip_ids.add(final_ctx.deploy_mem._id)
+        for mem_id, (ptr, size) in final_ctx.mem_allocator.allocated.items():
+            if mem_id in skip_ids:
+                continue
+            final_peak = max(final_peak, ptr + size)
+        assert (
+            final_peak <= peak
+        ), f"ctor peak grew after override: initial {peak}, final {final_peak}"
+
+        return final_ctx
 
     return _build_ctx(None)

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -191,9 +191,9 @@ def generate_venom(
         ctx.mem_allocator.allocate(IRAbstractMemLoc.FREE_VAR1)
         ctx.mem_allocator.allocate(IRAbstractMemLoc.FREE_VAR2)
 
-        # Pre-seed deploy_mem at offset 0 because codecopy/iload/istore 
+        # Pre-seed deploy_mem at offset 0 because codecopy/iload/istore
         # use runtime_code_start for absolute offsets. Restore eom so ctor scratch
-        # allocations start from the normal baseline 
+        # allocations start from the normal baseline
         # (deploy_mem shouldn't bump the ctor watermark).
         if ctx.deploy_mem is not None:
             old_eom = ctx.mem_allocator.eom

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -26,7 +26,6 @@ VOLATILE_INSTRUCTIONS = frozenset(
         "create2",
         "invoke",
         "sstore",
-        "istore",
         "tstore",
         "mstore",
         "calldatacopy",
@@ -55,7 +54,6 @@ NO_OUTPUT_INSTRUCTIONS = frozenset(
     [
         "mstore",
         "sstore",
-        "istore",
         "tstore",
         "dloadbytes",
         "calldatacopy",

--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -43,6 +43,8 @@ class IRContext:
     # Only set for deploy contexts
     deploy_mem: Optional[IRAbstractMemLoc]
     runtime_codesize: int
+    runtime_code_start: int
+    ctor_mem_watermark: int
 
     def __init__(self) -> None:
         self.functions = {}
@@ -55,6 +57,8 @@ class IRContext:
         self.mem_allocator = MemoryAllocator()
         self.deploy_mem = None
         self.runtime_codesize = 0
+        self.runtime_code_start = 0
+        self.ctor_mem_watermark = 0
 
     def get_basic_blocks(self) -> Iterator[IRBasicBlock]:
         for fn in self.functions.values():

--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -2,7 +2,7 @@ import textwrap
 from dataclasses import dataclass, field
 from typing import Iterator, Optional
 
-from vyper.venom.basicblock import IRBasicBlock, IRLabel, IRVariable
+from vyper.venom.basicblock import IRAbstractMemLoc, IRBasicBlock, IRLabel, IRVariable
 from vyper.venom.function import IRFunction
 from vyper.venom.memory_allocator import MemoryAllocator
 
@@ -39,6 +39,10 @@ class IRContext:
     last_label: int
     last_variable: int
     mem_allocator: MemoryAllocator
+    # Memory location for deploy region (runtime code + immutables)
+    # Only set for deploy contexts
+    deploy_mem: Optional[IRAbstractMemLoc]
+    runtime_codesize: int
 
     def __init__(self) -> None:
         self.functions = {}
@@ -49,6 +53,8 @@ class IRContext:
         self.last_label = 0
         self.last_variable = 0
         self.mem_allocator = MemoryAllocator()
+        self.deploy_mem = None
+        self.runtime_codesize = 0
 
     def get_basic_blocks(self) -> Iterator[IRBasicBlock]:
         for fn in self.functions.values():

--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -8,6 +8,13 @@ from vyper.venom.memory_allocator import MemoryAllocator
 
 
 @dataclass
+class DeployInfo:
+    runtime_codesize: int
+    immutables_len: int
+    data_sections: dict[str, bytes] = field(default_factory=dict)
+
+
+@dataclass
 class DataItem:
     data: IRLabel | bytes  # can be raw data or bytes
 
@@ -41,8 +48,8 @@ class IRContext:
     mem_allocator: MemoryAllocator
     # Memory location for deploy region (runtime code + immutables)
     # Only set for deploy contexts
+    deploy_info: Optional[DeployInfo]
     deploy_mem: Optional[IRAbstractMemLoc]
-    runtime_codesize: int
     runtime_code_start: int
 
     def __init__(self) -> None:
@@ -54,8 +61,8 @@ class IRContext:
         self.last_label = 0
         self.last_variable = 0
         self.mem_allocator = MemoryAllocator()
+        self.deploy_info = None
         self.deploy_mem = None
-        self.runtime_codesize = 0
         self.runtime_code_start = 0
 
     def get_basic_blocks(self) -> Iterator[IRBasicBlock]:

--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -44,7 +44,6 @@ class IRContext:
     deploy_mem: Optional[IRAbstractMemLoc]
     runtime_codesize: int
     runtime_code_start: int
-    ctor_mem_watermark: int
 
     def __init__(self) -> None:
         self.functions = {}
@@ -58,7 +57,6 @@ class IRContext:
         self.deploy_mem = None
         self.runtime_codesize = 0
         self.runtime_code_start = 0
-        self.ctor_mem_watermark = 0
 
     def get_basic_blocks(self) -> Iterator[IRBasicBlock]:
         for fn in self.functions.values():

--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -6,7 +6,6 @@ class Effects(Flag):
     TRANSIENT = auto()
     MEMORY = auto()
     MSIZE = auto()
-    IMMUTABLES = auto()
     RETURNDATA = auto()
     LOG = auto()
     BALANCE = auto()
@@ -19,7 +18,6 @@ STORAGE = Effects.STORAGE
 TRANSIENT = Effects.TRANSIENT
 MEMORY = Effects.MEMORY
 MSIZE = Effects.MSIZE
-IMMUTABLES = Effects.IMMUTABLES
 RETURNDATA = Effects.RETURNDATA
 LOG = Effects.LOG
 BALANCE = Effects.BALANCE
@@ -32,12 +30,11 @@ _writes = {
     "sstore": STORAGE,
     "tstore": TRANSIENT,
     "mstore": MEMORY,
-    "istore": IMMUTABLES,
-    "call": ALL ^ IMMUTABLES,
-    "delegatecall": ALL ^ IMMUTABLES,
+    "call": ALL,
+    "delegatecall": ALL,
     "staticcall": MEMORY | RETURNDATA,
-    "create": ALL ^ (MEMORY | IMMUTABLES),
-    "create2": ALL ^ (MEMORY | IMMUTABLES),
+    "create": ALL ^ MEMORY,
+    "create2": ALL ^ MEMORY,
     "invoke": ALL,  # could be smarter, look up the effects of the invoked function
     "log": LOG,
     "dloadbytes": MEMORY,
@@ -52,7 +49,6 @@ _writes = {
 _reads = {
     "sload": STORAGE,
     "tload": TRANSIENT,
-    "iload": IMMUTABLES,
     "mload": MEMORY,
     "mcopy": MEMORY,
     "call": ALL,
@@ -81,11 +77,11 @@ reads = _reads.copy()
 writes = _writes.copy()
 
 for k, v in reads.items():
-    if MEMORY in v or IMMUTABLES in v:
+    if MEMORY in v:
         if k not in writes:
             writes[k] = EMPTY
         writes[k] |= MSIZE
 
 for k, v in writes.items():
-    if MEMORY in v or IMMUTABLES in v:
+    if MEMORY in v:
         writes[k] |= MSIZE

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -162,13 +162,11 @@ def ir_node_to_venom(
         # refine it after fn passes run using the allocator watermark.
         ctor_high = max(ctor_mem_size_ir, MemoryAllocator.FN_START)
         runtime_code_start = max(ctor_high, MemoryAllocator.FN_START)
-        runtime_code_end = runtime_code_start + runtime_codesize
 
         deploy_size = runtime_codesize + immutables_len
         ctx.deploy_mem = IRAbstractMemLoc(deploy_size)
         ctx.runtime_codesize = runtime_codesize
         ctx.runtime_code_start = runtime_code_start
-        ctx.ctor_mem_watermark = ctor_mem_size_ir
 
     _convert_ir_bb(fn, ir, symbols)
 
@@ -459,7 +457,6 @@ def _convert_ir_bb(fn, ir, symbols):
         deploy_mem = ctx.deploy_mem
         assert deploy_mem is not None, "deploy without deploy_mem context"
         runtime_code_start = ctx.runtime_code_start
-        runtime_code_end = runtime_code_start + runtime_codesize
         deploy_size = runtime_codesize + immutables_len
         ctx.runtime_code_start = runtime_code_start
 

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -488,7 +488,7 @@ def _convert_ir_bb(fn, ir, symbols):
         else:
             # Dynamic offset - compute address at runtime
             imm_base = deploy_mem.with_offset(runtime_code_start + runtime_codesize)
-            addr = bb.append_instruction("add", offset, imm_base, annotation="istore_addr")
+            addr = bb.append_instruction("gep", imm_base, offset, annotation="istore_addr")
             bb.append_instruction("mstore", value, addr, annotation="istore")
         return None
     elif ir.value == "iload":
@@ -508,7 +508,7 @@ def _convert_ir_bb(fn, ir, symbols):
         else:
             # Dynamic offset - compute address at runtime
             imm_base = deploy_mem.with_offset(runtime_code_start + runtime_codesize)
-            addr = bb.append_instruction("add", offset, imm_base, annotation="iload_addr")
+            addr = bb.append_instruction("gep", imm_base, offset, annotation="iload_addr")
             return bb.append_instruction("mload", addr, annotation="iload")
     elif ir.value == "seq":
         if len(ir.args) == 0:

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -159,11 +159,10 @@ def ir_node_to_venom(
             ctor_mem_size_ir = MemoryAllocator.FN_START
 
         # ctor_mem_size_ir is an upper bound before venom optimizations; we’ll
-        # refine it after fn passes run using the allocator watermark.
-        ctor_high = max(ctor_mem_size_ir, MemoryAllocator.FN_START)
-        runtime_code_start = max(ctor_high, MemoryAllocator.FN_START)
+        # refine it after fn passes run using the allocator peak.
+        runtime_code_start = max(ctor_mem_size_ir, MemoryAllocator.FN_START)
 
-        deploy_size = runtime_codesize + immutables_len
+        deploy_size = runtime_code_start + runtime_codesize + immutables_len
         ctx.deploy_mem = IRAbstractMemLoc(deploy_size)
         ctx.runtime_codesize = runtime_codesize
         ctx.runtime_code_start = runtime_code_start
@@ -458,7 +457,6 @@ def _convert_ir_bb(fn, ir, symbols):
         assert deploy_mem is not None, "deploy without deploy_mem context"
         runtime_code_start = ctx.runtime_code_start
         deploy_size = runtime_codesize + immutables_len
-        ctx.runtime_code_start = runtime_code_start
 
         bb = fn.get_basic_block()
 

--- a/vyper/venom/memory_allocator.py
+++ b/vyper/venom/memory_allocator.py
@@ -38,7 +38,7 @@ class MemoryAllocator:
         self.allocated_fn.add(mem_loc)
         return ptr
 
-    def reserve_fixed(self, mem_loc: IRAbstractMemLoc, ptr: int) -> None:
+    def allocate_fixed_at(self, mem_loc: IRAbstractMemLoc, ptr: int) -> None:
         assert mem_loc._id not in self.allocated
         self.allocated[mem_loc._id] = (ptr, mem_loc.size)
         self.allocated_fn.add(mem_loc)

--- a/vyper/venom/memory_allocator.py
+++ b/vyper/venom/memory_allocator.py
@@ -38,6 +38,12 @@ class MemoryAllocator:
         self.allocated_fn.add(mem_loc)
         return ptr
 
+    def reserve_fixed(self, mem_loc: IRAbstractMemLoc, ptr: int) -> None:
+        assert mem_loc._id not in self.allocated
+        self.allocated[mem_loc._id] = (ptr, mem_loc.size)
+        self.allocated_fn.add(mem_loc)
+        self.eom = max(self.eom, ptr + mem_loc.size)
+
     def start_fn_allocation(self, fn):
         self.current_function = fn
         self.eom = MemoryAllocator.FN_START

--- a/vyper/venom/memory_location.py
+++ b/vyper/venom/memory_location.py
@@ -393,7 +393,9 @@ def fix_mem_loc(function: IRFunction):
             read_op = get_memory_read_op(inst)
             if write_op is not None:
                 size = get_write_size(inst)
-                if size is None or not isinstance(write_op.value, int):
+                if size is None or isinstance(write_op, IRAbstractMemLoc):
+                    continue
+                if not isinstance(write_op.value, int):
                     continue
 
                 if in_free_var(MemoryPositions.FREE_VAR_SPACE, write_op.value):
@@ -404,7 +406,9 @@ def fix_mem_loc(function: IRFunction):
                     _update_write_location(inst, IRAbstractMemLoc.FREE_VAR2.with_offset(offset))
             if read_op is not None:
                 size = _get_read_size(inst)
-                if size is None or not isinstance(read_op.value, int):
+                if size is None or isinstance(read_op, IRAbstractMemLoc):
+                    continue
+                if not isinstance(read_op.value, int):
                     continue
 
                 if in_free_var(MemoryPositions.FREE_VAR_SPACE, read_op.value):

--- a/vyper/venom/passes/concretize_mem_loc.py
+++ b/vyper/venom/passes/concretize_mem_loc.py
@@ -73,8 +73,6 @@ class ConcretizeMemLocPass(IRPass):
             inst.operands = new_ops
             if inst.opcode == "gep":
                 inst.opcode = "add"
-            elif inst.opcode == "mem_deploy_start":
-                inst.opcode = "assign"
 
     def _handle_op(self, op: IROperand, inst: IRInstruction) -> IROperand:
         """

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -409,21 +409,6 @@ class VenomCompiler:
         if opcode in ["jmp", "djmp", "jnz", "invoke"]:
             operands = list(inst.get_non_label_operands())
 
-        # iload and istore are special cases because they can take a literal
-        # that is handled specialy with the _OFST macro. Look below, after the
-        # stack reordering.
-        elif opcode == "iload":
-            addr = inst.operands[0]
-            if isinstance(addr, IRLiteral):
-                operands = []
-            else:
-                operands = inst.operands
-        elif opcode == "istore":
-            addr = inst.operands[1]
-            if isinstance(addr, IRLiteral):
-                operands = inst.operands[:1]
-            else:
-                operands = inst.operands
         elif opcode == "log":
             log_topic_count = inst.operands[0].value
             assert log_topic_count in [0, 1, 2, 3, 4], "Invalid topic count"
@@ -572,24 +557,6 @@ class VenomCompiler:
         elif opcode == "assert_unreachable":
             end_symbol = self.mklabel("reachable")
             assembly.extend([PUSHLABEL(end_symbol), "JUMPI", "INVALID", end_symbol])
-        elif opcode == "iload":
-            addr = inst.operands[0]
-            mem_deploy_end = self.ctx.constants["mem_deploy_end"]
-            if isinstance(addr, IRLiteral):
-                ptr = mem_deploy_end + addr.value
-                assembly.extend(PUSH(ptr))
-            else:
-                assembly.extend([*PUSH(mem_deploy_end), "ADD"])
-            assembly.append("MLOAD")
-        elif opcode == "istore":
-            addr = inst.operands[1]
-            mem_deploy_end = self.ctx.constants["mem_deploy_end"]
-            if isinstance(addr, IRLiteral):
-                ptr = mem_deploy_end + addr.value
-                assembly.extend(PUSH(ptr))
-            else:
-                assembly.extend([*PUSH(mem_deploy_end), "ADD"])
-            assembly.append("MSTORE")
         elif opcode == "log":
             assembly.extend([f"LOG{log_topic_count}"])
         elif opcode == "nop":


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
This commit reworks deploy immutables and ctor accounting. It removes
`iload`/`istore` support from venom and `IMMUTABLES` effects to allow for better
optimizations and builds the deploy context in two passes to honor ctor peak 
accurately without resorting to use the peak from the old pipeline. 
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
