### PR TITLE
fix[venom]: remove unreachable functions

### DIFF
--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -122,6 +122,10 @@ def run_passes_on(ctx: IRContext, flags: VenomOptimizationFlags) -> None:
     assert ctx.entry_function is not None
     fcg = ir_analyses[ctx.entry_function].force_analysis(FCGAnalysis)
 
+    # Remove functions not reachable from entry.
+    for fn in fcg.get_unreachable_functions():
+        ctx.remove_function(fn)
+
     _run_fn_passes(ctx, fcg, ctx.entry_function, flags, ir_analyses)
 
 

--- a/vyper/venom/analysis/fcg.py
+++ b/vyper/venom/analysis/fcg.py
@@ -8,42 +8,55 @@ from vyper.venom.function import IRFunction
 class FCGAnalysis(IRAnalysis):
     """
     Compute the function call graph for the context.
+    Only analyzes functions reachable from entry.
     """
 
     ctx: IRContext
     call_sites: dict[IRFunction, OrderedSet[IRInstruction]]
     callees: dict[IRFunction, OrderedSet[IRFunction]]
+    _reachable: OrderedSet[IRFunction]
 
     def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction):
         super().__init__(analyses_cache, function)
         self.ctx = function.ctx
         self.call_sites = dict()
         self.callees = dict()
+        self._reachable = OrderedSet()
 
     def analyze(self) -> None:
-        ctx = self.ctx
-        for func in ctx.get_functions():
-            self.call_sites[func] = OrderedSet()
-            self.callees[func] = OrderedSet()
+        # Single-pass DFS from entry: build call graph and reachability together
+        entry = self.ctx.entry_function
+        assert entry is not None
+        stack = [entry]
+        while stack:
+            fn = stack.pop()
+            if fn in self._reachable:
+                continue
+            self._reachable.add(fn)
+            self.call_sites.setdefault(fn, OrderedSet())
+            self.callees[fn] = OrderedSet()
 
-        for fn in ctx.get_functions():
-            self._analyze_function(fn)
+            for bb in fn.get_basic_blocks():
+                for inst in bb.instructions:
+                    if inst.opcode == "invoke":
+                        label = inst.operands[0]
+                        assert isinstance(label, IRLabel)
+                        callee = self.ctx.get_function(label)
+                        self.callees[fn].add(callee)
+                        self.call_sites.setdefault(callee, OrderedSet()).add(inst)
+                        stack.append(callee)
 
     def get_call_sites(self, fn: IRFunction) -> OrderedSet[IRInstruction]:
         return self.call_sites.get(fn, OrderedSet())
 
     def get_callees(self, fn: IRFunction) -> OrderedSet[IRFunction]:
-        return self.callees[fn]
+        return self.callees.get(fn, OrderedSet())
 
-    def _analyze_function(self, fn: IRFunction) -> None:
-        for bb in fn.get_basic_blocks():
-            for inst in bb.instructions:
-                if inst.opcode == "invoke":
-                    label = inst.operands[0]
-                    assert isinstance(label, IRLabel)  # mypy help
-                    callee = self.ctx.get_function(label)
-                    self.callees[fn].add(callee)
-                    self.call_sites[callee].add(inst)
+    def get_reachable_functions(self) -> OrderedSet[IRFunction]:
+        return self._reachable
+
+    def get_unreachable_functions(self) -> list[IRFunction]:
+        return [fn for fn in self.ctx.get_functions() if fn not in self._reachable]
 
     def invalidate(self):
         pass

--- a/vyper/venom/passes/function_inliner.py
+++ b/vyper/venom/passes/function_inliner.py
@@ -47,7 +47,7 @@ class FunctionInlinerPass(IRGlobalPass):
         for _ in range(function_count):
             candidate = self._select_inline_candidate()
             if candidate is None:
-                return
+                break
 
             # print(f"Inlining function {candidate.name} with cost {candidate.code_size_cost}")
 


### PR DESCRIPTION
### What I did

Modified FCGAnalysis to use DFS from entry, building the call graph and tracking reachability together. Added get_unreachable_functions() to expose orphan functions. In run_passes_on(), unreachable functions are now removed after FCG analysis.

This fixes an issue where orphan functions (unreachable from entry) would not get optimization passes run on them, causing assertion failures during assembly generation due to unnormalized CFGs. Orphans are generally not generated by the frontend, but can be generated from separate frontends like yul2venom.

### How I did it

### How to verify it

### Commit message

```
`FCGAnalysis` now computes reachability in a single DFS pass from entry,
building the call graph and tracking reachable functions together.
Orphan functions (unreachable from entry) are removed before running
per-function passes.

This fixes assertion failures during assembly generation caused by
unnormalized CFGs in orphan functions that never had optimization passes
run on them. Orphans are generally not generated by the vyper frontend,
but can arise from other frontends like yul2venom.

Also changes early `return` to `break` in function_inliner for hygiene,
ensuring the method exits at its end rather than mid-loop.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
