### PR TITLE
fix[venom]: layout-aware memory copy for type-compatible assignments

### DIFF
--- a/tests/functional/codegen/features/test_immutable.py
+++ b/tests/functional/codegen/features/test_immutable.py
@@ -670,6 +670,32 @@ def __init__(values: DynArray[uint256[2], 3]):
     assert c2.ctor_second_right() == 0
 
 
+def test_immutable_dynarray_multi_word_runtime_iteration(get_contract):
+    """
+    Regression test: iterating over an immutable DynArray with multi-word
+    elements (uint256[2] = 64 bytes) at RUNTIME (not constructor).
+    Immutables are in CODE location at runtime, so copy must use dload,
+    not mcopy/mload.
+    """
+    code = """
+arr: immutable(DynArray[uint256[2], 3])
+
+@deploy
+def __init__(values: DynArray[uint256[2], 3]):
+    arr = values
+
+@external
+@view
+def sum_pairs() -> uint256:
+    total: uint256 = 0
+    for pair: uint256[2] in arr:
+        total += pair[0] + pair[1]
+    return total
+    """
+    c = get_contract(code, [[1, 2], [3, 4], [5, 6]])
+    assert c.sum_pairs() == 21
+
+
 def test_constructor_immutable_dynarray_ternary_len_and_membership(get_contract):
     code = """
 left: immutable(DynArray[uint256, 4])

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2187,6 +2187,76 @@ def _ret_pair() -> (DynArray[Bytes[540], 9], DynArray[Bytes[540], 9]):
     assert c.foo() == [expected, expected]
 
 
+def test_venom_for_loop_bytes_elem_size_mismatch(get_contract):
+    code = """
+@external
+@pure
+def foo() -> DynArray[Bytes[704], 13]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    src: DynArray[Bytes[540], 9] = [v, v, v]
+    out: DynArray[Bytes[704], 13] = []
+    for item: Bytes[704] in src:
+        out.append(item)
+    return out
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected
+
+
+def test_venom_struct_ctor_bytes_elem_size_mismatch(get_contract):
+    code = """
+struct S:
+    data: DynArray[Bytes[704], 13]
+
+@external
+@pure
+def foo() -> DynArray[Bytes[704], 13]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    src: DynArray[Bytes[540], 9] = [v, v, v, v]
+    s: S = S(data=src)
+    return s.data
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected
+
+
+def test_venom_external_return_direct_bytes_elem_size_mismatch(get_contract):
+    code = """
+@external
+@pure
+def foo() -> DynArray[Bytes[704], 13]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    result: DynArray[Bytes[540], 9] = [v, v, v, v]
+    return result
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected
+
+
+def test_venom_sarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+@external
+@pure
+def foo() -> DynArray[Bytes[704], 3]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    src: Bytes[540][3] = [v, v, v]
+    out: DynArray[Bytes[704], 3] = []
+    for item: Bytes[704] in src:
+        out.append(item)
+    return out
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected
+
+
 def test_venom_storage_assign_dynarray_bytes_elem_size_mismatch(get_contract):
     code = """
 a: DynArray[Bytes[704], 13]

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2162,3 +2162,61 @@ def foo() -> DynArray[Bytes[704], 13]:
     c = get_contract(code)
     expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
     assert c.foo() == expected
+
+
+def test_venom_tuple_unpack_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+@external
+@pure
+def foo() -> DynArray[DynArray[Bytes[704], 13], 2]:
+    a: DynArray[Bytes[704], 13] = []
+    b: DynArray[Bytes[704], 13] = []
+    a, b = self._ret_pair()
+    return [a, b]
+
+@internal
+@pure
+def _ret_pair() -> (DynArray[Bytes[540], 9], DynArray[Bytes[540], 9]):
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    x: DynArray[Bytes[540], 9] = [v, v, v, v]
+    return x, x
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected, expected]
+
+
+def test_venom_storage_assign_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+a: DynArray[Bytes[704], 13]
+
+@external
+def foo() -> DynArray[Bytes[704], 13]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    x: DynArray[Bytes[540], 9] = [v, v, v, v]
+    self.a = x
+    return self.a
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected
+
+
+def test_venom_storage_append_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+a: DynArray[DynArray[Bytes[704], 13], 3]
+
+@external
+def foo() -> DynArray[DynArray[Bytes[704], 13], 3]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    x: DynArray[Bytes[540], 9] = [v, v, v, v]
+    self.a = []
+    self.a.append(x)
+    return self.a
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected]

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2039,3 +2039,25 @@ def test_append_self_ref_bytes() -> DynArray[Bytes[32], 5]:
     """
     c = get_contract(code_bytes)
     assert c.test_append_self_ref_bytes() == [b"hello", b"world", b"hello"]
+
+
+def test_venom_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+struct R:
+    x0: DynArray[Bytes[540], 9]
+
+@external
+@pure
+def foo() -> DynArray[DynArray[Bytes[704], 13], 7]:
+    result: DynArray[Bytes[540], 9] = self._make().x0
+    return [result]
+
+@pure
+def _make() -> R:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    return R(x0=[v, v, v, v])
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected]

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2243,18 +2243,19 @@ def test_venom_sarray_bytes_elem_size_mismatch(get_contract):
     code = """
 @external
 @pure
-def foo() -> DynArray[Bytes[704], 3]:
+def foo() -> DynArray[DynArray[Bytes[704], 13], 3]:
     v: Bytes[64] = concat(b'', 0xeeb5)
-    src: Bytes[540][3] = [v, v, v]
-    out: DynArray[Bytes[704], 3] = []
-    for item: Bytes[704] in src:
+    inner: DynArray[Bytes[540], 9] = [v, v]
+    src: DynArray[Bytes[540], 9][3] = [inner, inner, inner]
+    out: DynArray[DynArray[Bytes[704], 13], 3] = []
+    for item: DynArray[Bytes[704], 13] in src:
         out.append(item)
     return out
     """
 
     c = get_contract(code)
-    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
-    assert c.foo() == expected
+    expected = [b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected, expected, expected]
 
 
 def test_venom_nested_dynarray_bytes_elem_size_mismatch(get_contract):

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2087,3 +2087,78 @@ def _make() -> R:
     c = get_contract(code)
     expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
     assert c.foo() == [expected]
+
+
+def test_venom_external_call_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+interface IHelper:
+    def id(a: DynArray[Bytes[704], 13]) -> DynArray[Bytes[704], 13]: view
+
+struct R:
+    x0: DynArray[Bytes[540], 9]
+
+@external
+@view
+def foo() -> DynArray[DynArray[Bytes[704], 13], 7]:
+    result: DynArray[Bytes[704], 13] = staticcall IHelper(self).id(self._make().x0)
+    return [result]
+
+@external
+@view
+def id(a: DynArray[Bytes[704], 13]) -> DynArray[Bytes[704], 13]:
+    return a
+
+@pure
+def _make() -> R:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    return R(x0=[v, v, v, v])
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected]
+
+
+def test_venom_internal_return_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+struct R:
+    x0: DynArray[Bytes[540], 9]
+
+@external
+@pure
+def foo() -> DynArray[DynArray[Bytes[704], 13], 7]:
+    return [self._ret()]
+
+@pure
+def _ret() -> DynArray[Bytes[704], 13]:
+    result: DynArray[Bytes[540], 9] = self._make().x0
+    return result
+
+@pure
+def _make() -> R:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    return R(x0=[v, v, v, v])
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected]
+
+
+def test_venom_append_bytes_elem_size_mismatch(get_contract):
+    code = """
+@external
+@pure
+def foo() -> DynArray[Bytes[704], 13]:
+    out: DynArray[Bytes[704], 13] = []
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    out.append(v)
+    out.append(v)
+    out.append(v)
+    out.append(v)
+    return out
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2308,3 +2308,40 @@ def foo() -> DynArray[DynArray[Bytes[704], 13], 3]:
     c = get_contract(code)
     expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
     assert c.foo() == [expected]
+
+
+def test_venom_transient_assign_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+a: transient(DynArray[Bytes[704], 13])
+
+@external
+def foo() -> DynArray[Bytes[704], 13]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    x: DynArray[Bytes[540], 9] = [v, v, v, v]
+    self.a = x
+    return self.a
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == expected
+
+
+def test_venom_event_dynarray_bytes_elem_size_mismatch(get_contract, env):
+    code = """
+event MyEvent:
+    data: DynArray[Bytes[704], 13]
+
+@external
+def foo():
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    x: DynArray[Bytes[540], 9] = [v, v, v, v]
+    log MyEvent(x)
+    """
+
+    c = get_contract(code)
+    c.foo()
+    logs = env.get_logs(c)
+    assert len(logs) == 1
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert logs[0].args.data == expected

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2061,3 +2061,29 @@ def _make() -> R:
     c = get_contract(code)
     expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
     assert c.foo() == [expected]
+
+
+def test_venom_internal_call_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+struct R:
+    x0: DynArray[Bytes[540], 9]
+
+@external
+@pure
+def foo() -> DynArray[DynArray[Bytes[704], 13], 7]:
+    result: DynArray[Bytes[704], 13] = self._id(self._make().x0)
+    return [result]
+
+@pure
+def _id(a: DynArray[Bytes[704], 13]) -> DynArray[Bytes[704], 13]:
+    return a
+
+@pure
+def _make() -> R:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    return R(x0=[v, v, v, v])
+    """
+
+    c = get_contract(code)
+    expected = [b"\xee\xb5", b"\xee\xb5", b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [expected]

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2257,6 +2257,23 @@ def foo() -> DynArray[Bytes[704], 3]:
     assert c.foo() == expected
 
 
+def test_venom_nested_dynarray_bytes_elem_size_mismatch(get_contract):
+    code = """
+@external
+@pure
+def foo() -> DynArray[DynArray[Bytes[704], 13], 3]:
+    v: Bytes[64] = concat(b'', 0xeeb5)
+    inner: DynArray[Bytes[540], 9] = [v, v]
+    src: DynArray[DynArray[Bytes[540], 9], 3] = [inner, inner]
+    result: DynArray[DynArray[Bytes[704], 13], 3] = src
+    return result
+    """
+
+    c = get_contract(code)
+    inner = [b"\xee\xb5", b"\xee\xb5"]
+    assert c.foo() == [inner, inner]
+
+
 def test_venom_storage_assign_dynarray_bytes_elem_size_mismatch(get_contract):
     code = """
 a: DynArray[Bytes[704], 13]

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -2310,6 +2310,7 @@ def foo() -> DynArray[DynArray[Bytes[704], 13], 3]:
     assert c.foo() == [expected]
 
 
+@pytest.mark.requires_evm_version("cancun")
 def test_venom_transient_assign_dynarray_bytes_elem_size_mismatch(get_contract):
     code = """
 a: transient(DynArray[Bytes[704], 13])

--- a/tests/functional/syntax/test_msg_data.py
+++ b/tests/functional/syntax/test_msg_data.py
@@ -206,6 +206,27 @@ def bad() -> Bytes[4]:
     assert "TypeMismatch" not in err
 
 
+def test_successful_compilation_no_cross_pollution():
+    """Compile two contracts sequentially that use msg.data via slice();
+    verify the first compilation's BytesT._length mutation doesn't leak."""
+    code_a = """
+@external
+def foo() -> uint256:
+    val: Bytes[100] = slice(msg.data, 0, 100)
+    return convert(slice(val, 4, 32), uint256)
+    """
+    code_b = """
+@external
+def bar() -> uint256:
+    val: Bytes[36] = slice(msg.data, 0, 36)
+    return convert(slice(val, 4, 32), uint256)
+    """
+    # Both should compile without error; A's larger slice must not
+    # poison B's msg.data type with a fixed _length.
+    compiler.compile_code(code_a)
+    compiler.compile_code(code_b)
+
+
 def test_runtime_failure_bounds_check(get_contract, tx_failed):
     code = """
 @external

--- a/tests/unit/compiler/venom/test_calling_convention_api.py
+++ b/tests/unit/compiler/venom/test_calling_convention_api.py
@@ -1,0 +1,125 @@
+from vyper.codegen_venom.calling_convention import (
+    is_word_type,
+    pass_via_stack,
+    returns_stack_count,
+)
+from vyper.semantics.types import AddressT, BoolT
+from vyper.semantics.types.function import ContractFunctionT, PositionalArg
+from vyper.semantics.analysis.base import FunctionVisibility, StateMutability
+from vyper.semantics.types.shortcuts import UINT256_T
+from vyper.semantics.types.subscriptable import SArrayT, TupleT
+
+
+def _make_func(args, return_type=None):
+    pos_args = [PositionalArg(name=name, typ=typ) for name, typ in args]
+    return ContractFunctionT(
+        name="test_fn",
+        positional_args=pos_args,
+        keyword_args=[],
+        return_type=return_type,
+        function_visibility=FunctionVisibility.INTERNAL,
+        state_mutability=StateMutability.NONPAYABLE,
+    )
+
+
+# -- is_word_type --
+
+
+def test_is_word_type_uint256():
+    assert is_word_type(UINT256_T) is True
+
+
+def test_is_word_type_bool():
+    assert is_word_type(BoolT()) is True
+
+
+def test_is_word_type_address():
+    assert is_word_type(AddressT()) is True
+
+
+def test_is_word_type_sarray_one_element():
+    # uint256[1] is 32 bytes but NOT a primitive word
+    assert is_word_type(SArrayT(UINT256_T, 1)) is False
+
+
+def test_is_word_type_sarray_two_elements():
+    assert is_word_type(SArrayT(UINT256_T, 2)) is False
+
+
+# -- returns_stack_count --
+
+
+def test_returns_stack_count_none():
+    func_t = _make_func([])
+    assert returns_stack_count(func_t) == 0
+
+
+def test_returns_stack_count_single_word():
+    func_t = _make_func([], return_type=UINT256_T)
+    assert returns_stack_count(func_t) == 1
+
+
+def test_returns_stack_count_single_non_word():
+    func_t = _make_func([], return_type=SArrayT(UINT256_T, 1))
+    assert returns_stack_count(func_t) == 0
+
+
+def test_returns_stack_count_tuple_two_words():
+    func_t = _make_func([], return_type=TupleT([UINT256_T, UINT256_T]))
+    assert returns_stack_count(func_t) == 2
+
+
+def test_returns_stack_count_tuple_three_words():
+    # exceeds MAX_STACK_RETURNS (2)
+    func_t = _make_func([], return_type=TupleT([UINT256_T, UINT256_T, UINT256_T]))
+    assert returns_stack_count(func_t) == 0
+
+
+def test_returns_stack_count_tuple_mixed():
+    func_t = _make_func([], return_type=TupleT([UINT256_T, SArrayT(UINT256_T, 1)]))
+    assert returns_stack_count(func_t) == 0
+
+
+# -- pass_via_stack --
+
+
+def test_pass_via_stack_six_word_args():
+    args = [(f"a{i}", UINT256_T) for i in range(6)]
+    func_t = _make_func(args)
+    result = pass_via_stack(func_t)
+    assert all(result.values())
+
+
+def test_pass_via_stack_seven_word_args():
+    args = [(f"a{i}", UINT256_T) for i in range(7)]
+    func_t = _make_func(args)
+    result = pass_via_stack(func_t)
+    assert result["a6"] is False
+    assert sum(v for v in result.values()) == 6
+
+
+def test_pass_via_stack_with_single_return():
+    # 1 return slot + 5 args = 6 total
+    args = [(f"a{i}", UINT256_T) for i in range(6)]
+    func_t = _make_func(args, return_type=UINT256_T)
+    result = pass_via_stack(func_t)
+    assert result["a4"] is True
+    assert result["a5"] is False
+
+
+def test_pass_via_stack_with_tuple_return():
+    # 2 return slots + 4 args = 6 total
+    args = [(f"a{i}", UINT256_T) for i in range(6)]
+    func_t = _make_func(args, return_type=TupleT([UINT256_T, UINT256_T]))
+    result = pass_via_stack(func_t)
+    assert result["a3"] is True
+    assert result["a4"] is False
+    assert result["a5"] is False
+
+
+def test_pass_via_stack_non_word_arg():
+    args = [("arr", SArrayT(UINT256_T, 1)), ("x", UINT256_T)]
+    func_t = _make_func(args)
+    result = pass_via_stack(func_t)
+    assert result["arr"] is False
+    assert result["x"] is True

--- a/tests/unit/compiler/venom/test_calling_convention_api.py
+++ b/tests/unit/compiler/venom/test_calling_convention_api.py
@@ -1,11 +1,7 @@
-from vyper.codegen_venom.calling_convention import (
-    is_word_type,
-    pass_via_stack,
-    returns_stack_count,
-)
+from vyper.codegen_venom.calling_convention import is_word_type, pass_via_stack, returns_stack_count
+from vyper.semantics.analysis.base import FunctionVisibility, StateMutability
 from vyper.semantics.types import AddressT, BoolT
 from vyper.semantics.types.function import ContractFunctionT, PositionalArg
-from vyper.semantics.analysis.base import FunctionVisibility, StateMutability
 from vyper.semantics.types.shortcuts import UINT256_T
 from vyper.semantics.types.subscriptable import SArrayT, TupleT
 

--- a/vyper/codegen_venom/buffer.py
+++ b/vyper/codegen_venom/buffer.py
@@ -35,7 +35,7 @@ class Buffer:
 @dataclass(frozen=True)
 class Ptr:
     """
-    A pointer to a location (memory, storage, calldata, transient).
+    A pointer to a location (memory, storage, calldata, code, transient).
 
     location is required - a Ptr always points somewhere.
 

--- a/vyper/codegen_venom/builtins/create.py
+++ b/vyper/codegen_venom/builtins/create.py
@@ -257,15 +257,16 @@ def lower_raw_create(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
 
     # Encode ctor args after bytecode
     # First, store ctor args to a temp buffer
-    ctor_arg_values = [Expr(arg, ctx).lower_value() for arg in ctor_arg_nodes]
+    ctor_arg_vvs = [Expr(arg, ctx).lower() for arg in ctor_arg_nodes]
     ctor_args_val = ctx.new_temporary_value(ctor_tuple_typ)
     offset = 0
-    for val, arg_t in zip(ctor_arg_values, ctor_arg_types):
+    for vv, arg_t in zip(ctor_arg_vvs, ctor_arg_types):
+        val = ctx.unwrap(vv)
         if offset == 0:
             dst = ctor_args_val.operand
         else:
             dst = b.add(ctor_args_val.operand, IRLiteral(offset))
-        ctx.store_memory(val, dst, arg_t)
+        ctx.store_memory(val, dst, arg_t, src_typ=vv.typ)
         offset += arg_t.memory_bytes_required
 
     # Now ABI encode from ctor_args_val to args_start
@@ -523,15 +524,16 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
         args_buf = ctx.allocate_buffer(ctor_abi_size, annotation="ctor_args_buf")
 
         # Evaluate and store ctor args to temp buffer
-        ctor_arg_values = [Expr(arg, ctx).lower_value() for arg in ctor_arg_nodes]
+        ctor_arg_vvs = [Expr(arg, ctx).lower() for arg in ctor_arg_nodes]
         ctor_args_src = ctx.new_temporary_value(ctor_tuple_typ)
         offset = 0
-        for val, arg_t in zip(ctor_arg_values, ctor_arg_types):
+        for vv, arg_t in zip(ctor_arg_vvs, ctor_arg_types):
+            val = ctx.unwrap(vv)
             if offset == 0:
                 dst = ctor_args_src.operand
             else:
                 dst = b.add(ctor_args_src.operand, IRLiteral(offset))
-            ctx.store_memory(val, dst, arg_t)
+            ctx.store_memory(val, dst, arg_t, src_typ=vv.typ)
             offset += arg_t.memory_bytes_required
 
         # ABI encode from ctor_args_src to args_buf (BEFORE msize!)

--- a/vyper/codegen_venom/builtins/create.py
+++ b/vyper/codegen_venom/builtins/create.py
@@ -261,12 +261,11 @@ def lower_raw_create(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
     ctor_args_val = ctx.new_temporary_value(ctor_tuple_typ)
     offset = 0
     for vv, arg_t in zip(ctor_arg_vvs, ctor_arg_types):
-        val = ctx.unwrap(vv)
         if offset == 0:
             dst = ctor_args_val.operand
         else:
             dst = b.add(ctor_args_val.operand, IRLiteral(offset))
-        ctx.store_memory(val, dst, arg_t, src_typ=vv.typ)
+        ctx.store_vyper_value(vv, dst, arg_t)
         offset += arg_t.memory_bytes_required
 
     # Now ABI encode from ctor_args_val to args_start
@@ -528,12 +527,11 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
         ctor_args_src = ctx.new_temporary_value(ctor_tuple_typ)
         offset = 0
         for vv, arg_t in zip(ctor_arg_vvs, ctor_arg_types):
-            val = ctx.unwrap(vv)
             if offset == 0:
                 dst = ctor_args_src.operand
             else:
                 dst = b.add(ctor_args_src.operand, IRLiteral(offset))
-            ctx.store_memory(val, dst, arg_t, src_typ=vv.typ)
+            ctx.store_vyper_value(vv, dst, arg_t)
             offset += arg_t.memory_bytes_required
 
         # ABI encode from ctor_args_src to args_buf (BEFORE msize!)

--- a/vyper/codegen_venom/calling_convention.py
+++ b/vyper/codegen_venom/calling_convention.py
@@ -53,12 +53,11 @@ def pass_via_stack(func_t) -> dict[str, bool]:
     ret = {}
     stack_items = 0
 
-    # Return takes one stack slot if it's a word type
-    if func_t.return_type is not None and is_word_type(func_t.return_type):
-        stack_items += 1
+    # Reserve stack slots for return values
+    stack_items += returns_stack_count(func_t)
 
     for arg in func_t.arguments:
-        if not is_word_type(arg.typ) or stack_items > MAX_STACK_ARGS:
+        if not is_word_type(arg.typ) or stack_items >= MAX_STACK_ARGS:
             ret[arg.name] = False
         else:
             ret[arg.name] = True

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -169,6 +169,14 @@ class VenomCodegenContext:
         # Primitive word type: emit load based on location
         return self.load_word(vv.operand, vv.location)
 
+    def store_vyper_value(
+        self, vv: VyperValue, ptr: IROperand, typ: Optional[VyperType] = None
+    ) -> None:
+        """Store a VyperValue into memory, preserving its source layout."""
+        if typ is None:
+            typ = vv.typ
+        self.store_memory(self.unwrap(vv), ptr, typ, src_typ=vv.typ)
+
     def bytes_data_ptr(self, vv: VyperValue) -> IROperand:
         """Get pointer to bytestring data (skipping length word).
 

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -20,10 +20,12 @@ from vyper.codegen_venom.value import VyperValue
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import CompilerPanic, MemoryAllocationException, StateAccessViolation
 from vyper.semantics.data_locations import DataLocation
-from vyper.semantics.types import VyperType
+from vyper.semantics.types import TupleT, VyperType
 from vyper.semantics.types.bytestrings import _BytestringT
 from vyper.semantics.types.function import ContractFunctionT, StateMutability
 from vyper.semantics.types.module import ModuleT
+from vyper.semantics.types.subscriptable import DArrayT, SArrayT
+from vyper.semantics.types.user import StructT
 from vyper.venom.basicblock import IRLabel, IRLiteral, IROperand, IRVariable
 from vyper.venom.builder import VenomBuilder
 
@@ -356,7 +358,9 @@ class VenomCodegenContext:
             # Complex types: return pointer (caller handles copy if needed)
             return ptr
 
-    def store_memory(self, val: IROperand, ptr: IROperand, typ: VyperType) -> None:
+    def store_memory(
+        self, val: IROperand, ptr: IROperand, typ: VyperType, src_typ: Optional[VyperType] = None
+    ) -> None:
         """Store value to memory pointer.
 
         For primitive word types, stores the value directly via mstore.
@@ -368,6 +372,9 @@ class VenomCodegenContext:
         complex types that happen to fit in one word. The caller passes
         a pointer to struct data, not the struct value itself.
         """
+        if src_typ is None:
+            src_typ = typ
+
         if typ._is_prim_word:
             self.builder.mstore(ptr, val)
         elif isinstance(typ, _BytestringT):
@@ -383,9 +390,120 @@ class VenomCodegenContext:
             # Copy 32 (length word) + ceil32(length) bytes
             copy_len = self.builder.add(padded_len, IRLiteral(32))
             self.copy_memory_dynamic(ptr, val, copy_len)
+        elif src_typ != typ:
+            # Layout-aware copy for assignments between compatible but not
+            # identical memory layouts (e.g. DynArray[Bytes[540]] -> DynArray[Bytes[704]]).
+            self._store_memory_typed(dst=ptr, dst_typ=typ, src=val, src_typ=src_typ)
         else:
             # Complex type: val is a pointer, copy memory
             self.copy_memory(ptr, val, typ.memory_bytes_required)
+
+    def _store_memory_typed(
+        self, dst: IROperand, dst_typ: VyperType, src: IROperand, src_typ: VyperType
+    ) -> None:
+        """Store memory value with potential source/destination type layout differences."""
+        if dst_typ._is_prim_word:
+            self.builder.mstore(dst, self.builder.mload(src))
+            return
+
+        if isinstance(dst_typ, _BytestringT) and isinstance(src_typ, _BytestringT):
+            # Bytes/string assignment is value-based: copy actual runtime length.
+            self.store_memory(src, dst, dst_typ)
+            return
+
+        if isinstance(dst_typ, DArrayT) and isinstance(src_typ, DArrayT):
+            self._copy_dynarray_memory_typed(dst, dst_typ, src, src_typ)
+            return
+
+        if isinstance(dst_typ, SArrayT) and isinstance(src_typ, SArrayT):
+            count = src_typ.count
+            dst_elem_t = dst_typ.value_type
+            src_elem_t = src_typ.value_type
+            dst_elem_size = dst_elem_t.memory_bytes_required
+            src_elem_size = src_elem_t.memory_bytes_required
+            for i in range(count):
+                dst_ptr = self._with_byte_offset(dst, i * dst_elem_size)
+                src_ptr = self._with_byte_offset(src, i * src_elem_size)
+                self._store_memory_typed(dst_ptr, dst_elem_t, src_ptr, src_elem_t)
+            return
+
+        if isinstance(dst_typ, TupleT) and isinstance(src_typ, TupleT):
+            dst_ofst = 0
+            src_ofst = 0
+            for dst_member_t, src_member_t in zip(dst_typ.member_types, src_typ.member_types):
+                dst_ptr = self._with_byte_offset(dst, dst_ofst)
+                src_ptr = self._with_byte_offset(src, src_ofst)
+                self._store_memory_typed(dst_ptr, dst_member_t, src_ptr, src_member_t)
+                dst_ofst += dst_member_t.memory_bytes_required
+                src_ofst += src_member_t.memory_bytes_required
+            return
+
+        if isinstance(dst_typ, StructT) and isinstance(src_typ, StructT):
+            dst_ofst = 0
+            src_ofst = 0
+            for name, dst_member_t in dst_typ.member_types.items():
+                src_member_t = src_typ.member_types[name]
+                dst_ptr = self._with_byte_offset(dst, dst_ofst)
+                src_ptr = self._with_byte_offset(src, src_ofst)
+                self._store_memory_typed(dst_ptr, dst_member_t, src_ptr, src_member_t)
+                dst_ofst += dst_member_t.memory_bytes_required
+                src_ofst += src_member_t.memory_bytes_required
+            return
+
+        # Fallback for compatible layouts not covered above.
+        self.copy_memory(dst, src, dst_typ.memory_bytes_required)
+
+    def _copy_dynarray_memory_typed(
+        self, dst: IROperand, dst_typ: DArrayT, src: IROperand, src_typ: DArrayT
+    ) -> None:
+        """Copy DynArray in memory when source and destination element layouts may differ."""
+        b = self.builder
+        length = b.mload(src)
+        b.mstore(dst, length)
+
+        dst_elem_t = dst_typ.value_type
+        src_elem_t = src_typ.value_type
+        dst_elem_size = dst_elem_t.memory_bytes_required
+        src_elem_size = src_elem_t.memory_bytes_required
+
+        src_data = self._with_byte_offset(src, 32)
+        dst_data = self._with_byte_offset(dst, 32)
+
+        # Fast path when element layouts match: copy exactly `length` elements.
+        if src_elem_t == dst_elem_t and src_elem_size == dst_elem_size:
+            data_size = b.mul(length, IRLiteral(dst_elem_size))
+            self.copy_memory_dynamic(dst_data, src_data, data_size)
+            return
+
+        cond_block = b.create_block("typed_dyn_copy_cond")
+        body_block = b.create_block("typed_dyn_copy_body")
+        exit_block = b.create_block("typed_dyn_copy_exit")
+
+        counter = b.assign(IRLiteral(0))
+        b.jmp(cond_block.label)
+
+        b.append_block(cond_block)
+        b.set_block(cond_block)
+        done = b.iszero(b.lt(counter, length))
+        cond_finish = b.current_block
+
+        b.append_block(body_block)
+        b.set_block(body_block)
+
+        src_ofst = b.mul(counter, IRLiteral(src_elem_size))
+        dst_ofst = b.mul(counter, IRLiteral(dst_elem_size))
+        src_elem_ptr = b.add(src_data, src_ofst)
+        dst_elem_ptr = b.add(dst_data, dst_ofst)
+
+        self._store_memory_typed(dst_elem_ptr, dst_elem_t, src_elem_ptr, src_elem_t)
+
+        new_counter = b.add(counter, IRLiteral(1))
+        b.assign_to(new_counter, counter)
+        b.jmp(cond_block.label)
+
+        cond_finish.append_instruction("jnz", done, exit_block.label, body_block.label)
+        b.append_block(exit_block)
+        b.set_block(exit_block)
 
     # Threshold for using identity precompile vs unrolling (pre-Cancun).
     # Identity precompile has ~25 bytes overhead, unrolling is ~15 bytes/word.

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -450,8 +450,7 @@ class VenomCodegenContext:
                 src_ofst += src_member_t.memory_bytes_required
             return
 
-        # Fallback for compatible layouts not covered above.
-        self.copy_memory(dst, src, dst_typ.memory_bytes_required)
+        raise CompilerPanic(f"_store_memory_typed: unhandled types {src_typ} -> {dst_typ}")
 
     def _copy_dynarray_memory_typed(
         self, dst: IROperand, dst_typ: DArrayT, src: IROperand, src_typ: DArrayT

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -473,6 +473,8 @@ class VenomCodegenContext:
         """Copy DynArray in memory when source and destination element layouts may differ."""
         b = self.builder
         length = b.mload(src)
+        # defensive: runtime length must not exceed destination capacity
+        b.assert_(b.iszero(b.gt(length, IRLiteral(dst_typ.length))))
         b.mstore(dst, length)
 
         dst_elem_t = dst_typ.value_type

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -432,15 +432,7 @@ class VenomCodegenContext:
 
         if isinstance(dst_typ, SArrayT) and isinstance(src_typ, SArrayT):
             assert src_typ.count == dst_typ.count
-            count = src_typ.count
-            dst_elem_t = dst_typ.value_type
-            src_elem_t = src_typ.value_type
-            dst_elem_size = dst_elem_t.memory_bytes_required
-            src_elem_size = src_elem_t.memory_bytes_required
-            for i in range(count):
-                dst_ptr = self._with_byte_offset(dst, i * dst_elem_size)
-                src_ptr = self._with_byte_offset(src, i * src_elem_size)
-                self._store_memory_typed(dst_ptr, dst_elem_t, src_ptr, src_elem_t)
+            self._copy_sarray_memory_typed(dst, dst_typ, src, src_typ)
             return
 
         if isinstance(dst_typ, TupleT) and isinstance(src_typ, TupleT):
@@ -467,6 +459,62 @@ class VenomCodegenContext:
             return
 
         raise CompilerPanic(f"_store_memory_typed: unhandled types {src_typ} -> {dst_typ}")
+
+    def _copy_sarray_memory_typed(
+        self, dst: IROperand, dst_typ: SArrayT, src: IROperand, src_typ: SArrayT
+    ) -> None:
+        """Copy SArray in memory when source and destination element layouts
+        may differ.
+
+        Mirrors the legacy codegen heuristic (_complex_make_setter):
+        batch-copy when element layouts match and no dynamic-sized children;
+        otherwise emit a runtime loop that copies element-by-element.
+        """
+        count = src_typ.count
+        dst_elem_t = dst_typ.value_type
+        src_elem_t = src_typ.value_type
+        dst_elem_size = dst_elem_t.memory_bytes_required
+        src_elem_size = src_elem_t.memory_bytes_required
+
+        # Fast path: batch copy when element layouts match and there is no
+        # dynamic-sized data (same heuristic as legacy _complex_make_setter).
+        if dst_elem_size == src_elem_size and not dst_typ.abi_type.is_dynamic():
+            self.copy_memory(dst, src, dst_typ.memory_bytes_required)
+            return
+
+        # Slow path: runtime loop, element-by-element copy.
+        b = self.builder
+        length = IRLiteral(count)
+
+        cond_block = b.create_block("typed_sa_copy_cond")
+        body_block = b.create_block("typed_sa_copy_body")
+        exit_block = b.create_block("typed_sa_copy_exit")
+
+        counter = b.assign(IRLiteral(0))
+        b.jmp(cond_block.label)
+
+        b.append_block(cond_block)
+        b.set_block(cond_block)
+        done = b.iszero(b.lt(counter, length))
+        cond_finish = b.current_block
+
+        b.append_block(body_block)
+        b.set_block(body_block)
+
+        src_ofst = b.mul(counter, IRLiteral(src_elem_size))
+        dst_ofst = b.mul(counter, IRLiteral(dst_elem_size))
+        src_elem_ptr = b.add(src, src_ofst)
+        dst_elem_ptr = b.add(dst, dst_ofst)
+
+        self._store_memory_typed(dst_elem_ptr, dst_elem_t, src_elem_ptr, src_elem_t)
+
+        new_counter = b.add(counter, IRLiteral(1))
+        b.assign_to(new_counter, counter)
+        b.jmp(cond_block.label)
+
+        cond_finish.append_instruction("jnz", done, exit_block.label, body_block.label)
+        b.append_block(exit_block)
+        b.set_block(exit_block)
 
     def _copy_dynarray_memory_typed(
         self, dst: IROperand, dst_typ: DArrayT, src: IROperand, src_typ: DArrayT

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -431,6 +431,7 @@ class VenomCodegenContext:
             return
 
         if isinstance(dst_typ, SArrayT) and isinstance(src_typ, SArrayT):
+            assert src_typ.count == dst_typ.count
             count = src_typ.count
             dst_elem_t = dst_typ.value_type
             src_elem_t = src_typ.value_type

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1585,7 +1585,7 @@ class Expr:
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         if (
-            data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT, DataLocation.CODE)
+            data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT)
             and not elem_typ._is_prim_word
             and elem_src_typ != elem_typ
         ):

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1430,7 +1430,7 @@ class Expr:
                 # Memory-passed arg: allocate buffer, copy value, pass pointer.
                 # Backend passes can forward safe readonly arguments.
                 buf_val = self.ctx.new_temporary_value(arg_t.typ)
-                self.ctx.store_memory(arg_op, buf_val.operand, arg_t.typ)
+                self.ctx.store_memory(arg_op, buf_val.operand, arg_t.typ, src_typ=arg_val.typ)
                 invoke_args.append(buf_val.operand)
 
         # Emit invoke instruction

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1584,6 +1584,13 @@ class Expr:
         else:
             elem_val = arg_val
 
+        if not elem_typ._is_prim_word and elem_src_typ != elem_typ:
+            # Normalize source layout for non-memory destinations.
+            normalized = self.ctx.new_temporary_value(elem_typ)
+            self.ctx.store_memory(elem_val, normalized.operand, elem_typ, src_typ=elem_src_typ)
+            elem_val = normalized.operand
+            elem_src_typ = elem_typ
+
         # Get location from VyperValue
         data_loc = darray_vv.location or DataLocation.MEMORY
         word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1771,7 +1771,7 @@ class Expr:
 
         # Evaluate arguments.
         arg_vals: list[tuple[IROperand, VyperType]] = []
-        for i, arg in enumerate(call_node.args):
+        for _, arg in enumerate(call_node.args):
             arg_vv = Expr(arg, self.ctx).lower()
             arg_vals.append((self.ctx.unwrap(arg_vv), arg_vv.typ))
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -236,14 +236,15 @@ class Expr:
         offset = 0
         for i, elem_node in enumerate(node.elements):
             elem_typ = typ.member_types[i]
-            elem_val = Expr(elem_node, self.ctx).lower_value()
+            elem_vv = Expr(elem_node, self.ctx).lower()
+            elem_val = self.ctx.unwrap(elem_vv)
 
             if offset == 0:
                 dst = val.operand
             else:
                 dst = self.builder.add(val.operand, IRLiteral(offset))
 
-            self.ctx.store_memory(elem_val, dst, elem_typ)
+            self.ctx.store_memory(elem_val, dst, elem_typ, src_typ=elem_vv.typ)
             offset += elem_typ.memory_bytes_required
 
         return val
@@ -278,14 +279,15 @@ class Expr:
 
         # Store each element
         for elem_node in node.elements:
-            elem_val = Expr(elem_node, self.ctx).lower_value()
+            elem_vv = Expr(elem_node, self.ctx).lower()
+            elem_val = self.ctx.unwrap(elem_vv)
 
             if data_offset == 0:
                 dst = val.operand
             else:
                 dst = self.builder.add(val.operand, IRLiteral(data_offset))
 
-            self.ctx.store_memory(elem_val, dst, elem_typ)
+            self.ctx.store_memory(elem_val, dst, elem_typ, src_typ=elem_vv.typ)
             data_offset += elem_size
 
         return val

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -60,7 +60,7 @@ class _CallKwargs:
     value: IROperand  # ETH value to send (CALL only)
     gas: IROperand  # Gas limit for the call
     skip_contract_check: bool  # Skip extcodesize check
-    default_return_value: Optional[IROperand]  # Default if returndatasize==0
+    default_return_value: Optional[VyperValue]  # Default if returndatasize==0
 
 
 # Environment variable prefixes for attribute access
@@ -1491,14 +1491,15 @@ class Expr:
         offset = 0
         for field_name in struct_t.tuple_keys():
             field_typ = struct_t.member_types[field_name]
-            field_val = Expr(member_vals[field_name], self.ctx).lower_value()
+            field_vv = Expr(member_vals[field_name], self.ctx).lower()
+            field_val = self.ctx.unwrap(field_vv)
 
             if offset == 0:
                 dst = val.operand
             else:
                 dst = self.builder.add(val.operand, IRLiteral(offset))
 
-            self.ctx.store_memory(field_val, dst, field_typ)
+            self.ctx.store_memory(field_val, dst, field_typ, src_typ=field_vv.typ)
             offset += field_typ.memory_bytes_required
 
         return val
@@ -1570,14 +1571,18 @@ class Expr:
         assert len(node.args) == 1
         arg_node = node.args[0]
 
+        arg_vv = Expr(arg_node, self.ctx).lower()
+        arg_val = self.ctx.unwrap(arg_vv)
+        elem_src_typ = arg_vv.typ
+
         if not elem_typ._is_prim_word and _potential_overlap_ast(darray_node, arg_node):
             # Overlap detected: copy arg to temp buffer first
-            arg_val = Expr(arg_node, self.ctx).lower_value()
             temp_buf = self.ctx.new_temporary_value(elem_typ)
-            self.ctx.store_memory(arg_val, temp_buf.operand, elem_typ)
+            self.ctx.store_memory(arg_val, temp_buf.operand, elem_typ, src_typ=elem_src_typ)
             elem_val = temp_buf.operand
+            elem_src_typ = elem_typ
         else:
-            elem_val = Expr(arg_node, self.ctx).lower_value()
+            elem_val = arg_val
 
         # Get location from VyperValue
         data_loc = darray_vv.location or DataLocation.MEMORY
@@ -1605,7 +1610,7 @@ class Expr:
         if elem_typ._is_prim_word:
             self.builder.store(elem_ptr, elem_val, data_loc)
         elif data_loc == DataLocation.MEMORY:
-            self.ctx.store_memory(elem_val, elem_ptr, elem_typ)
+            self.ctx.store_memory(elem_val, elem_ptr, elem_typ, src_typ=elem_src_typ)
         elif data_loc == DataLocation.STORAGE:
             self.ctx.store_storage(elem_val, elem_ptr, elem_typ)
         elif data_loc == DataLocation.TRANSIENT:
@@ -1699,9 +1704,13 @@ class Expr:
         value: IROperand = IRLiteral(0)
         gas: IROperand = self.builder.gas()
         skip_contract_check = False
-        default_return_value = None
+        default_return_value: Optional[VyperValue] = None
 
         for kw in call_node.keywords:
+            if kw.arg == "default_return_value":
+                default_return_value = Expr(kw.value, self.ctx).lower()
+                continue
+
             kw_val = Expr(kw.value, self.ctx).lower_value()
             if kw.arg == "value":
                 value = kw_val
@@ -1712,8 +1721,6 @@ class Expr:
                 if not isinstance(kw_val, IRLiteral):
                     raise CompilerPanic(f"Expected IRLiteral for keyword, got {type(kw_val)}")
                 skip_contract_check = bool(kw_val.value)
-            elif kw.arg == "default_return_value":
-                default_return_value = kw_val
             else:
                 raise CompilerPanic(f"Unexpected keyword argument: {kw.arg}")
 
@@ -1751,13 +1758,13 @@ class Expr:
         contract_address = Expr(call_node.func.value, self.ctx).lower_value()
 
         # Evaluate arguments
-        args = [Expr(arg, self.ctx).lower_value() for arg in call_node.args]
+        arg_vvs = [Expr(arg, self.ctx).lower() for arg in call_node.args]
 
         # Parse kwargs
         call_kwargs = self._parse_external_call_kwargs(call_node)
 
         # Calculate buffer size needed
-        args_tuple_t = TupleT(tuple(fn_type.arguments[i].typ for i in range(len(args))))
+        args_tuple_t = TupleT(tuple(fn_type.arguments[i].typ for i in range(len(arg_vvs))))
         args_abi_t = args_tuple_t.abi_type
         args_abi_size = args_abi_t.size_bound()
 
@@ -1781,19 +1788,20 @@ class Expr:
         self.ctx.ptr_store(buf.base_ptr(), IRLiteral(method_id))
 
         # ABI-encode arguments starting at buf+32
-        if len(args) > 0:
+        if len(arg_vvs) > 0:
             # Create temp buffer for args in memory
             args_val = self.ctx.new_temporary_value(args_tuple_t)
 
             # Store each arg at its position in args_buf
             offset = 0
-            for i, arg_val in enumerate(args):
+            for i, arg_vv in enumerate(arg_vvs):
                 arg_typ = fn_type.arguments[i].typ
+                arg_val = self.ctx.unwrap(arg_vv)
                 if offset == 0:
                     dst = args_val.operand
                 else:
                     dst = b.add(args_val.operand, IRLiteral(offset))
-                self.ctx.store_memory(arg_val, dst, arg_typ)
+                self.ctx.store_memory(arg_val, dst, arg_typ, src_typ=arg_vv.typ)
                 offset += arg_typ.memory_bytes_required
 
             # ABI-encode from args_buf to buf+32
@@ -1881,13 +1889,15 @@ class Expr:
             # Store default value - needs wrapping if single value
             if needs_external_call_wrap(return_t):
                 # Wrap single value in tuple
-                self.ctx.store_memory(
-                    call_kwargs.default_return_value, result_val.operand, return_t
-                )
+                default_vv = call_kwargs.default_return_value
+                assert default_vv is not None
+                default_val = self.ctx.unwrap(default_vv)
+                self.ctx.store_memory(default_val, result_val.operand, return_t, src_typ=default_vv.typ)
             else:
-                self.ctx.store_memory(
-                    call_kwargs.default_return_value, result_val.operand, return_t
-                )
+                default_vv = call_kwargs.default_return_value
+                assert default_vv is not None
+                default_val = self.ctx.unwrap(default_vv)
+                self.ctx.store_memory(default_val, result_val.operand, return_t, src_typ=default_vv.typ)
 
             # Check extcodesize if not skipped (contract might have selfdestructed)
             if not call_kwargs.skip_contract_check:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -35,7 +35,6 @@ from vyper.semantics.types import (
     InterfaceT,
     StringT,
     TupleT,
-    VyperType,
     is_type_t,
 )
 from vyper.semantics.types.base import VOID_TYPE
@@ -238,14 +237,13 @@ class Expr:
         for i, elem_node in enumerate(node.elements):
             elem_typ = typ.member_types[i]
             elem_vv = Expr(elem_node, self.ctx).lower()
-            elem_val = self.ctx.unwrap(elem_vv)
 
             if offset == 0:
                 dst = val.operand
             else:
                 dst = self.builder.add(val.operand, IRLiteral(offset))
 
-            self.ctx.store_memory(elem_val, dst, elem_typ, src_typ=elem_vv.typ)
+            self.ctx.store_vyper_value(elem_vv, dst, elem_typ)
             offset += elem_typ.memory_bytes_required
 
         return val
@@ -281,14 +279,13 @@ class Expr:
         # Store each element
         for elem_node in node.elements:
             elem_vv = Expr(elem_node, self.ctx).lower()
-            elem_val = self.ctx.unwrap(elem_vv)
 
             if data_offset == 0:
                 dst = val.operand
             else:
                 dst = self.builder.add(val.operand, IRLiteral(data_offset))
 
-            self.ctx.store_memory(elem_val, dst, elem_typ, src_typ=elem_vv.typ)
+            self.ctx.store_vyper_value(elem_vv, dst, elem_typ)
             data_offset += elem_size
 
         return val
@@ -1429,7 +1426,7 @@ class Expr:
                 # Memory-passed arg: allocate buffer, copy value, pass pointer.
                 # Backend passes can forward safe readonly arguments.
                 buf_val = self.ctx.new_temporary_value(arg_t.typ)
-                self.ctx.store_memory(arg_op, buf_val.operand, arg_t.typ, src_typ=arg_val.typ)
+                self.ctx.store_vyper_value(arg_val, buf_val.operand, arg_t.typ)
                 invoke_args.append(buf_val.operand)
 
         # Emit invoke instruction
@@ -1491,14 +1488,13 @@ class Expr:
         for field_name in struct_t.tuple_keys():
             field_typ = struct_t.member_types[field_name]
             field_vv = Expr(member_vals[field_name], self.ctx).lower()
-            field_val = self.ctx.unwrap(field_vv)
 
             if offset == 0:
                 dst = val.operand
             else:
                 dst = self.builder.add(val.operand, IRLiteral(offset))
 
-            self.ctx.store_memory(field_val, dst, field_typ, src_typ=field_vv.typ)
+            self.ctx.store_vyper_value(field_vv, dst, field_typ)
             offset += field_typ.memory_bytes_required
 
         return val
@@ -1577,7 +1573,7 @@ class Expr:
         if not elem_typ._is_prim_word and _potential_overlap_ast(darray_node, arg_node):
             # Overlap detected: copy arg to temp buffer first
             temp_buf = self.ctx.new_temporary_value(elem_typ)
-            self.ctx.store_memory(arg_val, temp_buf.operand, elem_typ, src_typ=elem_src_typ)
+            self.ctx.store_vyper_value(arg_vv, temp_buf.operand, elem_typ)
             elem_val = temp_buf.operand
             elem_src_typ = elem_typ
         else:
@@ -1770,10 +1766,9 @@ class Expr:
         contract_address = Expr(call_node.func.value, self.ctx).lower_value()
 
         # Evaluate arguments.
-        arg_vals: list[tuple[IROperand, VyperType]] = []
-        for _, arg in enumerate(call_node.args):
-            arg_vv = Expr(arg, self.ctx).lower()
-            arg_vals.append((self.ctx.unwrap(arg_vv), arg_vv.typ))
+        arg_vals: list[VyperValue] = []
+        for arg in call_node.args:
+            arg_vals.append(Expr(arg, self.ctx).lower())
 
         # Parse kwargs
         call_kwargs = self._parse_external_call_kwargs(call_node)
@@ -1809,13 +1804,13 @@ class Expr:
 
             # Store each arg at its position in args_buf
             offset = 0
-            for i, (arg_val, arg_src_typ) in enumerate(arg_vals):
+            for i, arg_vv in enumerate(arg_vals):
                 arg_typ = fn_type.arguments[i].typ
                 if offset == 0:
                     dst = args_val.operand
                 else:
                     dst = b.add(args_val.operand, IRLiteral(offset))
-                self.ctx.store_memory(arg_val, dst, arg_typ, src_typ=arg_src_typ)
+                self.ctx.store_vyper_value(arg_vv, dst, arg_typ)
                 offset += arg_typ.memory_bytes_required
 
             # ABI-encode from args_buf to buf+32
@@ -1903,8 +1898,7 @@ class Expr:
             # Store default value
             default_vv = call_kwargs.default_return_value
             assert default_vv is not None
-            default_val = self.ctx.unwrap(default_vv)
-            self.ctx.store_memory(default_val, result_val.operand, return_t, src_typ=default_vv.typ)
+            self.ctx.store_vyper_value(default_vv, result_val.operand, return_t)
 
             # Check extcodesize if not skipped (contract might have selfdestructed)
             if not call_kwargs.skip_contract_check:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1716,7 +1716,17 @@ class Expr:
 
         for kw in call_node.keywords:
             if kw.arg == "default_return_value":
-                default_return_value = Expr(kw.value, self.ctx).lower()
+                drv_vv = Expr(kw.value, self.ctx).lower()
+                # Eagerly materialize mutable-location values so the read
+                # happens before CALL, not in the post-call default block
+                # (avoids reentrancy-dependent fallback semantics).
+                if drv_vv.location is not None and drv_vv.location in (
+                    DataLocation.STORAGE,
+                    DataLocation.TRANSIENT,
+                ):
+                    materialized = self.ctx.unwrap(drv_vv)
+                    drv_vv = VyperValue.from_stack_op(materialized, drv_vv.typ)
+                default_return_value = drv_vv
                 continue
 
             kw_val = Expr(kw.value, self.ctx).lower_value()

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1584,16 +1584,20 @@ class Expr:
         else:
             elem_val = arg_val
 
-        if not elem_typ._is_prim_word and elem_src_typ != elem_typ:
-            # Normalize source layout for non-memory destinations.
+        # Get location from VyperValue
+        data_loc = darray_vv.location or DataLocation.MEMORY
+        word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
+
+        if (
+            data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT, DataLocation.CODE)
+            and not elem_typ._is_prim_word
+            and elem_src_typ != elem_typ
+        ):
+            # Normalize source layout for locations that only understand destination layout.
             normalized = self.ctx.new_temporary_value(elem_typ)
             self.ctx.store_memory(elem_val, normalized.operand, elem_typ, src_typ=elem_src_typ)
             elem_val = normalized.operand
             elem_src_typ = elem_typ
-
-        # Get location from VyperValue
-        data_loc = darray_vv.location or DataLocation.MEMORY
-        word_scale = 1 if data_loc in (DataLocation.STORAGE, DataLocation.TRANSIENT) else 32
 
         elem_size = elem_typ.get_size_in(data_loc)
         capacity = darray_typ.count  # Maximum length

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1770,16 +1770,10 @@ class Expr:
         contract_address = Expr(call_node.func.value, self.ctx).lower_value()
 
         # Evaluate arguments.
-        # For primitive words, materialize values directly to avoid carrying
-        # location metadata through later ABI-pack staging.
         arg_vals: list[tuple[IROperand, VyperType]] = []
         for i, arg in enumerate(call_node.args):
-            arg_typ = fn_type.arguments[i].typ
-            if arg_typ._is_prim_word:
-                arg_vals.append((Expr(arg, self.ctx).lower_value(), arg_typ))
-            else:
-                arg_vv = Expr(arg, self.ctx).lower()
-                arg_vals.append((self.ctx.unwrap(arg_vv), arg_vv.typ))
+            arg_vv = Expr(arg, self.ctx).lower()
+            arg_vals.append((self.ctx.unwrap(arg_vv), arg_vv.typ))
 
         # Parse kwargs
         call_kwargs = self._parse_external_call_kwargs(call_node)

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -35,6 +35,7 @@ from vyper.semantics.types import (
     InterfaceT,
     StringT,
     TupleT,
+    VyperType,
     is_type_t,
 )
 from vyper.semantics.types.base import VOID_TYPE
@@ -1768,14 +1769,23 @@ class Expr:
         # Evaluate contract address (the interface value)
         contract_address = Expr(call_node.func.value, self.ctx).lower_value()
 
-        # Evaluate arguments
-        arg_vvs = [Expr(arg, self.ctx).lower() for arg in call_node.args]
+        # Evaluate arguments.
+        # For primitive words, materialize values directly to avoid carrying
+        # location metadata through later ABI-pack staging.
+        arg_vals: list[tuple[IROperand, VyperType]] = []
+        for i, arg in enumerate(call_node.args):
+            arg_typ = fn_type.arguments[i].typ
+            if arg_typ._is_prim_word:
+                arg_vals.append((Expr(arg, self.ctx).lower_value(), arg_typ))
+            else:
+                arg_vv = Expr(arg, self.ctx).lower()
+                arg_vals.append((self.ctx.unwrap(arg_vv), arg_vv.typ))
 
         # Parse kwargs
         call_kwargs = self._parse_external_call_kwargs(call_node)
 
         # Calculate buffer size needed
-        args_tuple_t = TupleT(tuple(fn_type.arguments[i].typ for i in range(len(arg_vvs))))
+        args_tuple_t = TupleT(tuple(fn_type.arguments[i].typ for i in range(len(arg_vals))))
         args_abi_t = args_tuple_t.abi_type
         args_abi_size = args_abi_t.size_bound()
 
@@ -1799,20 +1809,19 @@ class Expr:
         self.ctx.ptr_store(buf.base_ptr(), IRLiteral(method_id))
 
         # ABI-encode arguments starting at buf+32
-        if len(arg_vvs) > 0:
+        if len(arg_vals) > 0:
             # Create temp buffer for args in memory
             args_val = self.ctx.new_temporary_value(args_tuple_t)
 
             # Store each arg at its position in args_buf
             offset = 0
-            for i, arg_vv in enumerate(arg_vvs):
+            for i, (arg_val, arg_src_typ) in enumerate(arg_vals):
                 arg_typ = fn_type.arguments[i].typ
-                arg_val = self.ctx.unwrap(arg_vv)
                 if offset == 0:
                     dst = args_val.operand
                 else:
                     dst = b.add(args_val.operand, IRLiteral(offset))
-                self.ctx.store_memory(arg_val, dst, arg_typ, src_typ=arg_vv.typ)
+                self.ctx.store_memory(arg_val, dst, arg_typ, src_typ=arg_src_typ)
                 offset += arg_typ.memory_bytes_required
 
             # ABI-encode from args_buf to buf+32

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1893,18 +1893,11 @@ class Expr:
             b.append_block(default_bb)
             b.set_block(default_bb)
 
-            # Store default value - needs wrapping if single value
-            if needs_external_call_wrap(return_t):
-                # Wrap single value in tuple
-                default_vv = call_kwargs.default_return_value
-                assert default_vv is not None
-                default_val = self.ctx.unwrap(default_vv)
-                self.ctx.store_memory(default_val, result_val.operand, return_t, src_typ=default_vv.typ)
-            else:
-                default_vv = call_kwargs.default_return_value
-                assert default_vv is not None
-                default_val = self.ctx.unwrap(default_vv)
-                self.ctx.store_memory(default_val, result_val.operand, return_t, src_typ=default_vv.typ)
+            # Store default value
+            default_vv = call_kwargs.default_return_value
+            assert default_vv is not None
+            default_val = self.ctx.unwrap(default_vv)
+            self.ctx.store_memory(default_val, result_val.operand, return_t, src_typ=default_vv.typ)
 
             # Check extcodesize if not skipped (contract might have selfdestructed)
             if not call_kwargs.skip_contract_check:

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -1127,8 +1127,7 @@ def _handle_kwargs(
                 ctx.ptr_store(var.value.ptr(), default_val)
             else:
                 default_vv = Expr(default_node, ctx).lower()
-                default_val = ctx.unwrap(default_vv)
-                ctx.store_memory(default_val, var.value.operand, arg.typ, src_typ=default_vv.typ)
+                ctx.store_vyper_value(default_vv, var.value.operand, arg.typ)
 
 
 def _create_kwarg_allocas(
@@ -1213,8 +1212,7 @@ def _init_kwargs_in_entry_point(
                 ctx.builder.mstore(alloca_ptr, default_val)
             else:
                 default_vv = Expr(default_node, ctx).lower()
-                default_val = ctx.unwrap(default_vv)
-                ctx.store_memory(default_val, alloca_ptr, arg.typ, src_typ=default_vv.typ)
+                ctx.store_vyper_value(default_vv, alloca_ptr, arg.typ)
 
 
 def _register_kwarg_variables(ctx: VenomCodegenContext, func_t: ContractFunctionT) -> None:

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -1126,8 +1126,9 @@ def _handle_kwargs(
                 default_val = Expr(default_node, ctx).lower_value()
                 ctx.ptr_store(var.value.ptr(), default_val)
             else:
-                default_val = Expr(default_node, ctx).lower().operand
-                ctx.store_memory(default_val, var.value.operand, arg.typ)
+                default_vv = Expr(default_node, ctx).lower()
+                default_val = ctx.unwrap(default_vv)
+                ctx.store_memory(default_val, var.value.operand, arg.typ, src_typ=default_vv.typ)
 
 
 def _create_kwarg_allocas(
@@ -1211,8 +1212,9 @@ def _init_kwargs_in_entry_point(
                 default_val = Expr(default_node, ctx).lower_value()
                 ctx.builder.mstore(alloca_ptr, default_val)
             else:
-                default_val = Expr(default_node, ctx).lower().operand
-                ctx.store_memory(default_val, alloca_ptr, arg.typ)
+                default_vv = Expr(default_node, ctx).lower()
+                default_val = ctx.unwrap(default_vv)
+                ctx.store_memory(default_val, alloca_ptr, arg.typ, src_typ=default_vv.typ)
 
 
 def _register_kwarg_variables(ctx: VenomCodegenContext, func_t: ContractFunctionT) -> None:

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -131,17 +131,18 @@ class Stmt:
         no aliasing is possible and the staging copy is skipped.
         """
         src_loc = src_vv.location  # None for stack values, else DataLocation
+        src_typ = src_vv.typ
         src = self.ctx.unwrap(src_vv)  # always a memory ptr for complex types
 
         if src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY:
             # Both in memory — stage through temp for overlap safety.
-            tmp_val = self.ctx.new_temporary_value(typ)
-            self.ctx.copy_memory(tmp_val.operand, src, typ.memory_bytes_required)
+            tmp_val = self.ctx.new_temporary_value(src_typ)
+            self.ctx.copy_memory(tmp_val.operand, src, src_typ.memory_bytes_required)
             src = tmp_val.operand
 
-        self._store_complex_type(dst_ptr, src, typ)
+        self._store_complex_type(dst_ptr, src, typ, src_typ)
 
-    def _store_complex_type(self, dst_ptr: Ptr, src: IROperand, typ) -> None:
+    def _store_complex_type(self, dst_ptr: Ptr, src: IROperand, typ, src_typ) -> None:
         """Store complex value from memory `src` into `dst_ptr` (no overlap guard).
 
         Only called from `_copy_complex_type` which handles staging when needed.
@@ -174,7 +175,7 @@ class Stmt:
             else:
                 self.ctx.store_immutable(src, dst_ptr.operand, typ)
         else:
-            self.ctx.copy_memory(dst_ptr.operand, src, typ.memory_bytes_required)
+            self.ctx.store_memory(src, dst_ptr.operand, typ, src_typ=src_typ)
 
     def _lower_tuple_unpack(self) -> None:
         """Lower tuple unpacking assignment: a, b = expr.

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -204,6 +204,8 @@ class Stmt:
         # src is a pointer to the source tuple in memory
         src_tuple_typ = src_vv.typ
         dst_tuple_typ = target._metadata["type"]
+        assert isinstance(src_tuple_typ, TupleT)
+        assert isinstance(dst_tuple_typ, TupleT)
         targets = target.elements
 
         # First pass: load all values from source tuple to temp variables.

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -93,15 +93,11 @@ class Stmt:
         if isinstance(target, vy_ast.Tuple):
             return self._lower_tuple_unpack()
 
-        # Special case: empty Bytestring assignment to storage/transient.
+        # Special case: empty Bytestring assignment — just zero the length word.
         if isinstance(target_typ, _BytestringT) and self._is_empty_value(node.value):
             dst_ptr = self._get_target_ptr(target)
-            if dst_ptr.location == DataLocation.STORAGE:
-                self.builder.sstore(dst_ptr.operand, IRLiteral(0))
-                return
-            elif dst_ptr.location == DataLocation.TRANSIENT:
-                self.builder.tstore(dst_ptr.operand, IRLiteral(0))
-                return
+            self.ctx.ptr_store(dst_ptr, IRLiteral(0))
+            return
 
         # IMPORTANT: Evaluate RHS first, then compute LHS target pointer.
         # This matches legacy codegen and ensures proper semantics for cases
@@ -127,12 +123,7 @@ class Stmt:
         """
         if isinstance(typ, _BytestringT) and self._is_empty_value(src_node):
             # Empty bytes/string assignment only needs a zero length word.
-            if dst_ptr.location == DataLocation.STORAGE:
-                self.builder.sstore(dst_ptr.operand, IRLiteral(0))
-            elif dst_ptr.location == DataLocation.TRANSIENT:
-                self.builder.tstore(dst_ptr.operand, IRLiteral(0))
-            else:
-                self.ctx.ptr_store(dst_ptr, IRLiteral(0))
+            self.ctx.ptr_store(dst_ptr, IRLiteral(0))
             return
 
         if typ._is_prim_word:

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -824,19 +824,22 @@ class Stmt:
 
         # Evaluate return value if present
         ret_val: Optional[IROperand] = None
+        ret_src_typ = None
         if node.value is not None:
-            # lower_value() handles all locations (storage, memory, code)
-            # and returns a usable value (loaded for primitives, memory ptr for complex)
-            ret_val = Expr(node.value, self.ctx).lower_value()
+            # lower() preserves source type so return coercions can use
+            # layout-aware copying when source and declared return type differ.
+            ret_vv = Expr(node.value, self.ctx).lower()
+            ret_val = self.ctx.unwrap(ret_vv)
+            ret_src_typ = ret_vv.typ
 
         # Dispatch: internal vs external
         if self.ctx.return_pc is not None:
-            self._lower_internal_return(ret_val, func_t)
+            self._lower_internal_return(ret_val, func_t, ret_src_typ)
         else:
-            self._lower_external_return(ret_val, func_t)
+            self._lower_external_return(ret_val, func_t, ret_src_typ)
 
     def _lower_internal_return(
-        self, ret_val: Optional[IROperand], func_t: ContractFunctionT
+        self, ret_val: Optional[IROperand], func_t: ContractFunctionT, ret_src_typ=None
     ) -> None:
         """Lower internal function return.
 
@@ -878,14 +881,14 @@ class Stmt:
 
         elif self.ctx.return_buffer is not None:
             # Memory return - store to buffer, caller reads it
-            self.ctx.store_memory(ret_val, self.ctx.return_buffer, ret_typ)
+            self.ctx.store_memory(ret_val, self.ctx.return_buffer, ret_typ, src_typ=ret_src_typ)
             self.builder.ret(return_pc)
 
         else:
             raise CompilerPanic("Internal function missing return mechanism")
 
     def _lower_external_return(
-        self, ret_val: Optional[IROperand], func_t: ContractFunctionT
+        self, ret_val: Optional[IROperand], func_t: ContractFunctionT, ret_src_typ=None
     ) -> None:
         """Lower external function return.
 
@@ -905,13 +908,24 @@ class Stmt:
         ret_typ = func_t.return_type
         assert ret_typ is not None
 
+        if (
+            ret_src_typ is not None
+            and not ret_typ._is_prim_word
+            and ret_src_typ != ret_typ
+            and ret_val is not None
+        ):
+            normalized = self.ctx.new_temporary_value(ret_typ)
+            self.ctx.store_memory(ret_val, normalized.operand, ret_typ, src_typ=ret_src_typ)
+            ret_val = normalized.operand
+            ret_src_typ = ret_typ
+
         # Raw return: return bytes directly without ABI encoding
         # The @raw_return decorator bypasses ABI encoding for proxy patterns
         if func_t.do_raw_return:
             # ret_val is a pointer to [length (32 bytes)][data...]
             # Copy to a fresh buffer to ensure it's in memory
             buf_val = self.ctx.new_temporary_value(ret_typ)
-            self.ctx.store_memory(ret_val, buf_val.operand, ret_typ)
+            self.ctx.store_memory(ret_val, buf_val.operand, ret_typ, src_typ=ret_src_typ)
 
             # Get length from first 32 bytes
             return_len = self.builder.mload(buf_val.operand)
@@ -968,22 +982,23 @@ class Stmt:
             arg_nodes = call_node.args
 
         # Lower all argument expressions
-        # lower_value() handles storage/code -> memory copy for complex types
         args = []
         for arg in arg_nodes:
             arg_typ = arg._metadata["type"]
-            args.append((Expr(arg, self.ctx).lower_value(), arg_typ))
+            arg_vv = Expr(arg, self.ctx).lower()
+            arg_val = self.ctx.unwrap(arg_vv)
+            args.append((arg_val, arg_typ, arg_vv.typ))
 
         # Split into indexed (topics) and non-indexed (data)
         topic_vals = []
         data_vals = []
         data_typs = []
 
-        for (arg_val, arg_typ), is_indexed in zip(args, event.indexed):
+        for (arg_val, arg_typ, src_typ), is_indexed in zip(args, event.indexed):
             if is_indexed:
                 topic_vals.append((arg_val, arg_typ))
             else:
-                data_vals.append(arg_val)
+                data_vals.append((arg_val, src_typ))
                 data_typs.append(arg_typ)
 
         # Build topics list - starts with event signature hash
@@ -1006,12 +1021,12 @@ class Stmt:
 
             # Store each data value into the tuple buffer
             offset = 0
-            for val, typ in zip(data_vals, data_typs):
+            for (val, src_typ), typ in zip(data_vals, data_typs):
                 if offset == 0:
                     dst = data_buf._ptr
                 else:
                     dst = self.builder.add(data_buf._ptr, IRLiteral(offset))
-                self.ctx.store_memory(val, dst, typ)
+                self.ctx.store_memory(val, dst, typ, src_typ=src_typ)
                 offset += typ.memory_bytes_required
 
             # Allocate ABI encoding output buffer
@@ -1197,7 +1212,7 @@ class Stmt:
         # We need to store it at a location so we can encode the tuple
         # For a tuple (string,), we store the string pointer, then encode
         tuple_buf = self.ctx.allocate_buffer(wrapped_typ.memory_bytes_required)
-        self.ctx.store_memory(msg_val, tuple_buf._ptr, msg_typ)
+        self.ctx.store_memory(msg_val, tuple_buf._ptr, msg_typ, src_typ=msg_vv.typ)
 
         # ABI encode the wrapped message to payload buffer
         encoded_len = abi_encode_to_buf(self.ctx, payload_buf, tuple_buf._ptr, wrapped_typ)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -239,10 +239,22 @@ class Stmt:
             else:
                 # Complex element type: val is a memory pointer in source layout.
                 if target_ptr.location is DataLocation.MEMORY:
-                    # Keep source snapshot stable across earlier tuple stores.
-                    staged = self.ctx.new_temporary_value(src_elem_typ)
-                    self.ctx.copy_memory(staged.operand, val, src_elem_typ.memory_bytes_required)
-                    val = staged.operand
+                    if src_elem_typ != dst_elem_typ:
+                        # Normalize into destination layout (implicitly snapshots
+                        # source data, protecting against aliasing from earlier writes).
+                        normalized = self.ctx.new_temporary_value(dst_elem_typ)
+                        self.ctx.store_memory(
+                            val, normalized.operand, dst_elem_typ, src_typ=src_elem_typ
+                        )
+                        val = normalized.operand
+                        src_elem_typ = dst_elem_typ
+                    else:
+                        # Same layout: explicit snapshot for aliasing safety.
+                        staged = self.ctx.new_temporary_value(src_elem_typ)
+                        self.ctx.copy_memory(
+                            staged.operand, val, src_elem_typ.memory_bytes_required
+                        )
+                        val = staged.operand
                 self._store_complex_type(target_ptr, val, dst_elem_typ, src_elem_typ)
 
     def lower_AugAssign(self) -> None:
@@ -765,8 +777,11 @@ class Stmt:
                     val = self.builder.load(elem_addr, location)
                     self.builder.mstore(item_local.value.operand, val)
                 else:
-                    # Multi-word: use context helper which handles pre-Cancun
-                    self.ctx.copy_memory(item_local.value.operand, elem_addr, elem_size)
+                    # Multi-word: layout-aware copy handles element size mismatches
+                    self.ctx.store_memory(
+                        elem_addr, item_local.value.operand,
+                        target_type, src_typ=array_typ.value_type
+                    )
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -193,8 +193,11 @@ class Stmt:
                 self._copy_dynarray_to_storage(src, dst_ptr.operand, typ, transient=transient)
             else:
                 # store_storage / store_transient handle single-word mload internally.
-                store_fn = self.ctx.store_transient if loc is DataLocation.TRANSIENT \
+                store_fn = (
+                    self.ctx.store_transient
+                    if loc is DataLocation.TRANSIENT
                     else self.ctx.store_storage
+                )
                 store_fn(src, dst_ptr.operand, typ)
         elif loc == DataLocation.IMMUTABLES:
             # Immutables in constructor

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -779,8 +779,10 @@ class Stmt:
                 else:
                     # Multi-word: layout-aware copy handles element size mismatches
                     self.ctx.store_memory(
-                        elem_addr, item_local.value.operand,
-                        target_type, src_typ=array_typ.value_type
+                        elem_addr,
+                        item_local.value.operand,
+                        target_type,
+                        src_typ=array_typ.value_type,
                     )
 
             self._lower_body(node.body)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -826,10 +826,7 @@ class Stmt:
             else:
                 # Memory, complex type: type-aware copy handles
                 # layout mismatches (e.g. DynArray[Bytes[540]] -> Bytes[704])
-                self.ctx.store_memory(
-                    elem_addr, dst, target_type,
-                    src_typ=array_typ.value_type,
-                )
+                self.ctx.store_memory(elem_addr, dst, target_type, src_typ=array_typ.value_type)
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -147,7 +147,7 @@ class Stmt:
 
         Only called from `_copy_complex_type` which handles staging when needed.
         """
-        if src_typ != typ:
+        if src_typ != typ and dst_ptr.location is not DataLocation.MEMORY:
             # Normalize source into destination layout before writing to
             # storage/transient/code locations that don't carry src_typ.
             normalized = self.ctx.new_temporary_value(typ)
@@ -183,7 +183,10 @@ class Stmt:
             else:
                 self.ctx.store_immutable(src, dst_ptr.operand, typ)
         else:
-            self.ctx.store_memory(src, dst_ptr.operand, typ, src_typ=src_typ)
+            if src_typ == typ:
+                self.ctx.copy_memory(dst_ptr.operand, src, typ.memory_bytes_required)
+            else:
+                self.ctx.store_memory(src, dst_ptr.operand, typ, src_typ=src_typ)
 
     def _lower_tuple_unpack(self) -> None:
         """Lower tuple unpacking assignment: a, b = expr.
@@ -218,6 +221,23 @@ class Stmt:
             src_member_types = tuple(src_member_types.values())
         if isinstance(dst_member_types, dict):
             dst_member_types = tuple(dst_member_types.values())
+
+        # If source and destination may alias in memory, snapshot the source tuple once.
+        # This preserves tuple-assignment semantics (a, b = b, a) for complex members
+        # without staging each element individually.
+        src_expr = node.value.reduced()
+        source_is_memory_view = isinstance(
+            src_expr, (vy_ast.Name, vy_ast.Attribute, vy_ast.Subscript)
+        )
+        if (
+            source_is_memory_view
+            and src_vv.location is DataLocation.MEMORY
+            and any(not t._is_prim_word for t in src_member_types)
+        ):
+            staged_src = self.ctx.new_temporary_value(src_tuple_typ)
+            self.ctx.copy_memory(staged_src.operand, src, src_tuple_typ.memory_bytes_required)
+            src = staged_src.operand
+
         for src_elem_typ, dst_elem_typ in zip(src_member_types, dst_member_types):
             if src_offset == 0:
                 elem_ptr = src
@@ -240,23 +260,6 @@ class Stmt:
                 self.ctx.ptr_store(target_ptr, val)
             else:
                 # Complex element type: val is a memory pointer in source layout.
-                if target_ptr.location is DataLocation.MEMORY:
-                    if src_elem_typ != dst_elem_typ:
-                        # Normalize into destination layout (implicitly snapshots
-                        # source data, protecting against aliasing from earlier writes).
-                        normalized = self.ctx.new_temporary_value(dst_elem_typ)
-                        self.ctx.store_memory(
-                            val, normalized.operand, dst_elem_typ, src_typ=src_elem_typ
-                        )
-                        val = normalized.operand
-                        src_elem_typ = dst_elem_typ
-                    else:
-                        # Same layout: explicit snapshot for aliasing safety.
-                        staged = self.ctx.new_temporary_value(src_elem_typ)
-                        self.ctx.copy_memory(
-                            staged.operand, val, src_elem_typ.memory_bytes_required
-                        )
-                        val = staged.operand
                 self._store_complex_type(target_ptr, val, dst_elem_typ, src_elem_typ)
 
     def lower_AugAssign(self) -> None:
@@ -933,6 +936,9 @@ class Stmt:
         if (
             ret_src_typ is not None
             and not ret_typ._is_prim_word
+            and not (
+                isinstance(ret_typ, _BytestringT) and isinstance(ret_src_typ, _BytestringT)
+            )
             and ret_src_typ != ret_typ
             and ret_val is not None
         ):

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -182,26 +182,21 @@ class Stmt:
             src = normalized.operand
             src_typ = typ
 
-        if dst_ptr.location == DataLocation.STORAGE:
+        loc = dst_ptr.location
+        is_slot_addressed = loc in (DataLocation.STORAGE, DataLocation.TRANSIENT)
+
+        if is_slot_addressed:
             # DynArray special case: only copy length + actual elements, not full capacity.
             # This matches legacy codegen behavior (core.py:_dynarray_make_setter).
             if isinstance(typ, DArrayT):
-                self._copy_dynarray_to_storage(src, dst_ptr.operand, typ, transient=False)
-            elif typ.storage_size_in_words == 1:
-                val = self.builder.mload(src)
-                self.builder.sstore(dst_ptr.operand, val)
+                transient = loc is DataLocation.TRANSIENT
+                self._copy_dynarray_to_storage(src, dst_ptr.operand, typ, transient=transient)
             else:
-                self.ctx.store_storage(src, dst_ptr.operand, typ)
-        elif dst_ptr.location == DataLocation.TRANSIENT:
-            # DynArray special case for transient storage
-            if isinstance(typ, DArrayT):
-                self._copy_dynarray_to_storage(src, dst_ptr.operand, typ, transient=True)
-            elif typ.storage_size_in_words == 1:
-                val = self.builder.mload(src)
-                self.builder.tstore(dst_ptr.operand, val)
-            else:
-                self.ctx.store_transient(src, dst_ptr.operand, typ)
-        elif dst_ptr.location == DataLocation.IMMUTABLES:
+                # store_storage / store_transient handle single-word mload internally.
+                store_fn = self.ctx.store_transient if loc is DataLocation.TRANSIENT \
+                    else self.ctx.store_storage
+                store_fn(src, dst_ptr.operand, typ)
+        elif loc == DataLocation.IMMUTABLES:
             # Immutables in constructor
             if typ.memory_bytes_required <= 32:
                 val = self.builder.mload(src)
@@ -209,17 +204,8 @@ class Stmt:
             else:
                 self.ctx.store_immutable(src, dst_ptr.operand, typ)
         else:
-            if src_typ == typ:
-                self.ctx.copy_memory(dst_ptr.operand, src, typ.memory_bytes_required)
-            elif (
-                isinstance(src_typ, _BytestringT)
-                and isinstance(typ, _BytestringT)
-                and src_typ.memory_bytes_required == typ.memory_bytes_required
-            ):
-                # Same in-memory layout (same padded payload size): direct copy is enough.
-                self.ctx.copy_memory(dst_ptr.operand, src, typ.memory_bytes_required)
-            else:
-                self.ctx.store_memory(src, dst_ptr.operand, typ, src_typ=src_typ)
+            # Memory destination: use layout-aware copy when types differ.
+            self.ctx.store_memory(src, dst_ptr.operand, typ, src_typ=src_typ)
 
     def _lower_tuple_unpack(self) -> None:
         """Lower tuple unpacking assignment: a, b = expr.

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -167,9 +167,10 @@ class Stmt:
         should_stage = False
         if src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY:
             # Stage only when source and destination are views of the same memory root.
-            src_root = _get_root_variable(src_node) if src_node is not None else None
-            dst_root = _get_root_variable(dst_node) if dst_node is not None else None
-            should_stage = src_root is not None and src_root == dst_root
+            assert src_node is not None and dst_node is not None, "missing AST nodes for memory→memory aliasing check"
+            src_root = _get_root_variable(src_node)
+            dst_root = _get_root_variable(dst_node)
+            should_stage = src_root is None or dst_root is None or src_root == dst_root
 
         if should_stage:
             tmp_val = self.ctx.new_temporary_value(src_typ)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -125,7 +125,11 @@ class Stmt:
         (with overlap-safe copying when source and dest are in the same
         address space).
         """
-        if isinstance(typ, _BytestringT) and src_node is not None and self._is_empty_value(src_node):
+        if (
+            isinstance(typ, _BytestringT)
+            and src_node is not None
+            and self._is_empty_value(src_node)
+        ):
             # Empty bytes/string assignment only needs a zero length word.
             if dst_ptr.location == DataLocation.STORAGE:
                 self.builder.sstore(dst_ptr.operand, IRLiteral(0))
@@ -220,6 +224,13 @@ class Stmt:
                 self.ctx.store_immutable(src, dst_ptr.operand, typ)
         else:
             if src_typ == typ:
+                self.ctx.copy_memory(dst_ptr.operand, src, typ.memory_bytes_required)
+            elif (
+                isinstance(src_typ, _BytestringT)
+                and isinstance(typ, _BytestringT)
+                and src_typ.memory_bytes_required == typ.memory_bytes_required
+            ):
+                # Same in-memory layout (same padded payload size): direct copy is enough.
                 self.ctx.copy_memory(dst_ptr.operand, src, typ.memory_bytes_required)
             else:
                 self.ctx.store_memory(src, dst_ptr.operand, typ, src_typ=src_typ)
@@ -972,9 +983,7 @@ class Stmt:
         if (
             ret_src_typ is not None
             and not ret_typ._is_prim_word
-            and not (
-                isinstance(ret_typ, _BytestringT) and isinstance(ret_src_typ, _BytestringT)
-            )
+            and not (isinstance(ret_typ, _BytestringT) and isinstance(ret_src_typ, _BytestringT))
             and ret_src_typ != ret_typ
             and ret_val is not None
         ):

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -807,35 +807,29 @@ class Stmt:
                 total_offset = index_offset
             elem_addr = self.builder.add(array, total_offset)
 
-            # Copy element to loop variable (always in memory)
+            # Copy element to loop variable (always in memory).
+            # Invariant: type mismatches (target_type != value_type) only
+            # occur for memory sources — for-loop var type always matches
+            # the array element type for non-memory locations.
             dst = item_local.value.operand
             if is_slot_addressed:
+                # Word-addressed (STORAGE, TRANSIENT)
                 self.ctx.slot_to_memory(elem_addr, dst, elem_size, location)
-            elif location is DataLocation.MEMORY:
-                if elem_size <= 32:
-                    val = self.builder.mload(elem_addr)
-                    self.builder.mstore(dst, val)
-                else:
-                    # Layout-aware copy for element size mismatches
-                    self.ctx.store_memory(
-                        elem_addr, dst, target_type,
-                        src_typ=array_typ.value_type,
-                    )
+            elif location is not DataLocation.MEMORY:
+                # Byte-addressed non-memory (IMMUTABLES, CODE, CALLDATA):
+                # location-aware copy via load_word dispatch
+                self.ctx.copy_to_memory(dst, elem_addr, elem_size, location)
+            elif target_type._is_prim_word:
+                # Memory, single word
+                val = self.builder.mload(elem_addr)
+                self.builder.mstore(dst, val)
             else:
-                # Non-memory byte-addressed (IMMUTABLES, CODE, CALLDATA):
-                # materialize to memory first via location-aware copy
-                if target_type == array_typ.value_type:
-                    # Same type: copy directly to loop var
-                    self.ctx.copy_to_memory(dst, elem_addr, elem_size, location)
-                else:
-                    # Type mismatch: copy to temp, then repack
-                    tmp_buf = self.ctx.allocate_buffer(elem_size)
-                    tmp = tmp_buf.base_ptr().operand
-                    self.ctx.copy_to_memory(tmp, elem_addr, elem_size, location)
-                    self.ctx.store_memory(
-                        tmp, dst, target_type,
-                        src_typ=array_typ.value_type,
-                    )
+                # Memory, complex type: type-aware copy handles
+                # layout mismatches (e.g. DynArray[Bytes[540]] -> Bytes[704])
+                self.ctx.store_memory(
+                    elem_addr, dst, target_type,
+                    src_typ=array_typ.value_type,
+                )
 
             self._lower_body(node.body)
             body_finish = self.builder.current_block

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -1247,7 +1247,6 @@ class Stmt:
         try:
             self.ctx.constancy = Constancy.Constant
             msg_vv = Expr(msg, self.ctx).lower()
-            msg_val = self.ctx.unwrap(msg_vv)  # Copies storage/transient to memory
         finally:
             self.ctx.constancy = old_constancy
 
@@ -1272,11 +1271,11 @@ class Stmt:
         # Payload buffer starts at buf + 32
         payload_buf = self.builder.add(buf._ptr, IRLiteral(32))
 
-        # msg_val is a pointer to the string in memory
+        # msg is materialized to memory here
         # We need to store it at a location so we can encode the tuple
         # For a tuple (string,), we store the string pointer, then encode
         tuple_buf = self.ctx.allocate_buffer(wrapped_typ.memory_bytes_required)
-        self.ctx.store_memory(msg_val, tuple_buf._ptr, msg_typ, src_typ=msg_vv.typ)
+        self.ctx.store_vyper_value(msg_vv, tuple_buf._ptr, msg_typ)
 
         # ABI encode the wrapped message to payload buffer
         encoded_len = abi_encode_to_buf(self.ctx, payload_buf, tuple_buf._ptr, wrapped_typ)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -116,8 +116,8 @@ class Stmt:
         src: VyperValue,
         typ,
         *,
-        src_node: Optional[vy_ast.VyperNode] = None,
-        dst_node: Optional[vy_ast.VyperNode] = None,
+        src_node: vy_ast.VyperNode,
+        dst_node: vy_ast.VyperNode,
     ) -> None:
         """Assign a VyperValue to a destination pointer.
 
@@ -125,11 +125,7 @@ class Stmt:
         (with overlap-safe copying when source and dest are in the same
         address space).
         """
-        if (
-            isinstance(typ, _BytestringT)
-            and src_node is not None
-            and self._is_empty_value(src_node)
-        ):
+        if isinstance(typ, _BytestringT) and self._is_empty_value(src_node):
             # Empty bytes/string assignment only needs a zero length word.
             if dst_ptr.location == DataLocation.STORAGE:
                 self.builder.sstore(dst_ptr.operand, IRLiteral(0))
@@ -150,8 +146,8 @@ class Stmt:
         src_vv: VyperValue,
         typ,
         *,
-        src_node: Optional[vy_ast.VyperNode] = None,
-        dst_node: Optional[vy_ast.VyperNode] = None,
+        src_node: vy_ast.VyperNode,
+        dst_node: vy_ast.VyperNode,
     ) -> None:
         """Copy complex type into `dst_ptr`.
 
@@ -167,7 +163,6 @@ class Stmt:
         should_stage = False
         if src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY:
             # Stage only when source and destination are views of the same memory root.
-            assert src_node is not None and dst_node is not None, "missing AST nodes for memory→memory aliasing check"
             src_root = _get_root_variable(src_node)
             dst_root = _get_root_variable(dst_node)
             should_stage = src_root is None or dst_root is None or src_root == dst_root

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -808,20 +808,32 @@ class Stmt:
             elem_addr = self.builder.add(array, total_offset)
 
             # Copy element to loop variable (always in memory)
+            dst = item_local.value.operand
             if is_slot_addressed:
-                self.ctx.slot_to_memory(elem_addr, item_local.value.operand, elem_size, location)
-            else:
+                self.ctx.slot_to_memory(elem_addr, dst, elem_size, location)
+            elif location is DataLocation.MEMORY:
                 if elem_size <= 32:
-                    # Single word: load_word handles all byte-addressed locations
-                    # including IMMUTABLES (iload in ctor, dload at runtime)
-                    val = self.ctx.load_word(elem_addr, location)
-                    self.builder.mstore(item_local.value.operand, val)
+                    val = self.builder.mload(elem_addr)
+                    self.builder.mstore(dst, val)
                 else:
-                    # Multi-word: layout-aware copy handles element size mismatches
+                    # Layout-aware copy for element size mismatches
                     self.ctx.store_memory(
-                        elem_addr,
-                        item_local.value.operand,
-                        target_type,
+                        elem_addr, dst, target_type,
+                        src_typ=array_typ.value_type,
+                    )
+            else:
+                # Non-memory byte-addressed (IMMUTABLES, CODE, CALLDATA):
+                # materialize to memory first via location-aware copy
+                if target_type == array_typ.value_type:
+                    # Same type: copy directly to loop var
+                    self.ctx.copy_to_memory(dst, elem_addr, elem_size, location)
+                else:
+                    # Type mismatch: copy to temp, then repack
+                    tmp_buf = self.ctx.allocate_buffer(elem_size)
+                    tmp = tmp_buf.base_ptr().operand
+                    self.ctx.copy_to_memory(tmp, elem_addr, elem_size, location)
+                    self.ctx.store_memory(
+                        tmp, dst, target_type,
                         src_typ=array_typ.value_type,
                     )
 

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -25,7 +25,7 @@ from vyper.venom.basicblock import IRLiteral, IROperand
 from .buffer import Ptr
 from .calling_convention import returns_stack_count
 from .context import Constancy, VenomCodegenContext
-from .expr import Expr
+from .expr import Expr, _get_root_variable
 from .value import VyperValue
 
 
@@ -66,7 +66,7 @@ class Stmt:
         var = self.ctx.new_variable(varname, ltyp)
 
         rhs = Expr(node.value, self.ctx).lower()
-        self._assign_value(var.value.ptr(), rhs, ltyp)
+        self._assign_value(var.value.ptr(), rhs, ltyp, src_node=node.value, dst_node=node.target)
 
     def lower_Assign(self) -> None:
         """Lower regular assignment.
@@ -108,21 +108,47 @@ class Stmt:
         # like `c[0] = c.pop()` where RHS modifies array length.
         src = Expr(node.value, self.ctx).lower()
         dst_ptr = self._get_target_ptr(target)
-        self._assign_value(dst_ptr, src, target_typ)
+        self._assign_value(dst_ptr, src, target_typ, src_node=node.value, dst_node=target)
 
-    def _assign_value(self, dst_ptr: Ptr, src: VyperValue, typ) -> None:
+    def _assign_value(
+        self,
+        dst_ptr: Ptr,
+        src: VyperValue,
+        typ,
+        *,
+        src_node: Optional[vy_ast.VyperNode] = None,
+        dst_node: Optional[vy_ast.VyperNode] = None,
+    ) -> None:
         """Assign a VyperValue to a destination pointer.
 
         Handles both primitive word types (direct store) and complex types
         (with overlap-safe copying when source and dest are in the same
         address space).
         """
+        if isinstance(typ, _BytestringT) and src_node is not None and self._is_empty_value(src_node):
+            # Empty bytes/string assignment only needs a zero length word.
+            if dst_ptr.location == DataLocation.STORAGE:
+                self.builder.sstore(dst_ptr.operand, IRLiteral(0))
+            elif dst_ptr.location == DataLocation.TRANSIENT:
+                self.builder.tstore(dst_ptr.operand, IRLiteral(0))
+            else:
+                self.ctx.ptr_store(dst_ptr, IRLiteral(0))
+            return
+
         if typ._is_prim_word:
             self.ctx.ptr_store(dst_ptr, self.ctx.unwrap(src))
         else:
-            self._copy_complex_type(dst_ptr, src, typ)
+            self._copy_complex_type(dst_ptr, src, typ, src_node=src_node, dst_node=dst_node)
 
-    def _copy_complex_type(self, dst_ptr: Ptr, src_vv: VyperValue, typ) -> None:
+    def _copy_complex_type(
+        self,
+        dst_ptr: Ptr,
+        src_vv: VyperValue,
+        typ,
+        *,
+        src_node: Optional[vy_ast.VyperNode] = None,
+        dst_node: Optional[vy_ast.VyperNode] = None,
+    ) -> None:
         """Copy complex type into `dst_ptr`.
 
         Materializes `src_vv` to memory (via unwrap), then stages through a
@@ -134,8 +160,14 @@ class Stmt:
         src_typ = src_vv.typ
         src = self.ctx.unwrap(src_vv)  # always a memory ptr for complex types
 
+        should_stage = False
         if src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY:
-            # Both in memory — stage through temp for overlap safety.
+            # Stage only when source and destination are views of the same memory root.
+            src_root = _get_root_variable(src_node) if src_node is not None else None
+            dst_root = _get_root_variable(dst_node) if dst_node is not None else None
+            should_stage = src_root is not None and src_root == dst_root
+
+        if should_stage:
             tmp_val = self.ctx.new_temporary_value(src_typ)
             self.ctx.copy_memory(tmp_val.operand, src, src_typ.memory_bytes_required)
             src = tmp_val.operand
@@ -147,7 +179,11 @@ class Stmt:
 
         Only called from `_copy_complex_type` which handles staging when needed.
         """
-        if src_typ != typ and dst_ptr.location is not DataLocation.MEMORY:
+        if (
+            src_typ != typ
+            and dst_ptr.location is not DataLocation.MEMORY
+            and not (isinstance(src_typ, _BytestringT) and isinstance(typ, _BytestringT))
+        ):
             # Normalize source into destination layout before writing to
             # storage/transient/code locations that don't carry src_typ.
             normalized = self.ctx.new_temporary_value(typ)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -147,6 +147,14 @@ class Stmt:
 
         Only called from `_copy_complex_type` which handles staging when needed.
         """
+        if src_typ != typ:
+            # Normalize source into destination layout before writing to
+            # storage/transient/code locations that don't carry src_typ.
+            normalized = self.ctx.new_temporary_value(typ)
+            self.ctx.store_memory(src, normalized.operand, typ, src_typ=src_typ)
+            src = normalized.operand
+            src_typ = typ
+
         if dst_ptr.location == DataLocation.STORAGE:
             # DynArray special case: only copy length + actual elements, not full capacity.
             # This matches legacy codegen behavior (core.py:_dynarray_make_setter).
@@ -190,57 +198,52 @@ class Stmt:
         assert isinstance(node, vy_ast.Assign)
         assert isinstance(node.target, vy_ast.Tuple)
         target = node.target
-        src = Expr(node.value, self.ctx).lower().operand
+        src_vv = Expr(node.value, self.ctx).lower()
+        src = self.ctx.unwrap(src_vv)
 
-        # src is a pointer to the tuple in memory
-        tuple_typ = target._metadata["type"]
+        # src is a pointer to the source tuple in memory
+        src_tuple_typ = src_vv.typ
+        dst_tuple_typ = target._metadata["type"]
         targets = target.elements
 
         # First pass: load all values from source tuple to temp variables.
         # This ensures correct semantics for overlapping cases like a,b = b,a.
         temp_vals = []
-        offset = 0
-        member_types = tuple_typ.member_types
-        if isinstance(member_types, dict):
-            member_types = member_types.values()
-        for elem_typ in member_types:
-            if offset == 0:
+        src_offset = 0
+        src_member_types = src_tuple_typ.member_types
+        dst_member_types = dst_tuple_typ.member_types
+        if isinstance(src_member_types, dict):
+            src_member_types = tuple(src_member_types.values())
+        if isinstance(dst_member_types, dict):
+            dst_member_types = tuple(dst_member_types.values())
+        for src_elem_typ, dst_elem_typ in zip(src_member_types, dst_member_types):
+            if src_offset == 0:
                 elem_ptr = src
             elif isinstance(src, IRLiteral):
-                elem_ptr = IRLiteral(src.value + offset)
+                elem_ptr = IRLiteral(src.value + src_offset)
             else:
-                elem_ptr = self.builder.add(src, IRLiteral(offset))
+                elem_ptr = self.builder.add(src, IRLiteral(src_offset))
 
             # Load the value
-            val = self.ctx.load_memory(elem_ptr, elem_typ)
-            temp_vals.append((val, elem_typ))
+            val = self.ctx.load_memory(elem_ptr, src_elem_typ)
+            temp_vals.append((val, src_elem_typ, dst_elem_typ))
 
-            offset += elem_typ.memory_bytes_required
+            src_offset += src_elem_typ.memory_bytes_required
 
         # Second pass: assign each loaded value to its target
-        for (val, elem_typ), target_node in zip(temp_vals, targets):
+        for (val, src_elem_typ, dst_elem_typ), target_node in zip(temp_vals, targets):
             target_ptr = self._get_target_ptr(target_node)
 
-            if elem_typ._is_prim_word:
+            if dst_elem_typ._is_prim_word:
                 self.ctx.ptr_store(target_ptr, val)
             else:
-                # Complex element type: val is a memory pointer
-                if target_ptr.location == DataLocation.STORAGE:
-                    # For single-word types, need to load value from memory
-                    if elem_typ.storage_size_in_words == 1:
-                        loaded_val = self.builder.mload(val)
-                        self.builder.sstore(target_ptr.operand, loaded_val)
-                    else:
-                        self.ctx.store_storage(val, target_ptr.operand, elem_typ)
-                elif target_ptr.location == DataLocation.TRANSIENT:
-                    # For single-word types, need to load value from memory
-                    if elem_typ.storage_size_in_words == 1:
-                        loaded_val = self.builder.mload(val)
-                        self.builder.tstore(target_ptr.operand, loaded_val)
-                    else:
-                        self.ctx.store_transient(val, target_ptr.operand, elem_typ)
-                else:
-                    self.ctx.copy_memory(target_ptr.operand, val, elem_typ.memory_bytes_required)
+                # Complex element type: val is a memory pointer in source layout.
+                if target_ptr.location is DataLocation.MEMORY:
+                    # Keep source snapshot stable across earlier tuple stores.
+                    staged = self.ctx.new_temporary_value(src_elem_typ)
+                    self.ctx.copy_memory(staged.operand, val, src_elem_typ.memory_bytes_required)
+                    val = staged.operand
+                self._store_complex_type(target_ptr, val, dst_elem_typ, src_elem_typ)
 
     def lower_AugAssign(self) -> None:
         """Lower augmented assignment.

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -7,8 +7,6 @@ from vyper.semantics.types.shortcuts import BYTES32_T, UINT256_T
 
 # common properties for environment variables
 class _EnvType(VyperType):
-    _id: str
-
     def __eq__(self, other):
         return self is other
 
@@ -62,7 +60,7 @@ class _Tx(_EnvType):
     _type_members = {"origin": AddressT(), "gasprice": UINT256_T}
 
 
-_CONSTANT_ENV_TYPES = (_Block, _Chain, _Tx, _Msg)
+_CONSTANT_ENV_TYPES: tuple[type[_EnvType], ...] = (_Block, _Chain, _Tx, _Msg)
 
 CONSTANT_ENVIRONMENT_VARS = {cls._id for cls in _CONSTANT_ENV_TYPES}
 
@@ -83,7 +81,7 @@ def get_constant_vars() -> Dict:
     }
 
 
-MUTABLE_ENVIRONMENT_VARS: Dict[str, type] = {"self": SelfT}
+MUTABLE_ENVIRONMENT_VARS: Dict[str, type[VyperType]] = {"self": SelfT}
 
 
 def get_mutable_vars() -> Dict:

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -7,6 +7,8 @@ from vyper.semantics.types.shortcuts import BYTES32_T, UINT256_T
 
 # common properties for environment variables
 class _EnvType(VyperType):
+    _id: str
+
     def __eq__(self, other):
         return self is other
 

--- a/vyper/venom/optimization_levels/O2.py
+++ b/vyper/venom/optimization_levels/O2.py
@@ -74,6 +74,7 @@ PASSES_O2: List[PassConfig] = [
     SCCP,
     SimplifyCFGPass,
     MemMergePass,
+    LoadElimination,
     RemoveUnusedVariablesPass,
     BranchOptimizationPass,
     AlgebraicOptimizationPass,

--- a/vyper/venom/optimization_levels/O3.py
+++ b/vyper/venom/optimization_levels/O3.py
@@ -80,6 +80,7 @@ PASSES_O3: List[PassConfig] = [
     SCCP,
     SimplifyCFGPass,
     MemMergePass,
+    LoadElimination,
     MemoryCopyElisionPass,
     RemoveUnusedVariablesPass,
     BranchOptimizationPass,

--- a/vyper/venom/optimization_levels/Os.py
+++ b/vyper/venom/optimization_levels/Os.py
@@ -75,6 +75,7 @@ PASSES_Os: List[PassConfig] = [
     SCCP,
     SimplifyCFGPass,
     MemMergePass,
+    LoadElimination,
     RemoveUnusedVariablesPass,
     BranchOptimizationPass,
     AlgebraicOptimizationPass,


### PR DESCRIPTION
### What I did

Fixed a Venom codegen bug where copies between type-compatible values with different
in-memory layouts were treated as flat blobs.

The original failure mode was copying a value like `DynArray[Bytes[540], 9]` into
`DynArray[Bytes[704], 13]`. Venom used a plain memory copy based on the destination
layout, so every element after the first was read from the wrong offset. That caused
silent memory corruption in nested dynamic data.

This branch also fixes runtime iteration over immutable dynamic arrays with multi-word
elements. Immutables are byte-addressed code reads at runtime, so those loop values now
get materialized correctly before any layout-aware repacking.

### How I did it

### How to verify it

### Commit message

```
fix venom typed copies for layout-mismatched compatible types
when copying between compatible values with different in-memory layouts
(for example `DynArray[Bytes[540], 9]` into
`DynArray[Bytes[704], 13]`), venom treated the source as a flat blob
and copied using the destination layout. that misaligned elements after
the first and corrupted nested dynamic data.

fix this by threading source type information through venom memory
stores. when source and destination layouts differ, dispatch to a
recursive typed copy that walks the value by shape
(dynarray, sarray, tuple, struct, bytestring, prim word) with
independent src/dst offsets. dynarrays with matching element layouts
keep a bulk-copy fast path; mismatched layouts use an IR loop.

also fix runtime iteration over immutable dynarrays with multi-word
elements by materializing byte-addressed non-memory loop values before
typed repacking, add targeted regression coverage, and clean up the
common unwrap/store plumbing with a small helper.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
