### PR TITLE
fix[venom]: proper array subscript lowering

### DIFF
--- a/tests/functional/codegen/features/test_immutable.py
+++ b/tests/functional/codegen/features/test_immutable.py
@@ -579,6 +579,41 @@ def get_length() -> uint256:
     assert c2.get_length() == 2
 
 
+def test_constructor_reads_from_immutable_dynarray(get_contract):
+    code = """
+arr: immutable(DynArray[uint256, 10])
+ctor_len: public(uint256)
+ctor_sum: public(uint256)
+ctor_has_two: public(bool)
+ctor_not_in_nine: public(bool)
+
+@deploy
+def __init__(values: DynArray[uint256, 10]):
+    arr = values
+    self.ctor_len = len(arr)
+
+    total: uint256 = 0
+    for value: uint256 in arr:
+        total += value
+    self.ctor_sum = total
+
+    self.ctor_has_two = 2 in arr
+    self.ctor_not_in_nine = 9 not in arr
+    """
+
+    c = get_contract(code, [1, 2, 3, 4])
+    assert c.ctor_len() == 4
+    assert c.ctor_sum() == 10
+    assert c.ctor_has_two() is True
+    assert c.ctor_not_in_nine() is True
+
+    c2 = get_contract(code, [])
+    assert c2.ctor_len() == 0
+    assert c2.ctor_sum() == 0
+    assert c2.ctor_has_two() is False
+    assert c2.ctor_not_in_nine() is True
+
+
 @pytest.mark.parametrize("arg", [0, 1])
 def test_uninitialized_immutable_dynarray_read_reverts(get_contract, tx_failed, arg):
     code = """

--- a/tests/functional/codegen/features/test_immutable.py
+++ b/tests/functional/codegen/features/test_immutable.py
@@ -577,3 +577,18 @@ def get_length() -> uint256:
     c2 = get_contract(code, [100, 200])
     assert c2.sum_array() == 300
     assert c2.get_length() == 2
+
+
+@pytest.mark.parametrize("arg", [0, 1])
+def test_uninitialized_immutable_dynarray_read_reverts(get_contract, tx_failed, arg):
+    code = """
+arr: immutable(DynArray[uint256, 1])
+
+@deploy
+def __init__(arg: uint256):
+    x: uint256 = arr[0]
+    arr = []
+    """
+
+    with tx_failed():
+        get_contract(code, arg)

--- a/tests/functional/codegen/features/test_immutable.py
+++ b/tests/functional/codegen/features/test_immutable.py
@@ -614,6 +614,94 @@ def __init__(values: DynArray[uint256, 10]):
     assert c2.ctor_not_in_nine() is True
 
 
+def test_constructor_reads_immutable_dynarray_single_word_compound_elements(get_contract):
+    code = """
+arr: immutable(DynArray[uint256[1], 3])
+ctor_total: public(uint256)
+ctor_second: public(uint256)
+
+@deploy
+def __init__(values: DynArray[uint256[1], 3]):
+    arr = values
+
+    total: uint256 = 0
+    for item: uint256[1] in arr:
+        total += item[0]
+    self.ctor_total = total
+
+    if len(arr) > 1:
+        self.ctor_second = arr[1][0]
+    """
+
+    c = get_contract(code, [[5], [7], [11]])
+    assert c.ctor_total() == 23
+    assert c.ctor_second() == 7
+
+    c2 = get_contract(code, [[9]])
+    assert c2.ctor_total() == 9
+    assert c2.ctor_second() == 0
+
+
+def test_constructor_reads_immutable_dynarray_multi_word_elements(get_contract):
+    code = """
+arr: immutable(DynArray[uint256[2], 3])
+ctor_total: public(uint256)
+ctor_second_right: public(uint256)
+
+@deploy
+def __init__(values: DynArray[uint256[2], 3]):
+    arr = values
+
+    total: uint256 = 0
+    for pair: uint256[2] in arr:
+        total += pair[0] + pair[1]
+    self.ctor_total = total
+
+    if len(arr) > 1:
+        self.ctor_second_right = arr[1][1]
+    """
+
+    c = get_contract(code, [[1, 2], [3, 4]])
+    assert c.ctor_total() == 10
+    assert c.ctor_second_right() == 4
+
+    c2 = get_contract(code, [])
+    assert c2.ctor_total() == 0
+    assert c2.ctor_second_right() == 0
+
+
+def test_constructor_immutable_dynarray_ternary_len_and_membership(get_contract):
+    code = """
+left: immutable(DynArray[uint256, 4])
+right: immutable(DynArray[uint256, 4])
+selected_len: public(uint256)
+selected_has_seven: public(bool)
+selected_has_ninetynine: public(bool)
+
+@deploy
+def __init__(
+    use_left: bool,
+    left_values: DynArray[uint256, 4],
+    right_values: DynArray[uint256, 4]
+):
+    left = left_values
+    right = right_values
+    self.selected_len = len(left if use_left else right)
+    self.selected_has_seven = 7 in (left if use_left else right)
+    self.selected_has_ninetynine = 99 in (left if use_left else right)
+    """
+
+    c = get_contract(code, True, [7, 1, 2], [5])
+    assert c.selected_len() == 3
+    assert c.selected_has_seven() is True
+    assert c.selected_has_ninetynine() is False
+
+    c2 = get_contract(code, False, [7, 1, 2], [5])
+    assert c2.selected_len() == 1
+    assert c2.selected_has_seven() is False
+    assert c2.selected_has_ninetynine() is False
+
+
 @pytest.mark.parametrize("arg", [0, 1])
 def test_uninitialized_immutable_dynarray_read_reverts(get_contract, tx_failed, arg):
     code = """

--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -166,6 +166,20 @@ def test_ternary_simple(get_contract, code, test, inputs):
     assert c.foo(test, x, y) == (x if test else y)
 
 
+@pytest.mark.parametrize("test", [True, False])
+def test_ternary_dynarray_subscript(get_contract, test):
+    code = """
+@external
+def foo(t: bool, a: DynArray[uint256, 3], b: DynArray[uint256, 3]) -> uint256:
+    return (a if t else b)[0]
+    """
+    c = get_contract(code)
+
+    a = [11, 22]
+    b = [33, 44]
+    assert c.foo(test, a, b) == (a if test else b)[0]
+
+
 tuple_codes = [
     """
 @external

--- a/tests/functional/syntax/test_msg_data.py
+++ b/tests/functional/syntax/test_msg_data.py
@@ -2,7 +2,7 @@ import pytest
 from eth_utils import to_bytes
 
 from vyper import compiler
-from vyper.exceptions import StructureException, TypeMismatch
+from vyper.exceptions import StructureException, TypeMismatch, VyperException
 from vyper.utils import method_id
 
 
@@ -183,6 +183,27 @@ def foo() -> Bytes[7]:
     ):
         with pytest.raises(StructureException):
             compiler.compile_code(bad_code)
+
+
+def test_invalid_usages_compile_error_not_polluted_within_same_module():
+    bad_code = """
+a: HashMap[Bytes[10], uint256]
+
+@external
+def poison():
+    self.a[msg.data] += 1
+
+@external
+def bad() -> Bytes[4]:
+    bar: Bytes[4] = msg.data
+    return bar
+    """
+    with pytest.raises(VyperException) as exc_info:
+        compiler.compile_code(bad_code)
+
+    err = str(exc_info.value)
+    assert err.count("StructureException: msg.data is only allowed") == 2
+    assert "TypeMismatch" not in err
 
 
 def test_runtime_failure_bounds_check(get_contract, tx_failed):

--- a/tests/functional/syntax/test_msg_data.py
+++ b/tests/functional/syntax/test_msg_data.py
@@ -156,6 +156,35 @@ def test_invalid_usages_compile_error(bad_code):
         compiler.compile_code(bad_code[0])
 
 
+def test_invalid_usages_compile_error_not_polluted_by_prior_compilation():
+    poison_code = """
+a: HashMap[Bytes[10], uint256]
+
+@external
+def foo():
+    self.a[msg.data] += 1
+    """
+    with pytest.raises(StructureException):
+        compiler.compile_code(poison_code)
+
+    for bad_code in (
+        """
+@external
+def foo() -> Bytes[4]:
+    bar: Bytes[4] = msg.data
+    return bar
+        """,
+        """
+@external
+def foo() -> Bytes[7]:
+    bar: Bytes[7] = concat(msg.data, 0xc0ffee)
+    return bar
+        """,
+    ):
+        with pytest.raises(StructureException):
+            compiler.compile_code(bad_code)
+
+
 def test_runtime_failure_bounds_check(get_contract, tx_failed):
     code = """
 @external

--- a/tests/unit/semantics/test_namespace.py
+++ b/tests/unit/semantics/test_namespace.py
@@ -34,10 +34,10 @@ def test_builtin_types_persist_after_clear(namespace):
 
 def test_context_manager_constant_vars(namespace):
     with namespace.enter_scope():
-        for key in environment.CONSTANT_ENVIRONMENT_VARS.keys():
+        for key in environment.CONSTANT_ENVIRONMENT_VARS:
             assert key in namespace
 
-    for key in environment.CONSTANT_ENVIRONMENT_VARS.keys():
+    for key in environment.CONSTANT_ENVIRONMENT_VARS:
         assert key in namespace
 
 

--- a/tests/unit/semantics/test_namespace.py
+++ b/tests/unit/semantics/test_namespace.py
@@ -94,5 +94,3 @@ def test_undeclared_definition_across_scopes(namespace):
             namespace["foo"] = 42
     with pytest.raises(UndeclaredDefinition):
         namespace["foo"]
-
-

--- a/tests/unit/semantics/test_namespace.py
+++ b/tests/unit/semantics/test_namespace.py
@@ -2,8 +2,7 @@ import pytest
 
 from vyper.exceptions import CompilerPanic, NamespaceCollision, UndeclaredDefinition
 from vyper.semantics import environment
-from vyper.semantics import namespace as namespace_module
-from vyper.semantics.namespace import Namespace, get_namespace, override_global_namespace
+from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types import PRIMITIVE_TYPES
 
 
@@ -97,11 +96,3 @@ def test_undeclared_definition_across_scopes(namespace):
         namespace["foo"]
 
 
-def test_override_global_namespace_without_prior_init(monkeypatch):
-    monkeypatch.delattr(namespace_module, "_namespace", raising=False)
-
-    temp_namespace = Namespace()
-    with override_global_namespace(temp_namespace):
-        assert namespace_module._namespace is temp_namespace
-
-    assert not hasattr(namespace_module, "_namespace")

--- a/tests/unit/semantics/test_namespace.py
+++ b/tests/unit/semantics/test_namespace.py
@@ -2,7 +2,8 @@ import pytest
 
 from vyper.exceptions import CompilerPanic, NamespaceCollision, UndeclaredDefinition
 from vyper.semantics import environment
-from vyper.semantics.namespace import get_namespace
+from vyper.semantics import namespace as namespace_module
+from vyper.semantics.namespace import Namespace, get_namespace, override_global_namespace
 from vyper.semantics.types import PRIMITIVE_TYPES
 
 
@@ -94,3 +95,13 @@ def test_undeclared_definition_across_scopes(namespace):
             namespace["foo"] = 42
     with pytest.raises(UndeclaredDefinition):
         namespace["foo"]
+
+
+def test_override_global_namespace_without_prior_init(monkeypatch):
+    monkeypatch.delattr(namespace_module, "_namespace", raising=False)
+
+    temp_namespace = Namespace()
+    with override_global_namespace(temp_namespace):
+        assert namespace_module._namespace is temp_namespace
+
+    assert not hasattr(namespace_module, "_namespace")

--- a/vyper/codegen_venom/buffer.py
+++ b/vyper/codegen_venom/buffer.py
@@ -48,5 +48,7 @@ class Ptr:
     buf: Optional[Buffer] = None  # Provenance (MEMORY only)
 
     def __post_init__(self):
-        if (self.buf is not None) != (self.location == DataLocation.MEMORY):
-            raise CompilerPanic("Ptr: buf must be set iff location is MEMORY")
+        if self.buf is not None and self.location != DataLocation.MEMORY:
+            raise CompilerPanic("Ptr: buf only valid for MEMORY location")
+        if self.buf is None and self.location == DataLocation.MEMORY:
+            raise CompilerPanic("Ptr: MEMORY location requires buf")

--- a/vyper/codegen_venom/builtins/simple.py
+++ b/vyper/codegen_venom/builtins/simple.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Union
 
 from vyper import ast as vy_ast
 from vyper.codegen_venom.value import VyperValue
-from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.types.bytestrings import _BytestringT
 from vyper.semantics.types.shortcuts import UINT256_T
 from vyper.semantics.types.subscriptable import DArrayT
@@ -35,16 +34,7 @@ def lower_len(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
 
     # For bytes/string/DynArray: length is stored at pointer
     arg_vv = Expr(arg_node, ctx).lower()
-
-    # Stack values carry a raw pointer operand without pointer metadata,
-    # so keep location-based load dispatch for this case.
-    if arg_vv.is_stack_value:
-        location = arg_vv.location or DataLocation.MEMORY
-        return ctx.builder.load(arg_vv.operand, location)
-
-    # Located values should use pointer-aware dispatch so ctor-time immutable
-    # reads use the immutable staging area instead of dload on initcode.
-    return ctx.ptr_load(arg_vv.ptr())
+    return ctx.value_word_load(arg_vv)
 
 
 def lower_empty(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROperand, VyperValue]:

--- a/vyper/codegen_venom/builtins/simple.py
+++ b/vyper/codegen_venom/builtins/simple.py
@@ -34,6 +34,7 @@ def lower_len(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
 
     # For bytes/string/DynArray: length is stored at pointer
     arg_vv = Expr(arg_node, ctx).lower()
+    assert arg_vv.location is not None
     return ctx.load_word(arg_vv.operand, arg_vv.location)
 
 

--- a/vyper/codegen_venom/builtins/simple.py
+++ b/vyper/codegen_venom/builtins/simple.py
@@ -34,7 +34,7 @@ def lower_len(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
 
     # For bytes/string/DynArray: length is stored at pointer
     arg_vv = Expr(arg_node, ctx).lower()
-    return ctx.value_word_load(arg_vv)
+    return ctx.load_word(arg_vv.operand, arg_vv.location)
 
 
 def lower_empty(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROperand, VyperValue]:

--- a/vyper/codegen_venom/builtins/simple.py
+++ b/vyper/codegen_venom/builtins/simple.py
@@ -35,9 +35,16 @@ def lower_len(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
 
     # For bytes/string/DynArray: length is stored at pointer
     arg_vv = Expr(arg_node, ctx).lower()
-    # Use the location from the VyperValue
-    location = arg_vv.location or DataLocation.MEMORY
-    return ctx.builder.load(arg_vv.operand, location)
+
+    # Stack values carry a raw pointer operand without pointer metadata,
+    # so keep location-based load dispatch for this case.
+    if arg_vv.is_stack_value:
+        location = arg_vv.location or DataLocation.MEMORY
+        return ctx.builder.load(arg_vv.operand, location)
+
+    # Located values should use pointer-aware dispatch so ctor-time immutable
+    # reads use the immutable staging area instead of dload on initcode.
+    return ctx.ptr_load(arg_vv.ptr())
 
 
 def lower_empty(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROperand, VyperValue]:

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -454,8 +454,6 @@ class VenomCodegenContext:
         success = b.staticcall(b.gas(), IRLiteral(IDENTITY_PRECOMPILE), src, length, dst, length)
         b.assert_(success)
 
-
-
     def load_calldata(self, offset: IROperand, typ: VyperType) -> IROperand:
         """Load from calldata.
 
@@ -569,9 +567,15 @@ class VenomCodegenContext:
         """
         # TODO: refactor — DataLocation should have word_scale/word_addressable
         # properties (like AddrSpace does) instead of hardcoding this.
-        _byte_addressed = (DataLocation.MEMORY, DataLocation.CODE, DataLocation.IMMUTABLES, DataLocation.CALLDATA)
-        assert location in _byte_addressed, \
-            f"copy_to_memory: expected byte-addressed location, got {location}"
+        _byte_addressed = (
+            DataLocation.MEMORY,
+            DataLocation.CODE,
+            DataLocation.IMMUTABLES,
+            DataLocation.CALLDATA,
+        )
+        assert (
+            location in _byte_addressed
+        ), f"copy_to_memory: expected byte-addressed location, got {location}"
         for i in range(0, size, 32):
             src_ptr = self._with_byte_offset(src, i)
             dst_ptr = self._with_byte_offset(dst, i)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -206,9 +206,6 @@ class VenomCodegenContext:
         """
         if location == DataLocation.IMMUTABLES:
             if self.is_ctor_context:
-                if self.immutables_alloca is not None:
-                    ptr = self.builder.gep(self.immutables_alloca, addr)
-                    return self.builder.mload(ptr)
                 return self.builder.iload(addr)
             return self.builder.dload(addr)
         return self.builder.load(addr, location)
@@ -758,11 +755,7 @@ class VenomCodegenContext:
     def store_word(self, addr: IROperand, val: IROperand, location: DataLocation) -> None:
         """Store a single word to addr at the given location."""
         if location == DataLocation.IMMUTABLES:
-            if self.immutables_alloca is not None:
-                ptr = self.builder.gep(self.immutables_alloca, addr)
-                self.builder.mstore(ptr, val)
-            else:
-                self.builder.istore(addr, val)
+            self.builder.istore(addr, val)
         elif location == DataLocation.MEMORY:
             self.builder.mstore(addr, val)
         elif location == DataLocation.STORAGE:

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -97,8 +97,9 @@ class VenomCodegenContext:
     # Range expression context - set to True when evaluating range/iterator expressions
     in_range_expr: bool = False
 
-    # Immutables region alloca (for constructor context)
-    # When set, iload/istore use GEP from this base instead of raw offsets
+    # Immutables region alloca (for constructor context).
+    # Reserves memory at position 0 for immutables staging;
+    # used by deploy epilogue to copy staging area into bytecode.
     immutables_alloca: Optional[IRVariable] = None
 
     def new_alloca_id(self) -> int:
@@ -536,9 +537,10 @@ class VenomCodegenContext:
     def slot_to_memory(
         self, slot: IROperand, buf: IROperand, word_count: int, location: DataLocation
     ) -> None:
-        """Load multi-word slot-addressed value to memory buffer.
+        """Load word_count words from slot-addressed location to memory buffer.
 
-        Generic helper that dispatches based on location (STORAGE or TRANSIENT).
+        For slot-addressed locations (storage, transient) where slots
+        increment by 1.  For byte-addressed locations, use copy_to_memory.
         """
         if location == DataLocation.STORAGE:
             self._load_storage_to_memory(slot, buf, word_count)
@@ -557,10 +559,13 @@ class VenomCodegenContext:
     def copy_to_memory(
         self, dst: IROperand, src: IROperand, size: int, location: DataLocation
     ) -> None:
-        """Copy a region from any byte-addressed location into memory.
+        """Copy size bytes from src at location into dst (memory).
 
+        For byte-addressed locations (memory, code, immutables, calldata).
         Word-by-word using load_word, so IMMUTABLES is handled correctly
         in both constructor and runtime contexts.
+
+        For slot-addressed locations (storage, transient), use slot_to_memory.
         """
         for i in range(0, size, 32):
             src_ptr = self._with_byte_offset(src, i)
@@ -699,7 +704,7 @@ class VenomCodegenContext:
         """Load immutable value into a memory buffer.
 
         Uses load_word which dispatches correctly for IMMUTABLES
-        (iload/gep+mload in ctor, dload at runtime).
+        (iload in ctor, dload at runtime).
 
         For primitive word types, returns the loaded value directly.
         For complex types, allocates a memory buffer and returns the pointer.

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -208,6 +208,8 @@ class VenomCodegenContext:
             if self.is_ctor_context:
                 return self.builder.iload(addr)
             return self.builder.dload(addr)
+        # NOTE: CODE falls through to builder.load (dload). If a future
+        # code path needs ctor-aware CODE loads, add an explicit branch here.
         return self.builder.load(addr, location)
 
     def ensure_bytestring_in_memory(self, vv: VyperValue, typ: _BytestringT) -> VyperValue:

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -208,43 +208,28 @@ class VenomCodegenContext:
             return self.builder.mload(vv.operand)
         return self.builder.load(vv.operand, loc)
 
-    def value_location(
-        self, vv: VyperValue, fallback: Optional[DataLocation] = None
-    ) -> DataLocation:
-        """Resolve the effective location for a VyperValue.
+    def load_word(self, addr: IROperand, location: DataLocation) -> IROperand:
+        """Load a single word from addr at the given location.
 
-        UNSET/None locations are normalized to MEMORY.
+        Like builder.load() but handles CODE correctly in constructor context
+        (uses immutables_alloca / iload instead of dload).
         """
-        location = vv.location if vv.location is not None else fallback
-        if location is None or location == DataLocation.UNSET:
-            return DataLocation.MEMORY
-        return location
-
-    def value_word_load(
-        self,
-        vv: VyperValue,
-        addr: Optional[IROperand] = None,
-        fallback: Optional[DataLocation] = None,
-    ) -> IROperand:
-        """Load one word from an address associated with a VyperValue.
-
-        Stack values are expected to represent memory pointers. If a future code
-        path attempts to treat a non-memory stack value as a pointer, fail fast.
-        """
-        if addr is None:
-            addr = vv.operand
-
-        location = self.value_location(vv, fallback)
-
-        if vv.is_stack_value:
-            if location != DataLocation.MEMORY:
-                raise CompilerPanic(f"stack pointer load requires MEMORY location, got {location}")
-            return self.builder.mload(addr)
-
         if location == DataLocation.MEMORY:
             return self.builder.mload(addr)
-
-        return self.ptr_load(Ptr(addr, location))
+        if location == DataLocation.STORAGE:
+            return self.builder.sload(addr)
+        if location == DataLocation.TRANSIENT:
+            return self.builder.tload(addr)
+        if location == DataLocation.CALLDATA:
+            return self.builder.calldataload(addr)
+        if location == DataLocation.CODE:
+            if self.is_ctor_context:
+                if self.immutables_alloca is not None:
+                    ptr = self.builder.gep(self.immutables_alloca, addr)
+                    return self.builder.mload(ptr)
+                return self.builder.iload(addr)
+            return self.builder.dload(addr)
+        raise CompilerPanic(f"load_word: unsupported location {location}")
 
     def ensure_bytestring_in_memory(self, vv: VyperValue, typ: _BytestringT) -> VyperValue:
         """Return a bytestring value guaranteed to be in memory.

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -567,6 +567,11 @@ class VenomCodegenContext:
 
         For slot-addressed locations (storage, transient), use slot_to_memory.
         """
+        # TODO: refactor — DataLocation should have word_scale/word_addressable
+        # properties (like AddrSpace does) instead of hardcoding this.
+        _byte_addressed = (DataLocation.MEMORY, DataLocation.CODE, DataLocation.IMMUTABLES, DataLocation.CALLDATA)
+        assert location in _byte_addressed, \
+            f"copy_to_memory: expected byte-addressed location, got {location}"
         for i in range(0, size, 32):
             src_ptr = self._with_byte_offset(src, i)
             dst_ptr = self._with_byte_offset(dst, i)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -208,6 +208,44 @@ class VenomCodegenContext:
             return self.builder.mload(vv.operand)
         return self.builder.load(vv.operand, loc)
 
+    def value_location(
+        self, vv: VyperValue, fallback: Optional[DataLocation] = None
+    ) -> DataLocation:
+        """Resolve the effective location for a VyperValue.
+
+        UNSET/None locations are normalized to MEMORY.
+        """
+        location = vv.location if vv.location is not None else fallback
+        if location is None or location == DataLocation.UNSET:
+            return DataLocation.MEMORY
+        return location
+
+    def value_word_load(
+        self,
+        vv: VyperValue,
+        addr: Optional[IROperand] = None,
+        fallback: Optional[DataLocation] = None,
+    ) -> IROperand:
+        """Load one word from an address associated with a VyperValue.
+
+        Stack values are expected to represent memory pointers. If a future code
+        path attempts to treat a non-memory stack value as a pointer, fail fast.
+        """
+        if addr is None:
+            addr = vv.operand
+
+        location = self.value_location(vv, fallback)
+
+        if vv.is_stack_value:
+            if location != DataLocation.MEMORY:
+                raise CompilerPanic(f"stack pointer load requires MEMORY location, got {location}")
+            return self.builder.mload(addr)
+
+        if location == DataLocation.MEMORY:
+            return self.builder.mload(addr)
+
+        return self.ptr_load(Ptr(addr, location))
+
     def ensure_bytestring_in_memory(self, vv: VyperValue, typ: _BytestringT) -> VyperValue:
         """Return a bytestring value guaranteed to be in memory.
 
@@ -446,6 +484,35 @@ class VenomCodegenContext:
         # staticcall(gas, IDENTITY_PRECOMPILE, src, length, dst, length)
         success = b.staticcall(b.gas(), IRLiteral(IDENTITY_PRECOMPILE), src, length, dst, length)
         b.assert_(success)
+
+    def copy_word_aligned_to_memory(
+        self, dst: IROperand, src: IROperand, size: int, src_location: DataLocation
+    ) -> None:
+        """Copy a word-aligned region from src_location into memory.
+
+        CODE copies are immutable-aware in constructor context.
+        """
+        if size == 0:
+            return
+
+        if size % 32 != 0:
+            raise CompilerPanic(f"expected word-aligned copy size, got {size}")
+
+        if src_location == DataLocation.MEMORY:
+            self.copy_memory(dst, src, size)
+            return
+
+        if src_location == DataLocation.CALLDATA:
+            self.builder.calldatacopy(dst, src, IRLiteral(size))
+            return
+
+        if src_location == DataLocation.CODE:
+            self.code_to_memory(src, dst, size // 32)
+            return
+
+        raise CompilerPanic(
+            f"copy_word_aligned_to_memory: unexpected source location {src_location}"
+        )
 
     def load_calldata(self, offset: IROperand, typ: VyperType) -> IROperand:
         """Load from calldata.

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -146,7 +146,7 @@ class VenomCodegenContext:
         """Unwrap a VyperValue, loading from location if needed.
 
         - If already a value (location=None): return operand directly
-        - If complex type (>32 bytes): return operand as pointer (or copy for CODE)
+        - If complex type (>32 bytes): return operand as pointer (or copy)
         - Otherwise: emit load instruction and return the loaded value
         """
         if vv.location is None:
@@ -154,27 +154,17 @@ class VenomCodegenContext:
 
         # Complex types (>32 bytes)
         if vv.typ is not None and not vv.typ._is_prim_word:
-            # CODE location requires copy to memory (can't use pointer directly)
-            if vv.location == DataLocation.CODE:
-                if self.is_ctor_context:
-                    return self.load_immutable_ctor(vv.operand, vv.typ)
-                return self.load_immutable(vv.operand, vv.typ)
-            # STORAGE location requires copy to memory
+            if vv.location == DataLocation.IMMUTABLES:
+                return self.load_immutable_to_memory(vv.operand, vv.typ)
             if vv.location == DataLocation.STORAGE:
                 return self.load_storage(vv.operand, vv.typ)
-            # TRANSIENT location requires copy to memory
             if vv.location == DataLocation.TRANSIENT:
                 return self.load_transient(vv.operand, vv.typ)
             # MEMORY location: return pointer directly
             return vv.operand
 
         # Primitive word type: emit load based on location
-        if vv.location == DataLocation.CODE:
-            # ctor context uses iload; runtime uses dload
-            if self.is_ctor_context:
-                return self.builder.iload(vv.operand)
-            return self.builder.dload(vv.operand)
-        return self.builder.load(vv.operand, vv.location)
+        return self.load_word(vv.operand, vv.location)
 
     def bytes_data_ptr(self, vv: VyperValue) -> IROperand:
         """Get pointer to bytestring data (skipping length word).
@@ -211,25 +201,17 @@ class VenomCodegenContext:
     def load_word(self, addr: IROperand, location: DataLocation) -> IROperand:
         """Load a single word from addr at the given location.
 
-        Like builder.load() but handles CODE correctly in constructor context
-        (uses immutables_alloca / iload instead of dload).
+        Handles IMMUTABLES via iload (ctor) or dload (runtime).
+        CODE always uses dload (for constructor args in code section).
         """
-        if location == DataLocation.MEMORY:
-            return self.builder.mload(addr)
-        if location == DataLocation.STORAGE:
-            return self.builder.sload(addr)
-        if location == DataLocation.TRANSIENT:
-            return self.builder.tload(addr)
-        if location == DataLocation.CALLDATA:
-            return self.builder.calldataload(addr)
-        if location == DataLocation.CODE:
+        if location == DataLocation.IMMUTABLES:
             if self.is_ctor_context:
                 if self.immutables_alloca is not None:
                     ptr = self.builder.gep(self.immutables_alloca, addr)
                     return self.builder.mload(ptr)
                 return self.builder.iload(addr)
             return self.builder.dload(addr)
-        raise CompilerPanic(f"load_word: unsupported location {location}")
+        return self.builder.load(addr, location)
 
     def ensure_bytestring_in_memory(self, vv: VyperValue, typ: _BytestringT) -> VyperValue:
         """Return a bytestring value guaranteed to be in memory.
@@ -242,9 +224,11 @@ class VenomCodegenContext:
             self.slot_to_memory(vv.operand, buf_val.operand, typ.storage_size_in_words, vv.location)
             return buf_val
 
-        if vv.location is DataLocation.CODE:
+        if vv.location is DataLocation.IMMUTABLES:
             buf_val = self.new_temporary_value(typ)
-            self.code_to_memory(vv.operand, buf_val.operand, typ.storage_size_in_words)
+            self.copy_to_memory(
+                buf_val.operand, vv.operand, typ.memory_bytes_required, DataLocation.IMMUTABLES
+            )
             return buf_val
 
         assert vv.location is None or vv.location is DataLocation.MEMORY
@@ -470,34 +454,7 @@ class VenomCodegenContext:
         success = b.staticcall(b.gas(), IRLiteral(IDENTITY_PRECOMPILE), src, length, dst, length)
         b.assert_(success)
 
-    def copy_word_aligned_to_memory(
-        self, dst: IROperand, src: IROperand, size: int, src_location: DataLocation
-    ) -> None:
-        """Copy a word-aligned region from src_location into memory.
 
-        CODE copies are immutable-aware in constructor context.
-        """
-        if size == 0:
-            return
-
-        if size % 32 != 0:
-            raise CompilerPanic(f"expected word-aligned copy size, got {size}")
-
-        if src_location == DataLocation.MEMORY:
-            self.copy_memory(dst, src, size)
-            return
-
-        if src_location == DataLocation.CALLDATA:
-            self.builder.calldatacopy(dst, src, IRLiteral(size))
-            return
-
-        if src_location == DataLocation.CODE:
-            self.code_to_memory(src, dst, size // 32)
-            return
-
-        raise CompilerPanic(
-            f"copy_word_aligned_to_memory: unexpected source location {src_location}"
-        )
 
     def load_calldata(self, offset: IROperand, typ: VyperType) -> IROperand:
         """Load from calldata.
@@ -598,22 +555,19 @@ class VenomCodegenContext:
         """
         self._store_memory_to_storage(buf, slot, word_count)
 
-    def code_to_memory(self, offset: IROperand, dst: IROperand, word_count: int) -> None:
-        """Copy multi-word immutable from CODE to memory."""
-        b = self.builder
-        for i in range(word_count):
-            byte_offset = i * 32
-            imm_offset = self._with_byte_offset(offset, byte_offset)
+    def copy_to_memory(
+        self, dst: IROperand, src: IROperand, size: int, location: DataLocation
+    ) -> None:
+        """Copy a region from any byte-addressed location into memory.
 
-            if self.immutables_alloca is not None:
-                ptr = b.gep(self.immutables_alloca, imm_offset)
-                word = b.mload(ptr)
-            else:
-                word = b.dload(imm_offset)
-
-            mem_ptr = self._with_byte_offset(dst, byte_offset)
-
-            b.mstore(mem_ptr, word)
+        Word-by-word using load_word, so IMMUTABLES is handled correctly
+        in both constructor and runtime contexts.
+        """
+        for i in range(0, size, 32):
+            src_ptr = self._with_byte_offset(src, i)
+            dst_ptr = self._with_byte_offset(dst, i)
+            word = self.load_word(src_ptr, location)
+            self.builder.mstore(dst_ptr, word)
 
     def _word_copy_loop(
         self,
@@ -742,94 +696,37 @@ class VenomCodegenContext:
     # Immutables are stored in bytecode (CODE location), accessed via iload/istore.
     # They are byte-addressed (word_scale=32), like memory.
 
-    def load_immutable(self, offset: IROperand, typ: VyperType) -> IROperand:
-        """Load immutable value from deployed bytecode (runtime).
+    def load_immutable_to_memory(self, offset: IROperand, typ: VyperType) -> IROperand:
+        """Load immutable value into a memory buffer.
 
-        For primitive word types, returns dload result directly.
-        For complex types (structs, arrays), allocates memory buffer and copies.
+        Uses load_word which dispatches correctly for IMMUTABLES
+        (iload/gep+mload in ctor, dload at runtime).
+
+        For primitive word types, returns the loaded value directly.
+        For complex types, allocates a memory buffer and returns the pointer.
         """
         if typ._is_prim_word:
-            return self.builder.dload(offset)
-        else:
-            # Multi-word immutable: copy to memory buffer
-            val = self.new_temporary_value(typ)
-            buf = val.operand
-            size = typ.memory_bytes_required
-            for i in range(0, size, 32):
-                # Immutables are byte-addressed
-                imm_offset = self._with_byte_offset(offset, i)
+            return self.load_word(offset, DataLocation.IMMUTABLES)
 
-                word = self.builder.dload(imm_offset)
-
-                # Memory is byte-addressed
-                mem_ptr = self._with_byte_offset(buf, i)
-
-                self.builder.mstore(mem_ptr, word)
-
-            return buf
-
-    def load_immutable_ctor(self, offset: IROperand, typ: VyperType) -> IROperand:
-        """Load immutable value during constructor (uses GEP + mload).
-
-        For primitive word types, returns single mload result directly.
-        For complex types (structs, arrays), allocates memory buffer and copies.
-        """
-        if typ._is_prim_word:
-            if self.immutables_alloca is not None:
-                ptr = self.builder.gep(self.immutables_alloca, offset)
-                return self.builder.mload(ptr)
-            return self.builder.iload(offset)
-        else:
-            # Multi-word immutable: copy to memory buffer
-            val = self.new_temporary_value(typ)
-            buf = val.operand
-            size = typ.memory_bytes_required
-            for i in range(0, size, 32):
-                # Immutables are byte-addressed
-                imm_offset = self._with_byte_offset(offset, i)
-
-                if self.immutables_alloca is not None:
-                    ptr = self.builder.gep(self.immutables_alloca, imm_offset)
-                    word = self.builder.mload(ptr)
-                else:
-                    word = self.builder.iload(imm_offset)
-
-                # Memory is byte-addressed
-                mem_ptr = self._with_byte_offset(buf, i)
-
-                self.builder.mstore(mem_ptr, word)
-
-            return buf
+        val = self.new_temporary_value(typ)
+        self.copy_to_memory(val.operand, offset, typ.memory_bytes_required, DataLocation.IMMUTABLES)
+        return val.operand
 
     def store_immutable(self, val: IROperand, offset: IROperand, typ: VyperType) -> None:
         """Store immutable value (during constructor only).
 
-        For primitive types (<=32 bytes), direct mstore via GEP.
-        For multi-word types, val is memory ptr, copy to immutables.
+        For primitive types (<=32 bytes), store single word.
+        For multi-word types, val is memory ptr, copy word-by-word.
         """
         if typ.memory_bytes_required <= 32:
-            if self.immutables_alloca is not None:
-                ptr = self.builder.gep(self.immutables_alloca, offset)
-                self.builder.mstore(ptr, val)
-            else:
-                self.builder.istore(offset, val)
+            self.store_word(offset, val, DataLocation.IMMUTABLES)
         else:
-            # Multi-word: val is memory pointer, copy to immutables
             size = typ.memory_bytes_required
             for i in range(0, size, 32):
-                # Memory is byte-addressed
                 mem_ptr = self._with_byte_offset(val, i)
-
                 word = self.builder.mload(mem_ptr)
-
-                # Immutables are byte-addressed
                 imm_offset = self._with_byte_offset(offset, i)
-
-                if self.immutables_alloca is not None:
-                    ptr = self.builder.gep(self.immutables_alloca, imm_offset)
-                    self.builder.mstore(ptr, word)
-                else:
-                    self.builder.istore(imm_offset, word)
+                self.store_word(imm_offset, word, DataLocation.IMMUTABLES)
 
     # === Dynamic Array Length ===
 
@@ -852,40 +749,27 @@ class VenomCodegenContext:
 
     def ptr_load(self, src: Ptr) -> IROperand:
         """Load 32-byte value from pointer. Dispatches on location."""
-        if src.location == DataLocation.MEMORY:
-            return self.builder.mload(src.operand)
-        elif src.location == DataLocation.STORAGE:
-            return self.builder.sload(src.operand)
-        elif src.location == DataLocation.TRANSIENT:
-            return self.builder.tload(src.operand)
-        elif src.location == DataLocation.CALLDATA:
-            return self.builder.calldataload(src.operand)
-        elif src.location == DataLocation.CODE:
-            # Immutables: ctor context uses GEP from immutables_alloca, runtime uses dload
-            if self.is_ctor_context:
-                if self.immutables_alloca is not None:
-                    # Use GEP to get proper memory address within immutables region
-                    ptr = self.builder.gep(self.immutables_alloca, src.operand)
-                    return self.builder.mload(ptr)
-                return self.builder.iload(src.operand)
-            return self.builder.dload(src.operand)
-        else:
-            raise CompilerPanic(f"cannot load from: {src.location}")
+        return self.load_word(src.operand, src.location)
 
     def ptr_store(self, dst: Ptr, val: IROperand) -> None:
         """Store 32-byte value to pointer. Dispatches on location."""
-        if dst.location == DataLocation.MEMORY:
-            self.builder.mstore(dst.operand, val)
-        elif dst.location == DataLocation.STORAGE:
-            self.builder.sstore(dst.operand, val)
-        elif dst.location == DataLocation.TRANSIENT:
-            self.builder.tstore(dst.operand, val)
-        elif dst.location == DataLocation.CODE:
-            # Immutables in constructor context - use GEP from immutables_alloca
+        return self.store_word(dst.operand, val, dst.location)
+
+    def store_word(self, addr: IROperand, val: IROperand, location: DataLocation) -> None:
+        """Store a single word to addr at the given location."""
+        if location == DataLocation.IMMUTABLES:
             if self.immutables_alloca is not None:
-                ptr = self.builder.gep(self.immutables_alloca, dst.operand)
+                ptr = self.builder.gep(self.immutables_alloca, addr)
                 self.builder.mstore(ptr, val)
             else:
-                self.builder.istore(dst.operand, val)
+                self.builder.istore(addr, val)
+        elif location == DataLocation.MEMORY:
+            self.builder.mstore(addr, val)
+        elif location == DataLocation.STORAGE:
+            self.builder.sstore(addr, val)
+        elif location == DataLocation.TRANSIENT:
+            self.builder.tstore(addr, val)
+        elif location == DataLocation.CODE:
+            raise CompilerPanic("cannot store to CODE")
         else:
-            raise CompilerPanic(f"cannot store to: {dst.location}")
+            raise CompilerPanic(f"cannot store to: {location}")

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -158,9 +158,9 @@ class VenomCodegenContext:
             if vv.location == DataLocation.IMMUTABLES:
                 return self.load_immutable_to_memory(vv.operand, vv.typ)
             if vv.location == DataLocation.STORAGE:
-                return self.load_storage(vv.operand, vv.typ)
+                return self.load_storage_to_memory(vv.operand, vv.typ)
             if vv.location == DataLocation.TRANSIENT:
-                return self.load_transient(vv.operand, vv.typ)
+                return self.load_transient_to_memory(vv.operand, vv.typ)
             # MEMORY location: return pointer directly
             return vv.operand
 
@@ -487,7 +487,7 @@ class VenomCodegenContext:
     # Storage is word-addressed (word_scale=1): slot N is at slot N, not byte N*32.
     # This differs from memory which is byte-addressed (word_scale=32).
 
-    def load_storage(self, slot: IROperand, typ: VyperType) -> IROperand:
+    def load_storage_to_memory(self, slot: IROperand, typ: VyperType) -> IROperand:
         """Load value from storage slot.
 
         For primitive types, returns sload result directly.
@@ -654,7 +654,7 @@ class VenomCodegenContext:
 
     # === Transient Storage (EIP-1153, Cancun+) ===
 
-    def load_transient(self, slot: IROperand, typ: VyperType) -> IROperand:
+    def load_transient_to_memory(self, slot: IROperand, typ: VyperType) -> IROperand:
         """Load from transient storage (Cancun+).
 
         For primitive types, returns tload result directly.

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -841,7 +841,9 @@ class Expr:
         else_block_finish.append_instruction("jmp", exit_block.label)
 
         result_typ = node._metadata["type"]
-        return VyperValue.from_stack_op(result, result_typ)
+        if result_typ._is_prim_word:
+            return VyperValue.from_stack_op(result, result_typ)
+        return self._make_ptr_value(result, DataLocation.MEMORY, result_typ)
 
     # === Subscript Operations ===
 
@@ -884,7 +886,7 @@ class Expr:
         index_typ = node.slice._metadata["type"]
 
         # Propagate location from base (storage/memory/transient)
-        data_loc = self.ctx.value_location(base_vv)
+        data_loc = base_vv.location
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)
@@ -896,7 +898,7 @@ class Expr:
                 # Dynamic array: load length from first word.
                 # Use pointer-aware loading so ctor-time immutable reads come
                 # from the immutable staging area (not constructor args code).
-                length = self.ctx.value_word_load(base_vv, base, data_loc)
+                length = self.ctx.load_word(base, data_loc)
             else:
                 # Static array: compile-time length
                 length = IRLiteral(base_typ.count)
@@ -963,7 +965,7 @@ class Expr:
         slot = self.builder.sha3(ptr.operand, IRLiteral(64))
 
         # Preserve location from base (storage or transient)
-        location = base_vv.location or DataLocation.STORAGE
+        location = base_vv.location
         ptr = Ptr(operand=slot, location=location)
         return VyperValue.from_ptr(ptr, value_typ)
 
@@ -1046,7 +1048,7 @@ class Expr:
         index = reduced_slice.value
 
         # Propagate location from base
-        data_loc = base_vv.location or DataLocation.MEMORY
+        data_loc = base_vv.location
 
         # Compute offset by summing sizes of preceding elements
         attrs = list(base_typ.tuple_keys())
@@ -1078,7 +1080,7 @@ class Expr:
         attr = node.attr
 
         # Propagate location from base
-        data_loc = base_vv.location or DataLocation.MEMORY
+        data_loc = base_vv.location
 
         # Find field index and compute offset
         attrs = list(base_typ.tuple_keys())
@@ -1183,7 +1185,7 @@ class Expr:
             )
 
         haystack = haystack_vv.operand
-        location = self.ctx.value_location(haystack_vv)
+        location = haystack_vv.location
 
         # Determine word scale based on location
         # Storage: 1 slot per word, Memory: 32 bytes per word
@@ -1192,7 +1194,7 @@ class Expr:
         # Get array properties
         length: IROperand
         if isinstance(haystack_typ, DArrayT):
-            length = self.ctx.value_word_load(haystack_vv, haystack, location)
+            length = self.ctx.load_word(haystack, location)
             bound = haystack_typ.count
             offset_base = word_scale * DYNAMIC_ARRAY_OVERHEAD
         elif isinstance(haystack_typ, SArrayT):
@@ -1251,7 +1253,7 @@ class Expr:
         elem_addr = self.builder.add(haystack, total_offset)
 
         # Load element and compare
-        elem_val = self.ctx.value_word_load(haystack_vv, elem_addr, location)
+        elem_val = self.ctx.load_word(elem_addr, location)
         match = self.builder.eq(elem_val, needle)
         self.builder.jnz(match, found_block.label, incr_block.label)
 
@@ -1570,7 +1572,7 @@ class Expr:
             elem_val = Expr(arg_node, self.ctx).lower_value()
 
         # Get location from VyperValue
-        data_loc = darray_vv.location or DataLocation.MEMORY
+        data_loc = darray_vv.location
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)
@@ -1634,7 +1636,7 @@ class Expr:
         darray_ptr = darray_vv.operand
 
         # Get location from VyperValue
-        data_loc = darray_vv.location or DataLocation.MEMORY
+        data_loc = darray_vv.location
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -893,8 +893,6 @@ class Expr:
             length: IROperand = IRLiteral(0)
             if isinstance(base_typ, DArrayT):
                 # Dynamic array: load length from first word.
-                # Use pointer-aware loading so ctor-time immutable reads come
-                # from the immutable staging area (not constructor args code).
                 length = self.ctx.load_word(base, data_loc)
             else:
                 # Static array: compile-time length

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -888,6 +888,7 @@ class Expr:
 
         # Propagate location from base (storage/memory/transient)
         data_loc = base_vv.location
+        assert data_loc is not None
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)
@@ -965,6 +966,7 @@ class Expr:
 
         # Preserve location from base (storage or transient)
         location = base_vv.location
+        assert location is not None
         ptr = Ptr(operand=slot, location=location)
         return VyperValue.from_ptr(ptr, value_typ)
 
@@ -1048,6 +1050,7 @@ class Expr:
 
         # Propagate location from base
         data_loc = base_vv.location
+        assert data_loc is not None
 
         # Compute offset by summing sizes of preceding elements
         attrs = list(base_typ.tuple_keys())
@@ -1080,6 +1083,7 @@ class Expr:
 
         # Propagate location from base
         data_loc = base_vv.location
+        assert data_loc is not None
 
         # Find field index and compute offset
         attrs = list(base_typ.tuple_keys())
@@ -1185,6 +1189,7 @@ class Expr:
 
         haystack = haystack_vv.operand
         location = haystack_vv.location
+        assert location is not None
 
         # Determine word scale based on location
         # Storage: 1 slot per word, Memory: 32 bytes per word
@@ -1572,6 +1577,7 @@ class Expr:
 
         # Get location from VyperValue
         data_loc = darray_vv.location
+        assert data_loc is not None
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)
@@ -1636,6 +1642,7 @@ class Expr:
 
         # Get location from VyperValue
         data_loc = darray_vv.location
+        assert data_loc is not None
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1167,11 +1167,7 @@ class Expr:
         return result
 
     def _lower_array_membership(
-        self,
-        needle: IROperand,
-        haystack_vv: VyperValue,
-        haystack_typ,
-        is_in: bool,
+        self, needle: IROperand, haystack_vv: VyperValue, haystack_typ, is_in: bool
     ) -> IRVariable:
         """Lower array membership test: x in array or x not in array.
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -468,13 +468,9 @@ class Expr:
                 # For storage/memory arrays, use loop with early break
                 # Don't unwrap - iterate directly over storage/memory location
                 right_val = Expr(node.right, self.ctx).lower()
-                # Default to MEMORY if location is None (e.g., for stack values)
-                location = (
-                    right_val.location if right_val.location is not None else DataLocation.MEMORY
-                )
                 return VyperValue.from_stack_op(
                     self._lower_array_membership(
-                        left, right_val.operand, right_typ, location, isinstance(op, vy_ast.In)
+                        left, right_val, right_typ, isinstance(op, vy_ast.In)
                     ),
                     result_typ,
                 )
@@ -1173,9 +1169,8 @@ class Expr:
     def _lower_array_membership(
         self,
         needle: IROperand,
-        haystack: IROperand,
+        haystack_vv: VyperValue,
         haystack_typ,
-        location: DataLocation,
         is_in: bool,
     ) -> IRVariable:
         """Lower array membership test: x in array or x not in array.
@@ -1194,9 +1189,21 @@ class Expr:
                 "`in` not allowed for arrays of non-base types, tracked in issue #2637", self.node
             )
 
+        haystack = haystack_vv.operand
+        location = haystack_vv.location if haystack_vv.location is not None else DataLocation.MEMORY
+
         # Constants have UNSET location - use MEMORY sizing (same as CODE)
         if location == DataLocation.UNSET:
             location = DataLocation.MEMORY
+
+        def _load_array_word(addr: IROperand) -> IROperand:
+            # Stack values are raw pointer operands, so use direct load dispatch.
+            if haystack_vv.is_stack_value:
+                return self.builder.load(addr, location)
+
+            if location == DataLocation.MEMORY:
+                return self.ctx.ptr_load(Ptr(addr, location, haystack_vv.ptr().buf))
+            return self.ctx.ptr_load(Ptr(addr, location))
 
         # Determine word scale based on location
         # Storage: 1 slot per word, Memory: 32 bytes per word
@@ -1205,7 +1212,10 @@ class Expr:
         # Get array properties
         length: IROperand
         if isinstance(haystack_typ, DArrayT):
-            length = self.builder.load(haystack, location)
+            if haystack_vv.is_stack_value:
+                length = self.builder.load(haystack, location)
+            else:
+                length = self.ctx.get_dyn_array_length(haystack_vv.ptr())
             bound = haystack_typ.count
             offset_base = word_scale * DYNAMIC_ARRAY_OVERHEAD
         elif isinstance(haystack_typ, SArrayT):
@@ -1264,7 +1274,7 @@ class Expr:
         elem_addr = self.builder.add(haystack, total_offset)
 
         # Load element and compare
-        elem_val = self.builder.load(elem_addr, location)
+        elem_val = _load_array_word(elem_addr)
         match = self.builder.eq(elem_val, needle)
         self.builder.jnz(match, found_block.label, incr_block.label)
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -900,7 +900,10 @@ class Expr:
                 # Dynamic array: load length from first word.
                 # Use pointer-aware loading so ctor-time immutable reads come
                 # from the immutable staging area (not constructor args code).
-                length = self.ctx.get_dyn_array_length(base_vv.ptr())
+                if base_vv.is_stack_value:
+                    length = self.builder.load(base, data_loc)
+                else:
+                    length = self.ctx.get_dyn_array_length(base_vv.ptr())
             else:
                 # Static array: compile-time length
                 length = IRLiteral(base_typ.count)

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -646,13 +646,10 @@ class Expr:
         if varinfo.is_constant:
             return Expr(varinfo.decl_node.value, self.ctx).lower()
 
-        # Case 4: Immutable - always CODE location (iload/istore handle ctor vs runtime)
+        # Case 4: Immutable - IMMUTABLES location
         if varinfo.is_immutable:
             typ = node._metadata["type"]
-            # Immutables use iload/istore - CODE location handles both contexts
-            # In constructor: iload/istore access immutable staging area
-            # After deploy: dload accesses deployed bytecode
-            ptr = Ptr(operand=IRLiteral(varinfo.position.position), location=DataLocation.CODE)
+            ptr = Ptr(operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES)
             return VyperValue.from_ptr(ptr, typ)
 
         raise CompilerPanic(f"Unknown variable: {varname}")
@@ -722,9 +719,9 @@ class Expr:
             if varinfo.is_constant:
                 return Expr(varinfo.decl_node.value, self.ctx).lower()
 
-            # Immutable state variable - always CODE location
+            # Immutable state variable
             if varinfo.is_immutable:
-                ptr = Ptr(operand=IRLiteral(varinfo.position.position), location=DataLocation.CODE)
+                ptr = Ptr(operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES)
                 return VyperValue.from_ptr(ptr, typ)
 
             # Regular storage/transient variable - return location, don't load!

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -884,7 +884,7 @@ class Expr:
         index_typ = node.slice._metadata["type"]
 
         # Propagate location from base (storage/memory/transient)
-        data_loc = base_vv.location or DataLocation.MEMORY
+        data_loc = self.ctx.value_location(base_vv)
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)
@@ -896,10 +896,7 @@ class Expr:
                 # Dynamic array: load length from first word.
                 # Use pointer-aware loading so ctor-time immutable reads come
                 # from the immutable staging area (not constructor args code).
-                if base_vv.is_stack_value:
-                    length = self.builder.load(base, data_loc)
-                else:
-                    length = self.ctx.get_dyn_array_length(base_vv.ptr())
+                length = self.ctx.value_word_load(base_vv, base, data_loc)
             else:
                 # Static array: compile-time length
                 length = IRLiteral(base_typ.count)
@@ -1186,20 +1183,7 @@ class Expr:
             )
 
         haystack = haystack_vv.operand
-        location = haystack_vv.location if haystack_vv.location is not None else DataLocation.MEMORY
-
-        # Constants have UNSET location - use MEMORY sizing (same as CODE)
-        if location == DataLocation.UNSET:
-            location = DataLocation.MEMORY
-
-        def _load_array_word(addr: IROperand) -> IROperand:
-            # Stack values are raw pointer operands, so use direct load dispatch.
-            if haystack_vv.is_stack_value:
-                return self.builder.load(addr, location)
-
-            if location == DataLocation.MEMORY:
-                return self.ctx.ptr_load(Ptr(addr, location, haystack_vv.ptr().buf))
-            return self.ctx.ptr_load(Ptr(addr, location))
+        location = self.ctx.value_location(haystack_vv)
 
         # Determine word scale based on location
         # Storage: 1 slot per word, Memory: 32 bytes per word
@@ -1208,10 +1192,7 @@ class Expr:
         # Get array properties
         length: IROperand
         if isinstance(haystack_typ, DArrayT):
-            if haystack_vv.is_stack_value:
-                length = self.builder.load(haystack, location)
-            else:
-                length = self.ctx.get_dyn_array_length(haystack_vv.ptr())
+            length = self.ctx.value_word_load(haystack_vv, haystack, location)
             bound = haystack_typ.count
             offset_base = word_scale * DYNAMIC_ARRAY_OVERHEAD
         elif isinstance(haystack_typ, SArrayT):
@@ -1270,7 +1251,7 @@ class Expr:
         elem_addr = self.builder.add(haystack, total_offset)
 
         # Load element and compare
-        elem_val = _load_array_word(elem_addr)
+        elem_val = self.ctx.value_word_load(haystack_vv, elem_addr, location)
         match = self.builder.eq(elem_val, needle)
         self.builder.jnz(match, found_block.label, incr_block.label)
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -649,7 +649,9 @@ class Expr:
         # Case 4: Immutable - IMMUTABLES location
         if varinfo.is_immutable:
             typ = node._metadata["type"]
-            ptr = Ptr(operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES)
+            ptr = Ptr(
+                operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES
+            )
             return VyperValue.from_ptr(ptr, typ)
 
         raise CompilerPanic(f"Unknown variable: {varname}")
@@ -721,7 +723,9 @@ class Expr:
 
             # Immutable state variable
             if varinfo.is_immutable:
-                ptr = Ptr(operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES)
+                ptr = Ptr(
+                    operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES
+                )
                 return VyperValue.from_ptr(ptr, typ)
 
             # Regular storage/transient variable - return location, don't load!

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -897,8 +897,10 @@ class Expr:
         if bounds_check:
             length: IROperand = IRLiteral(0)
             if isinstance(base_typ, DArrayT):
-                # Dynamic array: load length from first word
-                length = self.builder.load(base, data_loc)
+                # Dynamic array: load length from first word.
+                # Use pointer-aware loading so ctor-time immutable reads come
+                # from the immutable staging area (not constructor args code).
+                length = self.ctx.get_dyn_array_length(base_vv.ptr())
             else:
                 # Static array: compile-time length
                 length = IRLiteral(base_typ.count)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -165,9 +165,8 @@ class Stmt:
                 self.builder.tstore(dst_ptr.operand, val)
             else:
                 self.ctx.store_transient(src, dst_ptr.operand, typ)
-        elif dst_ptr.location == DataLocation.CODE:
-            # Immutables in constructor - use ptr_store which handles GEP from immutables_alloca
-            # For single-word types, load value from temp buffer first
+        elif dst_ptr.location == DataLocation.IMMUTABLES:
+            # Immutables in constructor
             if typ.memory_bytes_required <= 32:
                 val = self.builder.mload(src)
                 self.ctx.ptr_store(dst_ptr, val)
@@ -414,7 +413,7 @@ class Stmt:
             # Check if it's an immutable assignment in constructor
             varinfo = target._expr_info.var_info
             if varinfo is not None and varinfo.is_immutable and self.ctx.is_ctor_context:
-                return Ptr(IRLiteral(varinfo.position.position), DataLocation.CODE)
+                return Ptr(IRLiteral(varinfo.position.position), DataLocation.IMMUTABLES)
 
             raise CompilerPanic(f"Unknown variable: {varname}")
 
@@ -429,7 +428,7 @@ class Stmt:
 
                 # Immutable in constructor context
                 if varinfo.is_immutable and self.ctx.is_ctor_context:
-                    return Ptr(IRLiteral(varinfo.position.position), DataLocation.CODE)
+                    return Ptr(IRLiteral(varinfo.position.position), DataLocation.IMMUTABLES)
 
                 if varinfo.is_constant:
                     raise TypeCheckFailure("Cannot assign to constant")
@@ -756,11 +755,13 @@ class Stmt:
                     val = self.ctx.load_word(elem_addr, location)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
-                    # Multi-word: copy from memory/calldata/code into loop local.
-                    # CODE copies are immutable-aware in constructor context.
-                    self.ctx.copy_word_aligned_to_memory(
-                        item_local.value.operand, elem_addr, elem_size, location
-                    )
+                    # Multi-word: word-by-word load from source, store to memory
+                    dst = item_local.value.operand
+                    for i in range(0, elem_size, 32):
+                        src_ptr = self.ctx._with_byte_offset(elem_addr, i)
+                        dst_ptr = self.ctx._with_byte_offset(dst, i)
+                        val = self.ctx.load_word(src_ptr, location)
+                        self.builder.mstore(dst_ptr, val)
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -740,13 +740,9 @@ class Stmt:
 
             # Copy element to loop variable (always in memory)
             if is_slot_addressed:
-                self.ctx.slot_to_memory(
-                    elem_addr, item_local.value.operand, elem_size, location
-                )
+                self.ctx.slot_to_memory(elem_addr, item_local.value.operand, elem_size, location)
             else:
-                self.ctx.copy_to_memory(
-                    item_local.value.operand, elem_addr, elem_size, location
-                )
+                self.ctx.copy_to_memory(item_local.value.operand, elem_addr, elem_size, location)
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -665,6 +665,7 @@ class Stmt:
         array = array_vv.operand
         array_typ = node.iter._metadata["type"]
         location = array_vv.location
+        assert location is not None
 
         # Determine word scale based on location
         # Storage/Transient: 1 slot per word, Memory: 32 bytes per word

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -665,35 +665,18 @@ class Stmt:
             array_vv = Expr(node.iter, self.ctx).lower()
         array = array_vv.operand
         array_typ = node.iter._metadata["type"]
-        location = array_vv.location or node.iter._expr_info.location
-
-        # If array is a stack value (e.g., from ternary expression), the operand
-        # is a pointer to memory. Use MEMORY as the location.
-        if location == DataLocation.UNSET:
-            location = DataLocation.MEMORY
+        location = self.ctx.value_location(array_vv, node.iter._expr_info.location)
 
         # Determine word scale based on location
         # Storage/Transient: 1 slot per word, Memory: 32 bytes per word
         is_slot_addressed = location in (DataLocation.STORAGE, DataLocation.TRANSIENT)
         word_scale = 1 if is_slot_addressed else 32
 
-        def _load_array_word(addr: IROperand) -> IROperand:
-            # Stack values are raw pointer operands, so use direct load dispatch.
-            if array_vv.is_stack_value:
-                return self.builder.load(addr, location)
-
-            if location == DataLocation.MEMORY:
-                return self.ctx.ptr_load(Ptr(addr, location, array_vv.ptr().buf))
-            return self.ctx.ptr_load(Ptr(addr, location))
-
         # Get length and bound
         length: IROperand
         if isinstance(array_typ, DArrayT):
             # Dynamic array: length is first word
-            if array_vv.is_stack_value:
-                length = self.builder.load(array, location)
-            else:
-                length = self.ctx.get_dyn_array_length(array_vv.ptr())
+            length = self.ctx.value_word_load(array_vv, array, location)
             bound = array_typ.count
         elif isinstance(array_typ, SArrayT):
             # Static array: length is compile-time constant
@@ -760,7 +743,7 @@ class Stmt:
             if is_slot_addressed:
                 if elem_size == 1:
                     # Single slot: load from storage/transient, mstore to memory
-                    val = _load_array_word(elem_addr)
+                    val = self.ctx.value_word_load(array_vv, elem_addr, location)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
                     # Multi-slot: use generic helper that dispatches on location
@@ -770,11 +753,14 @@ class Stmt:
             else:
                 if elem_size <= 32:
                     # Single word: load dispatches on location (mload/calldataload/dload)
-                    val = _load_array_word(elem_addr)
+                    val = self.ctx.value_word_load(array_vv, elem_addr, location)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
-                    # Multi-word: use context helper which handles pre-Cancun
-                    self.ctx.copy_memory(item_local.value.operand, elem_addr, elem_size)
+                    # Multi-word: copy from memory/calldata/code into loop local.
+                    # CODE copies are immutable-aware in constructor context.
+                    self.ctx.copy_word_aligned_to_memory(
+                        item_local.value.operand, elem_addr, elem_size, location
+                    )
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -740,28 +740,13 @@ class Stmt:
 
             # Copy element to loop variable (always in memory)
             if is_slot_addressed:
-                if elem_size == 1:
-                    # Single slot: load from storage/transient, mstore to memory
-                    val = self.ctx.load_word(elem_addr, location)
-                    self.builder.mstore(item_local.value.operand, val)
-                else:
-                    # Multi-slot: use generic helper that dispatches on location
-                    self.ctx.slot_to_memory(
-                        elem_addr, item_local.value.operand, elem_size, location
-                    )
+                self.ctx.slot_to_memory(
+                    elem_addr, item_local.value.operand, elem_size, location
+                )
             else:
-                if elem_size <= 32:
-                    # Single word: load dispatches on location (mload/calldataload/dload)
-                    val = self.ctx.load_word(elem_addr, location)
-                    self.builder.mstore(item_local.value.operand, val)
-                else:
-                    # Multi-word: word-by-word load from source, store to memory
-                    dst = item_local.value.operand
-                    for i in range(0, elem_size, 32):
-                        src_ptr = self.ctx._with_byte_offset(elem_addr, i)
-                        dst_ptr = self.ctx._with_byte_offset(dst, i)
-                        val = self.ctx.load_word(src_ptr, location)
-                        self.builder.mstore(dst_ptr, val)
+                self.ctx.copy_to_memory(
+                    item_local.value.operand, elem_addr, elem_size, location
+                )
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -665,7 +665,7 @@ class Stmt:
             array_vv = Expr(node.iter, self.ctx).lower()
         array = array_vv.operand
         array_typ = node.iter._metadata["type"]
-        location = self.ctx.value_location(array_vv, node.iter._expr_info.location)
+        location = array_vv.location
 
         # Determine word scale based on location
         # Storage/Transient: 1 slot per word, Memory: 32 bytes per word
@@ -676,7 +676,7 @@ class Stmt:
         length: IROperand
         if isinstance(array_typ, DArrayT):
             # Dynamic array: length is first word
-            length = self.ctx.value_word_load(array_vv, array, location)
+            length = self.ctx.load_word(array, location)
             bound = array_typ.count
         elif isinstance(array_typ, SArrayT):
             # Static array: length is compile-time constant
@@ -743,7 +743,7 @@ class Stmt:
             if is_slot_addressed:
                 if elem_size == 1:
                     # Single slot: load from storage/transient, mstore to memory
-                    val = self.ctx.value_word_load(array_vv, elem_addr, location)
+                    val = self.ctx.load_word(elem_addr, location)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
                     # Multi-slot: use generic helper that dispatches on location
@@ -753,7 +753,7 @@ class Stmt:
             else:
                 if elem_size <= 32:
                     # Single word: load dispatches on location (mload/calldataload/dload)
-                    val = self.ctx.value_word_load(array_vv, elem_addr, location)
+                    val = self.ctx.load_word(elem_addr, location)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
                     # Multi-word: copy from memory/calldata/code into loop local.

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -677,11 +677,23 @@ class Stmt:
         is_slot_addressed = location in (DataLocation.STORAGE, DataLocation.TRANSIENT)
         word_scale = 1 if is_slot_addressed else 32
 
+        def _load_array_word(addr: IROperand) -> IROperand:
+            # Stack values are raw pointer operands, so use direct load dispatch.
+            if array_vv.is_stack_value:
+                return self.builder.load(addr, location)
+
+            if location == DataLocation.MEMORY:
+                return self.ctx.ptr_load(Ptr(addr, location, array_vv.ptr().buf))
+            return self.ctx.ptr_load(Ptr(addr, location))
+
         # Get length and bound
         length: IROperand
         if isinstance(array_typ, DArrayT):
             # Dynamic array: length is first word
-            length = self.builder.load(array, location)
+            if array_vv.is_stack_value:
+                length = self.builder.load(array, location)
+            else:
+                length = self.ctx.get_dyn_array_length(array_vv.ptr())
             bound = array_typ.count
         elif isinstance(array_typ, SArrayT):
             # Static array: length is compile-time constant
@@ -748,7 +760,7 @@ class Stmt:
             if is_slot_addressed:
                 if elem_size == 1:
                     # Single slot: load from storage/transient, mstore to memory
-                    val = self.builder.load(elem_addr, location)
+                    val = _load_array_word(elem_addr)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
                     # Multi-slot: use generic helper that dispatches on location
@@ -758,7 +770,7 @@ class Stmt:
             else:
                 if elem_size <= 32:
                     # Single word: load dispatches on location (mload/calldataload/dload)
-                    val = self.builder.load(elem_addr, location)
+                    val = _load_array_word(elem_addr)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
                     # Multi-word: use context helper which handles pre-Cancun

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -53,10 +53,7 @@ def analyze_module(module_ast: vy_ast.Module) -> ModuleT:
     add all module-level objects to the namespace, type-check/validate
     semantics and annotate with type and analysis info
     """
-    # isolate global namespace per compilation unit to avoid cross-compilation
-    # state leakage (e.g. mutable type side effects on env vars).
-    with override_global_namespace(Namespace()):
-        return _analyze_module_r(module_ast, module_ast.is_interface)
+    return _analyze_module_r(module_ast, module_ast.is_interface)
 
 
 def _analyze_module_r(module_ast: vy_ast.Module, is_interface: bool = False):

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -53,7 +53,10 @@ def analyze_module(module_ast: vy_ast.Module) -> ModuleT:
     add all module-level objects to the namespace, type-check/validate
     semantics and annotate with type and analysis info
     """
-    return _analyze_module_r(module_ast, module_ast.is_interface)
+    # isolate global namespace per compilation unit to avoid cross-compilation
+    # state leakage (e.g. mutable type side effects on env vars).
+    with override_global_namespace(Namespace()):
+        return _analyze_module_r(module_ast, module_ast.is_interface)
 
 
 def _analyze_module_r(module_ast: vy_ast.Module, is_interface: bool = False):

--- a/vyper/semantics/data_locations.py
+++ b/vyper/semantics/data_locations.py
@@ -10,3 +10,4 @@ class DataLocation(StringEnum):
     CALLDATA = enum.auto()
     CODE = enum.auto()
     TRANSIENT = enum.auto()
+    IMMUTABLES = enum.auto()

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -16,50 +16,38 @@ class _EnvType(VyperType):
 
 class _Block(_EnvType):
     _id = "block"
-
-    def __init__(self):
-        super().__init__(
-            {
-                "coinbase": AddressT(),
-                "difficulty": UINT256_T,
-                "prevrandao": BYTES32_T,
-                "number": UINT256_T,
-                "gaslimit": UINT256_T,
-                "basefee": UINT256_T,
-                "blobbasefee": UINT256_T,
-                "prevhash": BYTES32_T,
-                "timestamp": UINT256_T,
-            }
-        )
+    _type_members = {
+        "coinbase": AddressT(),
+        "difficulty": UINT256_T,
+        "prevrandao": BYTES32_T,
+        "number": UINT256_T,
+        "gaslimit": UINT256_T,
+        "basefee": UINT256_T,
+        "blobbasefee": UINT256_T,
+        "prevhash": BYTES32_T,
+        "timestamp": UINT256_T,
+    }
 
 
 class _Chain(_EnvType):
     _id = "chain"
-
-    def __init__(self):
-        super().__init__({"id": UINT256_T})
+    _type_members = {"id": UINT256_T}
 
 
 class _Msg(_EnvType):
     _id = "msg"
-
-    def __init__(self):
-        super().__init__(
-            {
-                "data": BytesT(),
-                "gas": UINT256_T,
-                "mana": UINT256_T,
-                "sender": AddressT(),
-                "value": UINT256_T,
-            }
-        )
+    _type_members = {
+        "data": BytesT(),
+        "gas": UINT256_T,
+        "mana": UINT256_T,
+        "sender": AddressT(),
+        "value": UINT256_T,
+    }
 
 
 class _Tx(_EnvType):
     _id = "tx"
-
-    def __init__(self):
-        super().__init__({"origin": AddressT(), "gasprice": UINT256_T})
+    _type_members = {"origin": AddressT(), "gasprice": UINT256_T}
 
 
 _CONSTANT_ENV_TYPES = (_Block, _Chain, _Tx, _Msg)
@@ -71,8 +59,8 @@ def get_constant_vars() -> Dict:
     """
     Get a dictionary of constant environment variables.
     """
-    # create fresh instances each call to avoid mutable type pollution
-    # (e.g. BytesT().compare_type has side effects on length metadata)
+    # create fresh instances each call to avoid mutable singleton pollution
+    # (BytesT() in _Msg gets mutated by compare_type side effects)
     return {
         t._id: VarInfo(t, modifiability=Modifiability.RUNTIME_CONSTANT)
         for t in (cls() for cls in _CONSTANT_ENV_TYPES)

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -16,38 +16,50 @@ class _EnvType(VyperType):
 
 class _Block(_EnvType):
     _id = "block"
-    _type_members = {
-        "coinbase": AddressT(),
-        "difficulty": UINT256_T,
-        "prevrandao": BYTES32_T,
-        "number": UINT256_T,
-        "gaslimit": UINT256_T,
-        "basefee": UINT256_T,
-        "blobbasefee": UINT256_T,
-        "prevhash": BYTES32_T,
-        "timestamp": UINT256_T,
-    }
+
+    def __init__(self):
+        super().__init__(
+            {
+                "coinbase": AddressT(),
+                "difficulty": UINT256_T,
+                "prevrandao": BYTES32_T,
+                "number": UINT256_T,
+                "gaslimit": UINT256_T,
+                "basefee": UINT256_T,
+                "blobbasefee": UINT256_T,
+                "prevhash": BYTES32_T,
+                "timestamp": UINT256_T,
+            }
+        )
 
 
 class _Chain(_EnvType):
     _id = "chain"
-    _type_members = {"id": UINT256_T}
+
+    def __init__(self):
+        super().__init__({"id": UINT256_T})
 
 
 class _Msg(_EnvType):
     _id = "msg"
-    _type_members = {
-        "data": BytesT(),
-        "gas": UINT256_T,
-        "mana": UINT256_T,
-        "sender": AddressT(),
-        "value": UINT256_T,
-    }
+
+    def __init__(self):
+        super().__init__(
+            {
+                "data": BytesT(),
+                "gas": UINT256_T,
+                "mana": UINT256_T,
+                "sender": AddressT(),
+                "value": UINT256_T,
+            }
+        )
 
 
 class _Tx(_EnvType):
     _id = "tx"
-    _type_members = {"origin": AddressT(), "gasprice": UINT256_T}
+
+    def __init__(self):
+        super().__init__({"origin": AddressT(), "gasprice": UINT256_T})
 
 
 _CONSTANT_ENV_TYPES = (_Block, _Chain, _Tx, _Msg)
@@ -59,8 +71,8 @@ def get_constant_vars() -> Dict:
     """
     Get a dictionary of constant environment variables.
     """
-    # create fresh instances each call to avoid mutable singleton pollution
-    # (BytesT() in _Msg gets mutated by compare_type side effects)
+    # create fresh instances each call to avoid mutable type pollution
+    # (e.g. BytesT().compare_type has side effects on length metadata)
     return {
         t._id: VarInfo(t, modifiability=Modifiability.RUNTIME_CONSTANT)
         for t in (cls() for cls in _CONSTANT_ENV_TYPES)

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -50,18 +50,21 @@ class _Tx(_EnvType):
     _type_members = {"origin": AddressT(), "gasprice": UINT256_T}
 
 
-CONSTANT_ENVIRONMENT_VARS = {t._id: t for t in (_Block(), _Chain(), _Tx(), _Msg())}
+_CONSTANT_ENV_TYPES = (_Block, _Chain, _Tx, _Msg)
+
+CONSTANT_ENVIRONMENT_VARS = {cls._id for cls in _CONSTANT_ENV_TYPES}
 
 
 def get_constant_vars() -> Dict:
     """
     Get a dictionary of constant environment variables.
     """
-    result = {}
-    for k, v in CONSTANT_ENVIRONMENT_VARS.items():
-        result[k] = VarInfo(v, modifiability=Modifiability.RUNTIME_CONSTANT)
-
-    return result
+    # create fresh instances each call to avoid mutable singleton pollution
+    # (BytesT() in _Msg gets mutated by compare_type side effects)
+    return {
+        t._id: VarInfo(t, modifiability=Modifiability.RUNTIME_CONSTANT)
+        for t in (cls() for cls in _CONSTANT_ENV_TYPES)
+    }
 
 
 MUTABLE_ENVIRONMENT_VARS: Dict[str, type] = {"self": SelfT}

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -36,13 +36,23 @@ class _Chain(_EnvType):
 
 class _Msg(_EnvType):
     _id = "msg"
-    _type_members = {
-        "data": BytesT(),
-        "gas": UINT256_T,
-        "mana": UINT256_T,
-        "sender": AddressT(),
-        "value": UINT256_T,
-    }
+
+    def __init__(self):
+        # construct members in __init__ (not class-level _type_members)
+        # so each instance gets a fresh BytesT().  compare_type() mutates
+        # BytesT._length as a side effect; a class-level singleton would
+        # leak that mutation across compilations and function analyses.
+        # TODO: replace with _type_members once compare_type no longer mutates
+        # types.
+        super().__init__(
+            {
+                "data": BytesT(),
+                "gas": UINT256_T,
+                "mana": UINT256_T,
+                "sender": AddressT(),
+                "value": UINT256_T,
+            }
+        )
 
 
 class _Tx(_EnvType):
@@ -58,9 +68,13 @@ CONSTANT_ENVIRONMENT_VARS = {cls._id for cls in _CONSTANT_ENV_TYPES}
 def get_constant_vars() -> Dict:
     """
     Get a dictionary of constant environment variables.
+
+    Returns fresh instances each call — compare_type() has side effects
+    that mutate BytesT()._length, so env types (especially _Msg.data)
+    must not be shared across compilations or function analyses.
+    TODO: fix compare_type to not have side effects, then this can
+    return singletons again.
     """
-    # create fresh instances each call to avoid mutable singleton pollution
-    # (BytesT() in _Msg gets mutated by compare_type side effects)
     return {
         t._id: VarInfo(t, modifiability=Modifiability.RUNTIME_CONSTANT)
         for t in (cls() for cls in _CONSTANT_ENV_TYPES)

--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -71,6 +71,12 @@ class Namespace(dict):
 
         self._scopes.append(set())
 
+        # refresh constant env vars with fresh instances — compare_type()
+        # mutates BytesT._length, so they must not be shared across
+        # function analyses.
+        # TODO: remove once compare_type no longer mutates types.
+        dict.update(self, environment.get_constant_vars())
+
         if len(self._scopes) == 1:
             # add mutable vars (`self`) to the initial scope
             self.update(environment.get_mutable_vars())

--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -112,11 +112,15 @@ def get_namespace():
 @contextlib.contextmanager
 def override_global_namespace(ns):
     global _namespace
-    tmp = _namespace
+    had_namespace = "_namespace" in globals()
+    tmp = _namespace if had_namespace else None
     try:
         # clobber global namespace
         _namespace = ns
         yield
     finally:
         # unclobber
-        _namespace = tmp
+        if had_namespace:
+            _namespace = tmp
+        else:
+            del _namespace

--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -112,15 +112,11 @@ def get_namespace():
 @contextlib.contextmanager
 def override_global_namespace(ns):
     global _namespace
-    had_namespace = "_namespace" in globals()
-    tmp = _namespace if had_namespace else None
+    tmp = _namespace
     try:
         # clobber global namespace
         _namespace = ns
         yield
     finally:
         # unclobber
-        if had_namespace:
-            _namespace = tmp
-        else:
-            del _namespace
+        _namespace = tmp

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -1,3 +1,4 @@
+import copy
 from functools import cached_property
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -367,7 +368,13 @@ class VyperType:
 
     def get_member(self, key: str, node: vy_ast.VyperNode) -> "VyperType":
         if key in self.members:
-            return self.members[key]
+            member = self.members[key]
+            # Bytes/string member types can be length-inferred during type comparison.
+            # Return a copy for open-ended member types so member access cannot poison
+            # the stored namespace type across expressions or compilations.
+            if isinstance(member, VyperType) and member._is_bytestring and member._length == 0:
+                return copy.copy(member)
+            return member
 
         # special error message for types with no members
         if not self.members:

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -176,7 +176,7 @@ class VyperType:
             return self.storage_size_in_words
         if location == DataLocation.MEMORY:
             return self.memory_bytes_required
-        if location == DataLocation.CODE:
+        if location in (DataLocation.CODE, DataLocation.IMMUTABLES):
             return self.memory_bytes_required
         if location == DataLocation.CALLDATA:
             return self.memory_bytes_required

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -1,4 +1,3 @@
-import copy
 from functools import cached_property
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -368,13 +367,7 @@ class VyperType:
 
     def get_member(self, key: str, node: vy_ast.VyperNode) -> "VyperType":
         if key in self.members:
-            member = self.members[key]
-            # Bytes/string member types can be length-inferred during type comparison.
-            # Return a copy for open-ended member types so member access cannot poison
-            # the stored namespace type across expressions or compilations.
-            if isinstance(member, VyperType) and member._is_bytestring and member._length == 0:
-                return copy.copy(member)
-            return member
+            return self.members[key]
 
         # special error message for types with no members
         if not self.members:


### PR DESCRIPTION
### What I did

Fixes miscompile: 
```
arr: immutable(DynArray[uint256, 1])

@deploy
def __init__(arg: uint256):
    x: uint256 = arr[0]
    arr = []
```

Expected behavior:
- arr is uninitialized at that read site (length should be `0`)
- arr[0] should always fail bounds check and revert, independent of constructor arg value and codegen pipeline

### How I did it

### How to verify it

### Commit message

```
Three bugs caused immutable dynarray reads to miscompile in the venom
codegen pipeline:

1. `is_word_type` treated single-element arrays (`uint256[1]`) as word-
   sized, causing them to be passed on the stack instead of through
   memory. Fix by checking the type is actually a primitive word type,
   not just that its size fits in a word.

2. `DataLocation.CODE` was overloaded in constructor context to mean
   both "constructor args in the data section" (needs `dload`) and
   "immutables staging area" (needs `iload`). When reading an immutable
   dynarray during the constructor, `builder.load(addr, CODE)` emitted
   `dload` — reading from constructor arg bytes instead of the
   immutables buffer. Fix by adding `DataLocation.IMMUTABLES` as a
   distinct location. Immutable variables now use IMMUTABLES everywhere;
   `load_word` emits `iload` in constructor context and `dload` at
   runtime. `CODE` is reserved for constructor args only.

3. Ternary expressions (`x if cond else y`) with complex types lost
   their location tracking, producing `VyperValue`s with `location=None`
   that downstream code couldn't load correctly. Fix by having
   `lower_IfExp` return `from_ptr(MEMORY)` for complex types so the
   location propagates.

Also clean up duplicated copy routines: collapse
`load_immutable`/`load_immutable_ctor` into `load_immutable_to_memory`,
replace `code_to_memory` with generic `copy_to_memory`, rename
`load_storage`/`load_transient` to `load_*_to_memory` for consistency,
and dedup the iter-loop element copy logic.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
