### PR TITLE
chore[docs]: fix module/contract/interface terminology

### DIFF
--- a/docs/compiler-exceptions.rst
+++ b/docs/compiler-exceptions.rst
@@ -5,7 +5,7 @@ Compiler Exceptions
 
 .. _exceptions-common:
 
-Vyper raises one or more of the following exceptions when an issue is encountered while compiling a contract.
+Vyper raises one or more of the following exceptions when an issue is encountered while compiling a module.
 
 Whenever possible, exceptions include a source highlight displaying the location
 of the error within the code:
@@ -36,7 +36,7 @@ of the error within the code:
 
 .. py:exception:: EvmVersionException
 
-    Raises when a contract contains an action that cannot be performed with the active EVM ruleset.
+    Raises when a module contains an action that cannot be performed with the active EVM ruleset.
 
 .. py:exception:: FunctionDeclarationException
 
@@ -120,7 +120,7 @@ of the error within the code:
 
 .. py:exception:: NatSpecSyntaxException
 
-    Raises when a contract contains an invalid :ref:`NatSpec<natspec>` docstring.
+    Raises when a module contains an invalid :ref:`NatSpec<natspec>` docstring.
 
     .. code-block:: python
 
@@ -208,7 +208,7 @@ of the error within the code:
 
 .. py:exception:: VersionException
 
-    Raises when a contract version string is malformed or incompatible with the current compiler version.
+    Raises when a module version string is malformed or incompatible with the current compiler version.
 
 .. py:exception:: ZeroDivisionException
 

--- a/docs/compiler-exceptions.rst
+++ b/docs/compiler-exceptions.rst
@@ -5,7 +5,7 @@ Compiler Exceptions
 
 .. _exceptions-common:
 
-Vyper raises one or more of the following exceptions when an issue is encountered while compiling a module.
+Vyper raises one or more of the following exceptions when an issue is encountered while compiling a contract.
 
 Whenever possible, exceptions include a source highlight displaying the location
 of the error within the code:
@@ -36,7 +36,7 @@ of the error within the code:
 
 .. py:exception:: EvmVersionException
 
-    Raises when a module contains an action that cannot be performed with the active EVM ruleset.
+    Raises when a contract contains an action that cannot be performed with the active EVM ruleset.
 
 .. py:exception:: FunctionDeclarationException
 
@@ -120,7 +120,7 @@ of the error within the code:
 
 .. py:exception:: NatSpecSyntaxException
 
-    Raises when a module contains an invalid :ref:`NatSpec<natspec>` docstring.
+    Raises when a contract contains an invalid :ref:`NatSpec<natspec>` docstring.
 
     .. code-block:: python
 
@@ -208,7 +208,7 @@ of the error within the code:
 
 .. py:exception:: VersionException
 
-    Raises when a module version string is malformed or incompatible with the current compiler version.
+    Raises when a contract version string is malformed or incompatible with the current compiler version.
 
 .. py:exception:: ZeroDivisionException
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -8,7 +8,7 @@ Control Structures
 Functions
 =========
 
-Functions are executable units of code within a contract. Functions may only be declared within a module's :ref:`module scope <scoping-module>`.
+Functions are executable units of code within a module. Functions may only be declared within a module's :ref:`module scope <scoping-module>`.
 
 .. code-block:: vyper
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -8,7 +8,7 @@ Control Structures
 Functions
 =========
 
-Functions are executable units of code within a contract. Functions may only be declared within a contract's :ref:`module scope <scoping-module>`.
+Functions are executable units of code within a contract. Functions may only be declared within a module's :ref:`module scope <scoping-module>`.
 
 .. code-block:: vyper
 

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -8,7 +8,7 @@ An interface is a set of function definitions used to enable communication betwe
 Declaring and using Interfaces
 ==============================
 
-Interfaces can be added to contracts either through inline definition, or by importing them from a separate file.
+Interfaces can be added to a module either through inline definition, or by importing them from a separate file.
 
 The ``interface`` keyword is used to define an inline external interface:
 

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -110,7 +110,7 @@ You can define an interface for your module with the ``implements`` statement:
     implements: FooBarInterface
 
 
-This imports the defined interface from the vyper file at ``an_interface.vyi`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current contract implements all the necessary external functions. If any interface functions are not included in the contract, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20.
+This imports the defined interface from the vyper file at ``an_interface.vyi`` (or ``an_interface.json`` if using ABI json interface type) and ensures your current module implements all the necessary external functions. If any interface functions are not included in the module, it will fail to compile. This is especially useful when developing contracts around well-defined standards such as ERC20.
 
 Multiple ``implements`` statements can be grouped into one:
 
@@ -132,7 +132,7 @@ Multiple ``implements`` statements can be grouped into one:
 
 .. note::
 
-  Prior to v0.4.0, ``implements`` required that events defined in an interface were re-defined in the "implementing" contract. As of v0.4.0, this is no longer required because events can be used just by importing them. Any events used in a contract will automatically be exported in the ABI output.
+  Prior to v0.4.0, ``implements`` required that events defined in an interface were re-defined in the "implementing" module. As of v0.4.0, this is no longer required because events can be used just by importing them. Any events used in a contract will automatically be exported in the ABI output.
 
 .. note::
 

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -101,7 +101,7 @@ You can see all the available built-in interfaces in the `Vyper GitHub <https://
 Implementing an Interface
 =========================
 
-You can define an interface for your contract with the ``implements`` statement:
+You can define an interface for your module with the ``implements`` statement:
 
 .. code-block:: vyper
 
@@ -158,7 +158,7 @@ Standalone interfaces are written using a variant of standard Vyper syntax. The 
 Extracting Interfaces
 =====================
 
-Vyper has a built-in format option to allow you to easily export a Vyper interface from a pre-existing contract.
+Vyper has a built-in format option to allow you to easily export a Vyper interface from a pre-existing module.
 
 ::
 

--- a/docs/scoping-and-declarations.rst
+++ b/docs/scoping-and-declarations.rst
@@ -176,7 +176,7 @@ It is not permitted for a memory or calldata variable to shadow the name of an i
 Function Scope
 --------------
 
-Variables that are declared within a function, or given as function input arguments, are visible within the body of that function. For example, the following contract is valid because each declaration of ``a`` only exists within one function's body.
+Variables that are declared within a function, or given as function input arguments, are visible within the body of that function. For example, the following module is valid because each declaration of ``a`` only exists within one function's body.
 
 .. code-block:: vyper
 
@@ -217,7 +217,7 @@ The following examples will not compile:
 Block Scopes
 ------------
 
-Logical blocks created by ``for`` and ``if`` statements have their own scope. For example, the following contract is valid because ``x`` only exists within the block scopes for each branch of the ``if`` statement:
+Logical blocks created by ``for`` and ``if`` statements have their own scope. For example, the following module is valid because ``x`` only exists within the block scopes for each branch of the ``if`` statement:
 
 .. code-block:: vyper
 
@@ -228,7 +228,7 @@ Logical blocks created by ``for`` and ``if`` statements have their own scope. Fo
         else:
             x: bool = False
 
-In a ``for`` statement, the target variable exists within the scope of the loop. For example, the following contract is valid because ``i`` is no longer available upon exiting the loop:
+In a ``for`` statement, the target variable exists within the scope of the loop. For example, the following module is valid because ``i`` is no longer available upon exiting the loop:
 
 .. code-block:: vyper
 
@@ -238,7 +238,7 @@ In a ``for`` statement, the target variable exists within the scope of the loop.
             pass
         i: bool = False
 
-The following contract fails to compile because ``a`` has not been declared outside of the loop.
+The following module fails to compile because ``a`` has not been declared outside of the loop.
 
 .. code-block:: vyper
 

--- a/docs/solidity-differences.rst
+++ b/docs/solidity-differences.rst
@@ -94,7 +94,7 @@ In Vyper 0.4.0, a module system was introduced for powerful code reuse:
     def __init__():
         ownable.__init__()
 
-Three declarations manage module relationships: ``initializes`` (this contract manages the module's storage), ``uses`` (this contract reads module state without initializing), and ``exports`` (expose module functions in the ABI). See :doc:`using-modules` for details.
+Three declarations manage module relationships: ``initializes`` (this module manages another module's storage), ``uses`` (this module reads another module's state without initializing), and ``exports`` (expose module functions in the ABI). See :doc:`using-modules` for details.
 
 A contract can be understood by reading one file and its direct imports; dependencies and what is exposed in the external function table are explicit.
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -185,7 +185,7 @@ Therefore, a module encapsulates
 * functionality (types and functions), and
 * state (variables), which may be tightly coupled with that functionality 
 
-Modules can be added to contracts by importing them from a ``.vy`` file. Any ``.vy`` file is a valid module which can be imported into another contract! This is a very powerful feature which allows you to assemble contracts via other contracts as building blocks.
+Modules can be imported from any ``.vy`` file. Any ``.vy`` file is a valid module which can be imported into another module. When the entry-point module is compiled and deployed, it becomes a contract.
 
 .. code-block:: vyper
     # my_module.vy
@@ -236,7 +236,7 @@ Interfaces
 
 An interface is a set of function definitions used to enable calls between smart contracts. A contract interface defines all of that contract's externally available functions. By importing the interface, your contract now knows how to call these functions in other contracts.
 
-Interfaces can be added to contracts either through inline definition, or by importing them from a separate ``.vyi`` file.
+Interfaces can be added to a module either through inline definition, or by importing them from a separate ``.vyi`` file.
 
 .. code-block:: vyper
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -3,9 +3,9 @@
 Structure of a Contract
 #######################
 
-Vyper contracts are contained within files. Each file contains exactly one contract.
+Each Vyper source file contains exactly one module.
 
-This section provides a quick overview of the types of data present within a contract, with links to other sections where you can obtain more details.
+This section provides a quick overview of the types of data present within a module, with links to other sections where you can obtain more details.
 
 .. _structure-versions:
 
@@ -36,12 +36,12 @@ The following declaration is equivalent, and, prior to 0.3.10, was the only supp
     # @version ^0.4.0
 
 
-In the above examples, the contract will only compile with Vyper versions ``0.4.x``.
+In the above examples, the module will only compile with Vyper versions ``0.4.x``.
 
 Optimization Mode
 -----------------
 
-The optimization mode can be one of ``"none"``, ``"codesize"``, or ``"gas"`` (default). For example, adding the following line to a contract will cause it to try to optimize for codesize:
+The optimization mode can be one of ``"none"``, ``"codesize"``, or ``"gas"`` (default). For example, adding the following line to a module will cause it to try to optimize for codesize:
 
 .. code-block:: vyper
 
@@ -95,7 +95,7 @@ Using ``from`` you can perform both absolute and relative imports. You may optio
     # with an alias
     from my_package import foo as bar
 
-Relative imports are possible by prepending dots to the contract name. A single leading dot indicates a relative import starting with the current package. Two leading dots indicate a relative import from the parent of the current package:
+Relative imports are possible by prepending dots to the module name. A single leading dot indicates a relative import starting with the current package. Two leading dots indicate a relative import from the parent of the current package:
 
 .. code-block:: vyper
 
@@ -109,7 +109,7 @@ Further higher directories can be accessed with ``...``, ``....`` etc., as in Py
 Searching For Imports
 -----------------------------
 
-When looking for a file to import, Vyper will first search relative to the same folder as the contract being compiled. It then checks for the file in the provided search paths, in the precedence provided. Vyper checks for the file name with a ``.vy`` suffix first, then ``.vyi``, then ``.json``.
+When looking for a file to import, Vyper will first search relative to the same folder as the module being compiled. It then checks for the file in the provided search paths, in the precedence provided. Vyper checks for the file name with a ``.vy`` suffix first, then ``.vyi``, then ``.json``.
 
 When using the :ref:`vyper CLI <vyper-cli-command>`, the search path defaults to the current working directory, plus the python `syspath <https://docs.python.org/3.11/library/sys.html#sys.path>`_. You can append to the search path with the ``-p`` flag, e.g.:
 
@@ -155,7 +155,7 @@ See the documentation on :ref:`Types<types>` or :ref:`Scoping and Declarations<s
 Functions
 =========
 
-Functions are executable units of code within a contract.
+Functions are executable units of code within a module.
 
 .. code-block:: vyper
 

--- a/docs/using-modules.rst
+++ b/docs/using-modules.rst
@@ -49,7 +49,7 @@ A module can be imported using ``import`` or ``from ... import`` statements. The
     from . import ownable        # accessible as `ownable`
     from . import ownable as ow  # accessible as `ow`
 
-When importing using the ``as`` keyword, the module will be referred to by its alias in the rest of the contract.
+When importing using the ``as`` keyword, the module will be referred to by its alias in the rest of the importing module.
 
 The ``_times_two()`` helper function in the above module can be immediately used without any further work since it is "pure" and doesn't depend on initialized state.
 

--- a/docs/using-modules.rst
+++ b/docs/using-modules.rst
@@ -8,7 +8,7 @@ A module is a set of function definitions and variable declarations which enable
 Declaring and using modules
 ===========================
 
-The simplest way to define a module is to write a contract. In Vyper, any contract is a valid module! For example, the following contract is also a valid module.
+Any ``.vy`` file is a module. When a module is the entry point of compilation, it becomes a contract upon deployment. For example, the following module can be both deployed directly and imported by other modules.
 
 .. code-block:: vyper
 

--- a/docs/using-modules.rst
+++ b/docs/using-modules.rst
@@ -33,7 +33,7 @@ Any ``.vy`` file is a module. When a module is the entry point of compilation, i
 
         self.owner = new_owner
 
-This contract basically has two bits of functionality which can be reused upon import, the ``_check_owner()`` function and the ``update_owner()`` function. The ``_check_owner()`` is an internal function which can be used as a helper to check ownership in importing modules, while the ``update_owner()`` is an external function which an importing module can itself :ref:`export <exporting-functions>` as an externally facing piece of functionality.
+This module basically has two bits of functionality which can be reused upon import, the ``_check_owner()`` function and the ``update_owner()`` function. The ``_check_owner()`` is an internal function which can be used as a helper to check ownership in importing modules, while the ``update_owner()`` is an external function which an importing module can itself :ref:`export <exporting-functions>` as an externally facing piece of functionality.
 
 You can use this module's functionality simply by importing it, however any functionality that you do not use from a module will not be included in the final compilation target. For example, if you don't use the ``initializes`` statement to declare a module's location in the storage layout, you cannot use its state. Similarly, if you don't explicitly ``export`` an external function from a module, it will not appear in the runtime code.
 
@@ -112,7 +112,7 @@ A module's state can be directly accessed just by prefixing the name of a variab
 The ``uses`` statement
 ======================
 
-Another way of using a contract's state without directly initializing it is to use the ``uses`` keyword. This is a more advanced usage which is expected to be mostly utilized by library designers. The ``uses`` statement allows a module to use another module's state but defer its initialization to another module in the compilation tree (most likely a user of the library in question).
+Another way of using a module's state without directly initializing it is to use the ``uses`` keyword. This is a more advanced usage which is expected to be mostly utilized by library designers. The ``uses`` statement allows a module to use another module's state but defer its initialization to another module in the compilation tree (most likely a user of the library in question).
 
 This is best illustrated with an example:
 


### PR DESCRIPTION
### What I did
Fixed inconsistent use of "module", "contract", and "interface" throughout the docs, based on feedback from @Sporarum. Changes are consistent with the direction of #4877.

### How I did it
Replaced incorrect uses of "contract" with "module" where the text referred to source files. Fixed the inversion pattern that described "any contract is a valid module" — the correct relationship is that the entry-point module becomes a contract upon deployment.

### How to verify it
Read the changed files and check terminology is consistent with the module/contract/interface distinctions.
### Commit message

```
chore[docs]: fix module/contract/interface terminology
update docs to consistently distinguish between modules (source files),
contracts (deployed artifacts), and interfaces. fixes incorrect
inversion pattern which described any contract as a valid module. the
correct relationship is that the entry-point module becomes a contract
upon deployment.
```
