### PR TITLE
feat[tool]: add storage layout to test exports

### DIFF
--- a/tests/evm_backends/base_env.py
+++ b/tests/evm_backends/base_env.py
@@ -109,6 +109,7 @@ class BaseEnv:
                 "annotated_ast": export_metadata.get("annotated_ast"),
                 "solc_json": export_metadata.get("solc_json"),
                 "compiler_settings": export_metadata.get("compiler_settings"),
+                "storage_layout": export_metadata.get("storage_layout"),
                 "raw_ir": export_metadata.get("raw_ir"),
                 "blueprint_initcode_prefix": export_metadata.get("blueprint_initcode_prefix"),
                 "python_args": python_args,
@@ -154,6 +155,7 @@ class BaseEnv:
             output_formats["solc_json"] = True
             # settings_dict exports the resolved compiler settings used for compilation
             output_formats["settings_dict"] = True
+            output_formats["layout"] = True
 
         out = _compile(
             source_code,
@@ -184,6 +186,7 @@ class BaseEnv:
                 "annotated_ast": out.get("annotated_ast_dict"),
                 "solc_json": out.get("solc_json"),
                 "compiler_settings": compiler_settings_dict,
+                "storage_layout": out.get("layout"),
                 "deployment_origin": DeploymentOrigin.SOURCE,
             }
 
@@ -203,6 +206,7 @@ class BaseEnv:
         if self.exporter:
             output_formats["solc_json"] = True
             output_formats["settings_dict"] = True
+            output_formats["layout"] = True
 
         out = _compile(source_code, output_formats, input_bundle)
         abi, bytecode = out["abi"], bytes.fromhex(out["bytecode"].removeprefix("0x"))
@@ -231,6 +235,7 @@ class BaseEnv:
                 "annotated_ast": out.get("annotated_ast_dict"),
                 "solc_json": out.get("solc_json"),
                 "compiler_settings": compiler_settings_dict,
+                "storage_layout": out.get("layout"),
                 "blueprint_initcode_prefix": initcode_prefix.hex(),
                 "deployment_origin": DeploymentOrigin.BLUEPRINT,
             }

--- a/tests/exports.md
+++ b/tests/exports.md
@@ -36,6 +36,7 @@ The exported data is organized into JSON files that mirror the test directory st
         "annotated_ast": {...} | null,
         "solc_json": {...} | null,
         "compiler_settings": {...} | null,
+        "storage_layout": {...} | null,
         "raw_ir": "IR representation" | null,
         "blueprint_initcode_prefix": "0x..." | null,
         "deployed_address": "0x...",
@@ -109,6 +110,7 @@ The exported data is organized into JSON files that mirror the test directory st
 - `calldata` is `abi_encode(ctor_args)`
 - `source_code` is the source of the compilation target, imported modules are accessible from `solc_json`
 - `compiler_settings` contains the resolved compiler settings used for compilation. Non-null only for `deployment_type: "source" | "blueprint"`. Note: `enable_decimals` is always present (resolved default). See [Compiler Settings Schema](#compiler-settings-schema) below.
+- `storage_layout` contains storage, transient storage, and code (immutables) layout information. Non-null only for `deployment_type: "source" | "blueprint"`. See [Storage Layout Schema](#storage-layout-schema) below.
 - `deployment_type` denotes how the contract was deployed
   - this was added because some tests deploy directly from `ir` or from directly from `bytecode`
 - `env` field contains transaction and block environment data:
@@ -185,7 +187,28 @@ It is based on `Settings.as_dict()`, except `enable_decimals` is always included
 | `disable_remove_unused_variables` | `bool` | Disable unused variable removal |
 | `inline_threshold` | `uint \| null` | Inlining size threshold |
 
-  
+### Storage Layout Schema
+
+The `storage_layout` field contains information about where state variables are stored. It has up to three sections:
+
+```json
+{
+  "storage_layout": {
+    "<var_name>": {"slot": <uint>, "n_slots": <uint>, "type": <string>},
+    "<module_alias>": {
+      "<nested_var>": {"slot": <uint>, "n_slots": <uint>, "type": <string>}
+    },
+    "$.nonreentrant_key": {"slot": <uint>, "n_slots": <uint>, "type": "nonreentrant lock"}
+  },
+  "transient_storage_layout": {
+    "<var_name>": {"slot": <uint>, "n_slots": <uint>, "type": <string>}
+  },
+  "code_layout": {
+    "<immutable_name>": {"offset": <uint>, "length": <uint>, "type": <string>}
+  }
+}
+```
+
 ## How it works  
   
 The test export feature provides a way to capture and export all contract deployments and function calls that occur during test execution.   


### PR DESCRIPTION
### What I did
fix https://github.com/vyperlang/vyper/issues/4815
### How I did it

### How to verify it
```python
def test_foo(make_input_bundle, get_contract):
    lib1 = """
lib_storage_var: uint256
lib_transient_var: transient(uint256)
lib_immutable_var: immutable(uint256)

@deploy
def __init__(_immutable_val: uint256):
    lib_immutable_var = _immutable_val

@internal
@nonreentrant
def lib_foo():
    pass
    """

    main = """
import lib1

initializes: lib1

storage_var: uint256
transient_var: transient(uint256)
immutable_var: immutable(uint256)

@deploy
def __init__(_immutable_val: uint256):
    immutable_var = _immutable_val
    lib1.__init__(_immutable_val)

@external
@nonreentrant
def foo():
    pass
    """
    input_bundle = make_input_bundle({"lib1.vy": lib1})
    c = get_contract(main, 42, input_bundle=input_bundle)
    c.foo()
 ```
 ```json
"storage_layout": {
          "code_layout": {
            "immutable_var": {
              "length": 32,
              "offset": 32,
              "type": "uint256"
            },
            "lib1": {
              "lib_immutable_var": {
                "length": 32,
                "offset": 0,
                "type": "uint256"
              }
            }
          },
          "storage_layout": {
            "lib1": {
              "lib_storage_var": {
                "n_slots": 1,
                "slot": 0,
                "type": "uint256"
              }
            },
            "storage_var": {
              "n_slots": 1,
              "slot": 1,
              "type": "uint256"
            }
          },
          "transient_storage_layout": {
            "$.nonreentrant_key": {
              "n_slots": 1,
              "slot": 0,
              "type": "nonreentrant lock"
            },
            "lib1": {
              "lib_transient_var": {
                "n_slots": 1,
                "slot": 1,
                "type": "uint256"
              }
            },
            "transient_var": {
              "n_slots": 1,
              "slot": 2,
              "type": "uint256"
            }
          }
        },
 ```  
    
 
 
### Commit message

```
Add storage layout information to deployment traces in the test export
infrastructure. The `storage_layout` field includes:

- `storage_layout`: regular storage variables with slot, n_slots, type
- `transient_storage_layout`: transient storage (Cancun+)
- `code_layout`: immutable variables with offset, length, type
- `$.nonreentrant_key`: the global reentrancy lock position
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()