### PR TITLE
fix[venom]: fix palloca memory initialization in the presence of loops

### DIFF
--- a/tests/functional/codegen/features/test_palloca_loop_param_init.py
+++ b/tests/functional/codegen/features/test_palloca_loop_param_init.py
@@ -39,3 +39,25 @@ def foo() -> uint256:
     c = get_contract(code, compiler_settings=no_inline_settings)
     with tx_failed():
         c.foo()
+
+
+def test_memory_param_loop_store_not_hoisted(get_contract, no_inline_settings):
+    """
+    Ensure memory-passed params don't have first user mstore hoisted
+    when palloca is floated to entry.
+    """
+    code = """
+@internal
+def _set_first(arr: uint256[2]) -> uint256:
+    for i: uint256 in range(2):
+        arr[0] = i
+    return arr[0]
+
+@external
+def foo() -> uint256:
+    a: uint256[2] = [0, 0]
+    return self._set_first(a)
+    """
+
+    c = get_contract(code, compiler_settings=no_inline_settings)
+    assert c.foo() == 1

--- a/tests/functional/codegen/features/test_palloca_loop_param_init.py
+++ b/tests/functional/codegen/features/test_palloca_loop_param_init.py
@@ -1,0 +1,41 @@
+"""
+Regression test for palloca param initialization being incorrectly repeated in loops.
+
+When a stack-passed parameter is copied into palloca inside a loop body, the
+initializer mstore was being left in the loop after FloatAllocas moved the
+palloca to the entry block. This re-initialized the parameter each iteration,
+breaking loop-carried dependencies and suppressing expected reverts.
+"""
+import copy
+
+import pytest
+
+from vyper.compiler.settings import VenomOptimizationFlags
+
+
+@pytest.fixture
+def no_inline_settings(compiler_settings):
+    """Create settings with function inlining disabled (venom only)."""
+    settings = copy.copy(compiler_settings)
+    if settings.experimental_codegen:
+        settings.venom_flags = VenomOptimizationFlags(disable_inlining=True)
+    return settings
+
+
+def test_mod_by_zero_in_loop_reverts(get_contract, tx_failed, no_inline_settings):
+    code = """
+@internal
+def _helper(x: uint256) -> uint256:
+    for i: uint256 in range(2):
+        x %= x  # iter1: 1%1=0, iter2: 0%0 should revert
+    return 0
+
+@external
+def foo() -> uint256:
+    self._helper(1)
+    return 42
+    """
+
+    c = get_contract(code, compiler_settings=no_inline_settings)
+    with tx_failed():
+        c.foo()

--- a/vyper/venom/ir_node_to_venom.py
+++ b/vyper/venom/ir_node_to_venom.py
@@ -811,6 +811,9 @@ def _convert_ir_bb(fn, ir, symbols):
                 if _pass_via_stack(_current_func_t)[alloca.name]:
                     param = fn.get_param_by_id(alloca._id)
                     assert param is not None
+                    # NOTE: The mstore MUST immediately follow the palloca.
+                    # FloatAllocas pass depends on this invariant to move both
+                    # instructions together to the entry block.
                     bb.append_instruction("mstore", param.func_var, ptr)
                 _alloca_table[alloca._id] = ptr
             return _alloca_table[alloca._id]

--- a/vyper/venom/passes/float_allocas.py
+++ b/vyper/venom/passes/float_allocas.py
@@ -22,13 +22,29 @@ class FloatAllocas(IRPass):
 
             # Extract alloca instructions
             non_alloca_instructions = []
-            for inst in bb.instructions:
+            insts = bb.instructions
+            i = 0
+            while i < len(insts):
+                inst = insts[i]
                 if inst.opcode in ("alloca", "palloca", "calloca"):
                     # note: order of allocas impacts bytecode.
                     # TODO: investigate.
                     entry_bb.insert_instruction(inst)
+
+                    # If we move a palloca, also move its immediate param init
+                    # store (inserted by ir_node_to_venom).
+                    if inst.opcode == "palloca" and i + 1 < len(insts):
+                        next_inst = insts[i + 1]
+                        if (
+                            next_inst.opcode == "mstore"
+                            and len(next_inst.operands) >= 2
+                            and next_inst.operands[1] == inst.output
+                        ):
+                            entry_bb.insert_instruction(next_inst)
+                            i += 1  # skip the moved init store
                 else:
                     non_alloca_instructions.append(inst)
+                i += 1
 
             # Replace original instructions with filtered list
             bb.instructions = non_alloca_instructions

--- a/vyper/venom/passes/float_allocas.py
+++ b/vyper/venom/passes/float_allocas.py
@@ -59,7 +59,7 @@ class FloatAllocas(IRPass):
                                 and len(later_inst.operands) >= 2
                                 and later_inst.operands[1] == inst.output
                             ):
-                                assert False, (
+                                raise AssertionError(
                                     f"palloca {inst} has init mstore {later_inst} "
                                     f"but not immediately after. This violates the "
                                     f"invariant from ir_node_to_venom and will cause "


### PR DESCRIPTION
### What I did

Fixes venom `palloca` init move to preserve loop semantics.

### How I did it

### How to verify it

### Commit message

```
When `FloatAllocas` moves a `palloca` from a loop body to the entry
block, the companion `mstore` that initializes stack-passed parameters
was left behind in the loop. This caused the parameter to be re-
initialized on every iteration, breaking loop-carried dependencies.

For example, `x %= x` in a loop with `x=1` should yield `1%1=0` on
iteration 1, then revert on `0%0` on iteration 2. But the stale `mstore`
reset `x` back to 1 each iteration, suppressing the revert.

The fix detects the synthetic init `mstore` immediately following a
`palloca` (emitted by `ir_node_to_venom` for stack-passed params) and
moves both instructions together to the entry block. The detection is
conservative: it verifies the `mstore` destination matches the `palloca`
output, the alloca ID resolves to a known parameter, and the source
operand is the parameter's `func_var`.

- Add `_float_allocas_from_block` to handle per-block alloca extraction
- Add `_move_palloca_init_store` / `_is_palloca_init_store` helpers to
  identify and co-move the synthetic param init store
- Document the palloca/mstore adjacency invariant in
  `ir_node_to_venom.py`
- Add regression tests for loop-carried mod-by-zero revert and memory-
  passed param store behavior
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
