### PR TITLE
fix[codegen]: guard return fast-path for risky calls

### DIFF
--- a/vyper/codegen/return_.py
+++ b/vyper/codegen/return_.py
@@ -81,6 +81,7 @@ def make_return_stmt(ir_val: IRnode, stmt: Any, context: Context) -> Optional[IR
         can_skip_encode = (
             abi_encoding_matches_vyper(ir_val.typ)
             and ir_val.location == MEMORY
+            and not ir_val.contains_risky_call
             # ensure it has already been validated - could be
             # unvalidated ABI encoded returndata for example
             and not needs_clamp(ir_val.typ, ir_val.encoding)


### PR DESCRIPTION
## Summary
- guard the external return fast-path from bypassing ABI encoding when the return expression contains risky calls
- ensures return buffers are ABI-encoded before returning from external functions when the value originates from `call`/`staticcall`/`delegatecall`/`create`/`create2`

## Rationale
- risky calls can yield memory pointers/returndata buffers that are not safe to return as-is
- forcing ABI encoding in those cases prevents malformed offsets/lengths and avoids invalid memory expansion or out-of-gas errors

## Implementation Details
- add `and not ir_val.contains_risky_call` to the fast-path predicate in `vyper/codegen/return_.py`
- `contains_risky_call` is already defined on `IRnode` and covers `call`, `staticcall`, `delegatecall`, `create`, and `create2`

## Testing
- not run (behavioral change in the return fast-path only)
