### PR TITLE
fix[venom]: fix allocation in ternary fall through

### DIFF
--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -293,4 +293,3 @@ def foo() -> Bytes[10]:
 
     c = get_contract(source)
     assert c.foo() == b"\x01\x02"
-

--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -278,3 +278,19 @@ def foo(t: bool):
     else:
         assert c.track_taint_x() == 0
         assert c.track_taint_y() == 1
+
+
+def test_venom_ternary_with_memory_allocation(get_contract):
+    source = """
+buf: Bytes[10]
+
+@external
+def foo() -> Bytes[10]:
+    x: bool = True
+    self.buf = concat(b"\\x01", b"\\x02") if x else b""
+    return self.buf
+    """
+
+    c = get_contract(source)
+    assert c.foo() == b"\x01\x02"
+

--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -56,7 +56,7 @@ class Mem2Var(IRPass):
         var = IRVariable(var_name)
         uses = dfg.get_uses(alloca_inst.output)
 
-        if any(inst.opcode == "add" for inst in uses):
+        if any(inst.opcode in ("add", "phi", "assign") for inst in uses):
             self._fix_adds(alloca_inst)
             return
 
@@ -93,7 +93,7 @@ class Mem2Var(IRPass):
         # snapshot uses before any insertion - add_after mutates the live set
         uses = dfg.get_uses(palloca_inst.output).copy()
 
-        if any(inst.opcode == "add" for inst in uses):
+        if any(inst.opcode in ("add", "phi", "assign") for inst in uses):
             self._fix_adds(palloca_inst)
             return
 
@@ -137,16 +137,22 @@ class Mem2Var(IRPass):
         assert len(inst.operands) == 3
         self._fix_adds(inst)
 
-    def _fix_adds(self, mem_src: IRInstruction):
+    def _fix_adds(self, mem_src: IRInstruction, _visited=None):
+        if _visited is None:
+            _visited = set()
+        if mem_src in _visited:
+            return
+        _visited.add(mem_src)
+
         uses = self.dfg.get_uses(mem_src.output)
         output = mem_src.output
         for inst in uses.copy():
             if inst.opcode in ("phi", "assign"):
-                self._fix_adds(inst)
+                self._fix_adds(inst, _visited)
                 continue
             if inst.opcode != "add":
                 continue
             other = [op for op in inst.operands if op != mem_src.output]
             assert len(other) == 1
             self.updater.update(inst, "gep", [output, other[0]])
-            self._fix_adds(inst)
+            self._fix_adds(inst, _visited)

--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -141,6 +141,9 @@ class Mem2Var(IRPass):
         uses = self.dfg.get_uses(mem_src.output)
         output = mem_src.output
         for inst in uses.copy():
+            if inst.opcode in ("phi", "assign"):
+                self._fix_adds(inst)
+                continue
             if inst.opcode != "add":
                 continue
             other = [op for op in inst.operands if op != mem_src.output]


### PR DESCRIPTION
### What I did

When a ternary expression involves memory operations (e.g. `concat(...) if x else b""`), the alloca pointer flows through a `phi` node at the control-flow merge point. The `_fix_adds` method in `Mem2Var` was not following through `phi` and `assign` instructions, so downstream `add` operations on the merged pointer were never converted to `gep`. This caused `BasePtrAnalysis` to lose track of the pointer origin, leading to incorrect codegen.

### How I did it

Three changes to `vyper/venom/passes/mem2var.py`:

1. **`_fix_adds` now follows `phi`/`assign` chains**: when it encounters a `phi` or `assign` use of a pointer, it recurses into that instruction to find downstream `add`s that need conversion to `gep`.

2. **Caller guards extended**: `_process_alloca_var` and `_process_palloca_var` previously only checked for direct `add` uses to decide whether to call `_fix_adds`. If the alloca flowed through a `phi` first (no direct `add`), `_fix_adds` was never called. The guard now also checks for `phi`/`assign` among direct uses.

3. **Visited set for cycle safety**: `_fix_adds` now maintains a visited set to handle cyclic phi chains (e.g. loop back-edges) without infinite recursion.

### How to verify it

The included test compiles a contract using `concat(...) if x else b""` and verifies the result at runtime. All 4008 existing codegen tests continue to pass.

### Commit message

```
fix[venom]: fix allocation in ternary fall through

`Mem2Var._fix_adds` converts `add` instructions on alloca pointers into
`gep` (get-element-pointer) so that `BasePtrAnalysis` can track pointer
provenance through arithmetic. When a ternary expression merges two
pointer paths via a `phi` node, the `add` sits downstream of the phi
rather than as a direct use of the alloca — so `_fix_adds` never saw it.

The same gap existed in the caller guards: `_process_alloca_var` and
`_process_palloca_var` only dispatched to `_fix_adds` when a direct
`add` use was present, silently skipping allocas whose only non-trivial
uses were behind phi/assign nodes.

Additionally, following phi/assign chains introduces the possibility of
cycles through loop back-edges, so add a visited set to terminate
gracefully.
```

### Description for the changelog

Fix incorrect codegen when ternary expressions are used with memory-allocating operations like `concat`.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()