### PR TITLE
refactor[venom]: normalize bytestring memory handling and dedupe hash/slice paths

### DIFF
--- a/vyper/codegen_venom/builtins/hashing.py
+++ b/vyper/codegen_venom/builtins/hashing.py
@@ -9,13 +9,35 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from vyper import ast as vy_ast
-from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.types import BytesM_T
 from vyper.semantics.types.bytestrings import _BytestringT
 from vyper.venom.basicblock import IRLiteral, IROperand
 
 if TYPE_CHECKING:
     from vyper.codegen_venom.context import VenomCodegenContext
+
+
+def _prepare_hash_input(node: vy_ast.Call, ctx: VenomCodegenContext) -> tuple[IROperand, IROperand]:
+    """Normalize hash input to memory and return (data_ptr, length)."""
+    from vyper.codegen_venom.expr import Expr
+
+    b = ctx.builder
+    arg_node = node.args[0]
+    arg_t = arg_node._metadata["type"]
+
+    if isinstance(arg_t, _BytestringT):
+        arg_vv = Expr(arg_node, ctx).lower()
+        arg_mem = ctx.ensure_bytestring_in_memory(arg_vv, arg_t)
+        return ctx.bytes_data_ptr(arg_mem), ctx.bytestring_length(arg_mem)
+
+    # Fixed-size word values are hashed from a temporary 32-byte buffer.
+    arg_val = Expr(arg_node, ctx).lower_value()
+    buf = ctx.allocate_buffer(32)
+    b.mstore(buf._ptr, arg_val)
+
+    if isinstance(arg_t, BytesM_T):
+        return buf._ptr, IRLiteral(arg_t.m)
+    return buf._ptr, IRLiteral(32)
 
 
 def lower_keccak256(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
@@ -25,55 +47,9 @@ def lower_keccak256(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
     Computes Keccak-256 hash using native SHA3 opcode.
     Handles both variable-length bytes/string and fixed bytes32.
     """
-    from vyper.codegen_venom.expr import Expr
-
     b = ctx.builder
-
-    arg_node = node.args[0]
-    arg_t = arg_node._metadata["type"]
-
-    if isinstance(arg_t, _BytestringT):
-        # Variable-length bytes/string: ptr points to length word
-        # Data starts at ptr + 32
-        # sha3(length, data_ptr) - builder emits in EVM order
-        arg_vv = Expr(arg_node, ctx).lower()
-
-        # sha3 only works on memory - copy storage/transient/code data first
-        if arg_vv.location is not None and arg_vv.location in (
-            DataLocation.STORAGE,
-            DataLocation.TRANSIENT,
-        ):
-            buf_val = ctx.new_temporary_value(arg_t)
-            ctx.slot_to_memory(
-                arg_vv.operand, buf_val.operand, arg_t.storage_size_in_words, arg_vv.location
-            )
-            # Hash from memory buffer
-            data_ptr = ctx.bytes_data_ptr(buf_val)
-            length = ctx.bytestring_length(buf_val)
-        elif arg_vv.location is not None and arg_vv.location == DataLocation.CODE:
-            # Immutable bytestring: copy to memory first
-            buf_val = ctx.new_temporary_value(arg_t)
-            ctx.code_to_memory(arg_vv.operand, buf_val.operand, arg_t.storage_size_in_words)
-            data_ptr = ctx.bytes_data_ptr(buf_val)
-            length = ctx.bytestring_length(buf_val)
-        else:
-            data_ptr = ctx.bytes_data_ptr(arg_vv)
-            length = ctx.bytestring_length(arg_vv)
-
-        return b.sha3(data_ptr, length)
-    elif isinstance(arg_t, BytesM_T):
-        # Fixed bytesM: need to put value in memory first
-        # The value is already left-aligned in 32 bytes
-        arg_val = Expr(arg_node, ctx).lower_value()
-        buf = ctx.allocate_buffer(32)
-        b.mstore(buf._ptr, arg_val)
-        return b.sha3(buf._ptr, IRLiteral(arg_t.m))
-    else:
-        # bytes32 or other 32-byte type
-        arg_val = Expr(arg_node, ctx).lower_value()
-        buf = ctx.allocate_buffer(32)
-        b.mstore(buf._ptr, arg_val)
-        return b.sha3(buf._ptr, IRLiteral(32))
+    data_ptr, length = _prepare_hash_input(node, ctx)
+    return b.sha3(data_ptr, length)
 
 
 def lower_sha256(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
@@ -82,54 +58,8 @@ def lower_sha256(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
 
     Computes SHA-256 hash via precompile at address 0x2.
     """
-    from vyper.codegen_venom.expr import Expr
-
     b = ctx.builder
-
-    arg_node = node.args[0]
-    arg_t = arg_node._metadata["type"]
-
-    data_ptr: IROperand
-    length: IROperand
-    if isinstance(arg_t, _BytestringT):
-        # Variable-length bytes/string
-        arg_vv = Expr(arg_node, ctx).lower()
-
-        # staticcall only works with memory - copy storage/transient/code data first
-        if arg_vv.location is not None and arg_vv.location in (
-            DataLocation.STORAGE,
-            DataLocation.TRANSIENT,
-        ):
-            buf_val = ctx.new_temporary_value(arg_t)
-            ctx.slot_to_memory(
-                arg_vv.operand, buf_val.operand, arg_t.storage_size_in_words, arg_vv.location
-            )
-            # Hash from memory buffer
-            data_ptr = ctx.bytes_data_ptr(buf_val)
-            length = ctx.bytestring_length(buf_val)
-        elif arg_vv.location is not None and arg_vv.location == DataLocation.CODE:
-            # Immutable bytestring: copy to memory first
-            buf_val = ctx.new_temporary_value(arg_t)
-            ctx.code_to_memory(arg_vv.operand, buf_val.operand, arg_t.storage_size_in_words)
-            data_ptr = ctx.bytes_data_ptr(buf_val)
-            length = ctx.bytestring_length(buf_val)
-        else:
-            data_ptr = ctx.bytes_data_ptr(arg_vv)
-            length = ctx.bytestring_length(arg_vv)
-    elif isinstance(arg_t, BytesM_T):
-        # Fixed bytesM
-        arg_val = Expr(arg_node, ctx).lower_value()
-        buf = ctx.allocate_buffer(32)
-        b.mstore(buf._ptr, arg_val)
-        data_ptr = buf._ptr
-        length = IRLiteral(arg_t.m)
-    else:
-        # bytes32 or other 32-byte type
-        arg_val = Expr(arg_node, ctx).lower_value()
-        buf = ctx.allocate_buffer(32)
-        b.mstore(buf._ptr, arg_val)
-        data_ptr = buf._ptr
-        length = IRLiteral(32)
+    data_ptr, length = _prepare_hash_input(node, ctx)
 
     # Allocate output buffer (32 bytes for hash result)
     out_buf = ctx.allocate_buffer(32)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -194,7 +194,7 @@ class VenomCodegenContext:
             DataLocation.TRANSIENT,
         ), f"bytes_data_ptr expects MEMORY, STORAGE, or TRANSIENT, got {loc}"
         word_scale = 32 if loc is None or loc == DataLocation.MEMORY else 1
-        return self.builder.add(vv.operand, IRLiteral(word_scale))
+        return self._with_byte_offset(vv.operand, word_scale)
 
     def bytestring_length(self, vv: VyperValue) -> IROperand:
         """Get length of bytestring from its pointer.
@@ -212,6 +212,24 @@ class VenomCodegenContext:
         if loc is None:
             return self.builder.mload(vv.operand)
         return self.builder.load(vv.operand, loc)
+
+    def ensure_bytestring_in_memory(self, vv: VyperValue, typ: _BytestringT) -> VyperValue:
+        """Return a bytestring value guaranteed to be in memory.
+
+        Hashing and certain builtins require memory-backed bytestring data.
+        STORAGE/TRANSIENT/CODE values are copied into a temporary memory buffer.
+        """
+        if vv.location is DataLocation.STORAGE or vv.location is DataLocation.TRANSIENT:
+            buf_val = self.new_temporary_value(typ)
+            self.slot_to_memory(vv.operand, buf_val.operand, typ.storage_size_in_words, vv.location)
+            return buf_val
+
+        if vv.location is DataLocation.CODE:
+            buf_val = self.new_temporary_value(typ)
+            self.code_to_memory(vv.operand, buf_val.operand, typ.storage_size_in_words)
+            return buf_val
+
+        return vv
 
     def is_constant(self) -> bool:
         """Check if in constant (view) context or range expression."""
@@ -421,6 +439,14 @@ class VenomCodegenContext:
     # For 3+ words, identity precompile produces smaller bytecode.
     _IDENTITY_PRECOMPILE_THRESHOLD = 96  # 3 words
 
+    def _with_byte_offset(self, base: IROperand, byte_offset: int) -> IROperand:
+        """Add a compile-time byte offset to an operand, preserving literals."""
+        if byte_offset == 0:
+            return base
+        if isinstance(base, IRLiteral):
+            return IRLiteral(base.value + byte_offset)
+        return self.builder.add(base, IRLiteral(byte_offset))
+
     def copy_memory(self, dst: IROperand, src: IROperand, size: int) -> None:
         """Copy memory region from src to dst (static size known at compile time).
 
@@ -446,18 +472,8 @@ class VenomCodegenContext:
 
         # Pre-Cancun: word-by-word copy for small copies
         for offset in range(0, size, 32):
-            src_ptr: IROperand
-            if isinstance(src, IRLiteral):
-                src_ptr = IRLiteral(src.value + offset)
-            else:
-                src_ptr = self.builder.add(src, IRLiteral(offset))
-
-            dst_ptr: IROperand
-            if isinstance(dst, IRLiteral):
-                dst_ptr = IRLiteral(dst.value + offset)
-            else:
-                dst_ptr = self.builder.add(dst, IRLiteral(offset))
-
+            src_ptr = self._with_byte_offset(src, offset)
+            dst_ptr = self._with_byte_offset(dst, offset)
             val = self.builder.mload(src_ptr)
             self.builder.mstore(dst_ptr, val)
 
@@ -582,12 +598,7 @@ class VenomCodegenContext:
         b = self.builder
         for i in range(word_count):
             byte_offset = i * 32
-            if byte_offset == 0:
-                imm_offset = offset
-            elif isinstance(offset, IRLiteral):
-                imm_offset = IRLiteral(offset.value + byte_offset)
-            else:
-                imm_offset = b.add(offset, IRLiteral(byte_offset))
+            imm_offset = self._with_byte_offset(offset, byte_offset)
 
             if self.immutables_alloca is not None:
                 ptr = b.gep(self.immutables_alloca, imm_offset)
@@ -595,12 +606,7 @@ class VenomCodegenContext:
             else:
                 word = b.dload(imm_offset)
 
-            if byte_offset == 0:
-                mem_ptr = dst
-            elif isinstance(dst, IRLiteral):
-                mem_ptr = IRLiteral(dst.value + byte_offset)
-            else:
-                mem_ptr = b.add(dst, IRLiteral(byte_offset))
+            mem_ptr = self._with_byte_offset(dst, byte_offset)
 
             b.mstore(mem_ptr, word)
 
@@ -850,23 +856,12 @@ class VenomCodegenContext:
             size = typ.memory_bytes_required
             for i in range(0, size, 32):
                 # Immutables are byte-addressed
-                if i == 0:
-                    imm_offset = offset
-                elif isinstance(offset, IRLiteral):
-                    imm_offset = IRLiteral(offset.value + i)
-                else:
-                    imm_offset = self.builder.add(offset, IRLiteral(i))
+                imm_offset = self._with_byte_offset(offset, i)
 
                 word = self.builder.dload(imm_offset)
 
                 # Memory is byte-addressed
-                mem_ptr: IROperand
-                if i == 0:
-                    mem_ptr = buf
-                elif isinstance(buf, IRLiteral):
-                    mem_ptr = IRLiteral(buf.value + i)
-                else:
-                    mem_ptr = self.builder.add(buf, IRLiteral(i))
+                mem_ptr = self._with_byte_offset(buf, i)
 
                 self.builder.mstore(mem_ptr, word)
 
@@ -890,12 +885,7 @@ class VenomCodegenContext:
             size = typ.memory_bytes_required
             for i in range(0, size, 32):
                 # Immutables are byte-addressed
-                if i == 0:
-                    imm_offset = offset
-                elif isinstance(offset, IRLiteral):
-                    imm_offset = IRLiteral(offset.value + i)
-                else:
-                    imm_offset = self.builder.add(offset, IRLiteral(i))
+                imm_offset = self._with_byte_offset(offset, i)
 
                 if self.immutables_alloca is not None:
                     ptr = self.builder.gep(self.immutables_alloca, imm_offset)
@@ -904,13 +894,7 @@ class VenomCodegenContext:
                     word = self.builder.iload(imm_offset)
 
                 # Memory is byte-addressed
-                mem_ptr: IROperand
-                if i == 0:
-                    mem_ptr = buf
-                elif isinstance(buf, IRLiteral):
-                    mem_ptr = IRLiteral(buf.value + i)
-                else:
-                    mem_ptr = self.builder.add(buf, IRLiteral(i))
+                mem_ptr = self._with_byte_offset(buf, i)
 
                 self.builder.mstore(mem_ptr, word)
 
@@ -933,22 +917,12 @@ class VenomCodegenContext:
             size = typ.memory_bytes_required
             for i in range(0, size, 32):
                 # Memory is byte-addressed
-                if i == 0:
-                    mem_ptr = val
-                elif isinstance(val, IRLiteral):
-                    mem_ptr = IRLiteral(val.value + i)
-                else:
-                    mem_ptr = self.builder.add(val, IRLiteral(i))
+                mem_ptr = self._with_byte_offset(val, i)
 
                 word = self.builder.mload(mem_ptr)
 
                 # Immutables are byte-addressed
-                if i == 0:
-                    imm_offset = offset
-                elif isinstance(offset, IRLiteral):
-                    imm_offset = IRLiteral(offset.value + i)
-                else:
-                    imm_offset = self.builder.add(offset, IRLiteral(i))
+                imm_offset = self._with_byte_offset(offset, i)
 
                 if self.immutables_alloca is not None:
                     ptr = self.builder.gep(self.immutables_alloca, imm_offset)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -229,6 +229,7 @@ class VenomCodegenContext:
             self.code_to_memory(vv.operand, buf_val.operand, typ.storage_size_in_words)
             return buf_val
 
+        assert vv.location is None or vv.location is DataLocation.MEMORY
         return vv
 
     def is_constant(self) -> bool:


### PR DESCRIPTION
### What I did

Reduced duplicated normalization logic and make direct-to-venom behavior easier to reason about and maintain, while preserving semantics. Also fixes a latent `CompilerPanic` when `DataLocation` is compared with `None` via `==`/`in`.

### How I did it

- `ensure_bytestring_in_memory()`: centralizes the "copy from STORAGE/TRANSIENT/CODE into a memory buffer" pattern that was duplicated 4× across hashing.py and expr.py. Uses `is` identity checks to avoid `StringEnum.__eq__` panic when `location` is `None`.
- `_prepare_hash_input()`: shared input normalization for keccak256/sha256, handling both bytestring and fixed-size (bytesM/bytes32) cases.
- `_with_byte_offset()`: replaces ~8 copies of the 6-line `if offset == 0 / elif isinstance(base, IRLiteral) / else add` pattern in copy_memory, code_to_memory, load_immutable, load_immutable_ctor, store_immutable. Also elides dead `add 0` instructions.
- `_assert_slice_bounds()`: extracts the 4× duplicated overflow-safe bounds check from slice lowering paths.

### How to verify it

Existing test suite — pure refactor with no semantic changes (except the `is` vs `==` bugfix).

### Commit message

```
refactor[venom]: normalize bytestring memory handling and dedupe
hash/slice paths

the direct-to-venom codegen had four independent copies of the pattern
"if bytestring is in STORAGE/TRANSIENT/CODE, copy it to a memory buffer
first". keccak256 and sha256 each duplicated this in hashing.py, and
expr.py had two more copies in `_lower_keccak256_key` and
`_get_bytestring_hash` (used for mapping key hashing and bytestring
comparison). the slice builtin similarly had four identical copies of
the bounds-check sequence `start + length <= src_len` with overflow
protection.

separately, the offset arithmetic in `copy_memory`, `code_to_memory`,
`load_immutable`, `load_immutable_ctor`, and `store_immutable` each
manually special-cased `offset == 0` and `isinstance(base, IRLiteral)`
with 6-line if/elif/else blocks, repeated ~8 times.

add three helpers to eliminate the duplication:
- `ensure_bytestring_in_memory()`: centralizes STORAGE/TRANSIENT/CODE →
  memory copy; returns the value unchanged if already in memory
- `_prepare_hash_input()`: shared input normalization for keccak256 and
  sha256, handling both bytestring and fixed-size (bytesM/bytes32) cases
- `_with_byte_offset()`: compile-time offset addition that preserves
  IRLiteral folding and elides dead `add 0` instructions
- `_assert_slice_bounds()`: the overflow-safe bounds check extracted
  from slice lowering

also fixes a latent bug: expr.py used `vv.location in (DataLocation.X,
...)` which invokes `StringEnum.__eq__` — this panics with
`CompilerPanic("bad comparison")` when `location` is `None` (the
representation for memory-resident values). the new code uses identity
checks (`is`) throughout, which is safe for enum singletons.
```

### Description for the changelog

refactor bytestring memory normalization and deduplicate hash/slice codegen paths

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
