### PR TITLE
fix[ux]: handle function parameters in loop variable error message

### DIFF
--- a/tests/unit/semantics/analysis/test_for_loop.py
+++ b/tests/unit/semantics/analysis/test_for_loop.py
@@ -234,6 +234,21 @@ def foo():
     assert e.value._message == "Cannot modify loop variable `b`"
 
 
+def test_modify_loop_variable_function_param():
+    # GH issue 4797
+    code = """
+@internal
+def boo(a: DynArray[uint256, 12] = []):
+    for i: uint256 in a:
+        a[0] = 1
+    """
+    vyper_module = parse_to_ast(code)
+    with pytest.raises(ImmutableViolation) as e:
+        analyze_module(vyper_module)
+
+    assert e.value._message == "Cannot modify loop variable `a`"
+
+
 iterator_inference_codes = [
     """
 @external

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -691,7 +691,10 @@ class ExprVisitor(VyperNodeVisitorBase):
                         msg = "Cannot modify loop variable"
                         var = s.variable
                         if var.decl_node is not None:
-                            msg += f" `{var.decl_node.target.id}`"
+                            if isinstance(var.decl_node, vy_ast.arg):
+                                msg += f" `{var.decl_node.arg}`"
+                            else:
+                                msg += f" `{var.decl_node.target.id}`"
                         raise ImmutableViolation(msg, var.decl_node, node)
 
                 var_accesses = info._writes | info._reads


### PR DESCRIPTION
when constructing the "Cannot modify loop variable" error, the code assumed `decl_node.target.id` exists. for function parameters, `decl_node` is a `vy_ast.arg` node which has `.arg` instead of `.target.id`, causing a `CompilerPanic`.

apply the same `isinstance(var.decl_node, vy_ast.arg)` pattern already used in `base.py`.

add regression test for the fix.

closes #4797

### What I did

Fixed a compiler panic that occurred when trying to display an error message for modifying a loop variable that is a function parameter.

### How I did it

Added a check for `vy_ast.arg` nodes in `local.py:694`. Function parameters use `.arg` to get the name, while variable declarations use `.target.id`. Applied the same pattern already used in `base.py:279-282`.

### How to verify it

```vyper
@internal
def boo(a: DynArray[uint256, 12] = []):
    for i: uint256 in a:
        a[0] = 1
```

**Before:** `CompilerPanic: unhandled exception 'arg' object has no attribute 'target'`
**After:** `ImmutableViolation: Cannot modify loop variable 'a'`

### Commit message
```
when constructing the "Cannot modify loop variable" error, the code
assumed `decl_node.target.id` exists. for function parameters,
`decl_node` is a `vy_ast.arg` node which has `.arg` instead of
`.target.id`, causing a `CompilerPanic`.

apply the same `isinstance(var.decl_node, vy_ast.arg)` pattern already
used in `base.py`.

add regression test for the fix.
```

### Description for the changelog

Fixed compiler panic when modifying a function parameter used as a loop iterator

### Cute Animal Picture

![tree-kangaroo](https://upload.wikimedia.org/wikipedia/commons/c/c9/Matschies_tree_kangaroo_Dendrolagus_matschiei_at_Bronx_Zoo_1_cropped.jpg)
