### PR TITLE
fix[venom]: model `ret` as memory escape in `BasePtrAnalysis`

### DIFF
--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -196,6 +196,8 @@ class BasePtrAnalysis(IRAnalysis):
             return MemoryLocation.UNDEFINED
         if inst.opcode == "invoke":
             return MemoryLocation.UNDEFINED
+        if inst.opcode == "ret":
+            return MemoryLocation.UNDEFINED
 
         if inst.get_read_effects() & effects.MEMORY == effects.EMPTY:
             return MemoryLocation.EMPTY

--- a/vyper/venom/passes/dead_store_elimination.py
+++ b/vyper/venom/passes/dead_store_elimination.py
@@ -106,6 +106,9 @@ class DeadStoreElimination(IRPass):
             if clobbered:
                 continue
 
+            if bb.instructions and bb.instructions[-1].opcode == "ret":
+                return True
+
             # Otherwise, we add the block's offsprings to the worklist.
             # for all successor blocks, start from the 0'th instruction
             next_inst_idx = 0

--- a/vyper/venom/passes/dead_store_elimination.py
+++ b/vyper/venom/passes/dead_store_elimination.py
@@ -106,9 +106,6 @@ class DeadStoreElimination(IRPass):
             if clobbered:
                 continue
 
-            if bb.instructions and bb.instructions[-1].opcode == "ret":
-                return True
-
             # Otherwise, we add the block's offsprings to the worklist.
             # for all successor blocks, start from the 0'th instruction
             next_inst_idx = 0


### PR DESCRIPTION
### What I did

Fixed a bug where dead store elimination (DSE) incorrectly eliminated
memory stores preceding `ret` (internal function return).

### How I did it

Treat `ret` as reading `MemoryLocation.UNDEFINED` in
`BasePtrAnalysis._get_memory_read_location`. This mirrors how the
storage read analysis already handles `ret` — modelling it as a
conservative "future read" so DSE considers the store live.

Without this, `ret` fell through to `segment_from_ops` which returned
`EMPTY`, telling DSE that `ret` reads no memory. DSE then killed
preceding stores (e.g. the free memory pointer update in `alloc()`-style
functions), causing all allocations to alias.

### How to verify it

New unit tests in `test_dead_store_elimination.py`:
- `test_mstore_before_ret_is_not_dead` — store before `ret` must be
  preserved
- `test_mstore_before_ret_clobbered_is_dead` — store before `ret` that
  is clobbered by a later store is still correctly eliminated

### Commit message

```
fix[venom]: model `ret` as memory escape in `BasePtrAnalysis`

`BasePtrAnalysis._get_memory_read_location` did not handle the `ret`
opcode (internal function return). it fell through to `segment_from_ops`
which returned `MemoryLocation.EMPTY`, telling DSE that `ret` reads no
memory. this let DSE eliminate stores preceding `ret` that the caller
actually needs to observe — e.g. the free-memory-pointer update in
alloc()-style helpers, causing all allocations to alias.

add `ret` → `MemoryLocation.UNDEFINED` to `_get_memory_read_location`,
consistent with how the storage read analysis already treats `ret`.
```

### Description for the changelog

Fixed a bug where dead store elimination incorrectly removed memory
stores before internal function returns.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
