### PR TITLE
feat[venom]: add tail-merge pass for equivalent terminal blocks

### DIFF
--- a/tests/unit/compiler/venom/test_tail_merge.py
+++ b/tests/unit/compiler/venom/test_tail_merge.py
@@ -94,3 +94,126 @@ def test_no_merge_for_non_halting_blocks():
     """
 
     _check_no_change(pre)
+
+
+def test_merge_identical_stop_blocks():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @a, @b
+    a:
+        stop
+    b:
+        stop
+    """
+    post = """
+    main:
+        %cond = source
+        jnz %cond, @a, @a
+    a:
+        stop
+    """
+
+    _check_pre_post(pre, post)
+
+
+def test_merge_identical_return_blocks():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @a, @b
+    a:
+        %a0 = 0
+        %a1 = 32
+        return %a0, %a1
+    b:
+        %b0 = 0
+        %b1 = 32
+        return %b0, %b1
+    """
+    post = """
+    main:
+        %cond = source
+        jnz %cond, @a, @a
+    a:
+        %a0 = 0
+        %a1 = 32
+        return %a0, %a1
+    """
+
+    _check_pre_post(pre, post)
+
+
+def test_no_merge_different_halting_opcodes():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @a, @b
+    a:
+        revert 0, 0
+    b:
+        stop
+    """
+
+    _check_no_change(pre)
+
+
+def test_merge_three_identical_blocks():
+    pre = """
+    main:
+        %c1 = source
+        jnz %c1, @block_a, @dispatch
+    dispatch:
+        %c2 = source
+        jnz %c2, @block_b, @block_c
+    block_a:
+        revert 0, 0
+    block_b:
+        revert 0, 0
+    block_c:
+        revert 0, 0
+    """
+    post = """
+    main:
+        %c1 = source
+        jnz %c1, @block_a, @dispatch
+    dispatch:
+        %c2 = source
+        jnz %c2, @block_a, @block_a
+    block_a:
+        revert 0, 0
+    """
+
+    _check_pre_post(pre, post)
+
+
+def test_no_merge_entry_block():
+    pre = """
+    main:
+        stop
+    other:
+        stop
+    """
+
+    _check_no_change(pre)
+
+
+def test_no_merge_with_phi_nodes():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @left, @right
+    left:
+        %y = 2
+        jnz %cond, @phi_revert, @plain_revert
+    right:
+        %z = 3
+        jnz %cond, @phi_revert, @plain_revert
+    phi_revert:
+        %p = phi @left, %y, @right, %z
+        revert 0, 0
+    plain_revert:
+        revert 0, 0
+    """
+
+    _check_no_change(pre)

--- a/tests/unit/compiler/venom/test_tail_merge.py
+++ b/tests/unit/compiler/venom/test_tail_merge.py
@@ -1,0 +1,96 @@
+import pytest
+
+from tests.venom_utils import PrePostChecker
+from vyper.venom.passes import TailMergePass
+
+pytestmark = pytest.mark.hevm
+
+_check_pre_post = PrePostChecker([TailMergePass])
+
+
+def _check_no_change(pre: str, hevm: bool = True):
+    _check_pre_post(pre, pre, hevm=hevm)
+
+
+def test_merge_identical_revert_blocks():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @revert_a, @revert_b
+    revert_a:
+        revert 0, 0
+    revert_b:
+        revert 0, 0
+    """
+    post = """
+    main:
+        %cond = source
+        jnz %cond, @revert_a, @revert_a
+    revert_a:
+        revert 0, 0
+    """
+
+    _check_pre_post(pre, post)
+
+
+def test_merge_renamed_local_terminal_blocks():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @a, @b
+    a:
+        %a0 = 1
+        %a1 = add %a0, 2
+        revert 0, 0
+    b:
+        %b0 = 1
+        %b1 = add %b0, 2
+        revert 0, 0
+    """
+    post = """
+    main:
+        %cond = source
+        jnz %cond, @a, @a
+    a:
+        %a0 = 1
+        %a1 = add %a0, 2
+        revert 0, 0
+    """
+
+    _check_pre_post(pre, post)
+
+
+def test_no_merge_when_block_uses_live_ins():
+    pre = """
+    main:
+        %cond = source
+        %x = source
+        %y = source
+        jnz %cond, @a, @b
+    a:
+        assert %x
+        revert 0, 0
+    b:
+        assert %y
+        revert 0, 0
+    """
+
+    _check_no_change(pre)
+
+
+def test_no_merge_for_non_halting_blocks():
+    pre = """
+    main:
+        %cond = source
+        jnz %cond, @a, @b
+    a:
+        %a = 1
+        jmp @join
+    b:
+        %b = 1
+        jmp @join
+    join:
+        stop
+    """
+
+    _check_no_change(pre)

--- a/vyper/venom/optimization_levels/O3.py
+++ b/vyper/venom/optimization_levels/O3.py
@@ -31,6 +31,7 @@ from vyper.venom.passes import (
     RevertToAssert,
     SimplifyCFGPass,
     SingleUseExpansion,
+    TailMergePass,
 )
 
 # Aggressive optimizations (O3)
@@ -84,6 +85,7 @@ PASSES_O3: List[PassConfig] = [
     CSE,
     AssignElimination,
     RemoveUnusedVariablesPass,
+    TailMergePass,
     SingleUseExpansion,
     DFTPass,
     CFGNormalization,

--- a/vyper/venom/optimization_levels/O3.py
+++ b/vyper/venom/optimization_levels/O3.py
@@ -86,6 +86,7 @@ PASSES_O3: List[PassConfig] = [
     AssignElimination,
     RemoveUnusedVariablesPass,
     TailMergePass,
+    SimplifyCFGPass,
     SingleUseExpansion,
     DFTPass,
     CFGNormalization,

--- a/vyper/venom/passes/__init__.py
+++ b/vyper/venom/passes/__init__.py
@@ -25,3 +25,4 @@ from .revert_to_assert import RevertToAssert
 from .sccp import SCCP
 from .simplify_cfg import SimplifyCFGPass
 from .single_use_expansion import SingleUseExpansion
+from .tail_merge import TailMergePass

--- a/vyper/venom/passes/base_pass.py
+++ b/vyper/venom/passes/base_pass.py
@@ -25,8 +25,9 @@ class IRPass:
         # Also update labels in data segment.
         for data_section in self.function.ctx.data_segment:
             for item in data_section.data_items:
-                if item.data in label_map:
-                    item.data = label_map[item.data]
+                data = item.data
+                if isinstance(data, IRLabel) and data in label_map:
+                    item.data = label_map[data]
 
     def run_pass(self, *args, **kwargs):
         raise NotImplementedError(f"Not implemented! {self.__class__}.run_pass()")

--- a/vyper/venom/passes/base_pass.py
+++ b/vyper/venom/passes/base_pass.py
@@ -1,4 +1,5 @@
 from vyper.venom.analysis import IRAnalysesCache
+from vyper.venom.basicblock import IRLabel
 from vyper.venom.context import IRContext
 from vyper.venom.function import IRFunction
 from vyper.venom.passes.machinery.inst_updater import InstUpdater
@@ -16,6 +17,16 @@ class IRPass:
     def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction):
         self.function = function
         self.analyses_cache = analyses_cache
+
+    def _replace_all_labels(self, label_map: dict[IRLabel, IRLabel]) -> None:
+        for bb in self.function.get_basic_blocks():
+            bb.replace_operands(label_map)
+
+        # Also update labels in data segment.
+        for data_section in self.function.ctx.data_segment:
+            for item in data_section.data_items:
+                if item.data in label_map:
+                    item.data = label_map[item.data]
 
     def run_pass(self, *args, **kwargs):
         raise NotImplementedError(f"Not implemented! {self.__class__}.run_pass()")

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -111,17 +111,6 @@ class SimplifyCFGPass(IRPass):
         assert original_label not in self.label_map
         self.label_map[original_label] = replacement_label
 
-    def _replace_all_labels(self):
-        for bb in self.function.get_basic_blocks():
-            for inst in bb.instructions:
-                inst.replace_operands(self.label_map)
-
-        # Also update labels in data segment
-        for data_section in self.function.ctx.data_segment:
-            for item in data_section.data_items:
-                if item.data in self.label_map:
-                    item.data = self.label_map[item.data]
-
     def remove_unreachable_blocks(self) -> int:
         # Remove unreachable basic blocks
         removed = set()
@@ -183,7 +172,7 @@ class SimplifyCFGPass(IRPass):
         for _ in range(fn.num_basic_blocks):  # essentially `while True`
             self.label_map = {}
             self._collapse_chained_blocks(entry)
-            self._replace_all_labels()
+            self._replace_all_labels(self.label_map)
             self.cfg = self.analyses_cache.force_analysis(CFGAnalysis)
             if self.remove_unreachable_blocks() == 0:
                 break

--- a/vyper/venom/passes/tail_merge.py
+++ b/vyper/venom/passes/tail_merge.py
@@ -101,14 +101,3 @@ class TailMergePass(IRPass):
             signature.append((inst.opcode, outputs, operands))
 
         return tuple(signature)
-
-    def _replace_all_labels(self, label_map: dict[IRLabel, IRLabel]):
-        for bb in self.function.get_basic_blocks():
-            for inst in bb.instructions:
-                inst.replace_operands(label_map)
-
-        # Also update labels in data segment
-        for data_section in self.function.ctx.data_segment:
-            for item in data_section.data_items:
-                if item.data in label_map:
-                    item.data = label_map[item.data]

--- a/vyper/venom/passes/tail_merge.py
+++ b/vyper/venom/passes/tail_merge.py
@@ -17,22 +17,11 @@ class TailMergePass(IRPass):
     cfg: CFGAnalysis
 
     def run_pass(self):
-        fn = self.function
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
 
-        changed = False
-        for _ in range(fn.num_basic_blocks):
-            label_map = self._merge_equivalent_tails()
-            if len(label_map) == 0:
-                break
-
-            changed = True
+        label_map = self._merge_equivalent_tails()
+        if len(label_map) > 0:
             self._replace_all_labels(label_map)
-            self.cfg = self.analyses_cache.force_analysis(CFGAnalysis)
-        else:
-            raise CompilerPanic("Too many iterations in tail merge")
-
-        if changed:
             self.analyses_cache.invalidate_analysis(CFGAnalysis)
             self.analyses_cache.invalidate_analysis(DFGAnalysis)
 

--- a/vyper/venom/passes/tail_merge.py
+++ b/vyper/venom/passes/tail_merge.py
@@ -1,0 +1,114 @@
+from vyper.exceptions import CompilerPanic
+from vyper.venom.analysis import CFGAnalysis, DFGAnalysis
+from vyper.venom.basicblock import IRBasicBlock, IRLabel, IRLiteral, IROperand, IRVariable
+from vyper.venom.passes.base_pass import IRPass
+
+
+class TailMergePass(IRPass):
+    """
+    Merge structurally equivalent terminal basic blocks.
+
+    This is a conservative MVP:
+    - only reachable, non-entry, halting blocks are considered
+    - blocks with phi nodes are ignored
+    - blocks with live-in variables are ignored
+    """
+
+    cfg: CFGAnalysis
+
+    def run_pass(self):
+        fn = self.function
+        self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
+
+        changed = False
+        for _ in range(fn.num_basic_blocks):
+            label_map = self._merge_equivalent_tails()
+            if len(label_map) == 0:
+                break
+
+            changed = True
+            self._replace_all_labels(label_map)
+            self.cfg = self.analyses_cache.force_analysis(CFGAnalysis)
+        else:
+            raise CompilerPanic("Too many iterations in tail merge")
+
+        if changed:
+            self.analyses_cache.invalidate_analysis(CFGAnalysis)
+            self.analyses_cache.invalidate_analysis(DFGAnalysis)
+
+    def _merge_equivalent_tails(self) -> dict[IRLabel, IRLabel]:
+        groups: dict[tuple, IRBasicBlock] = {}
+        to_remove: list[IRBasicBlock] = []
+        label_map: dict[IRLabel, IRLabel] = {}
+
+        for bb in self.function.get_basic_blocks():
+            if bb == self.function.entry:
+                continue
+            if not self.cfg.is_reachable(bb):
+                continue
+
+            signature = self._block_signature(bb)
+            if signature is None:
+                continue
+
+            keeper = groups.get(signature)
+            if keeper is None:
+                groups[signature] = bb
+                continue
+
+            label_map[bb.label] = keeper.label
+            to_remove.append(bb)
+
+        for bb in to_remove:
+            self.function.remove_basic_block(bb)
+
+        return label_map
+
+    def _block_signature(self, bb: IRBasicBlock) -> tuple | None:
+        if not bb.is_halting:
+            return None
+
+        # reject blocks with phis or non-local variable inputs
+        defined: set[IRVariable] = set()
+        for inst in bb.instructions:
+            if inst.opcode == "phi":
+                return None
+            for op in inst.get_input_variables():
+                if op not in defined:
+                    return None
+            defined.update(inst.get_outputs())
+
+        var_map: dict[IRVariable, str] = {}
+
+        def _canon_var(var: IRVariable) -> str:
+            if var not in var_map:
+                var_map[var] = f"v{len(var_map)}"
+            return var_map[var]
+
+        def _canon_operand(op: IROperand):
+            if isinstance(op, IRVariable):
+                return ("var", _canon_var(op))
+            if isinstance(op, IRLiteral):
+                return ("lit", op.value)
+            if isinstance(op, IRLabel):
+                return ("label", op.value)
+            return ("other", repr(op))
+
+        signature = []
+        for inst in bb.instructions:
+            outputs = tuple(_canon_var(out) for out in inst.get_outputs())
+            operands = tuple(_canon_operand(op) for op in inst.operands)
+            signature.append((inst.opcode, outputs, operands))
+
+        return tuple(signature)
+
+    def _replace_all_labels(self, label_map: dict[IRLabel, IRLabel]):
+        for bb in self.function.get_basic_blocks():
+            for inst in bb.instructions:
+                inst.replace_operands(label_map)
+
+        # Also update labels in data segment
+        for data_section in self.function.ctx.data_segment:
+            for item in data_section.data_items:
+                if item.data in label_map:
+                    item.data = label_map[item.data]

--- a/vyper/venom/passes/tail_merge.py
+++ b/vyper/venom/passes/tail_merge.py
@@ -92,7 +92,7 @@ class TailMergePass(IRPass):
                 return ("lit", op.value)
             if isinstance(op, IRLabel):
                 return ("label", op.value)
-            return ("other", repr(op))
+            raise CompilerPanic(f"unexpected operand type in tail merge: {type(op)}")
 
         signature = []
         for inst in bb.instructions:

--- a/vyper/venom/passes/tail_merge.py
+++ b/vyper/venom/passes/tail_merge.py
@@ -12,6 +12,8 @@ class TailMergePass(IRPass):
     - only reachable, non-entry, halting blocks are considered
     - blocks with phi nodes are ignored
     - blocks with live-in variables are ignored
+    - requires running SimplifyCFGPass after this pass to clean up
+      degenerate branches introduced by label rewrites (e.g. jnz @x, @x)
     """
 
     cfg: CFGAnalysis


### PR DESCRIPTION
### What I did

I added a conservative `TailMergePass` that merges structurally equivalent halting
basic blocks to reduce code size in Venom IR, along with tests. Also refactored relabeling
to pass base to be used by SimplifyCFG and TailMerge.

### How I did it

### How to verify it

### Commit message

```
Adds a conservative `TailMergePass` that merges structurally equivalent halting
basic blocks to reduce code size in Venom IR.

- implements `TailMergePass` for reachable, non-entry, halting blocks
- wires TailMergePass into O3 only
- runs SimplifyCFGPass after TailMergePass in O3 for CFG cleanup
- [important] centralize label/data-segment relabeling in IRPass and reuse from passes
- add/expand unit tests for merge and non-merge scenarios
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
