### PR TITLE
chore[docs]: add CLAUDE.md and skills/ for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ trees/
 worktrees/
 repros/
 .agent-files/
+.sandbox
 
 # used by fmt_commit_msg.py
 commitmsg.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Vyper Compiler — Agent Guide
+
+Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
+
+## Quick Commands
+
+```bash
+pip install -e ".[dev]"        # install with dev deps
+./quicktest.sh -m "not fuzzing"          # run tests (-nauto by default via setup.cfg)
+make lint                       # enforces code style (same as CI)
+vyper contract.vy               # compile a contract
+vyper -f ir_runtime contract.vy # inspect Venom IR
+vyper -f asm contract.vy        # inspect assembly
+```
+
+## Architecture, Code Style, Entry Points
+
+See [skills/SKILL.md](skills/SKILL.md) for compilation pipeline, directory map, code style, and key entry points.
+
+## Topic Deep-Dives
+
+- **[Venom IR](skills/venom.md)** — SSA IR design, passes, optimization, working with Venom code
+- **[Semantics & Frontend](skills/semantics.md)** — Type system, analysis phases, namespace, validation
+- **[Code Generation](skills/codegen.md)** — Legacy IR, Venom codegen, the two pipelines
+- **[Testing](skills/testing.md)** — Test structure, fixtures, running tests, writing new tests
+- **[Contributing](skills/contributing.md)** — Commit message standards, PR workflow, code style summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,12 @@ Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
 ## Quick Commands
 
 ```bash
-pip install ".[dev]"                     # one-time: install dev deps (never -e)
-PYTHONPATH=. vyper contract.vy           # compile using local source
-PYTHONPATH=. vyper -f ir_runtime contract.vy # inspect Venom IR
-PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly
-./quicktest.sh -m "not fuzzing"          # run tests (-nauto by default via setup.cfg)
-make lint                                # enforces code style (same as CI)
+uv sync --extra dev              # install deps (per-worktree .venv, recommended)
+uv run vyper contract.vy                # compile a contract
+uv run vyper -f ir_runtime contract.vy  # inspect Venom IR
+uv run vyper -f asm contract.vy         # inspect assembly
+uv run ./quicktest.sh -m "not fuzzing"  # run tests (-nauto by default via setup.cfg)
+uv run make lint                        # enforces code style (same as CI)
 ```
 
 ## Architecture, Code Style, Entry Points

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
 ## Quick Commands
 
 ```bash
-pip install -e ".[dev]"                  # one-time: install dev deps
+pip install ".[dev]"                     # one-time: install dev deps (never -e)
 PYTHONPATH=. vyper contract.vy           # compile using local source
 PYTHONPATH=. vyper -f ir_runtime contract.vy # inspect Venom IR
 PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,12 @@ Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
 ## Quick Commands
 
 ```bash
-pip install -e ".[dev]"        # install with dev deps
+pip install -e ".[dev]"                  # one-time: install dev deps
+PYTHONPATH=. vyper contract.vy           # compile using local source
+PYTHONPATH=. vyper -f ir_runtime contract.vy # inspect Venom IR
+PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly
 ./quicktest.sh -m "not fuzzing"          # run tests (-nauto by default via setup.cfg)
-make lint                       # enforces code style (same as CI)
-vyper contract.vy               # compile a contract
-vyper -f ir_runtime contract.vy # inspect Venom IR
-vyper -f asm contract.vy        # inspect assembly
+make lint                                # enforces code style (same as CI)
 ```
 
 ## Architecture, Code Style, Entry Points

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -10,15 +10,17 @@ Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
 ## Quick Commands
 
 ```bash
-pip install ".[dev]"                     # one-time: install dev deps (never -e)
-PYTHONPATH=. vyper contract.vy           # compile using local source
-PYTHONPATH=. vyper -f ir_runtime contract.vy # inspect Venom IR
-PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly
-./quicktest.sh -m "not fuzzing"          # run tests (-nauto by default via setup.cfg)
-make lint                                # enforces code style (same as CI)
+uv sync --extra dev              # install deps (per-worktree .venv, recommended)
+uv run vyper contract.vy                # compile a contract
+uv run vyper -f ir_runtime contract.vy  # inspect Venom IR
+uv run vyper -f asm contract.vy         # inspect assembly
+uv run ./quicktest.sh -m "not fuzzing"  # run tests (-nauto by default via setup.cfg)
+uv run make lint                        # enforces code style (same as CI)
 ```
 
-Use `PYTHONPATH=.` to run against local source. **Never use `pip install -e .`** — it creates an egg-link in site-packages that permanently points the venv at one worktree, breaking all other worktrees. Install deps only: `pip install .[dev]` (no `-e`).
+Prefix all commands with `uv run` — it activates the local `.venv` per invocation, which is necessary in non-interactive shells. Each worktree gets its own `.venv`, so no cross-contamination.
+
+Alternative: `pip install ".[dev]"` + `PYTHONPATH=.` prefix on every command. **Never `pip install -e .`** — it creates an egg-link in site-packages that permanently points the venv at one worktree, breaking all others.
 
 ## Compilation Pipeline
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -79,7 +79,7 @@ Enforced by `make lint` (also what CI runs). Includes `black`, `flake8`, `isort`
 
 | What | Where |
 |------|-------|
-| Main compile function | `vyper.compiler.compile_codes()` |
+| Main compile function | `vyper.compiler.compile_code()` |
 | Pipeline phases | `vyper.compiler.phases.CompilerData` |
 | AST parsing | `vyper.ast.parse.parse_to_ast()` |
 | Semantic analysis | `vyper.semantics.analyze_module()` |

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: vyper-compiler
+description: Vyper smart contract compiler internals. Use when working on the Vyper compiler codebase — compilation pipeline, Venom IR, semantic analysis, code generation, testing, or contributing. Triggers on vyper compiler development, Venom passes, AST/semantics changes, codegen work, or test writing.
+---
+
+# Vyper Compiler
+
+Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
+
+## Quick Commands
+
+```bash
+pip install -e ".[dev]"                  # install with dev deps
+./quicktest.sh -m "not fuzzing"          # run tests (-nauto by default via setup.cfg)
+make lint                                # enforces code style (same as CI)
+vyper contract.vy                        # compile a contract
+vyper -f ir_runtime contract.vy          # inspect Venom IR
+vyper -f asm contract.vy                 # inspect assembly
+```
+
+## Compilation Pipeline
+
+```
+Source (.vy)
+  │
+  ├─ vyper/ast/            → Parse to AST (pre_parser → Python AST → Vyper AST)
+  ├─ vyper/semantics/      → Type check, validate, annotate AST
+  ├─ vyper/codegen/        → AST → s-expr IR (default production pipeline)
+  ├─ vyper/ir/             → s-expr IR → assembly → bytecode
+  └─ vyper/evm/            → Assembly → bytecode
+```
+
+Experimental Venom path (`--experimental-codegen`):
+```
+  ├─ vyper/codegen_venom/  → AST → Venom SSA IR
+  └─ vyper/venom/          → Venom IR optimization passes → assembly
+```
+
+Orchestrated by `vyper/compiler/phases.py` (`CompilerData`). Each phase is lazy.
+
+## Directory Map
+
+| Directory | Purpose |
+|-----------|---------|
+| `vyper/ast/` | Parsing, AST nodes, pre-parser. See [AST README](../vyper/ast/README.md) |
+| `vyper/semantics/` | Type system, analysis, validation. See [Semantics README](../vyper/semantics/README.md) |
+| `vyper/codegen/` | AST → s-expr IR (default production pipeline) |
+| `vyper/ir/` | s-expr IR → assembly → bytecode. See [IR README](../vyper/ir/README.md) |
+| `vyper/codegen_venom/` | AST → Venom IR (experimental, `--experimental-codegen`) |
+| `vyper/venom/` | Venom SSA IR: passes, analysis, assembly emission. See [Venom README](../vyper/venom/README.md) |
+| `vyper/compiler/` | Pipeline orchestration, settings, output formats. See [Compiler README](../vyper/compiler/README.md) |
+| `vyper/builtins/` | Built-in functions and interfaces |
+| `vyper/evm/` | EVM opcodes, assembler |
+| `vyper/cli/` | CLI entry points (`vyper`, `vyper-ir`, `venom`) |
+| `tests/unit/` | Unit tests (ast, semantics, compiler, venom) |
+| `tests/functional/` | Functional tests (builtins, codegen, grammar, syntax, venom) |
+
+## Topic Deep-Dives
+
+- **[Venom IR](venom.md)** — SSA IR design, passes, optimization, working with Venom code
+- **[Semantics & Frontend](semantics.md)** — Type system, analysis phases, namespace, validation
+- **[Code Generation](codegen.md)** — Legacy IR, Venom codegen, the two pipelines
+- **[Testing](testing.md)** — Test structure, fixtures, running tests, writing new tests
+- **[Contributing](contributing.md)** — Commit message standards, PR workflow, code style summary
+
+## Code Style
+
+Enforced by `make lint` (also what CI runs). Includes `black`, `flake8`, `isort`, `mypy`.
+
+- Line length: 100
+- No inline imports; standard library → third-party → local
+- snake_case throughout; type classes end in `T` (e.g. `IntegerT`, `ModuleT`)
+
+## Key Entry Points
+
+| What | Where |
+|------|-------|
+| Main compile function | `vyper.compiler.compile_codes()` |
+| Pipeline phases | `vyper.compiler.phases.CompilerData` |
+| AST parsing | `vyper.ast.parse.parse_to_ast()` |
+| Semantic analysis | `vyper.semantics.analyze_module()` |
+| Legacy codegen | `vyper.codegen.module` |
+| AST → Venom IR | `vyper.codegen_venom.module` |
+| Venom → assembly | `vyper.venom.generate_assembly_experimental()` |
+| CLI entry | `vyper.cli.vyper_compile` |

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -10,13 +10,15 @@ Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
 ## Quick Commands
 
 ```bash
-pip install -e ".[dev]"                  # install with dev deps
+pip install -e ".[dev]"                  # one-time: install dev deps
+PYTHONPATH=. vyper contract.vy           # compile using local source
+PYTHONPATH=. vyper -f ir_runtime contract.vy # inspect Venom IR
+PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly
 ./quicktest.sh -m "not fuzzing"          # run tests (-nauto by default via setup.cfg)
 make lint                                # enforces code style (same as CI)
-vyper contract.vy                        # compile a contract
-vyper -f ir_runtime contract.vy          # inspect Venom IR
-vyper -f asm contract.vy                 # inspect assembly
 ```
+
+Use `PYTHONPATH=.` to run against local source. Do NOT re-run `pip install -e` after changes — it's only needed once for dev deps. This is especially important with multiple worktrees.
 
 ## Compilation Pipeline
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -10,7 +10,7 @@ Pythonic smart contract language targeting the EVM. v0.4.x, Python 3.11+.
 ## Quick Commands
 
 ```bash
-pip install -e ".[dev]"                  # one-time: install dev deps
+pip install ".[dev]"                     # one-time: install dev deps (never -e)
 PYTHONPATH=. vyper contract.vy           # compile using local source
 PYTHONPATH=. vyper -f ir_runtime contract.vy # inspect Venom IR
 PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly
@@ -18,7 +18,7 @@ PYTHONPATH=. vyper -f asm contract.vy    # inspect assembly
 make lint                                # enforces code style (same as CI)
 ```
 
-Use `PYTHONPATH=.` to run against local source. Do NOT re-run `pip install -e` after changes — it's only needed once for dev deps. This is especially important with multiple worktrees.
+Use `PYTHONPATH=.` to run against local source. **Never use `pip install -e .`** — it creates an egg-link in site-packages that permanently points the venv at one worktree, breaking all other worktrees. Install deps only: `pip install .[dev]` (no `-e`).
 
 ## Compilation Pipeline
 

--- a/skills/codegen.md
+++ b/skills/codegen.md
@@ -1,0 +1,31 @@
+# Code Generation
+
+## Experimental Pipeline: Direct-to-Venom
+
+AST → `vyper/codegen_venom/` → Venom IR → optimization passes → assembly → bytecode.
+
+### `vyper/codegen_venom/`
+
+Translates annotated Vyper AST directly to Venom SSA IR.
+
+- `module.py` — entry point, module-level codegen
+- `expr.py` — expression translation
+- `stmt.py` — statement translation
+- `arithmetic.py` — numeric operations
+- `builtins/` — built-in function codegen
+- `abi/` — ABI encoding/decoding
+- `context.py` — codegen context (variable tracking, etc.)
+
+### Venom → Assembly
+
+After Venom IR is constructed, `vyper/venom/` runs optimization passes then
+`venom/venom_to_assembly.py` emits EVM assembly. The assembler in `vyper/evm/assembler/`
+produces final bytecode.
+
+## Default Production Pipeline: Legacy IR
+
+AST → `vyper/codegen/` → s-expression IR (`IRnode`) → `vyper/ir/compile_ir.py` → assembly → bytecode.
+
+This is the current default. See [vyper/ir/README.md](../vyper/ir/README.md) for IR grammar and structure.
+
+Key difference: legacy IR is tree-shaped s-expressions, Venom is SSA basic blocks.

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -98,11 +98,31 @@ Note: first paragraph is pure *why* (the bug mechanism). Second paragraph is a c
   ```bash
   gh pr create --repo vyperlang/vyper --base master --head <fork-owner>:<branch>
   ```
+- Follow the PR template (`.github/PULL_REQUEST_TEMPLATE.md`): What/How/Verify/Commit message/Changelog
+- To edit PR or issue bodies: use `gh pr view <N> --json body -q .body` to get current text, edit in a temp file, then `gh pr edit <N> --body-file <file>`
 - **NEVER rebase and force-push a branch that is already under review.** Rebasing destroys review context (inline comments become orphaned, diff history is lost). If you need to pull in upstream changes on a PR branch, **merge `master` into your branch**.
 
 ## Keeping Docs Current
 
 If anything you have done requires content updates to any files in `skills/` or `CLAUDE.md`, update them as part of the same PR.
+
+## Git Quick Reference
+
+```bash
+# undo a bad amend or commit (find the pre-amend state in reflog)
+git reflog -10
+git reset --mixed <good-sha>     # unstages changes, keeps working tree
+git add <files> && git commit    # recommit cleanly
+
+# sync with upstream on a branch under review (NEVER rebase+force-push)
+git merge master
+
+# interactive rebase doesn't work in non-interactive shells — use reset+cherry-pick instead
+git stash                        # protect uncommitted work
+git reset --hard <target>
+git cherry-pick <commits>        # resolve conflicts manually
+git stash pop
+```
 
 ## Code Style Summary
 

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -93,7 +93,7 @@ Note: first paragraph is pure *why* (the bug mechanism). Second paragraph is a c
 - Fork from `master`
 - Write tests for new features; place them under `tests/`
 - Larger changes: discuss in Discord `#compiler-dev` first
-- PRs are squash-merged — keep the PR title clean (it becomes the commit subject)
+- PRs are squash-merged — the PR title becomes the commit subject. Keep PR title and commit message title in sync.
 - Work from your individual fork. PRs target `vyperlang/vyper` upstream:
   ```bash
   gh pr create --repo vyperlang/vyper --base master --head <fork-owner>:<branch>

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -1,0 +1,114 @@
+# Contributing
+
+See also: [docs/contributing.rst](../docs/contributing.rst) for general contribution guidelines,
+[docs/style-guide.rst](../docs/style-guide.rst) for code style, naming, imports, exceptions, tests, and docs conventions.
+
+## Commit Messages
+
+We use squash merges for PRs. The squash commit message is the permanent record — it goes into
+`git log`, changelogs, and blame. The diff shows *what* changed; the PR shows *how* it evolved.
+The commit message must explain **why**.
+
+### Format
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[scope]: <description>
+
+<body>
+```
+
+Types: `feat`, `fix`, `refactor`, `perf`, `chore`, `release`.
+Scope is **required**. Validated by CI — see [pull-request.yaml](../.github/workflows/pull-request.yaml) for the canonical list.
+Current scopes: `venom`, `lang`, `codegen`, `parser`, `stdlib`, `ux`, `ir`, `test`, `docs`, `ci`, `build`, `tool`.
+
+### Subject Line
+
+- Imperative, present tense ("add X" not "added X")
+- ~50 chars, lowercase, no period
+- Scope in brackets: `feat[venom]: add tail-merge pass`
+
+### Body — Explain Why and Context
+
+The body is the most important part. It should answer:
+
+- **What problem does this solve?** What was broken, missing, or suboptimal?
+- **Why this approach?** What alternatives were considered? What tradeoffs were made?
+- **What are the non-obvious consequences?** Side effects, invariants established or broken, perf impact?
+
+Don't enumerate every file touched or mechanically list what each function does — that's the diff.
+Do explain the *reasoning* behind structural decisions, the bug mechanism, or the design rationale.
+
+### Good Example (from recent history)
+
+```
+fix[venom]: fix allocation in ternary fall through (#4846)
+
+`Mem2Var._fix_adds` converts `add` instructions on alloca pointers into
+`gep` (get-element-pointer) so that `BasePtrAnalysis` can track pointer
+provenance through arithmetic. When a ternary expression merges two
+pointer paths via a `phi` node, the `add` sits downstream of the phi
+rather than as a direct use of the alloca — so `_fix_adds` never saw it.
+
+The same gap existed in the caller guards: `_process_alloca_var` and
+`_process_palloca_var` only dispatched to `_fix_adds` when a direct
+`add` use was present, silently skipping allocas whose only non-trivial
+uses were behind phi/assign nodes.
+
+Additionally, following phi/assign chains introduces the possibility of
+cycles through loop back-edges, so add a visited set to terminate
+gracefully.
+```
+
+Note: explains the *mechanism* of the bug (why it happened), not just "fixed a crash in X".
+
+### Another Good Example
+
+```
+fix[venom]: treat immutables as global allocations (#4839)
+
+the immutables region (allocated at position 0 during deploy) was not
+reserved across function boundaries. when `ConcretizeMemLocPass` ran for
+internal functions, it started with an empty reserved set, allowing
+function-local buffers to overlap position 0 and clobber immutable
+values.
+
+add a `global_allocation` set to `MemoryAllocator` that persists across
+per-function allocation rounds. register the immutables alloca as global
+at IR conversion time.
+```
+
+Note: first paragraph is pure *why* (the bug mechanism). Second paragraph is a concise *what* — just enough to orient a reader, not a line-by-line walkthrough.
+
+### Anti-Patterns
+
+- ❌ "Fix bug" / "Update code" — says nothing
+- ❌ Listing every changed file or function — that's the diff
+- ❌ Only *what* with no *why* — "add field X to class Y, call Z in function W"
+- ❌ Copying the PR description verbatim (PR descriptions track evolution and review; commit messages are the final, distilled record)
+
+## Pull Requests
+
+- Fork from `master`
+- Write tests for new features; place them under `tests/`
+- Larger changes: discuss in Discord `#compiler-dev` first
+- PRs are squash-merged — keep the PR title clean (it becomes the commit subject)
+- **NEVER rebase and force-push a branch that is already under review.** Rebasing destroys review context (inline comments become orphaned, diff history is lost). If you need to pull in upstream changes on a PR branch, **merge `master` into your branch**.
+
+## Keeping Docs Current
+
+If anything you have done requires content updates to any files in `skills/` or `CLAUDE.md`, update them as part of the same PR.
+
+## Code Style Summary
+
+Full details in [docs/style-guide.rst](../docs/style-guide.rst). Highlights:
+
+- PEP 8, 100 char line length, enforced by `make lint`
+- Type classes end in `T` (`IntegerT`, `ModuleT`)
+- Method naming: `get_` (pure), `fetch_` (side effects), `build_` (creates new), `validate_` (raises or returns None)
+- No builtin exceptions — use custom exception classes from `vyper/exceptions.py`
+- f-strings for string formatting
+- Import modules, not objects (avoids circular deps)
+- Cross-package imports must not reach beyond root namespace of target package
+- Tests: no mocking, no interdependence (xdist parallel), parametrize where logical

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -94,6 +94,10 @@ Note: first paragraph is pure *why* (the bug mechanism). Second paragraph is a c
 - Write tests for new features; place them under `tests/`
 - Larger changes: discuss in Discord `#compiler-dev` first
 - PRs are squash-merged — keep the PR title clean (it becomes the commit subject)
+- Work from your individual fork. PRs target `vyperlang/vyper` upstream:
+  ```bash
+  gh pr create --repo vyperlang/vyper --base master --head <fork-owner>:<branch>
+  ```
 - **NEVER rebase and force-push a branch that is already under review.** Rebasing destroys review context (inline comments become orphaned, diff history is lost). If you need to pull in upstream changes on a PR branch, **merge `master` into your branch**.
 
 ## Keeping Docs Current

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -103,7 +103,12 @@ Note: first paragraph is pure *why* (the bug mechanism). Second paragraph is a c
   gh pr create --repo vyperlang/vyper --base master --head <fork-owner>:<branch>
   ```
 - Follow the PR template (`.github/PULL_REQUEST_TEMPLATE.md`): What/How/Verify/Commit message/Changelog
-- To edit PR or issue bodies: use `gh pr view <N> --json body -q .body` to get current text, edit in a temp file, then `gh pr edit <N> --body-file <file>`
+- To edit PR or issue bodies:
+  ```bash
+  gh pr view <N> --json body -q .body > /tmp/pr_body.md  # get current text
+  # edit /tmp/pr_body.md with Edit tool
+  gh pr edit <N> --body-file /tmp/pr_body.md              # upload
+  ```
 - **NEVER rebase and force-push a branch that is already under review.** Rebasing destroys review context (inline comments become orphaned, diff history is lost). If you need to pull in upstream changes on a PR branch, **merge `master` into your branch**.
 
 ## Keeping Docs Current

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -29,6 +29,10 @@ Current scopes: `venom`, `lang`, `codegen`, `parser`, `stdlib`, `ux`, `ir`, `tes
 - ~50 chars, lowercase, no period
 - Scope in brackets: `feat[venom]: add tail-merge pass`
 
+### Formatting
+
+Wrap body at 72 chars. Run `fmt_commit_msg.py` to prepare the "Commit message" section of the PR description (defaults to running on `commitmsg.txt`; modifies in place). See the script for full usage.
+
 ### Body — Explain Why and Context
 
 The body is the most important part. It should answer:

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -109,6 +109,10 @@ If anything you have done requires content updates to any files in `skills/` or 
 ## Git Quick Reference
 
 ```bash
+# ALWAYS check what's pushed before amending.
+# Only amend commits not yet pushed
+git log --oneline origin/<branch>..HEAD
+
 # undo a bad amend or commit (find the pre-amend state in reflog)
 git reflog -10
 git reset --mixed <good-sha>     # unstages changes, keeps working tree

--- a/skills/semantics.md
+++ b/skills/semantics.md
@@ -1,0 +1,59 @@
+# Semantics & Frontend
+
+Type checking, validation, and semantic analysis of Vyper AST.
+
+Primary reference: [vyper/semantics/README.md](../vyper/semantics/README.md) — full control flow, design, examples.
+
+## Pipeline
+
+```
+Source → pre_parser → Python AST → Vyper AST → semantic analysis → annotated AST
+```
+
+### AST Phase (`vyper/ast/`)
+
+See [vyper/ast/README.md](../vyper/ast/README.md).
+
+- `pre_parser.py`: Vyper source → parseable Python (substitutes `struct`/`interface` → `class`, etc.)
+- `grammar.lark`: Lark grammar definition
+- `nodes.py`: Vyper AST node classes (use `__slots__`)
+- `parse.py` / `utils.py`: `parse_to_ast()` — main entry
+
+### Semantic Analysis Phase (`vyper/semantics/`)
+
+Entry: `vyper.semantics.analyze_module()`
+
+Four steps:
+1. **Pre-typecheck** (`analysis/pre_typecheck.py`): fold constant expressions
+2. **Namespace init** (`namespace.py`): populate builtins, types, env vars
+3. **Module validation** (`analysis/module.py`): storage vars, user types, imports, function sigs
+4. **Local validation** (`analysis/local.py`): per-function type checking and annotation
+
+## Type System (`vyper/semantics/types/`)
+
+Type classes live in `vyper/semantics/types/`. Convention: classes end in `T` (e.g. `IntegerT`, `ModuleT`).
+Base classes in `bases.py`. Browse the directory for the full set — file names map to type categories
+(primitives, bytestrings, subscriptable, user-defined, function, module).
+
+Type checking is bottom-up: evaluate expression types → compare sides → validate operation.
+
+## Namespace
+
+`Namespace` (`namespace.py`) is a dict subclass with scoping via context manager:
+
+```python
+with namespace.enter_scope():
+    namespace["x"] = some_type
+# x no longer exists here
+```
+
+Scopes: builtin → module → local → (for/if blocks).
+
+## Analysis
+
+Analysis and validation logic lives in `vyper/semantics/analysis/`. Key files:
+- `module.py` — module-level validation (storage, types, imports)
+- `local.py` — `FunctionNodeVisitor`, per-function validation
+- `annotation.py` — type annotation of expressions
+
+Browse the directory for the full set. Also see `data_locations.py` and `environment.py` at the `semantics/` level.

--- a/skills/testing.md
+++ b/skills/testing.md
@@ -1,0 +1,48 @@
+# Testing
+
+## Running Tests
+
+```bash
+./quicktest.sh -m "not fuzzing"          # standard test run (-nauto by default via setup.cfg)
+./quicktest.sh tests/unit/               # unit tests only
+./quicktest.sh tests/functional/         # functional tests only
+./quicktest.sh tests/unit/compiler/venom/ # venom unit tests
+./quicktest.sh --hevm -m hevm            # hevm-based tests (needs hevm in PATH)
+```
+
+`quicktest.sh` wraps pytest with `-q -s --instafail -x` (bail on first failure).
+
+## Test Organization
+
+```
+tests/
+├── unit/           # isolated component tests
+│   ├── ast/
+│   ├── semantics/
+│   ├── compiler/
+│   │   └── venom/  # venom pass & analysis tests
+│   ├── cli/
+│   └── ...
+├── functional/     # end-to-end compilation & execution
+│   ├── builtins/
+│   ├── codegen/
+│   ├── grammar/
+│   ├── syntax/
+│   └── venom/
+├── conftest.py     # shared fixtures
+├── evm_backends/   # EVM execution backends for tests
+└── venom_utils.py  # helpers for venom tests
+```
+
+## Key Fixtures & Helpers
+
+- `tests/conftest.py` — main fixtures (compiler invocation, EVM backends)
+- `tests/evm_backends/` — pluggable EVM execution (pyevm, pyrevm)
+- `tests/venom_utils.py` — helpers for constructing Venom IR in tests
+
+## Writing Tests
+
+- Functional tests typically compile a Vyper snippet and execute it against an EVM backend
+- Venom unit tests construct IR programmatically, run passes, and assert on the result
+- Use `pytest.mark.fuzzing` for slow/fuzz tests (skipped in quick runs)
+- Use `pytest.mark.hevm` for hevm-specific tests

--- a/skills/venom.md
+++ b/skills/venom.md
@@ -1,0 +1,54 @@
+# Venom IR
+
+SSA-based intermediate representation for Vyper. Inspired by LLVM IR, adapted for stack-based EVM.
+
+Primary reference: [vyper/venom/README.md](../vyper/venom/README.md) — full instruction set, grammar, examples.
+
+## Structure
+
+```
+IRContext → IRFunction(s) → IRBasicBlock(s) → IRInstruction(s)
+```
+
+- Variables: `%`-prefixed, immutable after assignment (SSA)
+- Basic blocks: non-branching, terminated by `jmp`/`jnz`/`djmp`/`ret`/`return`/`stop`/`exit`
+- Normalized form: no block has both multiple predecessors AND multiple successors
+
+## Key Files
+
+Core data structures in `vyper/venom/`:
+- `context.py` — `IRContext`, top-level container
+- `function.py` — `IRFunction`
+- `basicblock.py` — `IRBasicBlock`, `IRInstruction`, `IROperand`
+- `builder.py` — helper for programmatic IR construction
+- `venom_to_assembly.py` — final pass: Venom → EVM assembly
+- `parser.py` — text format parser (for testing)
+
+Passes and analysis live in `venom/passes/` and `venom/analysis/` respectively.
+
+## Pass Architecture
+
+Passes inherit from base classes in `venom/passes/base_pass.py`. Three categories:
+- **Analysis** — `venom/analysis/` (CFG, DFG, liveness, dominators, etc.)
+- **Transformation** — normalization, SSA construction, phi elimination
+- **Optimization** — DCE, SCCP, CSE, load elimination, mem2var, inlining, etc.
+
+Pass ordering matters — e.g. assembly emission requires normalization, which requires CFG.
+
+Browse `venom/passes/` and `venom/analysis/` for the full set. File names are self-descriptive.
+
+## Inspecting Venom Output
+
+```bash
+vyper -f ir_runtime contract.vy        # Venom IR (runtime)
+vyper -f ir contract.vy                # Venom IR (deploy)
+vyper -f cfg_runtime contract.vy       # CFG as dot graph
+vyper -f asm contract.vy               # final assembly
+```
+
+Enable Venom: `--experimental-codegen` flag or `#pragma experimental-codegen` in source.
+
+## Entry Path
+
+AST → `vyper/codegen_venom/` → Venom IR (direct translation, no legacy IR involved).
+Entry point: `vyper/codegen_venom/module.py`.


### PR DESCRIPTION
### What I did

Add structured onboarding documentation for AI agents and new contributors working on the vyper compiler.

### How I did it

- `CLAUDE.md` — thin entry point with quick commands and pointers to topic files
- `skills/SKILL.md` — full architecture overview (pipeline, directory map, code style, entry points)
- `skills/venom.md` — Venom IR guide (points to `vyper/venom/README.md` for exhaustive reference)
- `skills/semantics.md` — type system, analysis phases, namespace
- `skills/codegen.md` — both pipelines (legacy production + experimental Venom)
- `skills/testing.md` — test structure, running tests, writing new tests
- `skills/contributing.md` — commit message standards (why > what), PR workflow, code style, git quick reference

Topic files are written to resist bit rot: they point to directories and existing READMEs rather than enumerating exhaustive lists. The contributing guide asks that `skills/` docs be updated alongside any PR that changes relevant content.

- Recommend `uv sync --extra dev` + `uv run` for dev setup (per-worktree `.venv` isolation)
- Warn against `pip install -e .` (permanently breaks venv via egg-link in multi-worktree setups)
- Document PR template, `gh` CLI workflow for editing PRs, upstream fork workflow
- Add git quick reference (reflog recovery, merge-not-rebase under review)
- Reference `fmt_commit_msg.py` for 72-char commit message wrapping
- Fix `compile_codes` → `compile_code` entry point (caught by Codex review)

### How to verify it

Read the files.

### Commit message

```
chore[docs]: add CLAUDE.md and skills/ agent onboarding docs

add structured onboarding documentation for AI agents and new
contributors working on the vyper compiler.

CLAUDE.md is a thin entry point with quick commands and pointers
to topic files. skills/SKILL.md has the full architecture overview
(pipeline, directory map, code style, entry points). topic files
in skills/ cover venom IR, semantics, codegen, testing, and
contributing conventions.

the contributing guide emphasizes commit message quality —
explaining *why* over *what* — with real examples from recent
history. it also documents the squash-merge workflow, the
no-force-push-under-review rule, and points to the CI workflow
for canonical commit scopes.

recommend uv for dev setup (per-worktree .venv isolation), warn
against pip install -e (breaks multi-worktree venvs via egg-link).
reference fmt_commit_msg.py for commit message formatting.
```

### Description for the changelog

Add `CLAUDE.md` and `skills/` directory with agent onboarding docs covering compiler architecture, Venom IR, semantics, codegen, testing, and contributing conventions.

### Cute Animal Picture

![vyper](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Gaboon_Viper.jpg/320px-Gaboon_Viper.jpg)


