### PR TITLE
feat[ci]: add PR commenting to bytecode-size workflow

### DIFF
--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Generate report
         id: report
         run: |
-          python3 head/.github/scripts/compare_bytecode.py base-sizes.json head-sizes.json > report.md
+          python3 base/.github/scripts/compare_bytecode.py base-sizes.json head-sizes.json > report.md
           cat report.md >> "$GITHUB_STEP_SUMMARY"
           {
             echo 'REPORT<<EOF'

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           script: |
             const marker = '<!-- bytecode-size-report -->';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number
@@ -90,7 +90,7 @@ jobs:
           script: |
             const marker = '<!-- bytecode-size-report -->';
             const body = marker + '\n\n' + process.env.REPORT;
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -2,9 +2,9 @@ name: Bytecode Size Report
 
 on:
   pull_request:
-    branches: [master, main]
+    branches: [master]
   pull_request_target:
-    branches: [master, main]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -55,6 +55,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Copy scripts to base
+        run: cp -r head/.github/scripts base/.github/
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -74,12 +77,12 @@ jobs:
 
       - name: Measure merge bytecode sizes
         working-directory: head
-        run: python3 ../base/.github/scripts/measure_bytecode.py > ../head-sizes.json
+        run: python .github/scripts/measure_bytecode.py > ../head-sizes.json
 
       - name: Generate report
         id: report
         run: |
-          python3 base/.github/scripts/compare_bytecode.py base-sizes.json head-sizes.json > report.md
+          python3 head/.github/scripts/compare_bytecode.py base-sizes.json head-sizes.json > report.md
           cat report.md >> "$GITHUB_STEP_SUMMARY"
           {
             echo 'REPORT<<EOF'

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -55,9 +55,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Copy scripts to base
-        run: cp -r head/.github/scripts base/.github/
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -77,7 +74,7 @@ jobs:
 
       - name: Measure merge bytecode sizes
         working-directory: head
-        run: python .github/scripts/measure_bytecode.py > ../head-sizes.json
+        run: python3 ../base/.github/scripts/measure_bytecode.py > ../head-sizes.json
 
       - name: Generate report
         id: report

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -39,7 +39,7 @@ jobs:
               body: marker + '\n\n⏳ **Recalculating bytecode sizes...**'
             });
 
-      - name: Checkout merge commit (for scripts)
+      - name: Checkout merge commit
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -1,6 +1,8 @@
 name: Bytecode Size Report
 
 on:
+  pull_request:
+    branches: [master, main]
   pull_request_target:
     branches: [master, main]
 
@@ -10,11 +12,15 @@ permissions:
 
 jobs:
   bytecode-size:
-    # Only run for trusted contributors (owner, member, collaborator)
-    if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    # pull_request: untrusted contributors only (step summary, no comment)
+    # pull_request_target: trusted contributors only (step summary + comment)
+    if: |
+      (github.event_name == 'pull_request' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      (github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
     steps:
       - name: Invalidate existing comment
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
           script: |
@@ -85,6 +91,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post or update PR comment
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -1,20 +1,42 @@
 name: Bytecode Size Report
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [master, main]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   bytecode-size:
+    # Only run for trusted contributors (owner, member, collaborator)
+    if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
+      - name: Invalidate existing comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- bytecode-size-report -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (!existing) return;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body: marker + '\n\n⏳ **Recalculating bytecode sizes...**'
+            });
+
       - name: Checkout merge commit (for scripts)
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           path: head
           fetch-depth: 0
           fetch-tags: true
@@ -52,7 +74,44 @@ jobs:
         run: python .github/scripts/measure_bytecode.py > ../head-sizes.json
 
       - name: Generate report
-        run: python3 head/.github/scripts/compare_bytecode.py base-sizes.json head-sizes.json >> "$GITHUB_STEP_SUMMARY"
+        id: report
+        run: |
+          python3 head/.github/scripts/compare_bytecode.py base-sizes.json head-sizes.json > report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo 'REPORT<<EOF'
+            cat report.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- bytecode-size-report -->';
+            const body = marker + '\n\n' + process.env.REPORT;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              return github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: body
+            });
+        env:
+          REPORT: ${{ steps.report.outputs.REPORT }}
 
       - name: Upload size data
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What I did

Post bytecode size reports as PR comments (currently only shows in step summary).

### How I did it

Follow-up to cf880fd50 which added the bytecode size workflow. Couldn't add PR comments in that PR because `pull_request_target` runs from the base branch, and the workflow file didn't exist on master yet.

The workflow now has two triggers:
- `pull_request` for outside contributors — just writes to step summary
- `pull_request_target` for org members/collaborators — also posts a PR comment

These are mutually exclusive (keyed on `author_association`) so the job doesn't run twice.

`pull_request_target` is needed because `pull_request` from forks gets a read-only token regardless of declared permissions. The contributor gate limits who can trigger `pip install .` of PR code. Token is scoped to `pull-requests: write` so the worst that can happen is comment spam.

### How to verify it

Merge this, then open a PR that changes bytecode output. Should get a comment with the size report.

### Commit message

```
follow-up to cf880fd50 — couldn't add comments there because
pull_request_target runs from the base branch and the workflow didn't
exist on master yet.

uses both pull_request and pull_request_target, mutually exclusive via
author_association so the job doesn't run twice. outside contributors
get step summary only, org members also get a PR comment.

pull_request_target is needed because fork PRs always get a read-only
GITHUB_TOKEN. contributor gate limits who can trigger pip install of PR
code. token scoped to pull-requests write only so the worst case is
comment spam.
```

### Description for the changelog

N/A (CI only)

### Cute Animal Picture

![capybara](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Capybara_%28Hydrochoerus_hydrochaeris%29.JPG/1280px-Capybara_%28Hydrochoerus_hydrochaeris%29.JPG)