### PR TITLE
fix[venom]: iszero chain optimization for `assert_unreachable`

### DIFF
--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -232,6 +232,48 @@ def test_offsets():
     _check_pre_post(pre, post)
 
 
+@pytest.mark.parametrize("iszero_count", range(5))
+def test_assert_unreachable_iszero_chain(iszero_count):
+    """
+    Test that iszero chains are optimized for assert_unreachable
+    the same way they are for jnz (truthy context)
+    """
+    iszero_chain = ""
+    for i in range(iszero_count):
+        new = i + 1
+        iszero_chain += f"""
+        %cond{new} = iszero %cond{i}"""
+    iszero_chain_output = f"cond{iszero_count}"
+
+    pre = f"""
+    main:
+        %par = source
+        %cond0 = add %par, 64
+        {iszero_chain}
+        assert_unreachable %{iszero_chain_output}
+        sink %par
+    """
+
+    if iszero_count % 2 == 1:
+        post_chain = "%cond1 = iszero %cond0"
+        assert_cond = "cond1"
+    else:
+        post_chain = ""
+        assert_cond = "cond0"
+
+    # note: add operands flipped due to commutative normalization
+    post = f"""
+    main:
+        %par = source
+        %cond0 = add 64, %par
+        {post_chain}
+        assert_unreachable %{assert_cond}
+        sink %par
+    """
+
+    _check_pre_post(pre, post)
+
+
 # Test the case of https://github.com/vyperlang/vyper/issues/4288
 def test_ssa_after_algebraic_optimization():
     code = """

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -62,7 +62,7 @@ class AlgebraicOptimizationPass(IRPass):
                     if opcode == "iszero":
                         # We keep iszero instuctions as is
                         continue
-                    if opcode in ("jnz", "assert"):
+                    if opcode in ("jnz", "assert", "assert_unreachable"):
                         # instructions that accept a truthy value as input:
                         # we can remove up to all the iszero instructions
                         keep_count = 1 - iszero_count % 2


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
The iszero chain optimization was missing `assert_unreachable` in the
truthy context check, causing it to not optimize iszero chains feeding
into assert_unreachable instructions.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
