### PR TITLE
fix[venom]: fix divisor check for signed div/mod

### DIFF
--- a/tests/functional/builtins/codegen/test_mulmod.py
+++ b/tests/functional/builtins/codegen/test_mulmod.py
@@ -104,3 +104,15 @@ def bar() -> uint256:
     assert c.foo1() == 2
     assert c.foo2() == 1
     assert c.foo3() == 2
+
+def test_tmp(get_contract):
+    code = """
+@external
+@pure
+def f(arg0: int128) -> int128:
+    return arg0 // arg0
+    """
+
+    c = get_contract(code)
+
+    assert c.f(-1) == 1

--- a/tests/functional/builtins/codegen/test_mulmod.py
+++ b/tests/functional/builtins/codegen/test_mulmod.py
@@ -105,14 +105,3 @@ def bar() -> uint256:
     assert c.foo2() == 1
     assert c.foo3() == 2
 
-def test_tmp(get_contract):
-    code = """
-@external
-@pure
-def f(arg0: int128) -> int128:
-    return arg0 // arg0
-    """
-
-    c = get_contract(code)
-
-    assert c.f(-1) == 1

--- a/tests/functional/builtins/codegen/test_mulmod.py
+++ b/tests/functional/builtins/codegen/test_mulmod.py
@@ -104,4 +104,3 @@ def bar() -> uint256:
     assert c.foo1() == 2
     assert c.foo2() == 1
     assert c.foo3() == 2
-

--- a/tests/functional/codegen/types/numbers/test_division.py
+++ b/tests/functional/codegen/types/numbers/test_division.py
@@ -39,3 +39,15 @@ def foo(a: decimal) -> decimal:
 @pytest.mark.parametrize("code", BAD_CODE)
 def test_divide_by_zero(code, assert_compile_failed, get_contract):
     assert_compile_failed(lambda: get_contract(code), ZeroDivisionException)
+
+def test_signed_negative(get_contract):
+    code = """
+@external
+@pure
+def f(arg0: int128) -> int128:
+    return arg0 // arg0
+    """
+
+    c = get_contract(code)
+
+    assert c.f(-1) == 1

--- a/tests/functional/codegen/types/numbers/test_division.py
+++ b/tests/functional/codegen/types/numbers/test_division.py
@@ -52,3 +52,15 @@ def f(arg0: int128) -> int128:
     c = get_contract(code)
 
     assert c.f(-1) == 1
+
+def test_signed_negative_decimal(get_contract):
+    code = """
+@external
+@pure
+def f(arg0: decimal) -> decimal:
+    return arg0 / arg0
+    """
+
+    c = get_contract(code)
+
+    assert c.f(-1) == 10000000000

--- a/tests/functional/codegen/types/numbers/test_division.py
+++ b/tests/functional/codegen/types/numbers/test_division.py
@@ -40,6 +40,7 @@ def foo(a: decimal) -> decimal:
 def test_divide_by_zero(code, assert_compile_failed, get_contract):
     assert_compile_failed(lambda: get_contract(code), ZeroDivisionException)
 
+
 def test_signed_negative(get_contract):
     code = """
 @external

--- a/tests/functional/codegen/types/numbers/test_division.py
+++ b/tests/functional/codegen/types/numbers/test_division.py
@@ -53,6 +53,7 @@ def f(arg0: int128) -> int128:
 
     assert c.f(-1) == 1
 
+
 def test_signed_negative_decimal(get_contract):
     code = """
 @external

--- a/tests/functional/codegen/types/numbers/test_modulo.py
+++ b/tests/functional/codegen/types/numbers/test_modulo.py
@@ -59,6 +59,7 @@ def bar(a: int128) -> bool:
     assert c.foo() == (1, 1, -1, -1)
     assert c.bar(-5) is True
 
+
 def test_signed_negative(get_contract):
     code = """
 @external

--- a/tests/functional/codegen/types/numbers/test_modulo.py
+++ b/tests/functional/codegen/types/numbers/test_modulo.py
@@ -59,6 +59,18 @@ def bar(a: int128) -> bool:
     assert c.foo() == (1, 1, -1, -1)
     assert c.bar(-5) is True
 
+def test_signed_negative(get_contract):
+    code = """
+@external
+@pure
+def f(arg0: int128) -> int128:
+    return arg0 % arg0
+    """
+
+    c = get_contract(code)
+
+    assert c.f(-1) == 0
+
 
 BAD_CODE = [
     """

--- a/vyper/codegen_venom/arithmetic.py
+++ b/vyper/codegen_venom/arithmetic.py
@@ -175,12 +175,8 @@ def safe_mod(
     is_signed = typ.is_signed
 
     with b.error_context("safemod"):
-        # Clamp divisor > 0
-        if is_signed:
-            y_gt_zero = b.sgt(y, IRLiteral(0))
-        else:
-            y_gt_zero = b.gt(y, IRLiteral(0))
-        b.assert_(y_gt_zero)
+        not_zero = b.gt(y, IRLiteral(0))
+        b.assert_(not_zero)
 
         MOD = b.smod if is_signed else b.mod
         return MOD(x, y)

--- a/vyper/codegen_venom/arithmetic.py
+++ b/vyper/codegen_venom/arithmetic.py
@@ -114,13 +114,14 @@ def safe_div(b: VenomBuilder, x: IROperand, y: IROperand, typ: DecimalT) -> IROp
     # Multiply numerator by divisor first
     x_scaled = b.mul(x, IRLiteral(typ.divisor))
 
-    # Clamp divisor > 0 for unsigned, or use sgt for signed
-    if typ.is_signed:
-        y_gt_zero = b.sgt(y, IRLiteral(0))
-    else:
-        y_gt_zero = b.gt(y, IRLiteral(0))
+    # check if divisor != zero
+    # even if the number is signed you can
+    # use gt since for every number in two's complement
+    # which is not zero is greater then 0
+    # if you read it as not signed
+    not_zero = b.gt(y, IRLiteral(0))
     with b.error_context("safediv"):
-        b.assert_(y_gt_zero)
+        b.assert_(not_zero)
 
     DIV = b.sdiv if typ.is_signed else b.div
     res = DIV(x_scaled, y)

--- a/vyper/codegen_venom/arithmetic.py
+++ b/vyper/codegen_venom/arithmetic.py
@@ -138,7 +138,7 @@ def safe_floordiv(b: VenomBuilder, x: IROperand, y: IROperand, typ: IntegerT) ->
 
     # Clamp divisor > 0
     if is_signed:
-        y_gt_zero = b.sgt(y, IRLiteral(0))
+        y_gt_zero = b.iszero(b.eq(y, IRLiteral(0)))
     else:
         y_gt_zero = b.gt(y, IRLiteral(0))
     with b.error_context("safediv"):

--- a/vyper/codegen_venom/arithmetic.py
+++ b/vyper/codegen_venom/arithmetic.py
@@ -136,13 +136,14 @@ def safe_floordiv(b: VenomBuilder, x: IROperand, y: IROperand, typ: IntegerT) ->
 
     is_signed = typ.is_signed
 
-    # Clamp divisor > 0
-    if is_signed:
-        y_gt_zero = b.iszero(b.eq(y, IRLiteral(0)))
-    else:
-        y_gt_zero = b.gt(y, IRLiteral(0))
+    # check if divisor != zero
+    # even if the number is signed you can
+    # use gt since for every number in two's complement
+    # which is not zero is greater then 0
+    # if you read it as not signed
+    not_zero = b.gt(y, IRLiteral(0))
     with b.error_context("safediv"):
-        b.assert_(y_gt_zero)
+        b.assert_(not_zero)
 
     DIV = b.sdiv if is_signed else b.div
     res: IROperand = DIV(x, y)

--- a/vyper/codegen_venom/arithmetic.py
+++ b/vyper/codegen_venom/arithmetic.py
@@ -115,10 +115,6 @@ def safe_div(b: VenomBuilder, x: IROperand, y: IROperand, typ: DecimalT) -> IROp
     x_scaled = b.mul(x, IRLiteral(typ.divisor))
 
     # check if divisor != zero
-    # even if the number is signed you can
-    # use gt since for every number in two's complement
-    # which is not zero is greater then 0
-    # if you read it as not signed
     not_zero = b.iszero(b.iszero(y))
     with b.error_context("safediv"):
         b.assert_(not_zero)
@@ -138,10 +134,6 @@ def safe_floordiv(b: VenomBuilder, x: IROperand, y: IROperand, typ: IntegerT) ->
     is_signed = typ.is_signed
 
     # check if divisor != zero
-    # even if the number is signed you can
-    # use gt since for every number in two's complement
-    # which is not zero is greater then 0
-    # if you read it as not signed
     not_zero = b.iszero(b.iszero(y))
     with b.error_context("safediv"):
         b.assert_(not_zero)

--- a/vyper/codegen_venom/arithmetic.py
+++ b/vyper/codegen_venom/arithmetic.py
@@ -119,7 +119,7 @@ def safe_div(b: VenomBuilder, x: IROperand, y: IROperand, typ: DecimalT) -> IROp
     # use gt since for every number in two's complement
     # which is not zero is greater then 0
     # if you read it as not signed
-    not_zero = b.gt(y, IRLiteral(0))
+    not_zero = b.iszero(b.iszero(y))
     with b.error_context("safediv"):
         b.assert_(not_zero)
 
@@ -142,7 +142,7 @@ def safe_floordiv(b: VenomBuilder, x: IROperand, y: IROperand, typ: IntegerT) ->
     # use gt since for every number in two's complement
     # which is not zero is greater then 0
     # if you read it as not signed
-    not_zero = b.gt(y, IRLiteral(0))
+    not_zero = b.iszero(b.iszero(y))
     with b.error_context("safediv"):
         b.assert_(not_zero)
 
@@ -175,7 +175,7 @@ def safe_mod(
     is_signed = typ.is_signed
 
     with b.error_context("safemod"):
-        not_zero = b.gt(y, IRLiteral(0))
+        not_zero = b.iszero(b.iszero(y))
         b.assert_(not_zero)
 
         MOD = b.smod if is_signed else b.mod


### PR DESCRIPTION
### What I did
Fixed error with `sdiv` check for signed numbers, it was `sgt` for some reason which would disallow division not only by zero but also by negative numbers.

### How I did it

### How to verify it

### Commit message

```
the zero-divisor guard in `safe_div`, `safe_floordiv`, and `safe_mod`
used `sgt(y, 0)` for signed types — "y is strictly greater than zero".
this rejects all negative divisors, causing e.g. `x // x` to revert
when `x` is negative.

the guard only needs to check for division by zero, not filter out
negative values. replace the signed/unsigned `sgt`/`gt` branch with a
uniform `iszero(iszero(y))` (i.e. `y != 0`) for all types.
```

### Description for the changelog

fix divisor check for signed div/mod

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
