### PR TITLE
fix[venom]: fix `fix_mem_loc`

### DIFF
--- a/vyper/venom/memory_location.py
+++ b/vyper/venom/memory_location.py
@@ -73,8 +73,7 @@ class MemoryLocation:
         if loc1 is MemoryLocation.UNDEFINED or loc2 is MemoryLocation.UNDEFINED:
             return True
         if type(loc1) is not type(loc2):
-            # CMC 2025-12-02 -- this should return True, no?
-            return False
+            return True
         if isinstance(loc1, MemoryLocationSegment):
             assert isinstance(loc2, MemoryLocationSegment)
             return MemoryLocationSegment.may_overlap_concrete(loc1, loc2)


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
fix the `fix_mem_loc()` util.

this case is wrong in the case that the op is an `IRAbstractMemLoc`,
because `.value` is just its id, not any meaning related to its pointer
offset.

previously this case (i.e., where the item is an `IRAbstractMemLoc`)
didn't get triggered because at that stage of compilation, all
`IRAbstractMemLoc`s are only contained in `*alloca` instructions. this
fixes the case for follow on PRs.

it also fixes a case in `may_overlap()` which incorrectly returns false
when comparing concrete memory with abstract memory. this is currently
unreachable in the codebase during alias analysis since we have an
invariant that we do not simultaneously have concrete and abstract
memory locations in generated venom code, but is not true for more
general venom code.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
