### PR TITLE
Fix: Avoid namespace collision on etherscan & sourcify verification  

### DIFF
--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -171,13 +171,13 @@ def get_inputs(input_dict: dict) -> dict[PurePath, Any]:
                 raise JSONError(
                     f"Calculated keccak of '{path}' does not match keccak given in input JSON"
                 )
-        if path.stem in seen:
+        if path in seen:
             raise JSONError(f"Contract namespace collision: {path}")
 
         # value looks like {"content": <source code>}
         # this will be interpreted by JSONInputBundle later
         ret[path] = value
-        seen[path.stem] = True
+        seen[path] = True
 
     for path, value in input_dict.get("interfaces", {}).items():
         path = PurePath(path)


### PR DESCRIPTION
use full path for collision detection, because this are valides imports and code compiles, but etherscan & sourcify uses vyper_json.py and fails on this. both files are named math.vy

`from snekmate.utils import math`
`from curve_std import math as crv_math`

Error massage from sourcify:
<img width="1560" height="214" alt="Screenshot at 2026-03-12 14-49-00" src="https://github.com/user-attachments/assets/5b25d8a0-c408-48fa-86e7-6b149e25f083" />


### What I did

Changed collision detection to full path, not only path.stem

### How I did it

use path and not only the path.stem

### How to verify it

1. clone  https://github.com/curvefi/curve-stablecoin
2. install localy
3. vyper -f solc_json curve_stablecoin/controller.vy > std_controller.json
4. vyper --standard-json < std_controller.json  (works now)

5. before:

`vyper --standard-json < controller_code.json 
{"compiler": "vyper-0.4.3", "errors": [{"component": "json", "message": "Contract namespace collision: .venv/lib/python3.10/site-packages/snekmate/utils/math.vy", "severity": "error", "sourceLocation": {"file": "<stdin>"}, "type": "JSONError"}]}`


### Description for the changelog

Avoid namespace collision on etherscan & sourcify verification  

### Cute Animal Picture
![cat](https://github.com/user-attachments/assets/20236e21-b6ea-45b9-aa9b-0ab0019b8116)

