### PR TITLE
refactor[venom]: algebraic representation for range analysis

### DIFF
--- a/tests/unit/venom/test_eval_byte.py
+++ b/tests/unit/venom/test_eval_byte.py
@@ -1,4 +1,4 @@
-"""Comprehensive tests for _eval_byte evaluator.
+"""Comprehensive tests for eval_byte evaluator.
 
 The byte instruction extracts the N-th byte (big-endian) from a 256-bit value.
 byte(N, x) returns the N-th byte from the high end (byte 0 is MSB, byte 31 is LSB).
@@ -10,27 +10,12 @@ from __future__ import annotations
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from vyper.venom.analysis.variable_range.evaluators import _eval_byte
+from vyper.venom.analysis.variable_range.evaluators import eval_byte
 from vyper.venom.analysis.variable_range.value_range import ValueRange
-from vyper.venom.basicblock import IRInstruction, IRLiteral, IRVariable
 
 # =============================================================================
 # HELPER FUNCTIONS
 # =============================================================================
-
-
-def make_byte_inst(index_op, value_op) -> IRInstruction:
-    """Create a byte instruction.
-
-    Note: operand order is operands[-1] = index, operands[-2] = value.
-    """
-    ops = []
-    for op in [value_op, index_op]:  # Reversed order for operand array
-        if isinstance(op, int):
-            ops.append(IRLiteral(op))
-        else:
-            ops.append(op)
-    return IRInstruction("byte", ops)
 
 
 def eval_evm_byte(index: int, value: int) -> int:
@@ -43,13 +28,6 @@ def eval_evm_byte(index: int, value: int) -> int:
     # Byte N is at bit position (31-N)*8 to (31-N)*8+7
     shift = (31 - index) * 8
     return (value >> shift) & 0xFF
-
-
-def to_unsigned(val: int) -> int:
-    """Convert signed 256-bit value to unsigned."""
-    if val < 0:
-        return val + (2**256)
-    return val
 
 
 def value_in_range(val: int, rng: ValueRange) -> bool:
@@ -77,38 +55,26 @@ class TestByteIndexOutOfRange:
 
     def test_index_32_returns_zero(self) -> None:
         """byte(32, x) should return 0."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(32, var_x)
-        state = {var_x: ValueRange.top()}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(32), ValueRange.top())
         assert result.is_constant
         assert result.lo == 0
 
     def test_index_33_returns_zero(self) -> None:
         """byte(33, x) should return 0."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(33, var_x)
-        state = {var_x: ValueRange.constant(0xFFFFFFFFFFFFFFFF)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(33), ValueRange.constant(0xFFFFFFFFFFFFFFFF))
         assert result.is_constant
         assert result.lo == 0
 
     def test_index_255_returns_zero(self) -> None:
         """byte(255, x) should return 0."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(255, var_x)
-        state = {var_x: ValueRange.top()}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(255), ValueRange.top())
         assert result.is_constant
         assert result.lo == 0
 
     def test_index_max_uint_returns_zero(self) -> None:
         """byte(MAX_UINT, x) should return 0."""
-        var_x = IRVariable("%x")
         # Using a large literal value
-        inst = make_byte_inst(2**64, var_x)
-        state = {var_x: ValueRange.top()}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(2**64), ValueRange.top())
         assert result.is_constant
         assert result.lo == 0
 
@@ -123,19 +89,13 @@ class TestByteEmptyRange:
 
     def test_empty_value_range_returns_empty(self) -> None:
         """byte(N, empty) should return empty."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(0, var_x)
-        state = {var_x: ValueRange.empty()}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(0), ValueRange.empty())
         assert result.is_empty
 
     def test_empty_value_range_any_index(self) -> None:
         """byte with empty value range returns empty for any index."""
-        var_x = IRVariable("%x")
         for idx in [0, 15, 31, 32]:
-            inst = make_byte_inst(idx, var_x)
-            state = {var_x: ValueRange.empty()}
-            result = _eval_byte(inst, state)
+            result = eval_byte(ValueRange.constant(idx), ValueRange.empty())
             assert result.is_empty, f"Failed for index {idx}"
 
 
@@ -149,20 +109,14 @@ class TestByteTopRange:
 
     def test_top_value_range_returns_bytes_range(self) -> None:
         """byte(N, TOP) should return [0, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(0, var_x)
-        state = {var_x: ValueRange.top()}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(0), ValueRange.top())
         assert result.lo == 0
         assert result.hi == 255
 
     def test_top_value_range_all_valid_indices(self) -> None:
         """byte with TOP value range returns [0, 255] for indices 0-31."""
-        var_x = IRVariable("%x")
         for idx in range(32):
-            inst = make_byte_inst(idx, var_x)
-            state = {var_x: ValueRange.top()}
-            result = _eval_byte(inst, state)
+            result = eval_byte(ValueRange.constant(idx), ValueRange.top())
             assert result.lo == 0, f"Failed for index {idx}"
             assert result.hi == 255, f"Failed for index {idx}"
 
@@ -177,20 +131,13 @@ class TestByteVariableIndex:
 
     def test_variable_index_returns_bytes_range(self) -> None:
         """byte(%idx, x) with variable index should return [0, 255]."""
-        var_idx = IRVariable("%idx")
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(var_idx, var_x)
-        state = {var_idx: ValueRange.iv(0, 31), var_x: ValueRange.constant(0x1234)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.iv(0, 31), ValueRange.constant(0x1234))
         assert result.lo == 0
         assert result.hi == 255
 
     def test_variable_index_with_constant_value(self) -> None:
         """byte with variable index returns [0, 255] even with constant value."""
-        var_idx = IRVariable("%idx")
-        inst = make_byte_inst(var_idx, 0xFF00FF)
-        state = {var_idx: ValueRange.constant(0)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.iv(0, 31), ValueRange.constant(0xFF00FF))
         # Even though value is constant, index is variable so we can't
         # determine which byte to extract
         assert result.lo == 0
@@ -207,29 +154,20 @@ class TestByteNegativeRange:
 
     def test_negative_constant_returns_bytes_range(self) -> None:
         """byte(N, negative) should return [0, 255] (conservative)."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)  # LSB
-        state = {var_x: ValueRange.constant(-1)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.constant(-1))
         # The function returns bytes_range for negative values
         assert result.lo == 0
         assert result.hi == 255
 
     def test_negative_range_returns_bytes_range(self) -> None:
         """byte with range including negatives returns [0, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(0, var_x)
-        state = {var_x: ValueRange.iv(-128, 127)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(0), ValueRange.iv(-128, 127))
         assert result.lo == 0
         assert result.hi == 255
 
     def test_purely_negative_range_returns_bytes_range(self) -> None:
         """byte with purely negative range returns [0, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(15, var_x)
-        state = {var_x: ValueRange.iv(-1000, -1)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(15), ValueRange.iv(-1000, -1))
         assert result.lo == 0
         assert result.hi == 255
 
@@ -244,32 +182,23 @@ class TestByteValueBelowBytePosition:
 
     def test_byte_0_small_value(self) -> None:
         """byte(0, small_value) where small_value < 2^248 returns 0."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(0, var_x)
         # Byte 0 extracts bits 248-255, so any value < 2^248 has byte 0 = 0
-        state = {var_x: ValueRange.iv(0, 2**247)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(0), ValueRange.iv(0, 2**247))
         assert result.is_constant
         assert result.lo == 0
 
     def test_byte_30_small_value(self) -> None:
         """byte(30, x) where x < 256 returns 0."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(30, var_x)
         # Byte 30 extracts bits 8-15, so any value < 256 has byte 30 = 0
-        state = {var_x: ValueRange.iv(0, 255)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(30), ValueRange.iv(0, 255))
         assert result.is_constant
         assert result.lo == 0
 
     def test_byte_20_value_below_position(self) -> None:
         """byte(20, x) where x < 2^88 returns 0."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(20, var_x)
         # Byte 20 extracts bits at position (31-20)*8 = 88 to 95
         # Any value < 2^88 has byte 20 = 0
-        state = {var_x: ValueRange.iv(0, 2**87)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(20), ValueRange.iv(0, 2**87))
         assert result.is_constant
         assert result.lo == 0
 
@@ -284,48 +213,33 @@ class TestByteSamePrefixBounded:
 
     def test_byte_31_small_range(self) -> None:
         """byte(31, [0, 10]) returns [0, 10]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
         # Byte 31 is the LSB, extracting bits 0-7
-        state = {var_x: ValueRange.iv(0, 10)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.iv(0, 10))
         assert result.lo == 0
         assert result.hi == 10
 
     def test_byte_31_range_0_255(self) -> None:
         """byte(31, [0, 255]) returns [0, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange.iv(0, 255)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.iv(0, 255))
         assert result.lo == 0
         assert result.hi == 255
 
     def test_byte_31_range_100_200(self) -> None:
         """byte(31, [100, 200]) returns [100, 200]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange.iv(100, 200)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.iv(100, 200))
         assert result.lo == 100
         assert result.hi == 200
 
     def test_byte_30_range_with_same_prefix(self) -> None:
         """byte(30, [0x100, 0x1FF]) returns [1, 1] (same high byte)."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(30, var_x)
         # 0x100 to 0x1FF all have byte 30 = 1
-        state = {var_x: ValueRange.iv(0x100, 0x1FF)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(30), ValueRange.iv(0x100, 0x1FF))
         assert result.lo == 1
         assert result.hi == 1
 
     def test_byte_30_range_partial(self) -> None:
         """byte(30, [0x180, 0x1C0]) returns [1, 1]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(30, var_x)
-        state = {var_x: ValueRange.iv(0x180, 0x1C0)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(30), ValueRange.iv(0x180, 0x1C0))
         assert result.lo == 1
         assert result.hi == 1
 
@@ -340,44 +254,32 @@ class TestByteDifferentPrefix:
 
     def test_byte_31_spans_boundary(self) -> None:
         """byte(31, [0, 256]) returns [0, 255] (spans byte 31 boundary)."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
         # Range spans from 0x00 to 0x100, byte 31 covers full range
-        state = {var_x: ValueRange.iv(0, 256)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.iv(0, 256))
         assert result.lo == 0
         assert result.hi == 255
 
     def test_byte_30_spans_boundary(self) -> None:
         """byte(30, [0, 0x20000]) returns [0, 255] (spans byte 30 boundary)."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(30, var_x)
         # For byte 30: shift = (31-30)*8 = 8
         # lo_prefix = lo >> 16, hi_prefix = hi >> 16
         # [0, 0x20000] has lo_prefix=0, hi_prefix=2 (different)
-        state = {var_x: ValueRange.iv(0, 0x20000)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(30), ValueRange.iv(0, 0x20000))
         assert result.lo == 0
         assert result.hi == 255
 
     def test_byte_31_large_range(self) -> None:
         """byte(31, [0, 1000]) returns [0, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange.iv(0, 1000)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.iv(0, 1000))
         assert result.lo == 0
         assert result.hi == 255
 
     def test_byte_29_spans_boundary(self) -> None:
         """byte(29, [0x10000, 0x3000000]) returns [0, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(29, var_x)
         # For byte 29: shift = (31-29)*8 = 16
         # lo_prefix = lo >> 24, hi_prefix = hi >> 24
         # [0x10000, 0x3000000] has lo_prefix=0, hi_prefix=3 (different)
-        state = {var_x: ValueRange.iv(0x10000, 0x3000000)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(29), ValueRange.iv(0x10000, 0x3000000))
         assert result.lo == 0
         assert result.hi == 255
 
@@ -392,10 +294,7 @@ class TestByteEdgeCases:
 
     def test_byte_0_all_ones(self) -> None:
         """byte(0, -1) should return [0, 255] (negative value)."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(0, var_x)
-        state = {var_x: ValueRange.constant(-1)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(0), ValueRange.constant(-1))
         # -1 is 0xFF...FF, so byte 0 = 0xFF = 255
         # But the function returns bytes_range for negative values
         assert result.lo == 0
@@ -403,29 +302,20 @@ class TestByteEdgeCases:
 
     def test_byte_at_exact_boundary_256(self) -> None:
         """byte(31, [256, 256]) returns [0, 0]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
         # 256 = 0x100, byte 31 = 0x00
-        state = {var_x: ValueRange.constant(256)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.constant(256))
         assert result.is_constant
         assert result.lo == 0
 
     def test_byte_at_exact_boundary_255(self) -> None:
         """byte(31, [255, 255]) returns [255, 255]."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange.constant(255)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.constant(255))
         assert result.is_constant
         assert result.lo == 255
 
     def test_byte_index_31_boundary_value(self) -> None:
         """Test byte 31 at the boundary between valid and invalid indices."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange.iv(128, 255)}
-        result = _eval_byte(inst, state)
+        result = eval_byte(ValueRange.constant(31), ValueRange.iv(128, 255))
         assert result.lo == 128
         assert result.hi == 255
 
@@ -445,10 +335,7 @@ class TestByteSoundness:
     @settings(deadline=None, max_examples=200)
     def test_byte_soundness_constants(self, index: int, value: int) -> None:
         """BYTE with constant inputs: result must be in computed range."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(index, var_x)
-        state = {var_x: ValueRange.constant(value)}
-        result_range = _eval_byte(inst, state)
+        result_range = eval_byte(ValueRange.constant(index), ValueRange.constant(value))
         actual = eval_evm_byte(index, value)
         assert value_in_range(
             actual, result_range
@@ -461,8 +348,7 @@ class TestByteSoundness:
     @settings(deadline=None, max_examples=50)
     def test_byte_soundness_out_of_range_index(self, index: int, value: int) -> None:
         """BYTE with out-of-range index always returns 0."""
-        inst = make_byte_inst(index, value)
-        result_range = _eval_byte(inst, {})
+        result_range = eval_byte(ValueRange.constant(index), ValueRange.constant(value))
         assert result_range.is_constant
         assert result_range.lo == 0
 
@@ -470,10 +356,7 @@ class TestByteSoundness:
     @settings(deadline=None, max_examples=50)
     def test_byte_soundness_top_range(self, index: int) -> None:
         """BYTE with TOP value range must include all possible byte values."""
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(index, var_x)
-        state = {var_x: ValueRange.top()}
-        result_range = _eval_byte(inst, state)
+        result_range = eval_byte(ValueRange.constant(index), ValueRange.top())
         # Result must cover [0, 255]
         assert result_range.lo <= 0
         assert result_range.hi >= 255
@@ -484,10 +367,7 @@ class TestByteSoundness:
         """BYTE(31, [lo, hi]) must contain all actual byte values."""
         if lo > hi:
             lo, hi = hi, lo
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange.iv(lo, hi)}
-        result_range = _eval_byte(inst, state)
+        result_range = eval_byte(ValueRange.constant(31), ValueRange.iv(lo, hi))
 
         # Check that all values in [lo, hi] produce results in result_range
         for val in range(lo, min(hi + 1, lo + 10)):  # Check first few
@@ -504,10 +384,7 @@ class TestByteSoundness:
         """BYTE(30, [lo, hi]) must contain all actual byte values."""
         if lo > hi:
             lo, hi = hi, lo
-        var_x = IRVariable("%x")
-        inst = make_byte_inst(30, var_x)
-        state = {var_x: ValueRange.iv(lo, hi)}
-        result_range = _eval_byte(inst, state)
+        result_range = eval_byte(ValueRange.constant(30), ValueRange.iv(lo, hi))
 
         # Check bounds
         actual_lo = eval_evm_byte(30, lo)

--- a/tests/unit/venom/test_eval_byte.py
+++ b/tests/unit/venom/test_eval_byte.py
@@ -180,7 +180,7 @@ class TestByteVariableIndex:
         var_idx = IRVariable("%idx")
         var_x = IRVariable("%x")
         inst = make_byte_inst(var_idx, var_x)
-        state = {var_idx: ValueRange((0, 31)), var_x: ValueRange.constant(0x1234)}
+        state = {var_idx: ValueRange.iv(0, 31), var_x: ValueRange.constant(0x1234)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -219,7 +219,7 @@ class TestByteNegativeRange:
         """byte with range including negatives returns [0, 255]."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(0, var_x)
-        state = {var_x: ValueRange((-128, 127))}
+        state = {var_x: ValueRange.iv(-128, 127)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -228,7 +228,7 @@ class TestByteNegativeRange:
         """byte with purely negative range returns [0, 255]."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(15, var_x)
-        state = {var_x: ValueRange((-1000, -1))}
+        state = {var_x: ValueRange.iv(-1000, -1)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -247,7 +247,7 @@ class TestByteValueBelowBytePosition:
         var_x = IRVariable("%x")
         inst = make_byte_inst(0, var_x)
         # Byte 0 extracts bits 248-255, so any value < 2^248 has byte 0 = 0
-        state = {var_x: ValueRange((0, 2**247))}
+        state = {var_x: ValueRange.iv(0, 2**247)}
         result = _eval_byte(inst, state)
         assert result.is_constant
         assert result.lo == 0
@@ -257,7 +257,7 @@ class TestByteValueBelowBytePosition:
         var_x = IRVariable("%x")
         inst = make_byte_inst(30, var_x)
         # Byte 30 extracts bits 8-15, so any value < 256 has byte 30 = 0
-        state = {var_x: ValueRange((0, 255))}
+        state = {var_x: ValueRange.iv(0, 255)}
         result = _eval_byte(inst, state)
         assert result.is_constant
         assert result.lo == 0
@@ -268,7 +268,7 @@ class TestByteValueBelowBytePosition:
         inst = make_byte_inst(20, var_x)
         # Byte 20 extracts bits at position (31-20)*8 = 88 to 95
         # Any value < 2^88 has byte 20 = 0
-        state = {var_x: ValueRange((0, 2**87))}
+        state = {var_x: ValueRange.iv(0, 2**87)}
         result = _eval_byte(inst, state)
         assert result.is_constant
         assert result.lo == 0
@@ -287,7 +287,7 @@ class TestByteSamePrefixBounded:
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
         # Byte 31 is the LSB, extracting bits 0-7
-        state = {var_x: ValueRange((0, 10))}
+        state = {var_x: ValueRange.iv(0, 10)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 10
@@ -296,7 +296,7 @@ class TestByteSamePrefixBounded:
         """byte(31, [0, 255]) returns [0, 255]."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange((0, 255))}
+        state = {var_x: ValueRange.iv(0, 255)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -305,7 +305,7 @@ class TestByteSamePrefixBounded:
         """byte(31, [100, 200]) returns [100, 200]."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange((100, 200))}
+        state = {var_x: ValueRange.iv(100, 200)}
         result = _eval_byte(inst, state)
         assert result.lo == 100
         assert result.hi == 200
@@ -315,7 +315,7 @@ class TestByteSamePrefixBounded:
         var_x = IRVariable("%x")
         inst = make_byte_inst(30, var_x)
         # 0x100 to 0x1FF all have byte 30 = 1
-        state = {var_x: ValueRange((0x100, 0x1FF))}
+        state = {var_x: ValueRange.iv(0x100, 0x1FF)}
         result = _eval_byte(inst, state)
         assert result.lo == 1
         assert result.hi == 1
@@ -324,7 +324,7 @@ class TestByteSamePrefixBounded:
         """byte(30, [0x180, 0x1C0]) returns [1, 1]."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(30, var_x)
-        state = {var_x: ValueRange((0x180, 0x1C0))}
+        state = {var_x: ValueRange.iv(0x180, 0x1C0)}
         result = _eval_byte(inst, state)
         assert result.lo == 1
         assert result.hi == 1
@@ -343,7 +343,7 @@ class TestByteDifferentPrefix:
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
         # Range spans from 0x00 to 0x100, byte 31 covers full range
-        state = {var_x: ValueRange((0, 256))}
+        state = {var_x: ValueRange.iv(0, 256)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -355,7 +355,7 @@ class TestByteDifferentPrefix:
         # For byte 30: shift = (31-30)*8 = 8
         # lo_prefix = lo >> 16, hi_prefix = hi >> 16
         # [0, 0x20000] has lo_prefix=0, hi_prefix=2 (different)
-        state = {var_x: ValueRange((0, 0x20000))}
+        state = {var_x: ValueRange.iv(0, 0x20000)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -364,7 +364,7 @@ class TestByteDifferentPrefix:
         """byte(31, [0, 1000]) returns [0, 255]."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange((0, 1000))}
+        state = {var_x: ValueRange.iv(0, 1000)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -376,7 +376,7 @@ class TestByteDifferentPrefix:
         # For byte 29: shift = (31-29)*8 = 16
         # lo_prefix = lo >> 24, hi_prefix = hi >> 24
         # [0x10000, 0x3000000] has lo_prefix=0, hi_prefix=3 (different)
-        state = {var_x: ValueRange((0x10000, 0x3000000))}
+        state = {var_x: ValueRange.iv(0x10000, 0x3000000)}
         result = _eval_byte(inst, state)
         assert result.lo == 0
         assert result.hi == 255
@@ -424,7 +424,7 @@ class TestByteEdgeCases:
         """Test byte 31 at the boundary between valid and invalid indices."""
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange((128, 255))}
+        state = {var_x: ValueRange.iv(128, 255)}
         result = _eval_byte(inst, state)
         assert result.lo == 128
         assert result.hi == 255
@@ -486,7 +486,7 @@ class TestByteSoundness:
             lo, hi = hi, lo
         var_x = IRVariable("%x")
         inst = make_byte_inst(31, var_x)
-        state = {var_x: ValueRange((lo, hi))}
+        state = {var_x: ValueRange.iv(lo, hi)}
         result_range = _eval_byte(inst, state)
 
         # Check that all values in [lo, hi] produce results in result_range
@@ -506,7 +506,7 @@ class TestByteSoundness:
             lo, hi = hi, lo
         var_x = IRVariable("%x")
         inst = make_byte_inst(30, var_x)
-        state = {var_x: ValueRange((lo, hi))}
+        state = {var_x: ValueRange.iv(lo, hi)}
         result_range = _eval_byte(inst, state)
 
         # Check bounds

--- a/tests/unit/venom/test_variable_range_properties.py
+++ b/tests/unit/venom/test_variable_range_properties.py
@@ -989,9 +989,7 @@ class TestBitwiseSoundness:
         inst = make_inst("or", var_x, 0)
         state = {var_x: test_range}
         result_range = _eval_or(inst, state)
-        assert (
-            result_range == test_range
-        ), f"OR with 0 should preserve range, got {result_range}"
+        assert result_range == test_range, f"OR with 0 should preserve range, got {result_range}"
 
     def test_or_with_all_ones_absorbing(self) -> None:
         """OR with -1 (all bits set) should return -1."""

--- a/tests/unit/venom/test_variable_range_properties.py
+++ b/tests/unit/venom/test_variable_range_properties.py
@@ -106,7 +106,7 @@ def value_range_strategy(draw: st.DrawFn, allow_empty: bool = False) -> ValueRan
         hi = draw(int256_strategy)
         if lo > hi:
             lo, hi = hi, lo
-        return ValueRange((lo, hi))
+        return ValueRange.iv(lo, hi)
 
 
 @st.composite
@@ -116,7 +116,7 @@ def nonnegative_range_strategy(draw: st.DrawFn) -> ValueRange:
 
     if range_type == "top":
         # For non-negative, use [0, UINT256_MAX]
-        return ValueRange((0, UINT256_MAX))
+        return ValueRange.iv(0, UINT256_MAX)
     elif range_type == "constant":
         val = draw(uint256_strategy)
         return ValueRange.constant(val)
@@ -125,7 +125,7 @@ def nonnegative_range_strategy(draw: st.DrawFn) -> ValueRange:
         hi = draw(uint256_strategy)
         if lo > hi:
             lo, hi = hi, lo
-        return ValueRange((lo, hi))
+        return ValueRange.iv(lo, hi)
 
 
 @st.composite
@@ -487,7 +487,7 @@ class TestValueRangeBasics:
         elif rng.is_empty:
             assert result.is_empty
         else:
-            assert result.bounds == rng.bounds
+            assert result == rng
 
     @given(value_range_strategy())
     @settings(deadline=None)
@@ -499,7 +499,7 @@ class TestValueRangeBasics:
         elif rng.is_empty:
             assert result.is_empty
         else:
-            assert result.bounds == rng.bounds
+            assert result == rng
 
     @given(value_range_strategy())
     @settings(deadline=None)
@@ -511,9 +511,9 @@ class TestValueRangeBasics:
     def test_bottom_canonical_representation(self) -> None:
         """All BOTTOM representations should be equal (canonical form)."""
         # Different ways to create BOTTOM (lo > hi)
-        bottom1 = ValueRange((1, 0))
-        bottom2 = ValueRange((2, 1))
-        bottom3 = ValueRange((100, 0))
+        bottom1 = ValueRange.iv(1, 0)
+        bottom2 = ValueRange.iv(2, 1)
+        bottom3 = ValueRange.iv(100, 0)
         bottom4 = ValueRange.empty()
 
         # All should be equal due to canonical normalization
@@ -522,11 +522,11 @@ class TestValueRangeBasics:
         assert bottom3 == bottom4
         assert bottom1 == bottom4
 
-        # All should have canonical bounds (1, 0)
-        assert bottom1.bounds == (1, 0)
-        assert bottom2.bounds == (1, 0)
-        assert bottom3.bounds == (1, 0)
-        assert bottom4.bounds == (1, 0)
+        # All should be bottom
+        assert bottom1.is_bottom
+        assert bottom2.is_bottom
+        assert bottom3.is_bottom
+        assert bottom4.is_bottom
 
     @given(int256_strategy)
     @settings(deadline=None)
@@ -985,12 +985,12 @@ class TestBitwiseSoundness:
     def test_or_with_zero_identity(self) -> None:
         """OR with 0 should return the other operand's range."""
         var_x = IRVariable("%x")
-        test_range = ValueRange((10, 20))
+        test_range = ValueRange.iv(10, 20)
         inst = make_inst("or", var_x, 0)
         state = {var_x: test_range}
         result_range = _eval_or(inst, state)
         assert (
-            result_range.bounds == test_range.bounds
+            result_range == test_range
         ), f"OR with 0 should preserve range, got {result_range}"
 
     def test_or_with_all_ones_absorbing(self) -> None:
@@ -1041,14 +1041,14 @@ class TestBitwiseSoundness:
         """
         var_x = IRVariable("%x")
         # Input range includes negatives
-        test_range = ValueRange((-128, 127))
+        test_range = ValueRange.iv(-128, 127)
         inst = make_inst("and", var_x, -1)
         state = {var_x: test_range}
         result_range = _eval_and(inst, state)
 
         # AND with -1 is identity, should preserve input range
         assert (
-            result_range.bounds == test_range.bounds
+            result_range == test_range
         ), f"AND with -1 should be identity, expected {test_range}, got {result_range}"
 
         # Verify a negative value is in range

--- a/tests/unit/venom/test_variable_range_properties.py
+++ b/tests/unit/venom/test_variable_range_properties.py
@@ -529,23 +529,21 @@ class TestValueRangeBasics:
         assert bottom3.is_bottom
         assert bottom4.is_bottom
 
-    def test_top_constructor_canonicalizes_payload(self) -> None:
-        """TOP should ignore any payload and normalize to a canonical value."""
+    def test_top_constructor_rejects_payload(self) -> None:
+        """TOP must not accept lo/hi values."""
         top1 = ValueRange()
-        top2 = ValueRange(VRangeKind.TOP, 1, 2)
-
         assert top1.is_top
-        assert top2.is_top
-        assert top1 == top2
 
-    def test_bottom_constructor_canonicalizes_payload(self) -> None:
-        """BOTTOM should ignore any payload and normalize to a canonical value."""
+        with pytest.raises(ValueError, match="TOP does not take lo/hi"):
+            ValueRange(VRangeKind.TOP, 1, 2)
+
+    def test_bottom_constructor_rejects_payload(self) -> None:
+        """BOTTOM must not accept lo/hi values."""
         bottom1 = ValueRange.empty()
-        bottom2 = ValueRange(VRangeKind.BOT, 7, 9)
-
         assert bottom1.is_bottom
-        assert bottom2.is_bottom
-        assert bottom1 == bottom2
+
+        with pytest.raises(ValueError, match="BOT does not take lo/hi"):
+            ValueRange(VRangeKind.BOT, 7, 9)
 
     def test_invalid_interval_constructor_rejected(self) -> None:
         """Raw IV construction must preserve the interval invariant."""

--- a/tests/unit/venom/test_variable_range_properties.py
+++ b/tests/unit/venom/test_variable_range_properties.py
@@ -884,9 +884,7 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_or_soundness(self, a: int, b: int) -> None:
         """OR: result must be in computed range."""
-        result_range = eval_or(
-            ValueRange.constant(to_signed(a)), ValueRange.constant(to_signed(b))
-        )
+        result_range = eval_or(ValueRange.constant(to_signed(a)), ValueRange.constant(to_signed(b)))
         actual = eval_evm_or(a, b)
         assert value_in_range(
             actual, result_range

--- a/tests/unit/venom/test_variable_range_properties.py
+++ b/tests/unit/venom/test_variable_range_properties.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
@@ -38,6 +39,7 @@ from vyper.venom.analysis.variable_range.value_range import (
     SIGNED_MIN,
     UNSIGNED_MAX,
     ValueRange,
+    VRangeKind,
 )
 
 # =============================================================================
@@ -526,6 +528,29 @@ class TestValueRangeBasics:
         assert bottom2.is_bottom
         assert bottom3.is_bottom
         assert bottom4.is_bottom
+
+    def test_top_constructor_canonicalizes_payload(self) -> None:
+        """TOP should ignore any payload and normalize to a canonical value."""
+        top1 = ValueRange()
+        top2 = ValueRange(VRangeKind.TOP, 1, 2)
+
+        assert top1.is_top
+        assert top2.is_top
+        assert top1 == top2
+
+    def test_bottom_constructor_canonicalizes_payload(self) -> None:
+        """BOTTOM should ignore any payload and normalize to a canonical value."""
+        bottom1 = ValueRange.empty()
+        bottom2 = ValueRange(VRangeKind.BOT, 7, 9)
+
+        assert bottom1.is_bottom
+        assert bottom2.is_bottom
+        assert bottom1 == bottom2
+
+    def test_invalid_interval_constructor_rejected(self) -> None:
+        """Raw IV construction must preserve the interval invariant."""
+        with pytest.raises(ValueError, match="IV requires lo <= hi"):
+            ValueRange(VRangeKind.IV, 5, 1)
 
     @given(int256_strategy)
     @settings(deadline=None)

--- a/tests/unit/venom/test_variable_range_properties.py
+++ b/tests/unit/venom/test_variable_range_properties.py
@@ -15,23 +15,23 @@ from hypothesis import strategies as st
 
 from vyper.utils import wrap256
 from vyper.venom.analysis.variable_range.evaluators import (
-    _eval_add,
-    _eval_and,
-    _eval_byte,
-    _eval_compare,
-    _eval_div,
-    _eval_eq,
-    _eval_iszero,
-    _eval_mod,
-    _eval_mul,
-    _eval_not,
-    _eval_or,
-    _eval_sar,
-    _eval_shl,
-    _eval_shr,
-    _eval_signextend,
-    _eval_sub,
-    _eval_xor,
+    eval_add,
+    eval_and,
+    eval_byte,
+    eval_compare,
+    eval_div,
+    eval_eq,
+    eval_iszero,
+    eval_mod,
+    eval_mul,
+    eval_not,
+    eval_or,
+    eval_sar,
+    eval_shl,
+    eval_shr,
+    eval_signextend,
+    eval_sub,
+    eval_xor,
 )
 from vyper.venom.analysis.variable_range.value_range import (
     SIGNED_MAX,
@@ -39,7 +39,6 @@ from vyper.venom.analysis.variable_range.value_range import (
     UNSIGNED_MAX,
     ValueRange,
 )
-from vyper.venom.basicblock import IRInstruction, IRLiteral, IRVariable
 
 # =============================================================================
 # CONSTANTS
@@ -632,32 +631,6 @@ class TestEVMOperations:
 
 
 # =============================================================================
-# MOCK INSTRUCTION HELPERS
-# =============================================================================
-
-
-def make_inst(opcode: str, *operands) -> IRInstruction:
-    """Create a mock IR instruction for testing evaluators.
-
-    Note: We don't set output as evaluators only use operands.
-    """
-    ops = []
-    for op in operands:
-        if isinstance(op, int):
-            ops.append(IRLiteral(op))
-        elif isinstance(op, (IRVariable, IRLiteral)):
-            ops.append(op)
-        else:
-            ops.append(op)
-    return IRInstruction(opcode, ops)
-
-
-def make_state(*var_ranges) -> dict:
-    """Create a state dictionary from (variable, range) pairs."""
-    return {var: rng for var, rng in var_ranges}
-
-
-# =============================================================================
 # SOUNDNESS TESTS: ARITHMETIC OPERATIONS
 # =============================================================================
 
@@ -669,8 +642,7 @@ class TestArithmeticSoundness:
     @settings(deadline=None, max_examples=200)
     def test_add_soundness_constants(self, a: int, b: int) -> None:
         """ADD with constant inputs: result must be in computed range."""
-        inst = make_inst("add", a, b)
-        result_range = _eval_add(inst, {})
+        result_range = eval_add(ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_add(a, b)
         assert value_in_range(
             actual, result_range
@@ -680,9 +652,7 @@ class TestArithmeticSoundness:
     @settings(deadline=None, max_examples=200)
     def test_sub_soundness_constants(self, a: int, b: int) -> None:
         """SUB with constant inputs: result must be in computed range."""
-        # Evaluator reads operands[-1] as lhs, operands[-2] as rhs
-        inst = make_inst("sub", b, a)
-        result_range = _eval_sub(inst, {})
+        result_range = eval_sub(ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_sub(a, b)
         assert value_in_range(
             actual, result_range
@@ -692,8 +662,7 @@ class TestArithmeticSoundness:
     @settings(deadline=None, max_examples=200)
     def test_mul_soundness_constants(self, a: int, b: int) -> None:
         """MUL with constant inputs: result must be in computed range."""
-        inst = make_inst("mul", a, b)
-        result_range = _eval_mul(inst, {})
+        result_range = eval_mul(ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_mul(a, b)
         assert value_in_range(
             actual, result_range
@@ -703,9 +672,7 @@ class TestArithmeticSoundness:
     @settings(deadline=None, max_examples=200)
     def test_div_soundness_constants(self, a: int, b: int) -> None:
         """DIV with constant inputs: result must be in computed range."""
-        # Evaluator reads operands[-1] as dividend, operands[-2] as divisor
-        inst = make_inst("div", b, a)
-        result_range = _eval_div(inst, {})
+        result_range = eval_div(ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_div(a, b)
         assert value_in_range(
             actual, result_range
@@ -715,9 +682,7 @@ class TestArithmeticSoundness:
     @settings(deadline=None, max_examples=200)
     def test_mod_soundness_constants(self, a: int, b: int) -> None:
         """MOD with constant inputs: result must be in computed range."""
-        # Evaluator reads operands[-2] as divisor
-        inst = make_inst("mod", b, a)
-        result_range = _eval_mod(inst, {})
+        result_range = eval_mod(ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_mod(a, b)
         assert value_in_range(
             actual, result_range
@@ -725,16 +690,12 @@ class TestArithmeticSoundness:
 
     def test_div_by_zero_returns_zero(self) -> None:
         """DIV by zero must return 0 (EVM spec)."""
-        # Evaluator reads operands[-1] as dividend, operands[-2] as divisor
-        inst = make_inst("div", 0, 12345)
-        result_range = _eval_div(inst, {})
+        result_range = eval_div(ValueRange.constant(12345), ValueRange.constant(0))
         assert value_in_range(0, result_range)
 
     def test_mod_by_zero_returns_zero(self) -> None:
         """MOD by zero must return 0 (EVM spec)."""
-        # Evaluator reads operands[-2] as divisor
-        inst = make_inst("mod", 0, 12345)
-        result_range = _eval_mod(inst, {})
+        result_range = eval_mod(ValueRange.constant(12345), ValueRange.constant(0))
         assert value_in_range(0, result_range)
 
 
@@ -750,12 +711,7 @@ class TestComparisonSoundness:
     @settings(deadline=None, max_examples=200)
     def test_lt_soundness(self, a: int, b: int) -> None:
         """LT (unsigned): result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # Evaluator reads operands[-1] as lhs, operands[-2] as rhs
-        inst = make_inst("lt", var_b, var_a)
-        state = {var_a: ValueRange.constant(a), var_b: ValueRange.constant(b)}
-        result_range = _eval_compare(inst, state)
+        result_range = eval_compare("lt", ValueRange.constant(a), ValueRange.constant(b))
         # EVM lt is unsigned
         actual = eval_evm_lt(to_unsigned(a), to_unsigned(b))
         assert value_in_range(
@@ -766,12 +722,7 @@ class TestComparisonSoundness:
     @settings(deadline=None, max_examples=200)
     def test_gt_soundness(self, a: int, b: int) -> None:
         """GT (unsigned): result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # Evaluator reads operands[-1] as lhs, operands[-2] as rhs
-        inst = make_inst("gt", var_b, var_a)
-        state = {var_a: ValueRange.constant(a), var_b: ValueRange.constant(b)}
-        result_range = _eval_compare(inst, state)
+        result_range = eval_compare("gt", ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_gt(to_unsigned(a), to_unsigned(b))
         assert value_in_range(
             actual, result_range
@@ -781,12 +732,7 @@ class TestComparisonSoundness:
     @settings(deadline=None, max_examples=200)
     def test_slt_soundness(self, a: int, b: int) -> None:
         """SLT (signed): result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # Evaluator reads operands[-1] as lhs, operands[-2] as rhs
-        inst = make_inst("slt", var_b, var_a)
-        state = {var_a: ValueRange.constant(a), var_b: ValueRange.constant(b)}
-        result_range = _eval_compare(inst, state)
+        result_range = eval_compare("slt", ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_slt(to_unsigned(a), to_unsigned(b))
         assert value_in_range(
             actual, result_range
@@ -796,12 +742,7 @@ class TestComparisonSoundness:
     @settings(deadline=None, max_examples=200)
     def test_sgt_soundness(self, a: int, b: int) -> None:
         """SGT (signed): result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # Evaluator reads operands[-1] as lhs, operands[-2] as rhs
-        inst = make_inst("sgt", var_b, var_a)
-        state = {var_a: ValueRange.constant(a), var_b: ValueRange.constant(b)}
-        result_range = _eval_compare(inst, state)
+        result_range = eval_compare("sgt", ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_sgt(to_unsigned(a), to_unsigned(b))
         assert value_in_range(
             actual, result_range
@@ -811,12 +752,7 @@ class TestComparisonSoundness:
     @settings(deadline=None, max_examples=200)
     def test_eq_soundness(self, a: int, b: int) -> None:
         """EQ: result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # EQ is commutative, but keep consistent with other tests
-        inst = make_inst("eq", var_b, var_a)
-        state = {var_a: ValueRange.constant(a), var_b: ValueRange.constant(b)}
-        result_range = _eval_eq(inst, state)
+        result_range = eval_eq(ValueRange.constant(a), ValueRange.constant(b))
         actual = eval_evm_eq(to_unsigned(a), to_unsigned(b))
         assert value_in_range(
             actual, result_range
@@ -826,10 +762,7 @@ class TestComparisonSoundness:
     @settings(deadline=None, max_examples=200)
     def test_iszero_soundness(self, a: int) -> None:
         """ISZERO: result must be in computed range."""
-        var_a = IRVariable("%a")
-        inst = make_inst("iszero", var_a)
-        state = {var_a: ValueRange.constant(a)}
-        result_range = _eval_iszero(inst, state)
+        result_range = eval_iszero(ValueRange.constant(a))
         actual = eval_evm_iszero(to_unsigned(a))
         assert value_in_range(
             actual, result_range
@@ -837,24 +770,14 @@ class TestComparisonSoundness:
 
     def test_lt_minus_one_vs_one(self) -> None:
         """Critical: lt(-1, 1) must be 0 (unsigned: MAX_UINT > 1)."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # Evaluator reads operands[-1] as lhs, operands[-2] as rhs
-        inst = make_inst("lt", var_b, var_a)
-        state = {var_a: ValueRange.constant(-1), var_b: ValueRange.constant(1)}
-        result_range = _eval_compare(inst, state)
+        result_range = eval_compare("lt", ValueRange.constant(-1), ValueRange.constant(1))
         # -1 as unsigned is MAX_UINT, MAX_UINT > 1, so lt returns 0
         assert value_in_range(0, result_range), f"lt(-1, 1) must include 0, got {result_range}"
 
     def test_eq_minus_one_and_max_uint(self) -> None:
         """Critical: eq(-1, MAX_UINT) must be 1 (same bit pattern)."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        # EQ is commutative, but keep consistent
-        inst = make_inst("eq", var_b, var_a)
         # Both -1 and UNSIGNED_MAX are the same 256-bit pattern
-        state = {var_a: ValueRange.constant(-1), var_b: ValueRange.constant(-1)}
-        result_range = _eval_eq(inst, state)
+        result_range = eval_eq(ValueRange.constant(-1), ValueRange.constant(-1))
         assert value_in_range(1, result_range), f"eq(-1, -1) must include 1, got {result_range}"
 
 
@@ -870,10 +793,9 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_and_soundness(self, value: int, mask: int) -> None:
         """AND with literal mask: result must be in computed range."""
-        var_x = IRVariable("%x")
-        inst = make_inst("and", var_x, mask)
-        state = {var_x: ValueRange.constant(value)}
-        result_range = _eval_and(inst, state)
+        result_range = eval_and(
+            ValueRange.constant(wrap256(mask, signed=True)), ValueRange.constant(value)
+        )
         actual = eval_evm_and(value, mask)
         assert value_in_range(
             actual, result_range
@@ -883,11 +805,9 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_shr_soundness(self, shift: int, value: int) -> None:
         """SHR: result must be in computed range."""
-        var_x = IRVariable("%x")
-        # Syntax: shr SHIFT, VALUE -> operands[-1]=SHIFT, operands[-2]=VALUE
-        inst = make_inst("shr", var_x, shift)
-        state = {var_x: ValueRange.constant(value)}
-        result_range = _eval_shr(inst, state)
+        result_range = eval_shr(
+            ValueRange.constant(wrap256(shift, signed=True)), ValueRange.constant(value)
+        )
         actual = eval_evm_shr(shift, value)
         assert value_in_range(
             actual, result_range
@@ -897,10 +817,9 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_shl_soundness(self, shift: int, value: int) -> None:
         """SHL: result must be in computed range."""
-        var_x = IRVariable("%x")
-        inst = make_inst("shl", var_x, shift)
-        state = {var_x: ValueRange.constant(value)}
-        result_range = _eval_shl(inst, state)
+        result_range = eval_shl(
+            ValueRange.constant(wrap256(shift, signed=True)), ValueRange.constant(value)
+        )
         actual = eval_evm_shl(shift, value)
         assert value_in_range(
             actual, result_range
@@ -910,10 +829,9 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_sar_soundness(self, shift: int, value: int) -> None:
         """SAR (arithmetic shift): result must be in computed range."""
-        var_x = IRVariable("%x")
-        inst = make_inst("sar", var_x, shift)
-        state = {var_x: ValueRange.constant(value)}
-        result_range = _eval_sar(inst, state)
+        result_range = eval_sar(
+            ValueRange.constant(wrap256(shift, signed=True)), ValueRange.constant(value)
+        )
         actual = eval_evm_sar(shift, to_unsigned(value))
         assert value_in_range(
             actual, result_range
@@ -923,10 +841,9 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_byte_soundness(self, n: int, value: int) -> None:
         """BYTE: result must be in computed range."""
-        var_x = IRVariable("%x")
-        inst = make_inst("byte", var_x, n)
-        state = {var_x: ValueRange.constant(to_signed(value))}
-        result_range = _eval_byte(inst, state)
+        result_range = eval_byte(
+            ValueRange.constant(wrap256(n, signed=True)), ValueRange.constant(to_signed(value))
+        )
         actual = eval_evm_byte(n, value)
         assert value_in_range(
             actual, result_range
@@ -934,22 +851,17 @@ class TestBitwiseSoundness:
 
     def test_shift_by_256_returns_zero(self) -> None:
         """Shift by 256 must return 0."""
-        var_x = IRVariable("%x")
-        for opcode, eval_fn in [("shr", _eval_shr), ("shl", _eval_shl)]:
-            inst = make_inst(opcode, var_x, 256)
-            state = {var_x: ValueRange.constant(UINT256_MAX)}
-            result_range = eval_fn(inst, state)
-            assert value_in_range(0, result_range), f"{opcode} by 256 must include 0"
+        for fn in [eval_shr, eval_shl]:
+            result_range = fn(ValueRange.constant(256), ValueRange.constant(UINT256_MAX))
+            assert value_in_range(0, result_range), f"{fn.__name__} by 256 must include 0"
 
     @given(a=uint256_strategy, b=uint256_strategy)
     @settings(deadline=None, max_examples=200)
     def test_or_soundness(self, a: int, b: int) -> None:
         """OR: result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        inst = make_inst("or", var_b, var_a)
-        state = {var_a: ValueRange.constant(to_signed(a)), var_b: ValueRange.constant(to_signed(b))}
-        result_range = _eval_or(inst, state)
+        result_range = eval_or(
+            ValueRange.constant(to_signed(a)), ValueRange.constant(to_signed(b))
+        )
         actual = eval_evm_or(a, b)
         assert value_in_range(
             actual, result_range
@@ -959,11 +871,9 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_xor_soundness(self, a: int, b: int) -> None:
         """XOR: result must be in computed range."""
-        var_a = IRVariable("%a")
-        var_b = IRVariable("%b")
-        inst = make_inst("xor", var_b, var_a)
-        state = {var_a: ValueRange.constant(to_signed(a)), var_b: ValueRange.constant(to_signed(b))}
-        result_range = _eval_xor(inst, state)
+        result_range = eval_xor(
+            ValueRange.constant(to_signed(a)), ValueRange.constant(to_signed(b))
+        )
         actual = eval_evm_xor(a, b)
         assert value_in_range(
             actual, result_range
@@ -973,10 +883,7 @@ class TestBitwiseSoundness:
     @settings(deadline=None, max_examples=200)
     def test_not_soundness(self, a: int) -> None:
         """NOT: result must be in computed range."""
-        var_a = IRVariable("%a")
-        inst = make_inst("not", var_a)
-        state = {var_a: ValueRange.constant(to_signed(a))}
-        result_range = _eval_not(inst, state)
+        result_range = eval_not(ValueRange.constant(to_signed(a)))
         actual = eval_evm_not(a)
         assert value_in_range(
             actual, result_range
@@ -984,49 +891,34 @@ class TestBitwiseSoundness:
 
     def test_or_with_zero_identity(self) -> None:
         """OR with 0 should return the other operand's range."""
-        var_x = IRVariable("%x")
         test_range = ValueRange.iv(10, 20)
-        inst = make_inst("or", var_x, 0)
-        state = {var_x: test_range}
-        result_range = _eval_or(inst, state)
+        result_range = eval_or(ValueRange.constant(0), test_range)
         assert result_range == test_range, f"OR with 0 should preserve range, got {result_range}"
 
     def test_or_with_all_ones_absorbing(self) -> None:
         """OR with -1 (all bits set) should return -1."""
-        var_x = IRVariable("%x")
-        inst = make_inst("or", var_x, -1)
-        state = {var_x: ValueRange.top()}
-        result_range = _eval_or(inst, state)
+        result_range = eval_or(ValueRange.constant(-1), ValueRange.top())
         assert (
             result_range.is_constant and result_range.lo == -1
         ), f"OR with -1 should give -1, got {result_range}"
 
     def test_xor_self_is_zero(self) -> None:
-        """XOR of variable with itself should be 0."""
-        var_x = IRVariable("%x")
-        inst = make_inst("xor", var_x, var_x)
-        state = {var_x: ValueRange.top()}
-        result_range = _eval_xor(inst, state)
+        """XOR of same constant with itself should be 0."""
+        # Self-xor with constant: pure evaluator can fold
+        result_range = eval_xor(ValueRange.constant(42), ValueRange.constant(42))
         assert (
             result_range.is_constant and result_range.lo == 0
         ), f"XOR self should be 0, got {result_range}"
+        # Self-xor with non-constant: pure evaluator returns TOP
+        # (driver handles variable identity)
+        result_range = eval_xor(ValueRange.top(), ValueRange.top())
+        assert result_range.is_top
 
     def test_not_involution(self) -> None:
         """NOT(NOT(x)) should equal x for constants."""
         test_val = 12345
-        var_x = IRVariable("%x")
-
-        # First NOT
-        inst1 = make_inst("not", var_x)
-        state1 = {var_x: ValueRange.constant(test_val)}
-        result1 = _eval_not(inst1, state1)
-
-        # Second NOT
-        var_y = IRVariable("%y")
-        inst2 = make_inst("not", var_y)
-        state2 = {var_y: result1}
-        result2 = _eval_not(inst2, state2)
-
+        result1 = eval_not(ValueRange.constant(test_val))
+        result2 = eval_not(result1)
         assert (
             result2.is_constant and result2.lo == test_val
         ), f"NOT(NOT({test_val})) should be {test_val}, got {result2}"
@@ -1037,12 +929,9 @@ class TestBitwiseSoundness:
         Regression test: Previously returned [0, UNSIGNED_MAX] which doesn't
         include negative values in signed range comparison.
         """
-        var_x = IRVariable("%x")
         # Input range includes negatives
         test_range = ValueRange.iv(-128, 127)
-        inst = make_inst("and", var_x, -1)
-        state = {var_x: test_range}
-        result_range = _eval_and(inst, state)
+        result_range = eval_and(ValueRange.constant(-1), test_range)
 
         # AND with -1 is identity, should preserve input range
         assert (
@@ -1053,14 +942,11 @@ class TestBitwiseSoundness:
         assert value_in_range(to_unsigned(-128), result_range), "-128 should be in result of AND -1"
 
     def test_xor_self_with_bottom_returns_bottom(self) -> None:
-        """XOR of variable with itself when variable is BOTTOM should return BOTTOM.
+        """XOR of BOTTOM with BOTTOM should return BOTTOM.
 
         Regression test: Previously returned 0 without checking for BOTTOM input.
         """
-        var_x = IRVariable("%x")
-        inst = make_inst("xor", var_x, var_x)
-        state = {var_x: ValueRange.empty()}
-        result_range = _eval_xor(inst, state)
+        result_range = eval_xor(ValueRange.empty(), ValueRange.empty())
 
         assert (
             result_range.is_empty
@@ -1068,10 +954,7 @@ class TestBitwiseSoundness:
 
     def test_and_with_bottom_returns_bottom(self) -> None:
         """AND with BOTTOM input should return BOTTOM."""
-        var_x = IRVariable("%x")
-        inst = make_inst("and", var_x, 255)
-        state = {var_x: ValueRange.empty()}
-        result_range = _eval_and(inst, state)
+        result_range = eval_and(ValueRange.constant(0xFF), ValueRange.empty())
 
         assert (
             result_range.is_empty
@@ -1090,11 +973,9 @@ class TestSignextendSoundness:
     @settings(deadline=None, max_examples=200)
     def test_signextend_soundness(self, b: int, value: int) -> None:
         """SIGNEXTEND: result must be in computed range."""
-        var_x = IRVariable("%x")
-        # Evaluator reads operands[-1] as byte index, operands[-2] as value
-        inst = make_inst("signextend", var_x, b)
-        state = {var_x: ValueRange.constant(to_signed(value))}
-        result_range = _eval_signextend(inst, state)
+        result_range = eval_signextend(
+            ValueRange.constant(wrap256(b, signed=True)), ValueRange.constant(to_signed(value))
+        )
         actual = eval_evm_signextend(b, value)
         actual_signed = to_signed(actual)
         assert value_in_range_signed(actual_signed, result_range), (
@@ -1110,11 +991,9 @@ class TestSignextendSoundness:
         expected_lo = -(1 << (bits - 1))
         expected_hi = (1 << (bits - 1)) - 1
 
-        var_x = IRVariable("%x")
-        # Evaluator reads operands[-1] as byte index, operands[-2] as value
-        inst = make_inst("signextend", var_x, b)
-        state = {var_x: ValueRange.top()}
-        result_range = _eval_signextend(inst, state)
+        result_range = eval_signextend(
+            ValueRange.constant(wrap256(b, signed=True)), ValueRange.top()
+        )
 
         assert (
             result_range.lo == expected_lo
@@ -1127,11 +1006,7 @@ class TestSignextendSoundness:
         """SIGNEXTEND with constant input should give exact result."""
         # signextend(0, 384) where 384 = 0x180
         # Low byte = 0x80, sign bit set, result = -128
-        var_x = IRVariable("%x")
-        # Evaluator reads operands[-1] as byte index, operands[-2] as value
-        inst = make_inst("signextend", var_x, 0)
-        state = {var_x: ValueRange.constant(384)}
-        result_range = _eval_signextend(inst, state)
+        result_range = eval_signextend(ValueRange.constant(0), ValueRange.constant(384))
 
         expected = -128
         assert (
@@ -1140,12 +1015,8 @@ class TestSignextendSoundness:
 
     def test_signextend_31_is_identity(self) -> None:
         """SIGNEXTEND with b >= 31 should be identity."""
-        var_x = IRVariable("%x")
-        # Evaluator reads operands[-1] as byte index, operands[-2] as value
-        inst = make_inst("signextend", var_x, 31)
         test_val = 12345
-        state = {var_x: ValueRange.constant(test_val)}
-        result_range = _eval_signextend(inst, state)
+        result_range = eval_signextend(ValueRange.constant(31), ValueRange.constant(test_val))
 
         assert (
             result_range.is_constant and result_range.lo == test_val

--- a/vyper/venom/analysis/variable_range/__init__.py
+++ b/vyper/venom/analysis/variable_range/__init__.py
@@ -12,8 +12,8 @@ from .value_range import (
     SIGNED_MIN,
     UNSIGNED_MAX,
     RangeState,
-    VRangeKind,
     ValueRange,
+    VRangeKind,
 )
 
 __all__ = [

--- a/vyper/venom/analysis/variable_range/__init__.py
+++ b/vyper/venom/analysis/variable_range/__init__.py
@@ -12,12 +12,14 @@ from .value_range import (
     SIGNED_MIN,
     UNSIGNED_MAX,
     RangeState,
+    VRangeKind,
     ValueRange,
 )
 
 __all__ = [
     "VariableRangeAnalysis",
     "ValueRange",
+    "VRangeKind",
     "RangeState",
     "SIGNED_MIN",
     "SIGNED_MAX",

--- a/vyper/venom/analysis/variable_range/analysis.py
+++ b/vyper/venom/analysis/variable_range/analysis.py
@@ -14,8 +14,62 @@ from vyper.venom.basicblock import (
     IRVariable,
 )
 
-from .evaluators import EVAL_DISPATCH
+from .evaluators import (
+    eval_add,
+    eval_and,
+    eval_byte,
+    eval_compare,
+    eval_div,
+    eval_eq,
+    eval_iszero,
+    eval_mod,
+    eval_mul,
+    eval_not,
+    eval_or,
+    eval_sar,
+    eval_sdiv,
+    eval_shl,
+    eval_shr,
+    eval_signextend,
+    eval_smod,
+    eval_sub,
+    eval_xor,
+)
 from .value_range import SIGNED_MAX, SIGNED_MIN, UNSIGNED_MAX, RangeState, ValueRange
+
+
+def _operand_range(operand: IROperand, env: RangeState) -> ValueRange:
+    """Convert an IR operand to its ValueRange using the current environment."""
+    if isinstance(operand, IRLiteral):
+        return ValueRange.constant(wrap256(operand.value, signed=True))
+    if isinstance(operand, IRVariable):
+        return env.get(operand, ValueRange.top())
+    return ValueRange.top()
+
+
+_BINARY_EVAL = {
+    "add": eval_add,
+    "sub": eval_sub,
+    "mul": eval_mul,
+    "and": eval_and,
+    "or": eval_or,
+    "xor": eval_xor,
+    "byte": eval_byte,
+    "signextend": eval_signextend,
+    "mod": eval_mod,
+    "div": eval_div,
+    "sdiv": eval_sdiv,
+    "smod": eval_smod,
+    "shr": eval_shr,
+    "shl": eval_shl,
+    "sar": eval_sar,
+    "eq": eval_eq,
+}
+
+_UNARY_EVAL = {
+    "iszero": eval_iszero,
+    "not": eval_not,
+}
 
 
 class VariableRangeAnalysis(IRAnalysis):
@@ -126,14 +180,44 @@ class VariableRangeAnalysis(IRAnalysis):
     def _evaluate_inst(self, inst: IRInstruction, env: RangeState) -> ValueRange:
         """
         Return the resulting range for an instruction.
+        Converts IR operands to ranges, then calls pure evaluators.
         Unknown opcodes conservatively return TOP.
         """
         opcode = inst.opcode
 
-        handler = EVAL_DISPATCH.get(opcode)
+        if opcode == "assign":
+            return _operand_range(inst.operands[-1], env)
+
+        # Unary operations
+        if opcode in _UNARY_EVAL:
+            arg = _operand_range(inst.operands[-1], env)
+            return _UNARY_EVAL[opcode](arg)
+
+        # Check for known binary opcode before extracting operands
+        is_compare = opcode in ("lt", "gt", "slt", "sgt")
+        handler = _BINARY_EVAL.get(opcode)
+        if not is_compare and handler is None and opcode != "xor":
+            return ValueRange.top()
+
+        first_op, second_op = inst.operands[-1], inst.operands[-2]
+        lhs = _operand_range(first_op, env)
+        rhs = _operand_range(second_op, env)
+
+        # Self-xor: IR-level variable identity check
+        if (
+            opcode == "xor"
+            and isinstance(first_op, IRVariable)
+            and isinstance(second_op, IRVariable)
+            and first_op == second_op
+        ):
+            return ValueRange.empty() if lhs.is_empty else ValueRange.constant(0)
+
+        if is_compare:
+            return eval_compare(opcode, lhs, rhs)
+
         if handler is None:
             return ValueRange.top()
-        return handler(inst, env)
+        return handler(lhs, rhs)
 
     def _phi_range(self, inst: IRInstruction) -> ValueRange:
         assert inst.opcode == "phi"

--- a/vyper/venom/analysis/variable_range/analysis.py
+++ b/vyper/venom/analysis/variable_range/analysis.py
@@ -237,7 +237,7 @@ class VariableRangeAnalysis(IRAnalysis):
             else:
                 # Range is entirely non-negative, intersect with [1, UNSIGNED_MAX]
                 # Write even if empty (BOTTOM) - means false branch is unreachable
-                nonzero_range = ValueRange((1, UNSIGNED_MAX))
+                nonzero_range = ValueRange.iv(1, UNSIGNED_MAX)
                 new_range = current.intersect(nonzero_range)
                 self._write_range(state, target, new_range)
         return state

--- a/vyper/venom/analysis/variable_range/analysis.py
+++ b/vyper/venom/analysis/variable_range/analysis.py
@@ -14,27 +14,7 @@ from vyper.venom.basicblock import (
     IRVariable,
 )
 
-from .evaluators import (
-    eval_add,
-    eval_and,
-    eval_byte,
-    eval_compare,
-    eval_div,
-    eval_eq,
-    eval_iszero,
-    eval_mod,
-    eval_mul,
-    eval_not,
-    eval_or,
-    eval_sar,
-    eval_sdiv,
-    eval_shl,
-    eval_shr,
-    eval_signextend,
-    eval_smod,
-    eval_sub,
-    eval_xor,
-)
+from .evaluators import eval_op
 from .value_range import SIGNED_MAX, SIGNED_MIN, UNSIGNED_MAX, RangeState, ValueRange
 
 
@@ -45,31 +25,6 @@ def _operand_range(operand: IROperand, env: RangeState) -> ValueRange:
     if isinstance(operand, IRVariable):
         return env.get(operand, ValueRange.top())
     return ValueRange.top()
-
-
-_BINARY_EVAL = {
-    "add": eval_add,
-    "sub": eval_sub,
-    "mul": eval_mul,
-    "and": eval_and,
-    "or": eval_or,
-    "xor": eval_xor,
-    "byte": eval_byte,
-    "signextend": eval_signextend,
-    "mod": eval_mod,
-    "div": eval_div,
-    "sdiv": eval_sdiv,
-    "smod": eval_smod,
-    "shr": eval_shr,
-    "shl": eval_shl,
-    "sar": eval_sar,
-    "eq": eval_eq,
-}
-
-_UNARY_EVAL = {
-    "iszero": eval_iszero,
-    "not": eval_not,
-}
 
 
 class VariableRangeAnalysis(IRAnalysis):
@@ -180,7 +135,7 @@ class VariableRangeAnalysis(IRAnalysis):
     def _evaluate_inst(self, inst: IRInstruction, env: RangeState) -> ValueRange:
         """
         Return the resulting range for an instruction.
-        Converts IR operands to ranges, then calls pure evaluators.
+        Converts IR operands to ranges, then delegates to eval_op.
         Unknown opcodes conservatively return TOP.
         """
         opcode = inst.opcode
@@ -188,16 +143,13 @@ class VariableRangeAnalysis(IRAnalysis):
         if opcode == "assign":
             return _operand_range(inst.operands[-1], env)
 
-        # Unary operations
-        if opcode in _UNARY_EVAL:
-            arg = _operand_range(inst.operands[-1], env)
-            return _UNARY_EVAL[opcode](arg)
-
-        # Check for known binary opcode before extracting operands
-        is_compare = opcode in ("lt", "gt", "slt", "sgt")
-        handler = _BINARY_EVAL.get(opcode)
-        if not is_compare and handler is None and opcode != "xor":
+        if len(inst.operands) == 0:
             return ValueRange.top()
+
+        if len(inst.operands) == 1:
+            # Unary: pass lhs only, rhs is ignored by eval_op
+            lhs = _operand_range(inst.operands[-1], env)
+            return eval_op(opcode, lhs, ValueRange.top())
 
         first_op, second_op = inst.operands[-1], inst.operands[-2]
         lhs = _operand_range(first_op, env)
@@ -212,12 +164,7 @@ class VariableRangeAnalysis(IRAnalysis):
         ):
             return ValueRange.empty() if lhs.is_empty else ValueRange.constant(0)
 
-        if is_compare:
-            return eval_compare(opcode, lhs, rhs)
-
-        if handler is None:
-            return ValueRange.top()
-        return handler(lhs, rhs)
+        return eval_op(opcode, lhs, rhs)
 
     def _phi_range(self, inst: IRInstruction) -> ValueRange:
         assert inst.opcode == "phi"

--- a/vyper/venom/analysis/variable_range/evaluators.py
+++ b/vyper/venom/analysis/variable_range/evaluators.py
@@ -88,7 +88,7 @@ def _eval_add(inst: IRInstruction, state: RangeState) -> ValueRange:
     hi = lhs.hi + rhs.hi
     if hi > UNSIGNED_MAX:
         return ValueRange.top()
-    return ValueRange((lo, hi))
+    return ValueRange.iv(lo, hi)
 
 
 def _eval_sub(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -109,7 +109,7 @@ def _eval_sub(inst: IRInstruction, state: RangeState) -> ValueRange:
     hi = lhs.hi - rhs.lo
     if lo < SIGNED_MIN or hi > UNSIGNED_MAX or lo > hi:
         return ValueRange.top()
-    return ValueRange((lo, hi))
+    return ValueRange.iv(lo, hi)
 
 
 def _eval_mul(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -144,7 +144,7 @@ def _eval_mul(inst: IRInstruction, state: RangeState) -> ValueRange:
     hi = lhs.hi * rhs.hi
     if hi > UNSIGNED_MAX:
         return ValueRange.top()
-    return ValueRange((lo, hi))
+    return ValueRange.iv(lo, hi)
 
 
 def _eval_and(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -194,12 +194,12 @@ def _eval_and(inst: IRInstruction, state: RangeState) -> ValueRange:
     # could be any value from 0 to the mask.
     if other_range.lo < 0:
         # Range includes negative values, result could be [0, mask]
-        return ValueRange((0, literal))
+        return ValueRange.iv(0, literal)
 
     # For non-negative ranges, the result is bounded by both the range
     # maximum and the mask
     hi = min(other_range.hi, literal)
-    return ValueRange((0, hi))
+    return ValueRange.iv(0, hi)
 
 
 def _eval_byte(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -234,7 +234,7 @@ def _eval_byte(inst: IRInstruction, state: RangeState) -> ValueRange:
             # Same prefix - byte range is bounded
             lo_byte = (value_range.lo >> shift) & 0xFF
             hi_byte = (value_range.hi >> shift) & 0xFF
-            return ValueRange((lo_byte, hi_byte))
+            return ValueRange.iv(lo_byte, hi_byte)
 
     return ValueRange.bytes_range()
 
@@ -291,7 +291,7 @@ def _eval_signextend(inst: IRInstruction, state: RangeState) -> ValueRange:
 
     # For wide ranges or ranges outside target, the low bits could be
     # anything, so return the full signed range for the given byte width
-    return ValueRange((lo, hi))
+    return ValueRange.iv(lo, hi)
 
 
 def _eval_mod(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -306,7 +306,7 @@ def _eval_mod(inst: IRInstruction, state: RangeState) -> ValueRange:
         return ValueRange.top()
     if divisor == 0:
         return ValueRange.constant(0)
-    return ValueRange((0, divisor - 1))
+    return ValueRange.iv(0, divisor - 1)
 
 
 def _eval_div(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -325,7 +325,7 @@ def _eval_div(inst: IRInstruction, state: RangeState) -> ValueRange:
     # interpretation, but this requires handling disjoint ranges
     if dividend_range.lo < 0:
         return ValueRange.top()
-    return ValueRange((dividend_range.lo // divisor, dividend_range.hi // divisor))
+    return ValueRange.iv(dividend_range.lo // divisor, dividend_range.hi // divisor)
 
 
 def _eval_shr(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -344,7 +344,7 @@ def _eval_shr(inst: IRInstruction, state: RangeState) -> ValueRange:
     if value_range.lo < 0:
         return ValueRange.top()
     amount = 1 << shift
-    return ValueRange((value_range.lo // amount, value_range.hi // amount))
+    return ValueRange.iv(value_range.lo // amount, value_range.hi // amount)
 
 
 def _eval_shl(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -373,7 +373,7 @@ def _eval_shl(inst: IRInstruction, state: RangeState) -> ValueRange:
     # If conversion causes lo > hi (range wraps around), return TOP
     if result_lo > result_hi:
         return ValueRange.top()
-    return ValueRange((result_lo, result_hi))
+    return ValueRange.iv(result_lo, result_hi)
 
 
 def _eval_sar(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -393,8 +393,8 @@ def _eval_sar(inst: IRInstruction, state: RangeState) -> ValueRange:
             return ValueRange.constant(0)
         if value_range.hi < 0:
             return ValueRange.constant(-1)
-        return ValueRange((-1, 0))
-    return ValueRange((value_range.lo >> shift, value_range.hi >> shift))
+        return ValueRange.iv(-1, 0)
+    return ValueRange.iv(value_range.lo >> shift, value_range.hi >> shift)
 
 
 def _eval_sdiv(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -448,7 +448,7 @@ def _eval_sdiv(inst: IRInstruction, state: RangeState) -> ValueRange:
         # TODO: could be more precise for negative divisors
         return ValueRange.top()
 
-    return ValueRange((result_lo, result_hi))
+    return ValueRange.iv(result_lo, result_hi)
 
 
 def _eval_smod(inst: IRInstruction, state: RangeState) -> ValueRange:
@@ -472,13 +472,13 @@ def _eval_smod(inst: IRInstruction, state: RangeState) -> ValueRange:
     # Result sign follows dividend sign, so we can narrow based on dividend range
     if dividend_range.lo >= 0:
         # Dividend is non-negative, result is non-negative
-        return ValueRange((0, min(limit, dividend_range.hi)))
+        return ValueRange.iv(0, min(limit, dividend_range.hi))
     elif dividend_range.hi <= 0:
         # Dividend is non-positive, result is non-positive
-        return ValueRange((max(-limit, dividend_range.lo), 0))
+        return ValueRange.iv(max(-limit, dividend_range.lo), 0)
     else:
         # Dividend spans zero, result could be in full range
-        return ValueRange((-limit, limit))
+        return ValueRange.iv(-limit, limit)
 
 
 def _eval_compare(inst: IRInstruction, state: RangeState) -> ValueRange:

--- a/vyper/venom/analysis/variable_range/evaluators.py
+++ b/vyper/venom/analysis/variable_range/evaluators.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 from vyper.utils import wrap256
 
-from .value_range import (
-    RANGE_WIDTH_LIMIT,
-    SIGNED_MAX,
-    SIGNED_MIN,
-    UNSIGNED_MAX,
-    ValueRange,
-)
+from .value_range import RANGE_WIDTH_LIMIT, SIGNED_MAX, SIGNED_MIN, UNSIGNED_MAX, ValueRange
 
 
 def _range_spans_sign_boundary(r: ValueRange) -> bool:
@@ -123,14 +117,16 @@ def eval_and(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     other = None
 
     if lhs.is_constant:
-        mask = wrap256(lhs.as_constant())
+        mask = lhs.as_constant()
         other = rhs
     elif rhs.is_constant:
-        mask = wrap256(rhs.as_constant())
+        mask = rhs.as_constant()
         other = lhs
 
     if mask is None or other is None:
         return ValueRange.top()
+
+    mask = wrap256(mask)
 
     # AND with -1 (all bits set) is identity
     if mask == UNSIGNED_MAX:

--- a/vyper/venom/analysis/variable_range/evaluators.py
+++ b/vyper/venom/analysis/variable_range/evaluators.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
-
 from vyper.utils import wrap256
-from vyper.venom.basicblock import IRInstruction, IRLiteral, IROperand, IRVariable
 
 from .value_range import (
     RANGE_WIDTH_LIMIT,
     SIGNED_MAX,
     SIGNED_MIN,
     UNSIGNED_MAX,
-    RangeState,
     ValueRange,
 )
 
@@ -29,48 +25,8 @@ def _range_spans_sign_boundary(r: ValueRange) -> bool:
     return r.lo < 0 and r.hi >= 0
 
 
-# Type alias for range evaluator functions
-RangeEvaluator = Callable[[IRInstruction, RangeState], ValueRange]
-
-
-def _get_uint_literal(op: IROperand) -> Optional[int]:
-    """Extract unsigned literal value from operand, if it is a literal."""
-    if not isinstance(op, IRLiteral):
-        return None
-    return wrap256(op.value)
-
-
-def _get_signed_literal(op: IROperand) -> Optional[int]:
-    """Extract signed literal value from operand, if it is a literal."""
-    if not isinstance(op, IRLiteral):
-        return None
-    return wrap256(op.value, signed=True)
-
-
-def _operand_range(operand: IROperand, env: RangeState) -> ValueRange:
-    """Get the range of an operand from the current environment.
-
-    Literals are normalized to signed representation since the range system
-    uses signed bounds internally. This ensures values >= 2^255 are treated
-    as negative numbers (e.g., 2^255 becomes SIGNED_MIN).
-    """
-    if isinstance(operand, IRLiteral):
-        return ValueRange.constant(wrap256(operand.value, signed=True))
-    if isinstance(operand, IRVariable):
-        return env.get(operand, ValueRange.top())
-    return ValueRange.top()
-
-
-def _eval_assign(inst: IRInstruction, state: RangeState) -> ValueRange:
-    """Evaluate assign instruction."""
-    op = inst.operands[-1]
-    return _operand_range(op, state)
-
-
-def _eval_add(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_add(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate add instruction."""
-    lhs = _operand_range(inst.operands[-1], state)
-    rhs = _operand_range(inst.operands[-2], state)
     if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
     if lhs.is_constant and rhs.is_constant:
@@ -91,10 +47,8 @@ def _eval_add(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.iv(lo, hi)
 
 
-def _eval_sub(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_sub(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate sub instruction."""
-    lhs = _operand_range(inst.operands[-1], state)
-    rhs = _operand_range(inst.operands[-2], state)
     if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
     if lhs.is_constant and rhs.is_constant:
@@ -112,10 +66,8 @@ def _eval_sub(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.iv(lo, hi)
 
 
-def _eval_mul(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_mul(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate mul instruction."""
-    lhs = _operand_range(inst.operands[-1], state)
-    rhs = _operand_range(inst.operands[-2], state)
     if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
 
@@ -147,7 +99,7 @@ def _eval_mul(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.iv(lo, hi)
 
 
-def _eval_and(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_and(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate bitwise and instruction.
 
     For `and x, mask` where mask is a literal:
@@ -164,82 +116,78 @@ def _eval_and(inst: IRInstruction, state: RangeState) -> ValueRange:
     Special case: AND with -1 (all bits set) is identity, so return
     the input range unchanged.
     """
-    first = inst.operands[-1]
-    second = inst.operands[-2]
-    first_range = _operand_range(first, state)
-    second_range = _operand_range(second, state)
-
-    if first_range.is_empty or second_range.is_empty:
+    if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
 
-    literal: Optional[int] = None
-    other_range: Optional[ValueRange] = None
+    mask = None
+    other = None
 
-    if isinstance(first, IRLiteral):
-        literal = wrap256(first.value)
-        other_range = second_range
-    elif isinstance(second, IRLiteral):
-        literal = wrap256(second.value)
-        other_range = first_range
+    if lhs.is_constant:
+        mask = wrap256(lhs.as_constant())
+        other = rhs
+    elif rhs.is_constant:
+        mask = wrap256(rhs.as_constant())
+        other = lhs
 
-    if literal is None or other_range is None:
+    if mask is None or other is None:
         return ValueRange.top()
 
     # AND with -1 (all bits set) is identity
-    if literal == UNSIGNED_MAX:
-        return other_range
+    if mask == UNSIGNED_MAX:
+        return other
 
     # If the range includes negative values, those are large unsigned values
     # with potentially all bits set in the low positions. The AND result
     # could be any value from 0 to the mask.
-    if other_range.lo < 0:
+    if other.lo < 0:
         # Range includes negative values, result could be [0, mask]
-        return ValueRange.iv(0, literal)
+        return ValueRange.iv(0, mask)
 
     # For non-negative ranges, the result is bounded by both the range
     # maximum and the mask
-    hi = min(other_range.hi, literal)
+    hi = min(other.hi, mask)
     return ValueRange.iv(0, hi)
 
 
-def _eval_byte(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_byte(index: ValueRange, value: ValueRange) -> ValueRange:
     """Evaluate byte instruction.
 
     EVM byte(N, x) returns the N-th byte (from high end, big-endian).
     When N >= 32, the result is always 0.
     """
-    index_op = inst.operands[-1]
-    value_op = inst.operands[-2]
-    value_range = _operand_range(value_op, state)
-    if value_range.is_empty:
+    if index.is_empty or value.is_empty:
         return ValueRange.empty()
-    index = _get_uint_literal(index_op)
-    if index is not None and index >= 32:
+
+    idx = index.as_constant()
+    if idx is not None:
+        idx = wrap256(idx)
+
+    if idx is not None and idx >= 32:
         return ValueRange.constant(0)
 
-    # Use value_range to constrain result when possible
-    if index is not None and not value_range.is_top and value_range.lo >= 0:
+    # Use value range to constrain result when possible
+    if idx is not None and not value.is_top and value.lo >= 0:
         # byte N extracts bits at position (31-N)*8 to (31-N)*8+7
-        shift = (31 - index) * 8
+        shift = (31 - idx) * 8
 
         # If entire range is below this byte position, result is 0
-        if value_range.hi < (1 << shift):
+        if value.hi < (1 << shift):
             return ValueRange.constant(0)
 
         # Check if range spans multiple "byte boundaries"
-        lo_prefix = value_range.lo >> (shift + 8)
-        hi_prefix = value_range.hi >> (shift + 8)
+        lo_prefix = value.lo >> (shift + 8)
+        hi_prefix = value.hi >> (shift + 8)
 
         if lo_prefix == hi_prefix:
             # Same prefix - byte range is bounded
-            lo_byte = (value_range.lo >> shift) & 0xFF
-            hi_byte = (value_range.hi >> shift) & 0xFF
+            lo_byte = (value.lo >> shift) & 0xFF
+            hi_byte = (value.hi >> shift) & 0xFF
             return ValueRange.iv(lo_byte, hi_byte)
 
     return ValueRange.bytes_range()
 
 
-def _eval_signextend(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_signextend(index: ValueRange, value: ValueRange) -> ValueRange:
     """Evaluate signextend instruction.
 
     SIGNEXTEND(b, x) sign-extends x from (b+1)*8 bits to 256 bits.
@@ -252,26 +200,27 @@ def _eval_signextend(inst: IRInstruction, state: RangeState) -> ValueRange:
     The old implementation incorrectly intersected the input range with
     the output range, which would give BOTTOM for inputs like 384.
     """
-    index_op = inst.operands[-1]
-    value_op = inst.operands[-2]
-    value_range = _operand_range(value_op, state)
-    if value_range.is_empty:
+    if index.is_empty or value.is_empty:
         return ValueRange.empty()
-    index = _get_uint_literal(index_op)
-    if index is None:
-        return ValueRange.top()
-    if index >= 32:
-        return value_range
 
-    bits = 8 * (index + 1)
+    idx = index.as_constant()
+    if idx is not None:
+        idx = wrap256(idx)
+
+    if idx is None:
+        return ValueRange.top()
+    if idx >= 32:
+        return value
+
+    bits = 8 * (idx + 1)
     sign_bit = 1 << (bits - 1)
     mask = (1 << bits) - 1
     lo = -(1 << (bits - 1))  # e.g., -128 for index=0
     hi = (1 << (bits - 1)) - 1  # e.g., 127 for index=0
 
     # For constant inputs, compute the exact result
-    if value_range.is_constant:
-        val = value_range.lo
+    if value.is_constant:
+        val = value.lo
         # Extract low bits and sign-extend
         low_bits = val & mask
         if low_bits & sign_bit:
@@ -285,88 +234,80 @@ def _eval_signextend(inst: IRInstruction, state: RangeState) -> ValueRange:
     # For ranges, if the range fits within the target signed range,
     # we can intersect. Otherwise, the result could be any value
     # in the signed output range since high bits are ignored.
-    if value_range.lo >= lo and value_range.hi <= hi:
+    if value.lo >= lo and value.hi <= hi:
         # Input already within target range, sign extension is identity
-        return value_range
+        return value
 
     # For wide ranges or ranges outside target, the low bits could be
     # anything, so return the full signed range for the given byte width
     return ValueRange.iv(lo, hi)
 
 
-def _eval_mod(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_mod(dividend: ValueRange, divisor: ValueRange) -> ValueRange:
     """Evaluate mod instruction."""
-    dividend_op = inst.operands[-1]
-    divisor_op = inst.operands[-2]
-    dividend_range = _operand_range(dividend_op, state)
-    if dividend_range.is_empty:
+    if dividend.is_empty or divisor.is_empty:
         return ValueRange.empty()
-    divisor = _get_uint_literal(divisor_op)
-    if divisor is None:
+    d = divisor.as_constant()
+    if d is None:
         return ValueRange.top()
-    if divisor == 0:
+    d = wrap256(d)
+    if d == 0:
         return ValueRange.constant(0)
-    return ValueRange.iv(0, divisor - 1)
+    return ValueRange.iv(0, d - 1)
 
 
-def _eval_div(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_div(dividend: ValueRange, divisor: ValueRange) -> ValueRange:
     """Evaluate div instruction (unsigned division)."""
-    dividend_op = inst.operands[-1]
-    divisor_op = inst.operands[-2]
-    dividend_range = _operand_range(dividend_op, state)
-    if dividend_range.is_empty:
+    if dividend.is_empty or divisor.is_empty:
         return ValueRange.empty()
-    divisor = _get_uint_literal(divisor_op)
-    if divisor is None:
+    d = divisor.as_constant()
+    if d is None:
         return ValueRange.top()
-    if divisor == 0:
+    d = wrap256(d)
+    if d == 0:
         return ValueRange.constant(0)
     # TODO: could handle negative dividend ranges by converting to unsigned
     # interpretation, but this requires handling disjoint ranges
-    if dividend_range.lo < 0:
+    if dividend.lo < 0:
         return ValueRange.top()
-    return ValueRange.iv(dividend_range.lo // divisor, dividend_range.hi // divisor)
+    return ValueRange.iv(dividend.lo // d, dividend.hi // d)
 
 
-def _eval_shr(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_shr(shift: ValueRange, value: ValueRange) -> ValueRange:
     """Evaluate shr (shift right) instruction."""
-    shift_op = inst.operands[-1]
-    value_op = inst.operands[-2]
-    value_range = _operand_range(value_op, state)
-    if value_range.is_empty:
+    if shift.is_empty or value.is_empty:
         return ValueRange.empty()
-    shift = _get_uint_literal(shift_op)
-    if shift is None:
+    s = shift.as_constant()
+    if s is None:
         return ValueRange.top()
+    s = wrap256(s)
     # shift >= 256 always produces 0 regardless of input
-    if shift >= 256:
+    if s >= 256:
         return ValueRange.constant(0)
-    if value_range.lo < 0:
+    if value.lo < 0:
         return ValueRange.top()
-    amount = 1 << shift
-    return ValueRange.iv(value_range.lo // amount, value_range.hi // amount)
+    amount = 1 << s
+    return ValueRange.iv(value.lo // amount, value.hi // amount)
 
 
-def _eval_shl(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_shl(shift: ValueRange, value: ValueRange) -> ValueRange:
     """Evaluate shl (shift left) instruction."""
-    shift_op = inst.operands[-1]
-    value_op = inst.operands[-2]
-    value_range = _operand_range(value_op, state)
-    if value_range.is_empty:
+    if shift.is_empty or value.is_empty:
         return ValueRange.empty()
-    shift = _get_uint_literal(shift_op)
-    if shift is None:
+    s = shift.as_constant()
+    if s is None:
         return ValueRange.top()
+    s = wrap256(s)
     # shift >= 256 always produces 0 regardless of input
-    if shift >= 256:
+    if s >= 256:
         return ValueRange.constant(0)
-    if value_range.lo < 0:
+    if value.lo < 0:
         return ValueRange.top()
-    max_input = UNSIGNED_MAX >> shift
-    if value_range.hi > max_input:
+    max_input = UNSIGNED_MAX >> s
+    if value.hi > max_input:
         return ValueRange.top()
-    result_lo = value_range.lo << shift
-    result_hi = value_range.hi << shift
+    result_lo = value.lo << s
+    result_hi = value.hi << s
     # Convert to signed representation for consistency with range system
     result_lo = wrap256(result_lo, signed=True)
     result_hi = wrap256(result_hi, signed=True)
@@ -376,73 +317,69 @@ def _eval_shl(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.iv(result_lo, result_hi)
 
 
-def _eval_sar(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_sar(shift: ValueRange, value: ValueRange) -> ValueRange:
     """Evaluate sar (arithmetic shift right) instruction."""
-    shift_op = inst.operands[-1]
-    value_op = inst.operands[-2]
-    shift = _get_uint_literal(shift_op)
-    value_range = _operand_range(value_op, state)
-    if shift is None:
-        return ValueRange.top()
-    if value_range.is_empty:
+    if shift.is_empty or value.is_empty:
         return ValueRange.empty()
-    if value_range.hi > SIGNED_MAX:
+    s = shift.as_constant()
+    if s is None:
         return ValueRange.top()
-    if shift >= 256:
-        if value_range.lo >= 0:
+    s = wrap256(s)
+    if value.hi > SIGNED_MAX:
+        return ValueRange.top()
+    if s >= 256:
+        if value.lo >= 0:
             return ValueRange.constant(0)
-        if value_range.hi < 0:
+        if value.hi < 0:
             return ValueRange.constant(-1)
         return ValueRange.iv(-1, 0)
-    return ValueRange.iv(value_range.lo >> shift, value_range.hi >> shift)
+    return ValueRange.iv(value.lo >> s, value.hi >> s)
 
 
-def _eval_sdiv(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_sdiv(dividend: ValueRange, divisor: ValueRange) -> ValueRange:
     """Evaluate sdiv (signed division) instruction.
 
     EVM sdiv interprets both operands as signed and returns a signed result.
     Special case: SIGNED_MIN / -1 = SIGNED_MIN (overflow, doesn't negate).
     """
-    dividend_op = inst.operands[-1]
-    divisor_op = inst.operands[-2]
-    dividend_range = _operand_range(dividend_op, state)
-    if dividend_range.is_empty:
+    if dividend.is_empty or divisor.is_empty:
         return ValueRange.empty()
-    divisor = _get_signed_literal(divisor_op)
-    if divisor is None:
+    d = divisor.as_constant()
+    # d is already signed from as_constant()
+    if d is None:
         return ValueRange.top()
-    if divisor == 0:
+    if d == 0:
         return ValueRange.constant(0)
 
     # For constant dividend, compute exact result
-    if dividend_range.is_constant:
-        dividend = dividend_range.lo
+    if dividend.is_constant:
+        dv = dividend.lo
         # Special case: SIGNED_MIN / -1 = SIGNED_MIN (no negation due to overflow)
-        if dividend == SIGNED_MIN and divisor == -1:
+        if dv == SIGNED_MIN and d == -1:
             return ValueRange.constant(SIGNED_MIN)
         # Standard signed division
-        sign = -1 if (dividend < 0) != (divisor < 0) else 1
-        result = sign * (abs(dividend) // abs(divisor))
+        sign = -1 if (dv < 0) != (d < 0) else 1
+        result = sign * (abs(dv) // abs(d))
         return ValueRange.constant(result)
 
     # For ranges, compute bounds
     # Division by positive divisor preserves order: lo/d <= x/d <= hi/d
     # Division by negative divisor reverses order: hi/d <= x/d <= lo/d
-    if divisor > 0:
+    if d > 0:
         # Truncation toward zero means we need to be careful with bounds
         # Python uses floor division, so for negative dividends we adjust
-        if dividend_range.lo >= 0:
-            result_lo = dividend_range.lo // divisor
-            result_hi = dividend_range.hi // divisor
-        elif dividend_range.hi < 0:
+        if dividend.lo >= 0:
+            result_lo = dividend.lo // d
+            result_hi = dividend.hi // d
+        elif dividend.hi < 0:
             # Both negative: division truncates toward zero
             # -7 // 3 in EVM = -2 (truncate), in Python = -3 (floor)
-            result_hi = -(abs(dividend_range.lo) // divisor)
-            result_lo = -(abs(dividend_range.hi) // divisor)
+            result_hi = -(abs(dividend.lo) // d)
+            result_lo = -(abs(dividend.hi) // d)
         else:
             # Range spans zero - result spans from negative to positive
-            result_lo = -(abs(dividend_range.lo) // divisor)
-            result_hi = dividend_range.hi // divisor
+            result_lo = -(abs(dividend.lo) // d)
+            result_hi = dividend.hi // d
     else:
         # Negative divisor - more complex, return TOP for now
         # TODO: could be more precise for negative divisors
@@ -451,37 +388,35 @@ def _eval_sdiv(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.iv(result_lo, result_hi)
 
 
-def _eval_smod(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_smod(dividend: ValueRange, divisor: ValueRange) -> ValueRange:
     """Evaluate smod (signed modulo) instruction.
 
     EVM smod: the result has the same sign as the dividend.
     smod(x, y) = sign(x) * (abs(x) % abs(y))
     """
-    dividend_op = inst.operands[-1]
-    divisor_op = inst.operands[-2]
-    dividend_range = _operand_range(dividend_op, state)
-    if dividend_range.is_empty:
+    if dividend.is_empty or divisor.is_empty:
         return ValueRange.empty()
-    divisor = _get_signed_literal(divisor_op)
-    if divisor is None:
+    d = divisor.as_constant()
+    # d is already signed from as_constant()
+    if d is None:
         return ValueRange.top()
-    if divisor == 0:
+    if d == 0:
         return ValueRange.constant(0)
-    limit = abs(divisor) - 1
+    limit = abs(d) - 1
 
     # Result sign follows dividend sign, so we can narrow based on dividend range
-    if dividend_range.lo >= 0:
+    if dividend.lo >= 0:
         # Dividend is non-negative, result is non-negative
-        return ValueRange.iv(0, min(limit, dividend_range.hi))
-    elif dividend_range.hi <= 0:
+        return ValueRange.iv(0, min(limit, dividend.hi))
+    elif dividend.hi <= 0:
         # Dividend is non-positive, result is non-positive
-        return ValueRange.iv(max(-limit, dividend_range.lo), 0)
+        return ValueRange.iv(max(-limit, dividend.lo), 0)
     else:
         # Dividend spans zero, result could be in full range
         return ValueRange.iv(-limit, limit)
 
 
-def _eval_compare(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_compare(opcode: str, lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate comparison instructions (lt, gt, slt, sgt).
 
     IMPORTANT: EVM lt/gt are UNSIGNED comparisons, while slt/sgt are SIGNED.
@@ -494,12 +429,9 @@ def _eval_compare(inst: IRInstruction, state: RangeState) -> ValueRange:
     and non-negative values), unsigned comparisons cannot be resolved
     definitively using signed range bounds.
     """
-    lhs = _operand_range(inst.operands[-1], state)
-    rhs = _operand_range(inst.operands[-2], state)
     if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
 
-    opcode = inst.opcode
     is_signed = opcode in {"slt", "sgt"}
 
     # For unsigned comparisons, if either range spans the sign boundary,
@@ -547,7 +479,7 @@ def _eval_compare(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.bool_range()
 
 
-def _eval_eq(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_eq(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate eq (equality) instruction.
 
     IMPORTANT: In EVM, eq compares 256-bit values directly. -1 and MAX_UINT
@@ -557,9 +489,6 @@ def _eval_eq(inst: IRInstruction, state: RangeState) -> ValueRange:
     since the same value can be represented as both -1 (signed) and
     MAX_UINT (unsigned) in our range representation.
     """
-    lhs = _operand_range(inst.operands[-1], state)
-    rhs = _operand_range(inst.operands[-2], state)
-
     if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
 
@@ -592,20 +521,18 @@ def _eval_eq(inst: IRInstruction, state: RangeState) -> ValueRange:
     return ValueRange.bool_range()
 
 
-def _eval_iszero(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_iszero(operand: ValueRange) -> ValueRange:
     """Evaluate iszero instruction."""
-    operand = inst.operands[-1]
-    target = _operand_range(operand, state)
-    if target.is_empty:
+    if operand.is_empty:
         return ValueRange.empty()
-    if target.is_constant:
-        return ValueRange.constant(int(target.lo == 0))
-    if target.lo > 0 or target.hi < 0:
+    if operand.is_constant:
+        return ValueRange.constant(int(operand.lo == 0))
+    if operand.lo > 0 or operand.hi < 0:
         return ValueRange.constant(0)
     return ValueRange.bool_range()
 
 
-def _eval_or(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_or(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate bitwise or instruction.
 
     For `or x, y`:
@@ -614,68 +541,51 @@ def _eval_or(inst: IRInstruction, state: RangeState) -> ValueRange:
     - If either operand is -1 (all bits set): return -1
     - Otherwise: return TOP (hard to bound precisely)
     """
-    first = inst.operands[-1]
-    second = inst.operands[-2]
-    first_range = _operand_range(first, state)
-    second_range = _operand_range(second, state)
-
-    if first_range.is_empty or second_range.is_empty:
+    if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
 
     # Both constants: compute exact result
-    if first_range.is_constant and second_range.is_constant:
+    if lhs.is_constant and rhs.is_constant:
         # Convert to unsigned for bitwise op, then wrap result
-        a = wrap256(first_range.lo)
-        b = wrap256(second_range.lo)
+        a = wrap256(lhs.lo)
+        b = wrap256(rhs.lo)
         return ValueRange.constant(wrap256(a | b, signed=True))
 
     # If either is constant 0: return the other
-    if first_range.is_constant and first_range.lo == 0:
-        return second_range
-    if second_range.is_constant and second_range.lo == 0:
-        return first_range
+    if lhs.is_constant and lhs.lo == 0:
+        return rhs
+    if rhs.is_constant and rhs.lo == 0:
+        return lhs
 
     # If either is -1 (all bits set): result is -1
-    if first_range.is_constant and wrap256(first_range.lo) == UNSIGNED_MAX:
+    if lhs.is_constant and wrap256(lhs.lo) == UNSIGNED_MAX:
         return ValueRange.constant(-1)
-    if second_range.is_constant and wrap256(second_range.lo) == UNSIGNED_MAX:
+    if rhs.is_constant and wrap256(rhs.lo) == UNSIGNED_MAX:
         return ValueRange.constant(-1)
 
     return ValueRange.top()
 
 
-def _eval_xor(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_xor(lhs: ValueRange, rhs: ValueRange) -> ValueRange:
     """Evaluate bitwise xor instruction.
 
     For `xor x, y`:
-    - If x and y are the same variable: return 0
     - If both are constants: return x ^ y
     - Otherwise: return TOP
     """
-    first = inst.operands[-1]
-    second = inst.operands[-2]
-    first_range = _operand_range(first, state)
-    second_range = _operand_range(second, state)
-
-    if first_range.is_empty or second_range.is_empty:
+    if lhs.is_empty or rhs.is_empty:
         return ValueRange.empty()
 
-    # Self-xor optimization: xor %x, %x = 0
-    # Must check after empty check to return BOTTOM for unreachable code
-    if isinstance(first, IRVariable) and isinstance(second, IRVariable):
-        if first == second:
-            return ValueRange.constant(0)
-
     # Both constants: compute exact result
-    if first_range.is_constant and second_range.is_constant:
-        a = wrap256(first_range.lo)
-        b = wrap256(second_range.lo)
+    if lhs.is_constant and rhs.is_constant:
+        a = wrap256(lhs.lo)
+        b = wrap256(rhs.lo)
         return ValueRange.constant(wrap256(a ^ b, signed=True))
 
     return ValueRange.top()
 
 
-def _eval_not(inst: IRInstruction, state: RangeState) -> ValueRange:
+def eval_not(operand: ValueRange) -> ValueRange:
     """Evaluate bitwise not instruction.
 
     EVM NOT: ~x = UNSIGNED_MAX ^ x (flips all bits)
@@ -683,43 +593,12 @@ def _eval_not(inst: IRInstruction, state: RangeState) -> ValueRange:
     For constant input: return exact result
     Otherwise: return TOP
     """
-    operand = inst.operands[-1]
-    operand_range = _operand_range(operand, state)
-
-    if operand_range.is_empty:
+    if operand.is_empty:
         return ValueRange.empty()
 
-    if operand_range.is_constant:
-        val = wrap256(operand_range.lo)
+    if operand.is_constant:
+        val = wrap256(operand.lo)
         result = UNSIGNED_MAX ^ val
         return ValueRange.constant(wrap256(result, signed=True))
 
     return ValueRange.top()
-
-
-# Dispatch table mapping opcodes to their evaluator functions
-EVAL_DISPATCH: dict[str, RangeEvaluator] = {
-    "assign": _eval_assign,
-    "add": _eval_add,
-    "sub": _eval_sub,
-    "mul": _eval_mul,
-    "and": _eval_and,
-    "or": _eval_or,
-    "xor": _eval_xor,
-    "not": _eval_not,
-    "byte": _eval_byte,
-    "signextend": _eval_signextend,
-    "mod": _eval_mod,
-    "div": _eval_div,
-    "sdiv": _eval_sdiv,
-    "shr": _eval_shr,
-    "shl": _eval_shl,
-    "sar": _eval_sar,
-    "smod": _eval_smod,
-    "lt": _eval_compare,
-    "gt": _eval_compare,
-    "slt": _eval_compare,
-    "sgt": _eval_compare,
-    "eq": _eval_eq,
-    "iszero": _eval_iszero,
-}

--- a/vyper/venom/analysis/variable_range/evaluators.py
+++ b/vyper/venom/analysis/variable_range/evaluators.py
@@ -602,3 +602,50 @@ def eval_not(operand: ValueRange) -> ValueRange:
         return ValueRange.constant(wrap256(result, signed=True))
 
     return ValueRange.top()
+
+
+def eval_op(opcode: str, lhs: ValueRange, rhs: ValueRange) -> ValueRange:
+    """Evaluate a binary opcode on two ranges.
+
+    Pure case dispatch. For unary ops, caller passes ValueRange.top() as rhs
+    (unused by the evaluator).
+    """
+    if opcode == "add":
+        return eval_add(lhs, rhs)
+    if opcode == "sub":
+        return eval_sub(lhs, rhs)
+    if opcode == "mul":
+        return eval_mul(lhs, rhs)
+    if opcode == "and":
+        return eval_and(lhs, rhs)
+    if opcode == "or":
+        return eval_or(lhs, rhs)
+    if opcode == "xor":
+        return eval_xor(lhs, rhs)
+    if opcode == "byte":
+        return eval_byte(lhs, rhs)
+    if opcode == "signextend":
+        return eval_signextend(lhs, rhs)
+    if opcode == "mod":
+        return eval_mod(lhs, rhs)
+    if opcode == "div":
+        return eval_div(lhs, rhs)
+    if opcode == "sdiv":
+        return eval_sdiv(lhs, rhs)
+    if opcode == "smod":
+        return eval_smod(lhs, rhs)
+    if opcode == "shr":
+        return eval_shr(lhs, rhs)
+    if opcode == "shl":
+        return eval_shl(lhs, rhs)
+    if opcode == "sar":
+        return eval_sar(lhs, rhs)
+    if opcode == "eq":
+        return eval_eq(lhs, rhs)
+    if opcode in ("lt", "gt", "slt", "sgt"):
+        return eval_compare(opcode, lhs, rhs)
+    if opcode == "iszero":
+        return eval_iszero(lhs)
+    if opcode == "not":
+        return eval_not(lhs)
+    return ValueRange.top()

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -28,7 +28,7 @@ class VRangeKind(Enum):
     IV = auto()
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class ValueRange:
     """Immutable interval representation for 256-bit modular arithmetic.
 
@@ -42,6 +42,23 @@ class ValueRange:
     _kind: VRangeKind = VRangeKind.TOP
     _lo: int = 0
     _hi: int = 0
+
+    def __init__(self, kind: VRangeKind = VRangeKind.TOP, lo: int = 0, hi: int = 0) -> None:
+        if kind == VRangeKind.TOP:
+            lo = 0
+            hi = 0
+        elif kind == VRangeKind.BOT:
+            lo = 0
+            hi = 0
+        elif kind == VRangeKind.IV:
+            if lo > hi:
+                raise ValueError("IV requires lo <= hi; use ValueRange.iv() for smart construction")
+        else:
+            raise TypeError(f"invalid ValueRange kind: {kind!r}")
+
+        object.__setattr__(self, "_kind", kind)
+        object.__setattr__(self, "_lo", lo)
+        object.__setattr__(self, "_hi", hi)
 
     @property
     def lo(self) -> int:

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -50,8 +50,8 @@ class ValueRange:
 
     def __post_init__(self):
         if self._kind == VRangeKind.TOP or self._kind == VRangeKind.BOT:
-            object.__setattr__(self, "_lo", None)
-            object.__setattr__(self, "_hi", None)
+            if self._lo is not None or self._hi is not None:
+                raise ValueError(f"{self._kind.name} does not take lo/hi values")
         elif self._kind == VRangeKind.IV:
             if self._lo is None or self._hi is None:
                 raise ValueError("IV requires lo and hi values")

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -45,14 +45,16 @@ class ValueRange:
     """
 
     _kind: VRangeKind = VRangeKind.TOP
-    _lo: int = 0
-    _hi: int = 0
+    _lo: Optional[int] = None
+    _hi: Optional[int] = None
 
     def __post_init__(self):
         if self._kind == VRangeKind.TOP or self._kind == VRangeKind.BOT:
-            object.__setattr__(self, "_lo", 0)
-            object.__setattr__(self, "_hi", 0)
+            object.__setattr__(self, "_lo", None)
+            object.__setattr__(self, "_hi", None)
         elif self._kind == VRangeKind.IV:
+            if self._lo is None or self._hi is None:
+                raise ValueError("IV requires lo and hi values")
             if self._lo > self._hi:
                 raise ValueError("IV requires lo <= hi; use ValueRange.iv() for smart construction")
         else:
@@ -60,16 +62,18 @@ class ValueRange:
 
     @property
     def lo(self) -> int:
-        """Lower bound. For TOP, returns SIGNED_MIN."""
+        """Lower bound. For TOP, returns SIGNED_MIN. Raises on BOT."""
         if self._kind == VRangeKind.TOP:
             return SIGNED_MIN
+        assert self._lo is not None, "BOT has no lo bound"
         return self._lo
 
     @property
     def hi(self) -> int:
-        """Upper bound. For TOP, returns UNSIGNED_MAX."""
+        """Upper bound. For TOP, returns UNSIGNED_MAX. Raises on BOT."""
         if self._kind == VRangeKind.TOP:
             return UNSIGNED_MAX
+        assert self._hi is not None, "BOT has no hi bound"
         return self._hi
 
     @classmethod

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -155,7 +155,7 @@ class ValueRange:
         if other._kind == VRangeKind.BOT:
             return self
 
-        return ValueRange.iv(min(self._lo, other._lo), max(self._hi, other._hi))
+        return ValueRange.iv(min(self.lo, other.lo), max(self.hi, other.hi))
 
     def intersect(self, other: ValueRange) -> ValueRange:
         """Compute the intersection (meet) of two ranges."""
@@ -166,8 +166,8 @@ class ValueRange:
         if self._kind == VRangeKind.BOT or other._kind == VRangeKind.BOT:
             return ValueRange.empty()
 
-        lo = max(self._lo, other._lo)
-        hi = min(self._hi, other._hi)
+        lo = max(self.lo, other.lo)
+        hi = min(self.hi, other.hi)
         return ValueRange.iv(lo, hi)
 
     def clamp(self, lo: Optional[int] = None, hi: Optional[int] = None) -> ValueRange:
@@ -178,8 +178,8 @@ class ValueRange:
         elif self._kind == VRangeKind.BOT:
             return self
         else:
-            new_lo = self._lo if lo is None else max(self._lo, lo)
-            new_hi = self._hi if hi is None else min(self._hi, hi)
+            new_lo = self.lo if lo is None else max(self.lo, lo)
+            new_hi = self.hi if hi is None else min(self.hi, hi)
         return ValueRange.iv(new_lo, new_hi)
 
     def __repr__(self) -> str:
@@ -187,9 +187,9 @@ class ValueRange:
             return "TOP"
         if self._kind == VRangeKind.BOT:
             return "BOTTOM"
-        if self._lo == self._hi:
-            return f"{{{self._lo}}}"
-        return f"[{self._lo}, {self._hi}]"
+        if self.lo == self.hi:
+            return f"{{{self.lo}}}"
+        return f"[{self.lo}, {self.hi}]"
 
 
 RangeState = dict[IRVariable, ValueRange]

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -28,7 +28,7 @@ class VRangeKind(Enum):
     IV = auto()
 
 
-@dataclass(frozen=True, slots=True, init=False)
+@dataclass(frozen=True, slots=True)
 class ValueRange:
     """Immutable interval representation for 256-bit modular arithmetic.
 
@@ -48,22 +48,15 @@ class ValueRange:
     _lo: int = 0
     _hi: int = 0
 
-    def __init__(self, kind: VRangeKind = VRangeKind.TOP, lo: int = 0, hi: int = 0) -> None:
-        if kind == VRangeKind.TOP:
-            lo = 0
-            hi = 0
-        elif kind == VRangeKind.BOT:
-            lo = 0
-            hi = 0
-        elif kind == VRangeKind.IV:
-            if lo > hi:
+    def __post_init__(self):
+        if self._kind == VRangeKind.TOP or self._kind == VRangeKind.BOT:
+            object.__setattr__(self, "_lo", 0)
+            object.__setattr__(self, "_hi", 0)
+        elif self._kind == VRangeKind.IV:
+            if self._lo > self._hi:
                 raise ValueError("IV requires lo <= hi; use ValueRange.iv() for smart construction")
         else:
-            raise TypeError(f"invalid ValueRange kind: {kind!r}")
-
-        object.__setattr__(self, "_kind", kind)
-        object.__setattr__(self, "_lo", lo)
-        object.__setattr__(self, "_hi", hi)
+            raise TypeError(f"invalid ValueRange kind: {self._kind!r}")
 
     @property
     def lo(self) -> int:

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -37,6 +37,11 @@ class ValueRange:
     - VRangeKind.TOP: unknown / full range
     - VRangeKind.BOT: empty / unreachable
     - VRangeKind.IV:  concrete interval [_lo, _hi] where _lo <= _hi
+
+    Construction: use the factory methods top(), empty(), iv(), constant().
+    The raw constructor ValueRange(IV, lo, hi) enforces lo <= hi (raises
+    ValueError otherwise). The smart constructor iv(lo, hi) normalizes
+    lo > hi to BOT instead of raising.
     """
 
     _kind: VRangeKind = VRangeKind.TOP
@@ -86,7 +91,11 @@ class ValueRange:
 
     @classmethod
     def iv(cls, lo: int, hi: int) -> ValueRange:
-        """Create an interval [lo, hi]. Returns BOT if lo > hi."""
+        """Create an interval [lo, hi], normalizing lo > hi to BOT.
+
+        Unlike the raw constructor (which raises on lo > hi), this
+        smart constructor treats invalid bounds as empty ranges.
+        """
         if lo > hi:
             return cls(VRangeKind.BOT)
         return cls(VRangeKind.IV, lo, hi)

--- a/vyper/venom/analysis/variable_range/value_range.py
+++ b/vyper/venom/analysis/variable_range/value_range.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Optional
 
 from vyper.utils import SizeLimits
@@ -17,58 +18,71 @@ UNSIGNED_MAX = SizeLimits.MAX_UINT256
 RANGE_WIDTH_LIMIT = 1 << 128
 
 
+class VRangeKind(Enum):
+    """
+    Value range variants: Top | Bot | Iv of (int * int)
+    """
+
+    TOP = auto()
+    BOT = auto()
+    IV = auto()
+
+
 @dataclass(frozen=True, slots=True)
 class ValueRange:
     """Immutable interval representation for 256-bit modular arithmetic.
 
-    bounds:
-        None -> TOP (unknown / full range)
-        (lo, hi) with lo > hi -> BOTTOM (empty / unreachable)
-        Otherwise -> concrete interval [lo, hi]
+    Top | Bot | Iv of (int * int)
+
+    - VRangeKind.TOP: unknown / full range
+    - VRangeKind.BOT: empty / unreachable
+    - VRangeKind.IV:  concrete interval [_lo, _hi] where _lo <= _hi
     """
 
-    bounds: Optional[tuple[int, int]] = None
-
-    def __post_init__(self):
-        # Normalize BOTTOM to canonical form (1, 0) for consistent equality
-        if self.bounds is not None:
-            lo, hi = self.bounds
-            if lo > hi:
-                object.__setattr__(self, "bounds", (1, 0))
+    _kind: VRangeKind = VRangeKind.TOP
+    _lo: int = 0
+    _hi: int = 0
 
     @property
     def lo(self) -> int:
-        """Lower bound. For top ranges, returns SIGNED_MIN."""
-        if self.bounds is None:
+        """Lower bound. For TOP, returns SIGNED_MIN."""
+        if self._kind == VRangeKind.TOP:
             return SIGNED_MIN
-        return self.bounds[0]
+        return self._lo
 
     @property
     def hi(self) -> int:
-        """Upper bound. For top ranges, returns UNSIGNED_MAX."""
-        if self.bounds is None:
+        """Upper bound. For TOP, returns UNSIGNED_MAX."""
+        if self._kind == VRangeKind.TOP:
             return UNSIGNED_MAX
-        return self.bounds[1]
+        return self._hi
 
     @classmethod
     def top(cls) -> ValueRange:
         """Create a range representing all possible values (TOP)."""
-        return cls()  # bounds=None means full range
+        return cls(VRangeKind.TOP)
 
     @classmethod
     def empty(cls) -> ValueRange:
         """Create an empty range (BOTTOM)."""
-        return cls((1, 0))  # lo > hi convention
+        return cls(VRangeKind.BOT)
+
+    @classmethod
+    def iv(cls, lo: int, hi: int) -> ValueRange:
+        """Create an interval [lo, hi]. Returns BOT if lo > hi."""
+        if lo > hi:
+            return cls(VRangeKind.BOT)
+        return cls(VRangeKind.IV, lo, hi)
 
     @classmethod
     def constant(cls, value: int) -> ValueRange:
         """Create a range containing a single value."""
-        return cls((value, value))
+        return cls(VRangeKind.IV, value, value)
 
     @classmethod
     def bool_range(cls) -> ValueRange:
         """Create a range for boolean values [0, 1]."""
-        return cls((0, 1))
+        return cls(VRangeKind.IV, 0, 1)
 
     @classmethod
     def bytes_range(cls, length: int = 1) -> ValueRange:
@@ -76,87 +90,83 @@ class ValueRange:
         if length < 0 or length > 32:
             raise ValueError("Byte length must be between 0 and 32")
         hi = (1 << (8 * length)) - 1
-        return cls((0, hi))
+        return cls(VRangeKind.IV, 0, hi)
+
+    @property
+    def kind(self) -> VRangeKind:
+        """The constructor tag of this range."""
+        return self._kind
 
     @property
     def is_top(self) -> bool:
         """Check if this is the top element (full range)."""
-        return self.bounds is None
+        return self._kind == VRangeKind.TOP
 
     @property
     def is_empty(self) -> bool:
         """Check if this is the bottom element (empty range)."""
-        return self.bounds is not None and self.bounds[0] > self.bounds[1]
+        return self._kind == VRangeKind.BOT
 
     @property
     def is_bottom(self) -> bool:
         """Alias for is_empty."""
-        return self.is_empty
+        return self._kind == VRangeKind.BOT
 
     @property
     def is_constant(self) -> bool:
         """Check if this range represents a single constant value."""
-        b = self.bounds
-        return b is not None and b[0] == b[1]
+        return self._kind == VRangeKind.IV and self._lo == self._hi
 
     def as_constant(self) -> Optional[int]:
         """Return the constant value if this is a constant range, else None."""
         if self.is_constant:
-            assert self.bounds is not None
-            return self.bounds[0]
+            return self._lo
         return None
 
     def union(self, other: ValueRange) -> ValueRange:
         """Compute the union (join) of two ranges."""
-        if self.is_top or other.is_top:
+        if self._kind == VRangeKind.TOP or other._kind == VRangeKind.TOP:
             return ValueRange.top()
-        if self.is_empty:
+        if self._kind == VRangeKind.BOT:
             return other
-        if other.is_empty:
+        if other._kind == VRangeKind.BOT:
             return self
 
-        assert self.bounds is not None and other.bounds is not None
-        lo = min(self.bounds[0], other.bounds[0])
-        hi = max(self.bounds[1], other.bounds[1])
-        return ValueRange((lo, hi))
+        return ValueRange.iv(min(self._lo, other._lo), max(self._hi, other._hi))
 
     def intersect(self, other: ValueRange) -> ValueRange:
         """Compute the intersection (meet) of two ranges."""
-        if self.is_top:
+        if self._kind == VRangeKind.TOP:
             return other
-        if other.is_top:
+        if other._kind == VRangeKind.TOP:
             return self
-        if self.is_empty or other.is_empty:
+        if self._kind == VRangeKind.BOT or other._kind == VRangeKind.BOT:
             return ValueRange.empty()
 
-        assert self.bounds is not None and other.bounds is not None
-        lo = max(self.bounds[0], other.bounds[0])
-        hi = min(self.bounds[1], other.bounds[1])
-        return ValueRange((lo, hi)) if lo <= hi else ValueRange.empty()
+        lo = max(self._lo, other._lo)
+        hi = min(self._hi, other._hi)
+        return ValueRange.iv(lo, hi)
 
     def clamp(self, lo: Optional[int] = None, hi: Optional[int] = None) -> ValueRange:
         """Clamp this range to the specified bounds."""
-        if self.is_top:
+        if self._kind == VRangeKind.TOP:
             new_lo = SIGNED_MIN if lo is None else max(SIGNED_MIN, lo)
             new_hi = UNSIGNED_MAX if hi is None else min(UNSIGNED_MAX, hi)
-        elif self.is_empty:
+        elif self._kind == VRangeKind.BOT:
             return self
         else:
-            assert self.bounds is not None
-            new_lo = self.bounds[0] if lo is None else max(self.bounds[0], lo)
-            new_hi = self.bounds[1] if hi is None else min(self.bounds[1], hi)
-        return ValueRange((new_lo, new_hi))
+            new_lo = self._lo if lo is None else max(self._lo, lo)
+            new_hi = self._hi if hi is None else min(self._hi, hi)
+        return ValueRange.iv(new_lo, new_hi)
 
     def __repr__(self) -> str:
-        if self.is_top:
+        if self._kind == VRangeKind.TOP:
             return "TOP"
-        if self.is_empty:
+        if self._kind == VRangeKind.BOT:
             return "BOTTOM"
-        assert self.bounds is not None
-        lo, hi = self.bounds
-        if lo == hi:
-            return f"{{{lo}}}"
-        return f"[{lo}, {hi}]"
+        if self._lo == self._hi:
+            return f"{{{self._lo}}}"
+        return f"[{self._lo}, {self._hi}]"
 
 
 RangeState = dict[IRVariable, ValueRange]


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
Refactor the variable range analysis to use an explicit algebraic
representation that maps directly to a formal sum type
(Top | Bot | Iv of int * int), making the code amenable to
mechanical translation and formal verification.

Three changes:

1.Explicit tagged union for ValueRange. Replace the
  Optional[tuple[int, int]] encoding (where None = TOP,
  (1,0) = BOT, (lo,hi) = interval) with a VRangeKind enum
  (TOP/BOT/IV) and typed fields. Construction goes through
  ValueRange.top(), .empty(), .iv(lo, hi), .constant(v).
  The __init__ validates invariants (IV requires lo <= hi).
2.Pure evaluators. Evaluator functions no longer take
  (IRInstruction, RangeState). They are now pure functions on
  ValueRange values (e.g. eval_add(lhs, rhs) -> ValueRange),
  with zero IR dependencies. The IR-to-range conversion
  (_operand_range) moves to the analysis driver. A single
  eval_op(opcode, lhs, rhs) entry point replaces the dict-based
  dispatch, mapping directly to a case expression.
3.Test simplification. Tests call evaluators directly with
  ValueRange arguments instead of constructing mock
  IRInstruction objects. make_inst helpers removed.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
