### PR TITLE
refactor[venom]: move more opt to venom

### DIFF
--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -67,7 +67,6 @@ class _CallKwargs:
 ENVIRONMENT_VARIABLES = {"block", "msg", "tx", "chain"}
 
 
-
 class Expr:
     """Lower Vyper expressions to Venom IR.
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -67,49 +67,6 @@ class _CallKwargs:
 ENVIRONMENT_VARIABLES = {"block", "msg", "tx", "chain"}
 
 
-def _get_root_variable(node: vy_ast.VyperNode) -> Optional[str]:
-    """Extract the root variable name from an AST expression.
-
-    Examples:
-        arr -> "arr"
-        self.arr -> "self.arr"
-        arr[0] -> "arr"
-        self.arr[i].field -> "self.arr"
-
-    Returns None if the expression doesn't have a clear root variable.
-    """
-    if isinstance(node, vy_ast.Name):
-        return node.id
-    if isinstance(node, vy_ast.Attribute):
-        # Handle self.x -> "self.x"
-        if isinstance(node.value, vy_ast.Name) and node.value.id == "self":
-            return f"self.{node.attr}"
-        # For struct field access, get root of the struct
-        return _get_root_variable(node.value)
-    if isinstance(node, vy_ast.Subscript):
-        # arr[i] -> root of arr
-        return _get_root_variable(node.value)
-    return None
-
-
-def _potential_overlap_ast(darray_node: vy_ast.VyperNode, arg_node: vy_ast.VyperNode) -> bool:
-    """Check if arg_node potentially references the same variable as darray_node.
-
-    This is a conservative check - returns True if unsure.
-    Used to prevent issues like arr.append(arr[0]) where reading the arg
-    could be affected by the append operation modifying the array.
-
-    Reference: vyper/codegen/core.py:potential_overlap
-    """
-    darray_root = _get_root_variable(darray_node)
-    arg_root = _get_root_variable(arg_node)
-
-    if darray_root is None or arg_root is None:
-        # Can't determine roots - be conservative
-        return True
-
-    return darray_root == arg_root
-
 
 class Expr:
     """Lower Vyper expressions to Venom IR.
@@ -1570,8 +1527,10 @@ class Expr:
         arg_val = self.ctx.unwrap(arg_vv)
         elem_src_typ = arg_vv.typ
 
-        if not elem_typ._is_prim_word and _potential_overlap_ast(darray_node, arg_node):
-            # Overlap detected: copy arg to temp buffer first
+        if not elem_typ._is_prim_word:
+            # Always stage complex elements through a temp buffer to guard
+            # against aliasing (e.g. arr.append(arr[0])).
+            # MemoryCopyElisionPass eliminates the copy when safe.
             temp_buf = self.ctx.new_temporary_value(elem_typ)
             self.ctx.store_vyper_value(arg_vv, temp_buf.operand, elem_typ)
             elem_val = temp_buf.operand

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -641,15 +641,10 @@ class Expr:
         # Case 2: Address properties
         attr = node.attr
         if attr == "balance":
-            # Check if it's self.balance
-            if isinstance(node.value, vy_ast.Name) and node.value.id == "self":
-                return VyperValue.from_stack_op(self.builder.selfbalance(), UINT256_T)
             sub = Expr(node.value, self.ctx).lower_value()
             return VyperValue.from_stack_op(self.builder.balance(sub), UINT256_T)
 
         if attr == "codesize":
-            if isinstance(node.value, vy_ast.Name) and node.value.id == "self":
-                return VyperValue.from_stack_op(self.builder.codesize(), UINT256_T)
             sub = Expr(node.value, self.ctx).lower_value()
             return VyperValue.from_stack_op(self.builder.extcodesize(sub), UINT256_T)
 
@@ -1491,16 +1486,15 @@ class Expr:
     def _lower_dynarray_append(self) -> VyperValue:
         """Lower DynArray.append(val).
 
-        1. Check for potential overlap between darray and arg
-        2. If overlap and non-primitive, copy arg to temp buffer first
-        3. Load current length
+        1. For non-primitive elements, stage arg to a temporary buffer
+           (conservative alias guard)
+        2. Load current length
         4. Assert length < capacity (bounds check)
         5. Compute element pointer: data_ptr + length * elem_size
         6. Store element
         7. Increment and store new length
 
         Reference: vyper/codegen/core.py:append_dyn_array
-        Reference: vyper/codegen/expr.py (potential_overlap check before append)
         """
         node = self.node
         assert isinstance(node, vy_ast.Call)
@@ -1514,12 +1508,10 @@ class Expr:
         darray_vv = Expr(darray_node, self.ctx).lower()
         darray_ptr = darray_vv.operand
 
-        # Get the element value
-        # Check for potential overlap: if arg references same variable as darray,
-        # and element is not primitive, copy arg to temp buffer first.
-        # This prevents issues like arr.append(arr[0]) where reading the arg
-        # could be affected by the append operation.
-        # Reference: vyper/codegen/expr.py lines 729-735
+        # Get the element value.
+        # For complex elements, always stage through a temporary buffer to
+        # guard against aliasing cases like arr.append(arr[0]). Backend passes
+        # can elide the staging copy when it is provably redundant.
         assert len(node.args) == 1
         arg_node = node.args[0]
 

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -766,9 +766,12 @@ class Stmt:
             elem_addr = self.builder.add(array, total_offset)
 
             # Copy element to loop variable (always in memory).
-            # Invariant: type mismatches (target_type != value_type) only
-            # occur for memory sources — for-loop var type always matches
-            # the array element type for non-memory locations.
+            # Note: type mismatches (target_type != value_type) are possible
+            # for any source location (the type checker allows e.g.
+            # Bytes[704] target with Bytes[540] elements). For non-memory
+            # sources, the linear copy is safe for flat types since the
+            # source is smaller than the destination buffer. Only the
+            # memory path uses type-aware copying (store_memory).
             dst = item_local.value.operand
             if is_slot_addressed:
                 # Word-addressed (STORAGE, TRANSIENT)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -107,12 +107,7 @@ class Stmt:
         self._assign_value(dst_ptr, src, target_typ, src_node=node.value)
 
     def _assign_value(
-        self,
-        dst_ptr: Ptr,
-        src: VyperValue,
-        typ,
-        *,
-        src_node: Optional[vy_ast.VyperNode] = None,
+        self, dst_ptr: Ptr, src: VyperValue, typ, *, src_node: Optional[vy_ast.VyperNode] = None
     ) -> None:
         """Assign a VyperValue to a destination pointer.
 
@@ -145,9 +140,7 @@ class Stmt:
         # Always stage when both src and dst are in memory to guard against
         # aliasing.  MemoryCopyElisionPass will eliminate the redundant copy
         # when src/dst are provably non-overlapping (different allocas).
-        should_stage = (
-            src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY
-        )
+        should_stage = src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY
 
         if should_stage:
             tmp_val = self.ctx.new_temporary_value(src_typ)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -25,7 +25,7 @@ from vyper.venom.basicblock import IRLiteral, IROperand
 from .buffer import Ptr
 from .calling_convention import returns_stack_count
 from .context import Constancy, VenomCodegenContext
-from .expr import Expr, _get_root_variable
+from .expr import Expr
 from .value import VyperValue
 
 
@@ -66,7 +66,7 @@ class Stmt:
         var = self.ctx.new_variable(varname, ltyp)
 
         rhs = Expr(node.value, self.ctx).lower()
-        self._assign_value(var.value.ptr(), rhs, ltyp, src_node=node.value, dst_node=node.target)
+        self._assign_value(var.value.ptr(), rhs, ltyp, src_node=node.value)
 
     def lower_Assign(self) -> None:
         """Lower regular assignment.
@@ -104,7 +104,7 @@ class Stmt:
         # like `c[0] = c.pop()` where RHS modifies array length.
         src = Expr(node.value, self.ctx).lower()
         dst_ptr = self._get_target_ptr(target)
-        self._assign_value(dst_ptr, src, target_typ, src_node=node.value, dst_node=target)
+        self._assign_value(dst_ptr, src, target_typ, src_node=node.value)
 
     def _assign_value(
         self,
@@ -112,8 +112,7 @@ class Stmt:
         src: VyperValue,
         typ,
         *,
-        src_node: vy_ast.VyperNode,
-        dst_node: vy_ast.VyperNode,
+        src_node: Optional[vy_ast.VyperNode] = None,
     ) -> None:
         """Assign a VyperValue to a destination pointer.
 
@@ -129,34 +128,26 @@ class Stmt:
         if typ._is_prim_word:
             self.ctx.ptr_store(dst_ptr, self.ctx.unwrap(src))
         else:
-            self._copy_complex_type(dst_ptr, src, typ, src_node=src_node, dst_node=dst_node)
+            self._copy_complex_type(dst_ptr, src, typ)
 
-    def _copy_complex_type(
-        self,
-        dst_ptr: Ptr,
-        src_vv: VyperValue,
-        typ,
-        *,
-        src_node: vy_ast.VyperNode,
-        dst_node: vy_ast.VyperNode,
-    ) -> None:
+    def _copy_complex_type(self, dst_ptr: Ptr, src_vv: VyperValue, typ) -> None:
         """Copy complex type into `dst_ptr`.
 
         Materializes `src_vv` to memory (via unwrap), then stages through a
         temporary buffer when source and destination are both in memory
-        (potential aliasing).  When they are in different address spaces
-        no aliasing is possible and the staging copy is skipped.
+        (potential aliasing).  MemoryCopyElisionPass eliminates the staging
+        copy when src/dst are provably non-overlapping.
         """
         src_loc = src_vv.location  # None for stack values, else DataLocation
         src_typ = src_vv.typ
         src = self.ctx.unwrap(src_vv)  # always a memory ptr for complex types
 
-        should_stage = False
-        if src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY:
-            # Stage only when source and destination are views of the same memory root.
-            src_root = _get_root_variable(src_node)
-            dst_root = _get_root_variable(dst_node)
-            should_stage = src_root is None or dst_root is None or src_root == dst_root
+        # Always stage when both src and dst are in memory to guard against
+        # aliasing.  MemoryCopyElisionPass will eliminate the redundant copy
+        # when src/dst are provably non-overlapping (different allocas).
+        should_stage = (
+            src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY
+        )
 
         if should_stage:
             tmp_val = self.ctx.new_temporary_value(src_typ)

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -107,7 +107,7 @@ class Stmt:
         self._assign_value(dst_ptr, src, target_typ, src_node=node.value)
 
     def _assign_value(
-        self, dst_ptr: Ptr, src: VyperValue, typ, *, src_node: Optional[vy_ast.VyperNode] = None
+        self, dst_ptr: Ptr, src: VyperValue, typ, *, src_node: vy_ast.VyperNode
     ) -> None:
         """Assign a VyperValue to a destination pointer.
 

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -128,26 +128,17 @@ class Stmt:
     def _copy_complex_type(self, dst_ptr: Ptr, src_vv: VyperValue, typ) -> None:
         """Copy complex type into `dst_ptr`.
 
-        Materializes `src_vv` to memory (via unwrap), then stages through a
-        temporary buffer when source and destination are both in memory
-        (potential aliasing).  MemoryCopyElisionPass eliminates the staging
-        copy when src/dst are provably non-overlapping.
+        Always stages through a temporary buffer to guard against aliasing.
+        MemoryCopyElisionPass eliminates the staging copy when src/dst are
+        provably non-overlapping.
         """
-        src_loc = src_vv.location  # None for stack values, else DataLocation
         src_typ = src_vv.typ
         src = self.ctx.unwrap(src_vv)  # always a memory ptr for complex types
 
-        # Always stage when both src and dst are in memory to guard against
-        # aliasing.  MemoryCopyElisionPass will eliminate the redundant copy
-        # when src/dst are provably non-overlapping (different allocas).
-        should_stage = src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY
+        tmp_val = self.ctx.new_temporary_value(src_typ)
+        self.ctx.copy_memory(tmp_val.operand, src, src_typ.memory_bytes_required)
 
-        if should_stage:
-            tmp_val = self.ctx.new_temporary_value(src_typ)
-            self.ctx.copy_memory(tmp_val.operand, src, src_typ.memory_bytes_required)
-            src = tmp_val.operand
-
-        self._store_complex_type(dst_ptr, src, typ, src_typ)
+        self._store_complex_type(dst_ptr, tmp_val.operand, typ, src_typ)
 
     def _store_complex_type(self, dst_ptr: Ptr, src: IROperand, typ, src_typ) -> None:
         """Store complex value from memory `src` into `dst_ptr` (no overlap guard).

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -128,17 +128,24 @@ class Stmt:
     def _copy_complex_type(self, dst_ptr: Ptr, src_vv: VyperValue, typ) -> None:
         """Copy complex type into `dst_ptr`.
 
-        Always stages through a temporary buffer to guard against aliasing.
-        MemoryCopyElisionPass eliminates the staging copy when src/dst are
-        provably non-overlapping.
+        Materializes `src_vv` to memory (via unwrap), then stages through a
+        temporary buffer when source and destination are both in memory
+        (potential aliasing).  MemoryCopyElisionPass eliminates the staging
+        copy when src/dst are provably non-overlapping.
         """
+        src_loc = src_vv.location  # None for stack values, else DataLocation
         src_typ = src_vv.typ
         src = self.ctx.unwrap(src_vv)  # always a memory ptr for complex types
 
-        tmp_val = self.ctx.new_temporary_value(src_typ)
-        self.ctx.copy_memory(tmp_val.operand, src, src_typ.memory_bytes_required)
+        # Stage when both src and dst are in memory to guard against aliasing.
+        # MemoryCopyElisionPass will eliminate the redundant copy when
+        # src/dst are provably non-overlapping (different allocas).
+        if src_loc is DataLocation.MEMORY and dst_ptr.location is DataLocation.MEMORY:
+            tmp_val = self.ctx.new_temporary_value(src_typ)
+            self.ctx.copy_memory(tmp_val.operand, src, src_typ.memory_bytes_required)
+            src = tmp_val.operand
 
-        self._store_complex_type(dst_ptr, tmp_val.operand, typ, src_typ)
+        self._store_complex_type(dst_ptr, src, typ, src_typ)
 
     def _store_complex_type(self, dst_ptr: Ptr, src: IROperand, typ, src_typ) -> None:
         """Store complex value from memory `src` into `dst_ptr` (no overlap guard).

--- a/vyper/venom/optimization_levels/O2.py
+++ b/vyper/venom/optimization_levels/O2.py
@@ -25,6 +25,7 @@ from vyper.venom.passes import (
     MakeSSA,
     Mem2Var,
     MemMergePass,
+    MemoryCopyElisionPass,
     PhiEliminationPass,
     ReadonlyInvokeArgCopyForwardingPass,
     RemoveUnusedVariablesPass,
@@ -63,6 +64,8 @@ PASSES_O2: List[PassConfig] = [
     ReadonlyInvokeArgCopyForwardingPass,
     # run memmerge before LowerDload
     MemMergePass,
+    MemoryCopyElisionPass,
+    LoadElimination,
     LowerDloadPass,
     RemoveUnusedVariablesPass,
     (DeadStoreElimination, {"addr_space": MEMORY}),

--- a/vyper/venom/optimization_levels/O3.py
+++ b/vyper/venom/optimization_levels/O3.py
@@ -69,6 +69,7 @@ PASSES_O3: List[PassConfig] = [
     # run memmerge before LowerDload
     MemMergePass,
     MemoryCopyElisionPass,
+    LoadElimination,
     LowerDloadPass,
     RemoveUnusedVariablesPass,
     (DeadStoreElimination, {"addr_space": MEMORY}),

--- a/vyper/venom/optimization_levels/Os.py
+++ b/vyper/venom/optimization_levels/Os.py
@@ -25,6 +25,7 @@ from vyper.venom.passes import (
     MakeSSA,
     Mem2Var,
     MemMergePass,
+    MemoryCopyElisionPass,
     PhiEliminationPass,
     ReadonlyInvokeArgCopyForwardingPass,
     ReduceLiteralsCodesize,
@@ -64,6 +65,8 @@ PASSES_Os: List[PassConfig] = [
     ReadonlyInvokeArgCopyForwardingPass,
     # run memmerge before LowerDload
     MemMergePass,
+    MemoryCopyElisionPass,
+    LoadElimination,
     LowerDloadPass,
     RemoveUnusedVariablesPass,
     (DeadStoreElimination, {"addr_space": MEMORY}),

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -153,15 +153,19 @@ class AlgebraicOptimizationPass(IRPass):
             operands = inst.operands
 
         # balance(address()) → selfbalance()
-        # extcodesize(address()) → codesize()
-        if inst.opcode in ("balance", "extcodesize"):
+        # note: extcodesize(address()) → codesize() is NOT safe because
+        # during initcode EXTCODESIZE(ADDRESS()) returns 0 while CODESIZE
+        # returns the initcode length.
+        if inst.opcode == "balance":
             op = operands[0]
             if isinstance(op, IRVariable):
                 producer = self.dfg.get_producing_instruction(op)
                 if producer is not None and producer.opcode == "address":
-                    new_op = "selfbalance" if inst.opcode == "balance" else "codesize"
-                    self.updater.update(inst, new_op, [])
+                    self.updater.update(inst, "selfbalance", [])
                     return
+            return
+
+        if inst.opcode == "extcodesize":
             return
 
         if inst.opcode in {"shl", "shr", "sar"}:

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -152,6 +152,18 @@ class AlgebraicOptimizationPass(IRPass):
             inst.flip()
             operands = inst.operands
 
+        # balance(address()) → selfbalance()
+        # extcodesize(address()) → codesize()
+        if inst.opcode in ("balance", "extcodesize"):
+            op = operands[0]
+            if isinstance(op, IRVariable):
+                producer = self.dfg.get_producing_instruction(op)
+                if producer is not None and producer.opcode == "address":
+                    new_op = "selfbalance" if inst.opcode == "balance" else "codesize"
+                    self.updater.update(inst, new_op, [])
+                    return
+            return
+
         if inst.opcode in {"shl", "shr", "sar"}:
             # (x >> 0) == (x << 0) == x
             if lit_eq(operands[1], 0):


### PR DESCRIPTION
### What I did

Move frontend AST-level optimizations into Venom IR passes, simplifying the codegen and making optimizations more composable.

### How I did it

- selfbalance/codesize: Remove self.balance and self.codesize special cases from expr.py. The codegen now emits balance(address()) and extcodesize(address()) uniformly. AlgebraicOptimizationPass folds these to selfbalance() and codesize().
- Alias analysis: Remove _get_root_variable and _potential_overlap_ast from the frontend. For dynarray append, always stage non-primitive elements through a temp buffer. For assignments, stage whenever both src and dst are in memory. MemoryCopyElisionPass elides redundant copies.
- Pass ordering: Add MemoryCopyElisionPass + LoadElimination to O2/Os (new) and O3 (LoadElimination only, after existing MemoryCopyElisionPass) to clean up the more conservative staging.


### How to verify it

### Commit message

```
the venom codegen frontend had several AST-level optimizations that are
better expressed as IR passes: `self.balance` and `self.codesize` were
special-cased to emit `selfbalance`/`codesize` directly, and
`_potential_overlap_ast`/`_get_root_variable` performed fragile AST-
level alias analysis to decide when to stage complex copies through
temporaries.

move the `self.balance`/`self.codesize` folding into
`AlgebraicOptimizationPass` as `balance(address()) -> selfbalance()` and
`extcodesize(address()) -> codesize()`. for dynarray append, always
stage non-primitive elements through a temp buffer instead of guessing
aliasing from AST root variables -- `MemoryCopyElisionPass` elides the
copy when safe. for assignments, simplify the staging condition to
always stage when both src and dst are in memory, removing the AST-level
`_get_root_variable` check.

add `MemoryCopyElisionPass` + `LoadElimination` to O2/Os/O3 pass lists
(after `MemMergePass`, before `LowerDloadPass`) to compensate for the
more conservative staging.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
