### PR TITLE
feat[docs]: add Moccasin to testing frameworks

### DIFF
--- a/docs/testing-contracts.rst
+++ b/docs/testing-contracts.rst
@@ -6,6 +6,7 @@ Testing a Contract
 For testing Vyper contracts we recommend the use of `pytest <https://docs.pytest.org/en/latest/contents.html>`_ along with one of the following packages:
 
     * `Titanoboa <https://github.com/vyperlang/titanoboa>`_: A Vyper interpreter, pretty tracebacks, forking, debugging and deployment features. Maintained by the Vyper team.
+    * `Moccasin <https://github.com/Cyfrin/moccasin>`_: A fast, Pythonic smart contract development and testing framework built on Titanoboa.
     * `Brownie <https://github.com/iamdefinitelyahuman/brownie>`_: A development and testing framework for smart contracts targeting the Ethereum Virtual Machine
 
 Example usage for each package is provided in the sections listed below.


### PR DESCRIPTION
What I did
Added Cyfrin Moccasin to the documentation as a Python-based smart contract development and testing framework for Vyper.

How I did it
Added Moccasin to Testing a Contract section with a brief description and link to the official documentation.

Commit message
Docs: add Cyfrin Moccasin to documentation
Add Moccasin as a recommended Python framework for Vyper development and testing.

Description for the changelog
Added Cyfrin Moccasin to documentation as a Python-native smart contract development framework.
