### PR TITLE
fix[venom]: uninitialized mem after mem2var

### DIFF
--- a/tests/unit/compiler/venom/test_mem2var.py
+++ b/tests/unit/compiler/venom/test_mem2var.py
@@ -1,7 +1,6 @@
 from tests.venom_utils import PrePostChecker
-from vyper.venom.passes import MakeSSA, Mem2Var
-
-_check_pre_post = PrePostChecker([Mem2Var, MakeSSA])
+from vyper.venom.passes import Mem2Var
+from vyper.utils import CompilerPanic
 
 
 def test_mem2var_alloca_without_initalization():
@@ -25,30 +24,11 @@ def test_mem2var_alloca_without_initalization():
         sink %res
     """
 
-    post = """
-    main:
-        %x = source
-        %ptr = alloca 1, 32
+    checker = PrePostChecker([Mem2Var])
 
-        ; by default set to zero to mimic
-        ; uninitialized memory
-        %alloca_ptr_0 = 0
-        jmp @loop_header
-    loop_header:
-        %alloca_ptr_0:1 = phi @main, %alloca_ptr_0, @loop_body, %alloca_ptr_0:2
-        %i:1 = phi @main, %x, @loop_body, %nexti
-        %i = %i:1
-        %cond = iszero %i:1
-        jnz %i:1, @loop_body, @exit
-    loop_body:
-        %inv = sload 0
-        %y = add %i:1, %inv
-        %alloca_ptr_0:2 = %y
-        %nexti = add %i:1, 1
-        jmp @loop_header
-    exit:
-        %res = %alloca_ptr_0:1
-        sink %res
-    """
-
-    _check_pre_post(pre, post)
+    try:
+        checker.run_passes(pre, pre)
+    except CompilerPanic:  
+        pass
+    except:
+        assert False

--- a/tests/unit/compiler/venom/test_mem2var.py
+++ b/tests/unit/compiler/venom/test_mem2var.py
@@ -1,0 +1,53 @@
+from vyper.venom.passes import Mem2Var, MakeSSA
+from tests.venom_utils import PrePostChecker
+
+_check_pre_post = PrePostChecker([Mem2Var, MakeSSA])
+
+def test_mem2var_alloca_without_initalization():
+    pre = """
+    main:
+        %x = source
+        %ptr = alloca 1, 32
+        jmp @loop_header
+    loop_header:
+        %i = phi @main, %x, @loop_body, %nexti
+        %cond = iszero %i
+        jnz %i, @loop_body, @exit
+    loop_body:
+        %inv = sload 0
+        %y = add %i, %inv
+        mstore %ptr, %y
+        %nexti = add %i, 1
+        jmp @loop_header
+    exit:
+        %res = mload %ptr
+        sink %res
+    """
+
+    post = """
+    main:
+        %x = source
+        %ptr = alloca 1, 32
+
+        ; by default set to zero to mimic 
+        ; uninitialized memory
+        %alloca_ptr_0 = 0
+        jmp @loop_header
+    loop_header:
+        %alloca_ptr_0:1 = phi @main, %alloca_ptr_0, @loop_body, %alloca_ptr_0:2
+        %i:1 = phi @main, %x, @loop_body, %nexti
+        %i = %i:1
+        %cond = iszero %i:1
+        jnz %i:1, @loop_body, @exit
+    loop_body:
+        %inv = sload 0
+        %y = add %i:1, %inv
+        %alloca_ptr_0:2 = %y
+        %nexti = add %i:1, 1
+        jmp @loop_header
+    exit:
+        %res = %alloca_ptr_0:1
+        sink %res
+    """
+
+    _check_pre_post(pre, post)

--- a/tests/unit/compiler/venom/test_mem2var.py
+++ b/tests/unit/compiler/venom/test_mem2var.py
@@ -30,7 +30,7 @@ def test_mem2var_alloca_without_initalization():
         %x = source
         %ptr = alloca 1, 32
 
-        ; by default set to zero to mimic 
+        ; by default set to zero to mimic
         ; uninitialized memory
         %alloca_ptr_0 = 0
         jmp @loop_header

--- a/tests/unit/compiler/venom/test_mem2var.py
+++ b/tests/unit/compiler/venom/test_mem2var.py
@@ -1,7 +1,8 @@
-from vyper.venom.passes import Mem2Var, MakeSSA
 from tests.venom_utils import PrePostChecker
+from vyper.venom.passes import MakeSSA, Mem2Var
 
 _check_pre_post = PrePostChecker([Mem2Var, MakeSSA])
+
 
 def test_mem2var_alloca_without_initalization():
     pre = """

--- a/vyper/venom/analysis/__init__.py
+++ b/vyper/venom/analysis/__init__.py
@@ -11,3 +11,4 @@ from .reachable import ReachableAnalysis
 from .stack_order import StackOrderAnalysis
 from .var_definition import VarDefinition
 from .variable_range import VariableRangeAnalysis
+from .defined_mem import DefinedMemoryVars

--- a/vyper/venom/analysis/defined_mem.py
+++ b/vyper/venom/analysis/defined_mem.py
@@ -1,0 +1,68 @@
+from vyper.venom.analysis.analysis import IRAnalysis
+from vyper.venom.analysis import CFGAnalysis
+from vyper.venom.basicblock import IRInstruction, IRBasicBlock, IRVariable
+from collections import deque
+
+class DefinedMemoryVars(IRAnalysis):
+    defined_at: dict[IRInstruction, set[IRVariable]]
+    bb_defined: dict[IRBasicBlock, set[IRVariable]]
+
+    allocas: set[IRVariable]
+
+    def analyze(self):
+        self.defined_at = dict()
+        self.bb_defined = dict()
+        self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
+
+        # assumes that all allocas are at entry
+        self.allocas = set()
+        for inst in self.function.entry.instructions:
+            if inst.opcode == "alloca":
+                self.allocas.add(inst.output)
+
+        worklist = deque()
+        worklist.append(self.function.entry)
+        while len(worklist) > 0:
+            bb = worklist.popleft()
+            if self._process_bb(bb):
+                for succ in self.cfg.cfg_out(bb):
+                    worklist.append(succ)
+
+
+    def _merge(self, bb: IRBasicBlock) -> set[IRVariable]:
+        preds = list(self.cfg.cfg_in(bb))
+
+        if len(preds) == 0:
+            return set()
+
+        preds_state = [self.bb_defined.get(pred, self.allocas) for pred in preds] 
+        if len(preds_state) == 0:
+            return set()
+
+        result = preds_state[0].copy()
+
+        for pred in preds_state[1:]:
+            if pred is not None:
+                result = result & pred
+
+        return result
+    
+    def _process_bb(self, bb: IRBasicBlock) -> bool:
+        curr = self._merge(bb)
+
+        for inst in bb.instructions:
+            if inst.opcode == "mstore":
+                _, ptr = inst.operands
+                if ptr in self.allocas:
+                    assert isinstance(ptr, IRVariable)
+                    curr.add(ptr)
+            if inst.opcode == "mload":
+                self.defined_at[inst] = curr.copy()
+            if inst.opcode == "return":
+                self.defined_at[inst] = curr.copy()
+        
+        if bb not in self.bb_defined or self.bb_defined[bb] != curr:
+            self.bb_defined[bb] = curr
+            return True
+
+        return False

--- a/vyper/venom/passes/machinery/inst_updater.py
+++ b/vyper/venom/passes/machinery/inst_updater.py
@@ -155,7 +155,12 @@ class InstUpdater:
         return self._insert_instruction(inst, opcode, args, after=True, var=var)
 
     def _insert_instruction(
-        self, inst: IRInstruction, opcode: str, args: list[IROperand], after: bool = False, var: IRVariable | None = None,
+        self,
+        inst: IRInstruction,
+        opcode: str,
+        args: list[IROperand],
+        after: bool = False,
+        var: IRVariable | None = None,
     ) -> Optional[IRVariable]:
         index = inst.parent.instructions.index(inst)
         if after:

--- a/vyper/venom/passes/machinery/inst_updater.py
+++ b/vyper/venom/passes/machinery/inst_updater.py
@@ -139,31 +139,31 @@ class InstUpdater:
         self.update(inst, "assign", [op], new_output=new_output)
 
     def add_before(
-        self, inst: IRInstruction, opcode: str, args: list[IROperand]
+        self, inst: IRInstruction, opcode: str, args: list[IROperand], var: IRVariable | None = None
     ) -> Optional[IRVariable]:
         """
         Insert another instruction before the given instruction
         """
-        return self._insert_instruction(inst, opcode, args, after=False)
+        return self._insert_instruction(inst, opcode, args, after=False, var=var)
 
     def add_after(
-        self, inst: IRInstruction, opcode: str, args: list[IROperand]
+        self, inst: IRInstruction, opcode: str, args: list[IROperand], var: IRVariable | None = None
     ) -> Optional[IRVariable]:
         """
         Insert another instruction after the given instruction
         """
-        return self._insert_instruction(inst, opcode, args, after=True)
+        return self._insert_instruction(inst, opcode, args, after=True, var=var)
 
     def _insert_instruction(
-        self, inst: IRInstruction, opcode: str, args: list[IROperand], after: bool = False
+        self, inst: IRInstruction, opcode: str, args: list[IROperand], after: bool = False, var: IRVariable | None = None,
     ) -> Optional[IRVariable]:
         index = inst.parent.instructions.index(inst)
         if after:
             index += 1
 
-        var = None
-        if opcode not in NO_OUTPUT_INSTRUCTIONS:
-            var = inst.parent.parent.get_next_variable()
+        if var is None:
+            if opcode not in NO_OUTPUT_INSTRUCTIONS:
+                var = inst.parent.parent.get_next_variable()
 
         operands = list(args)
         new_inst = IRInstruction(opcode, operands, [var] if var is not None else None)

--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -62,6 +62,8 @@ class Mem2Var(IRPass):
         assert isinstance(size_lit, IRLiteral)
         size = size_lit.value
 
+        self.updater.add_after(alloca_inst, "assign", [IRLiteral(0)], var=var)
+
         for inst in uses.copy():
             if inst.opcode == "mstore":
                 if size == 32:


### PR DESCRIPTION
### What I did
Fixed problem with `Mem2Var` pass where if the value is read before written for the first time the semantics with memory would be to return 0. This was not reflected after the pass. To achieve this I added the initial assign to variable.

Before mem2var:

```
main:
    %x = source
    %ptr = alloca 1, 32
    jmp @loop_header
loop_header:
    %i = phi @main, %x, @loop_body, %nexti
    %cond = iszero %i
    jnz %i, @loop_body, @exit
loop_body:
    %inv = sload 0
    %y = add %i, %inv
    mstore %ptr, %y
    %nexti = add %i, 1
    jmp @loop_header
exit:
    ; if the loop body is not run
    ; then the result should be 0
    %res = mload %ptr 
    sink %res
```

After mem2var and makessa:

```
main:
    %x = source
    %ptr = alloca 1, 32

    ; by default set to zero to mimic 
    ; uninitialized memory
    %alloca_ptr_0 = 0
    jmp @loop_header
loop_header:
    %alloca_ptr_0:1 = phi @main, %alloca_ptr_0, @loop_body, %alloca_ptr_0:2
    %i:1 = phi @main, %x, @loop_body, %nexti
    %i = %i:1
    %cond = iszero %i:1
    jnz %i:1, @loop_body, @exit
loop_body:
    %inv = sload 0
    %y = add %i:1, %inv
    %alloca_ptr_0:2 = %y
    %nexti = add %i:1, 1
    jmp @loop_header
exit:
    %res = %alloca_ptr_0:1
    sink %res
```


### How I did it

### How to verify it

### Commit message

Added initial assign to the `Mem2Var` pass for cases where it would be necessary to read from uninitialized memory.

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
