### PR TITLE
refactor[venom]: unify algebraic pass into forward-only lattice architecture

### DIFF
--- a/tests/unit/compiler/venom/test_algebraic_binopt.py
+++ b/tests/unit/compiler/venom/test_algebraic_binopt.py
@@ -508,15 +508,15 @@ def test_comparison_almost_always():
         %6 = not %par
         %7 = iszero %6
         %2 = iszero %7
-        assert %2
-        %8 = xor %par, {max_int256}
+        assert %6
+        %8 = xor {max_int256}, %par
         %9 = iszero %8
         %3 = iszero %9
-        assert %3
-        %10 = xor %par, {min_int256}
+        assert %8
+        %10 = xor {min_int256}, %par
         %11 = iszero %10
         %4 = iszero %11
-        assert %4
+        assert %10
         sink %1
     """
 

--- a/tests/unit/compiler/venom/test_algebraic_binopt.py
+++ b/tests/unit/compiler/venom/test_algebraic_binopt.py
@@ -508,15 +508,15 @@ def test_comparison_almost_always():
         %6 = not %par
         %7 = iszero %6
         %2 = iszero %7
-        assert %6
-        %8 = xor {max_int256}, %par
+        assert %2
+        %8 = xor %par, {max_int256}
         %9 = iszero %8
         %3 = iszero %9
-        assert %8
-        %10 = xor {min_int256}, %par
+        assert %3
+        %10 = xor %par, {min_int256}
         %11 = iszero %10
         %4 = iszero %11
-        assert %10
+        assert %4
         sink %1
     """
 

--- a/tests/unit/compiler/venom/test_algebraic_binopt.py
+++ b/tests/unit/compiler/venom/test_algebraic_binopt.py
@@ -505,17 +505,17 @@ def test_comparison_almost_always():
         %par = source
         %5 = iszero %par
         %1 = iszero %5
-        %9 = not %par  ; (eq -1 x) => (iszero (not x))
-        %6 = iszero %9
-        %2 = iszero %6
+        %6 = not %par
+        %7 = iszero %6
+        %2 = iszero %7
         assert %2
-        %10 = xor %par, {max_int256}
-        %7 = iszero %10
-        %3 = iszero %7
+        %8 = xor %par, {max_int256}
+        %9 = iszero %8
+        %3 = iszero %9
         assert %3
-        %11 = xor %par, {min_int256}
-        %8 = iszero %11
-        %4 = iszero %8
+        %10 = xor %par, {min_int256}
+        %11 = iszero %10
+        %4 = iszero %11
         assert %4
         sink %1
     """

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -310,16 +310,14 @@ def test_iszero_chain_after_comparator_rewrite():
     else:
         sink %x
     """
-    # The comparator handler rewrites gt %x, 5 -> slt 6, %x and
-    # absorbs the iszero at %a. The iszero chain is broken but
-    # the pass must not crash.
+    # The comparator handler rewrites gt %x, 5 and absorbs the
+    # iszero at %a. The forward-computed targets still point to
+    # %cmp as the root, so jnz gets redirected directly.
     post = """
     main:
         %x = source
         %cmp = gt 6, %x
-        %a = %cmp
-        %b = iszero %a
-        jnz %b, @then, @else
+        jnz %cmp, @then, @else
     then:
         sink %x
     else:

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -310,14 +310,17 @@ def test_iszero_chain_after_comparator_rewrite():
     else:
         sink %x
     """
-    # The comparator handler rewrites gt %x, 5 and absorbs the
-    # iszero at %a. The forward-computed targets still point to
-    # %cmp as the root, so jnz gets redirected directly.
+    # The comparator handler flips gt to lt and absorbs the iszero
+    # at %a (converting it to assign). The chain is now stale —
+    # %cmp has inverted semantics. The chain validator detects that
+    # %a is no longer iszero and bails out, leaving jnz %b intact.
     post = """
     main:
         %x = source
         %cmp = gt 6, %x
-        jnz %cmp, @then, @else
+        %a = %cmp
+        %b = iszero %a
+        jnz %b, @then, @else
     then:
         sink %x
     else:

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -56,7 +56,7 @@ def test_simple_jump_case(iszero_count):
         {post_chain}
         jnz %{jnz_cond}, @then, @else
     then:
-        %4 = add 10, %3
+        %4 = add 74, %par
         sink %4
     else:
         %5 = add %3, %par
@@ -256,8 +256,8 @@ def test_fold_add_chain_cancels_to_zero():
     _check_pre_post(pre, post)
 
 
-def test_fold_add_chain_multi_use_stops():
-    """Don't fold through intermediates with multiple uses."""
+def test_fold_add_chain_multi_use():
+    """Lattice sees through multi-use intermediates."""
     pre = """
     main:
         %x = source
@@ -269,7 +269,7 @@ def test_fold_add_chain_multi_use_stops():
     main:
         %x = source
         %tmp = add 3, %x
-        %out = add 5, %tmp
+        %out = add 8, %x
         sink %out, %tmp
     """
     _check_pre_post(pre, post)

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -56,7 +56,7 @@ def test_simple_jump_case(iszero_count):
         {post_chain}
         jnz %{jnz_cond}, @then, @else
     then:
-        %4 = add 74, %par
+        %4 = add 10, %3
         sink %4
     else:
         %5 = add %3, %par
@@ -256,8 +256,8 @@ def test_fold_add_chain_cancels_to_zero():
     _check_pre_post(pre, post)
 
 
-def test_fold_add_chain_multi_use():
-    """Lattice sees through multi-use intermediates."""
+def test_fold_add_chain_multi_use_stops():
+    """Don't fold through intermediates with multiple uses."""
     pre = """
     main:
         %x = source
@@ -269,7 +269,7 @@ def test_fold_add_chain_multi_use():
     main:
         %x = source
         %tmp = add 3, %x
-        %out = add 8, %x
+        %out = add 5, %tmp
         sink %out, %tmp
     """
     _check_pre_post(pre, post)

--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -294,6 +294,40 @@ def test_fold_add_chain_three_deep():
     _check_pre_post(pre, post)
 
 
+def test_iszero_chain_after_comparator_rewrite():
+    """Comparator rewrite can mutate an iszero in the chain (e.g. gt -> slt
+    removes an iszero), making the pre-computed iszero_depth stale.
+    The walk must bail out gracefully instead of asserting."""
+    pre = """
+    main:
+        %x = source
+        %cmp = gt %x, 5
+        %a = iszero %cmp
+        %b = iszero %a
+        jnz %b, @then, @else
+    then:
+        sink %x
+    else:
+        sink %x
+    """
+    # The comparator handler rewrites gt %x, 5 -> slt 6, %x and
+    # absorbs the iszero at %a. The iszero chain is broken but
+    # the pass must not crash.
+    post = """
+    main:
+        %x = source
+        %cmp = gt 6, %x
+        %a = %cmp
+        %b = iszero %a
+        jnz %b, @then, @else
+    then:
+        sink %x
+    else:
+        sink %x
+    """
+    _check_pre_post(pre, post)
+
+
 def test_offsets():
     """
     Test of addition to offset rewrites

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -172,7 +172,7 @@ class AlgebraicOptimizationPass(IRPass):
             return
         if self._rewrite_affine(inst):
             return
-        if self._rewrite_producer(inst):
+        if self._rewrite_or_skip_producer(inst):
             return
         self._rewrite_local(inst)
 
@@ -224,8 +224,9 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater.update(inst, "add", [base, IRLiteral(offset)])
         return True
 
-    def _rewrite_producer(self, inst: IRInstruction) -> bool:
-        """Producer-based pattern rewrites."""
+    def _rewrite_or_skip_producer(self, inst: IRInstruction) -> bool:
+        """Producer-based pattern rewrites. Returns True if a rewrite was
+        applied OR if the opcode should be skipped by _rewrite_local."""
         operands = inst.operands
 
         # balance(address()) -> selfbalance()

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -205,12 +205,6 @@ class AlgebraicOptimizationPass(IRPass):
         if base == imm_base:
             return False
 
-        # Only fold through single-use intermediates — folding through
-        # multi-use doesn't eliminate instructions and the variable
-        # reference change can increase DUP depth in codegen
-        if isinstance(imm_base, IRVariable) and not self.dfg.is_single_use(imm_base):
-            return False
-
         if offset == 0:
             self.updater.mk_assign(inst, base)
             return True

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -23,6 +23,14 @@ def lit_eq(op: IROperand, val: int) -> bool:
     return isinstance(op, IRLiteral) and wrap256(op.value) == wrap256(val)
 
 
+def _push_size(value: int) -> int:
+    """Number of data bytes needed for a PUSH instruction."""
+    value = wrap256(value)
+    if value == 0:
+        return 0  # PUSH0
+    return (value.bit_length() + 7) // 8
+
+
 # --- VarInfo ADT (pure, immutable) ---
 
 
@@ -184,17 +192,19 @@ class AlgebraicOptimizationPass(IRPass):
         if base == inst.output:
             return False
 
-        # Find the immediate variable operand of this instruction
+        # Find the immediate variable operand and current literal
         if inst.opcode == "add":
             val_op, lit_op = self._extract_value_and_literal_operands(inst)
             if val_op is None or lit_op is None:
                 return False
             imm_base = val_op
+            curr_lit = lit_op.value
         else:  # sub
             op0, op1 = inst.operands
             if not isinstance(op0, IRLiteral) or isinstance(op1, IRLiteral):
                 return False
             imm_base = op1
+            curr_lit = op0.value
 
         # Only rewrite if chain folding found a deeper base
         if base == imm_base:
@@ -203,6 +213,11 @@ class AlgebraicOptimizationPass(IRPass):
         if offset == 0:
             self.updater.mk_assign(inst, base)
             return True
+
+        # Don't rewrite if it would increase literal byte width
+        if _push_size(offset) > _push_size(curr_lit):
+            return False
+
         self.updater.update(inst, "add", [base, IRLiteral(offset)])
         return True
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import Enum, auto
 
 from vyper.utils import SizeLimits, int_bounds, int_log2, is_power_of_two, wrap256
 from vyper.venom.analysis.dfg import DFGAnalysis
@@ -32,34 +31,18 @@ def _push_size(value: int) -> int:
 
 
 # --- VarInfo ADT (pure, immutable) ---
-
-
-class VarInfoKind(Enum):
-    UNKNOWN = auto()  # no information
-    AFFINE = auto()  # base + offset
+# Represents affine knowledge: value = base + offset (mod 2^256).
+# base=None means a pure constant (offset only).
 
 
 @dataclass(frozen=True, slots=True)
 class VarInfo:
-    _kind: VarInfoKind
-    _base: IROperand | None  # for AFFINE: the root variable (None = pure constant)
-    _offset: int  # for AFFINE: the constant offset (wrap256)
+    base: IROperand | None  # root variable, or None for pure constant
+    offset: int  # constant offset (wrap256)
 
     @classmethod
-    def unknown(cls) -> "VarInfo":
-        return cls(_kind=VarInfoKind.UNKNOWN, _base=None, _offset=0)
-
-    @classmethod
-    def affine(cls, base: IROperand | None, offset: int) -> "VarInfo":
-        return cls(_kind=VarInfoKind.AFFINE, _base=base, _offset=wrap256(offset))
-
-    @property
-    def is_affine(self) -> bool:
-        return self._kind == VarInfoKind.AFFINE
-
-    @property
-    def is_unknown(self) -> bool:
-        return self._kind == VarInfoKind.UNKNOWN
+    def of(cls, base: IROperand | None, offset: int = 0) -> "VarInfo":
+        return cls(base=base, offset=wrap256(offset))
 
 
 # --- Pure transfer functions (module-level, no self) ---
@@ -70,35 +53,33 @@ def _lookup(op: IROperand, info: dict[IRVariable, VarInfo]) -> VarInfo:
     if isinstance(op, IRVariable):
         if op in info:
             return info[op]
-        return VarInfo.affine(op, 0)
+        return VarInfo.of(op)
     if isinstance(op, IRLiteral):
-        return VarInfo.affine(None, op.value)
-    # IRLabel or other
-    return VarInfo.unknown()
+        return VarInfo.of(None, op.value)
+    # IRLabel — not trackable
+    return VarInfo.of(op)
 
 
 def transfer_add(lhs: VarInfo, rhs: VarInfo, out: IRVariable) -> VarInfo:
     """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for add."""
-    if lhs.is_affine and rhs.is_affine:
-        if lhs._base is None:
-            return VarInfo.affine(rhs._base, rhs._offset + lhs._offset)
-        if rhs._base is None:
-            return VarInfo.affine(lhs._base, lhs._offset + rhs._offset)
-    return VarInfo.affine(out, 0)
+    if lhs.base is None:
+        return VarInfo.of(rhs.base, rhs.offset + lhs.offset)
+    if rhs.base is None:
+        return VarInfo.of(lhs.base, lhs.offset + rhs.offset)
+    return VarInfo.of(out)
 
 
 def transfer_sub(minuend: VarInfo, subtrahend: VarInfo, out: IRVariable) -> VarInfo:
     """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for sub
     (minuend - subtrahend)."""
-    if minuend.is_affine and subtrahend.is_affine:
-        if subtrahend._base is None:
-            return VarInfo.affine(minuend._base, minuend._offset - subtrahend._offset)
-    return VarInfo.affine(out, 0)
+    if subtrahend.base is None:
+        return VarInfo.of(minuend.base, minuend.offset - subtrahend.offset)
+    return VarInfo.of(out)
 
 
 def transfer_assign(src: VarInfo) -> VarInfo:
-    """Pure: VarInfo -> VarInfo (inherit)."""
-    return VarInfo(src._kind, src._base, src._offset)
+    """Pure: VarInfo -> VarInfo (inherit). VarInfo is frozen, so identity."""
+    return src
 
 
 class AlgebraicOptimizationPass(IRPass):
@@ -124,6 +105,9 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater = InstUpdater(self.dfg)
         self._handle_offset()
 
+        # Two passes: iszero chain optimization can expose new affine
+        # folding opportunities (e.g. removing iszero nodes that were
+        # blocking chain traversal), so we recompute and rewrite after.
         self.var_info = self._compute_var_info()
         self._rewrite_all()
         self._optimize_iszero_chains()
@@ -152,7 +136,7 @@ class AlgebraicOptimizationPass(IRPass):
                 elif inst.opcode == "assign":
                     info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
                 else:
-                    info[inst.output] = VarInfo.affine(inst.output, 0)
+                    info[inst.output] = VarInfo.of(inst.output)
         return info
 
     # --- Rewrite phase (imperative shell) ---
@@ -179,11 +163,11 @@ class AlgebraicOptimizationPass(IRPass):
         if inst.opcode not in ("add", "sub"):
             return False
         vi = self.var_info.get(inst.output)
-        if vi is None or not vi.is_affine or vi._base is None:
+        if vi is None or vi.base is None:
             return False
 
-        base = vi._base
-        offset = vi._offset
+        base = vi.base
+        offset = vi.offset
         if base == inst.output:
             return False
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -92,9 +92,7 @@ def transfer_sub(minuend: VarInfo, subtrahend: VarInfo, out: IRVariable) -> VarI
     (minuend - subtrahend)."""
     if minuend.is_affine and subtrahend.is_affine:
         if subtrahend._base is None:
-            return VarInfo.affine(
-                minuend._base, minuend._offset - subtrahend._offset
-            )
+            return VarInfo.affine(minuend._base, minuend._offset - subtrahend._offset)
     return VarInfo.affine(out, 0)
 
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -174,13 +174,20 @@ class AlgebraicOptimizationPass(IRPass):
             if keep >= depth:
                 continue
 
-            # walk back (depth - keep) iszero producers from op
+            # walk back (depth - keep) iszero producers from op.
+            # bail if the chain no longer matches — mid-pass rewrites
+            # (e.g. comparator handler) can change opcodes, making
+            # the pre-computed iszero_depth stale.
             target: IROperand = op
             for _ in range(depth - keep):
+                if not isinstance(target, IRVariable):
+                    break
                 prod = self.dfg.get_producing_instruction(target)
-                assert prod is not None and prod.opcode == "iszero"
+                if prod is None or prod.opcode != "iszero":
+                    break
                 target = prod.operands[0]
-            replacements[op] = target
+            else:
+                replacements[op] = target
 
         if len(replacements) > 0:
             self.updater.update_operands(inst, replacements)

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -39,8 +39,7 @@ def _push_size(value: int) -> int:
 class VarInfo:
     base: IROperand | None  # root variable, or None for pure constant
     offset: int  # constant offset (wrap256)
-    iszero_depth: int  # number of iszero applications from iszero_root
-    iszero_root: IROperand | None  # operand at the base of the iszero chain
+    iszero_depth: int  # number of iszero applications (0 = not in a chain)
 
     @classmethod
     def of(
@@ -48,11 +47,8 @@ class VarInfo:
         base: IROperand | None,
         offset: int = 0,
         iszero_depth: int = 0,
-        iszero_root: IROperand | None = None,
     ) -> "VarInfo":
-        return cls(
-            base=base, offset=wrap256(offset), iszero_depth=iszero_depth, iszero_root=iszero_root
-        )
+        return cls(base=base, offset=wrap256(offset), iszero_depth=iszero_depth)
 
 
 # --- Pure transfer functions (module-level, no self) ---
@@ -66,6 +62,7 @@ def _lookup(op: IROperand, info: dict[IRVariable, VarInfo]) -> VarInfo:
         return VarInfo.of(op)
     if isinstance(op, IRLiteral):
         return VarInfo.of(None, op.value)
+    assert isinstance(op, IRLabel)
     # IRLabel — tracked as opaque base (not decomposable)
     return VarInfo.of(op)
 
@@ -92,13 +89,9 @@ def transfer_assign(src: VarInfo) -> VarInfo:
     return src
 
 
-def transfer_iszero(src: VarInfo, op: IROperand) -> VarInfo:
+def transfer_iszero(src: VarInfo) -> VarInfo:
     """Pure: extend or start an iszero chain."""
-    if src.iszero_depth > 0:
-        # extend existing chain
-        return VarInfo.of(None, iszero_depth=src.iszero_depth + 1, iszero_root=src.iszero_root)
-    # start new chain — root is the operand fed into this iszero
-    return VarInfo.of(None, iszero_depth=1, iszero_root=op)
+    return VarInfo.of(None, iszero_depth=src.iszero_depth + 1)
 
 
 class AlgebraicOptimizationPass(IRPass):
@@ -150,7 +143,7 @@ class AlgebraicOptimizationPass(IRPass):
                     info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
                 elif inst.opcode == "iszero":
                     src = _lookup(inst.operands[0], info)
-                    info[inst.output] = transfer_iszero(src, inst.operands[0])
+                    info[inst.output] = transfer_iszero(src)
                 else:
                     info[inst.output] = VarInfo.of(inst.output)
         return info
@@ -657,11 +650,11 @@ class AlgebraicOptimizationPass(IRPass):
             # e.g. gt x 0, slt x MAX_INT256
             # produce iszero(iszero(xor x N)) directly, with
             # xor x 0 = x and xor x -1 = not x as special cases
-            val = operands[0].value
+            val = wrap256(operands[0].value)
             x = operands[1]
             if val == 0:
                 inner = x
-            elif wrap256(val) == wrap256(-1):
+            elif val == wrap256(-1):
                 inner = self.updater.add_before(inst, "not", [x])
             else:
                 inner = self.updater.add_before(inst, "xor", [operands[0], x])

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -112,8 +112,12 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater = InstUpdater(self.dfg)
         self._handle_offset()
 
-        self.var_info = self._compute_var_info()
-        self._rewrite_all()
+        # two iterations: the first pass may create new iszero chains
+        # (e.g. comparator rewrites) or change operands (iszero shortening)
+        # that expose new folding opportunities in the second pass.
+        for _ in range(2):
+            self.var_info = self._compute_var_info()
+            self._rewrite_all()
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
 
@@ -174,13 +178,19 @@ class AlgebraicOptimizationPass(IRPass):
             if keep >= depth:
                 continue
 
-            # walk back (depth - keep) iszero producers from op
+            # walk back (depth - keep) iszero producers from op.
+            # the chain may not match if prior rewrites changed opcodes,
+            # in which case we bail out for this operand.
             target: IROperand = op
             for _ in range(depth - keep):
+                if not isinstance(target, IRVariable):
+                    break
                 prod = self.dfg.get_producing_instruction(target)
-                assert prod is not None and prod.opcode == "iszero"
+                if prod is None or prod.opcode != "iszero":
+                    break
                 target = prod.operands[0]
-            replacements[op] = target
+            else:
+                replacements[op] = target
 
         if len(replacements) > 0:
             self.updater.update_operands(inst, replacements)

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+
 from vyper.utils import SizeLimits, int_bounds, int_log2, is_power_of_two, wrap256
 from vyper.venom.analysis.dfg import DFGAnalysis
 from vyper.venom.analysis.liveness import LivenessAnalysis
@@ -12,7 +15,6 @@ from vyper.venom.basicblock import (
     flip_comparison_opcode,
 )
 from vyper.venom.passes.base_pass import InstUpdater, IRPass
-from vyper.venom.passes.sccp.eval import eval_arith
 
 TRUTHY_INSTRUCTIONS = ("iszero", "jnz", "assert", "assert_unreachable")
 
@@ -21,14 +23,94 @@ def lit_eq(op: IROperand, val: int) -> bool:
     return isinstance(op, IRLiteral) and wrap256(op.value) == wrap256(val)
 
 
-def lit_add(op: IROperand, val: int) -> int:
-    assert isinstance(op, IRLiteral)
-    return eval_arith("add", [op, IRLiteral(val)])
+# --- VarInfo ADT (pure, immutable) ---
 
 
-def lit_sub(val: int, op: IROperand) -> int:
-    assert isinstance(op, IRLiteral)
-    return eval_arith("sub", [op, IRLiteral(val)])
+class VarInfoKind(Enum):
+    UNKNOWN = auto()  # no information
+    AFFINE = auto()  # base + offset
+
+
+@dataclass(frozen=True, slots=True)
+class VarInfo:
+    _kind: VarInfoKind
+    _base: IROperand | None  # for AFFINE: the root variable (None = pure constant)
+    _offset: int  # for AFFINE: the constant offset (wrap256)
+    _producer: str | None  # opcode that produced this value
+
+    @classmethod
+    def unknown(cls, producer: str | None = None) -> "VarInfo":
+        return cls(
+            _kind=VarInfoKind.UNKNOWN, _base=None, _offset=0, _producer=producer
+        )
+
+    @classmethod
+    def affine(
+        cls, base: IROperand | None, offset: int, producer: str | None = None
+    ) -> "VarInfo":
+        return cls(
+            _kind=VarInfoKind.AFFINE,
+            _base=base,
+            _offset=wrap256(offset),
+            _producer=producer,
+        )
+
+    @property
+    def is_affine(self) -> bool:
+        return self._kind == VarInfoKind.AFFINE
+
+    @property
+    def is_unknown(self) -> bool:
+        return self._kind == VarInfoKind.UNKNOWN
+
+
+# --- Pure transfer functions (module-level, no self) ---
+
+
+def _lookup(op: IROperand, info: dict[IRVariable, VarInfo]) -> VarInfo:
+    """Look up the VarInfo for an operand."""
+    if isinstance(op, IRVariable):
+        if op in info:
+            return info[op]
+        return VarInfo.affine(op, 0)
+    if isinstance(op, IRLiteral):
+        return VarInfo.affine(None, op.value)
+    # IRLabel or other
+    return VarInfo.unknown()
+
+
+def transfer_add(lhs: VarInfo, rhs: VarInfo, out: IRVariable) -> VarInfo:
+    """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for add."""
+    if lhs.is_affine and rhs.is_affine:
+        if lhs._base is None:
+            return VarInfo.affine(
+                rhs._base, rhs._offset + lhs._offset, producer="add"
+            )
+        if rhs._base is None:
+            return VarInfo.affine(
+                lhs._base, lhs._offset + rhs._offset, producer="add"
+            )
+    return VarInfo.affine(out, 0, producer="add")
+
+
+def transfer_sub(
+    minuend: VarInfo, subtrahend: VarInfo, out: IRVariable
+) -> VarInfo:
+    """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for sub
+    (minuend - subtrahend)."""
+    if minuend.is_affine and subtrahend.is_affine:
+        if subtrahend._base is None:
+            return VarInfo.affine(
+                minuend._base,
+                minuend._offset - subtrahend._offset,
+                producer="sub",
+            )
+    return VarInfo.affine(out, 0, producer="sub")
+
+
+def transfer_assign(src: VarInfo) -> VarInfo:
+    """Pure: VarInfo -> VarInfo (inherit)."""
+    return VarInfo(src._kind, src._base, src._offset, _producer="assign")
 
 
 class AlgebraicOptimizationPass(IRPass):
@@ -39,12 +121,14 @@ class AlgebraicOptimizationPass(IRPass):
       - iszero chains
       - binops
       - offset adds
+      - affine chain folding (lattice-driven)
       - signextend elimination via range analysis
     """
 
     dfg: DFGAnalysis
     updater: InstUpdater
     range_analysis: VariableRangeAnalysis
+    var_info: dict[IRVariable, VarInfo]
 
     def run_pass(self):
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
@@ -52,184 +136,135 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater = InstUpdater(self.dfg)
         self._handle_offset()
 
-        self._algebraic_opt()
+        self.var_info = self._compute_var_info()
+        self._rewrite_all()
         self._optimize_iszero_chains()
-        self._algebraic_opt()
+        self.var_info = self._compute_var_info()
+        self._rewrite_all()
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
 
-    def _optimize_iszero_chains(self) -> None:
-        fn = self.function
-        for bb in fn.get_basic_blocks():
-            for inst in bb.instructions:
-                if inst.opcode != "iszero":
-                    continue
+    # --- Forward propagation (imperative shell) ---
 
-                iszero_chain = self._get_iszero_chain(inst.operands[0])
-                iszero_count = len(iszero_chain)
-                if iszero_count == 0:
-                    continue
-
-                inst_out = inst.output
-                for use_inst in self.dfg.get_uses(inst_out).copy():
-                    opcode = use_inst.opcode
-
-                    if opcode == "iszero":
-                        # We keep iszero instuctions as is
-                        continue
-                    if opcode in ("jnz", "assert", "assert_unreachable"):
-                        # instructions that accept a truthy value as input:
-                        # we can remove up to all the iszero instructions
-                        keep_count = 1 - iszero_count % 2
-                    else:
-                        # all other instructions:
-                        # we need to keep at least one or two iszero instructions
-                        keep_count = 1 + iszero_count % 2
-
-                    if keep_count >= iszero_count:
-                        continue
-
-                    out_var = iszero_chain[keep_count].operands[0]
-                    self.updater.update_operands(use_inst, {inst_out: out_var})
-
-    def _get_iszero_chain(self, op: IROperand) -> list[IRInstruction]:
-        chain: list[IRInstruction] = []
-
-        while True:
-            if not isinstance(op, IRVariable):
-                break
-            inst = self.dfg.get_producing_instruction(op)
-            if inst is None or inst.opcode != "iszero":
-                break
-            op = inst.operands[0]
-            chain.append(inst)
-
-        chain.reverse()
-        return chain
-
-    def _handle_offset(self):
+    def _compute_var_info(self) -> dict[IRVariable, VarInfo]:
+        info: dict[IRVariable, VarInfo] = {}
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
-                if (
-                    inst.opcode == "add"
-                    and self._is_lit(inst.operands[0])
-                    and isinstance(inst.operands[1], IRLabel)
-                ):
-                    inst.opcode = "offset"
-
-    def _is_lit(self, operand: IROperand) -> bool:
-        return isinstance(operand, IRLiteral)
-
-    def _extract_value_and_literal_operands(
-        self, inst: IRInstruction
-    ) -> tuple[IROperand | None, IRLiteral | None]:
-        value_op = None
-        literal_op = None
-        for op in inst.operands:
-            if self._is_lit(op):
-                if literal_op is not None:
-                    return None, None
-                literal_op = op
-            else:
-                value_op = op
-        assert isinstance(literal_op, IRLiteral) or literal_op is None  # help mypy
-        return value_op, literal_op
-
-    def _fold_add_chain(self, inst: IRInstruction) -> bool:
-        if inst.opcode not in {"add", "sub"}:
-            return False
-
-        op0, op1 = inst.operands
-        base_operand: IROperand | None = None
-        total = 0
-
-        if inst.opcode == "add":
-            base_operand, literal = self._extract_value_and_literal_operands(inst)
-            if literal is None or base_operand is None:
-                return False
-            total = lit_add(literal, total)
-        else:  # sub
-            if self._is_lit(op0) and not self._is_lit(op1):
-                total = lit_sub(total, op0)
-                base_operand = op1
-            else:
-                return False
-
-        base_operand, traced = self._trace_add_chain(base_operand)
-        total += traced
-
-        if total == 0:
-            self.updater.mk_assign(inst, base_operand)
-            return True
-
-        self.updater.update(inst, "add", [base_operand, IRLiteral(total)])
-        return True
-
-    def _trace_add_chain(self, operand: IROperand) -> tuple[IROperand, int]:
-        total = 0
-        current = operand
-
-        while isinstance(current, IRVariable):
-            producer = self.dfg.get_producing_instruction(current)
-            if producer is None:
-                break
-
-            if producer.opcode == "add":
-                assert producer.output is not None  # help mypy
-                if not self.dfg.is_single_use(producer.output):
-                    break
-
-                value_op, literal = self._extract_value_and_literal_operands(producer)
-                if literal is None or value_op is None:
-                    break
-
-                assert isinstance(literal, IRLiteral)  # help mypy
-                total = lit_add(literal, total)
-                current = value_op
-                continue
-
-            if producer.opcode == "sub":
-                assert producer.output is not None  # help mypy
-                if not self.dfg.is_single_use(producer.output):
-                    break
-                op0, op1 = producer.operands
-                if self._is_lit(op0) and not self._is_lit(op1):
-                    total = lit_sub(total, op0)
-                    current = op1
+                if inst.num_outputs != 1:
                     continue
-                break
+                if inst.opcode == "add":
+                    lhs = _lookup(inst.operands[1], info)
+                    rhs = _lookup(inst.operands[0], info)
+                    info[inst.output] = transfer_add(lhs, rhs, inst.output)
+                elif inst.opcode == "sub":
+                    # sub computes operands[1] - operands[0]
+                    minuend = _lookup(inst.operands[1], info)
+                    subtrahend = _lookup(inst.operands[0], info)
+                    info[inst.output] = transfer_sub(
+                        minuend, subtrahend, inst.output
+                    )
+                elif inst.opcode == "assign":
+                    info[inst.output] = transfer_assign(
+                        _lookup(inst.operands[0], info)
+                    )
+                else:
+                    info[inst.output] = VarInfo.affine(
+                        inst.output, 0, producer=inst.opcode
+                    )
+        return info
 
-            break
+    # --- Rewrite phase (imperative shell) ---
 
-        return current, total
-
-    def _algebraic_opt(self):
-        self._algebraic_opt_pass()
-
-    def _algebraic_opt_pass(self):
+    def _rewrite_all(self):
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
-                self._handle_inst_peephole(inst)
+                self._rewrite_inst(inst)
                 self._flip_inst(inst)
 
-    def _flip_inst(self, inst: IRInstruction):
-        ops = inst.operands
-        # improve code. this seems like it should be properly handled by
-        # better heuristics in DFT pass.
-        if inst.flippable and self._is_lit(ops[0]) and not self._is_lit(ops[1]):
-            inst.flip()
-
-    # "peephole", weakening algebraic optimizations
-    def _handle_inst_peephole(self, inst: IRInstruction):
+    def _rewrite_inst(self, inst: IRInstruction):
         if inst.num_outputs != 1:
             return
+        if inst.is_volatile or inst.opcode == "assign" or inst.is_pseudo:
+            return
+        if self._rewrite_affine(inst):
+            return
+        if self._rewrite_producer(inst):
+            return
+        self._rewrite_local(inst)
+
+    def _rewrite_affine(self, inst: IRInstruction) -> bool:
+        """Lattice-driven affine chain folding."""
+        if inst.opcode not in ("add", "sub"):
+            return False
+        vi = self.var_info.get(inst.output)
+        if vi is None or not vi.is_affine or vi._base is None:
+            return False
+
+        base = vi._base
+        offset = vi._offset
+        if base == inst.output:
+            return False
+
+        # Find the immediate variable operand of this instruction
+        if inst.opcode == "add":
+            val_op, lit_op = self._extract_value_and_literal_operands(inst)
+            if val_op is None or lit_op is None:
+                return False
+            imm_base = val_op
+        else:  # sub
+            op0, op1 = inst.operands
+            if not isinstance(op0, IRLiteral) or isinstance(op1, IRLiteral):
+                return False
+            imm_base = op1
+
+        # Only rewrite if chain folding found a deeper base
+        if base == imm_base:
+            return False
+
+        if offset == 0:
+            self.updater.mk_assign(inst, base)
+            return True
+        self.updater.update(inst, "add", [base, IRLiteral(offset)])
+        return True
+
+    def _rewrite_producer(self, inst: IRInstruction) -> bool:
+        """Producer-based pattern rewrites."""
+        operands = inst.operands
+
+        # balance(address()) -> selfbalance()
+        # note: extcodesize(address()) -> codesize() is NOT safe because
+        # during initcode EXTCODESIZE(ADDRESS()) returns 0 while CODESIZE
+        # returns the initcode length.
+        if inst.opcode == "balance":
+            op = operands[0]
+            if isinstance(op, IRVariable):
+                producer = self.dfg.get_producing_instruction(op)
+                if producer is not None and producer.opcode == "address":
+                    self.updater.update(inst, "selfbalance", [])
+            return True  # no other rules for balance
+
+        if inst.opcode == "extcodesize":
+            return True  # no optimizations for extcodesize
+
+        # signextend(n, signextend(m, x)) where n >= m -> signextend(m, x)
+        if inst.opcode == "signextend":
+            n_op = operands[-1]
+            x_op = operands[-2]
+            if isinstance(x_op, IRVariable) and self._is_lit(n_op):
+                producer = self.dfg.get_producing_instruction(x_op)
+                if producer is not None and producer.opcode == "signextend":
+                    inner_n = producer.operands[-1]
+                    if self._is_lit(inner_n) and n_op.value >= inner_n.value:
+                        self.updater.mk_assign(inst, x_op)
+                        return True
+
+        return False
+
+    # --- Local peephole rules ---
+
+    def _rewrite_local(self, inst: IRInstruction):
+        operands = inst.operands
         inst_out = inst.output
-        if inst.is_volatile:
-            return
-        if inst.opcode == "assign":
-            return
-        if inst.is_pseudo:
-            return
 
         # TODO nice to have rules:
         # -1 * x => 0 - x
@@ -239,28 +274,10 @@ class AlgebraicOptimizationPass(IRPass):
         # 1 % x => x > 1(?)
         # !!x => x > 0  # saves 1 gas as of shanghai
 
-        operands = inst.operands
-
         # make logic easier for commutative instructions.
         if inst.flippable and self._is_lit(operands[1]) and not self._is_lit(operands[0]):
             inst.flip()
             operands = inst.operands
-
-        # balance(address()) → selfbalance()
-        # note: extcodesize(address()) → codesize() is NOT safe because
-        # during initcode EXTCODESIZE(ADDRESS()) returns 0 while CODESIZE
-        # returns the initcode length.
-        if inst.opcode == "balance":
-            op = operands[0]
-            if isinstance(op, IRVariable):
-                producer = self.dfg.get_producing_instruction(op)
-                if producer is not None and producer.opcode == "address":
-                    self.updater.update(inst, "selfbalance", [])
-                    return
-            return
-
-        if inst.opcode == "extcodesize":
-            return
 
         if inst.opcode in {"shl", "shr", "sar"}:
             # (x >> 0) == (x << 0) == x
@@ -293,16 +310,6 @@ class AlgebraicOptimizationPass(IRPass):
                         signed_max = (1 << (bits - 1)) - 1
                         # If x is already in valid range, signextend is no-op
                         if x_range.lo >= signed_min and x_range.hi <= signed_max:
-                            self.updater.mk_assign(inst, x_op)
-                            return
-
-            # signextend(n, signextend(m, x)) where n >= m -> signextend(m, x)
-            if isinstance(x_op, IRVariable):
-                producer = self.dfg.get_producing_instruction(x_op)
-                if producer is not None and producer.opcode == "signextend":
-                    inner_n = producer.operands[-1]  # inner byte count
-                    if self._is_lit(n_op) and self._is_lit(inner_n):
-                        if n_op.value >= inner_n.value:
                             self.updater.mk_assign(inst, x_op)
                             return
             return
@@ -359,10 +366,6 @@ class AlgebraicOptimizationPass(IRPass):
             if inst.opcode == "xor" and lit_eq(operands[0], -1):
                 self.updater.update(inst, "not", [operands[1]])
                 return
-
-            if inst.opcode in {"add", "sub"}:
-                if self._fold_add_chain(inst):
-                    return
 
             return
 
@@ -458,6 +461,92 @@ class AlgebraicOptimizationPass(IRPass):
 
         if inst.opcode in COMPARATOR_INSTRUCTIONS:
             self._optimize_comparator_instruction(inst, prefer_iszero)
+
+    # --- Unchanged methods ---
+
+    def _optimize_iszero_chains(self) -> None:
+        fn = self.function
+        for bb in fn.get_basic_blocks():
+            for inst in bb.instructions:
+                if inst.opcode != "iszero":
+                    continue
+
+                iszero_chain = self._get_iszero_chain(inst.operands[0])
+                iszero_count = len(iszero_chain)
+                if iszero_count == 0:
+                    continue
+
+                inst_out = inst.output
+                for use_inst in self.dfg.get_uses(inst_out).copy():
+                    opcode = use_inst.opcode
+
+                    if opcode == "iszero":
+                        # We keep iszero instuctions as is
+                        continue
+                    if opcode in ("jnz", "assert", "assert_unreachable"):
+                        # instructions that accept a truthy value as input:
+                        # we can remove up to all the iszero instructions
+                        keep_count = 1 - iszero_count % 2
+                    else:
+                        # all other instructions:
+                        # we need to keep at least one or two iszero instructions
+                        keep_count = 1 + iszero_count % 2
+
+                    if keep_count >= iszero_count:
+                        continue
+
+                    out_var = iszero_chain[keep_count].operands[0]
+                    self.updater.update_operands(use_inst, {inst_out: out_var})
+
+    def _get_iszero_chain(self, op: IROperand) -> list[IRInstruction]:
+        chain: list[IRInstruction] = []
+
+        while True:
+            if not isinstance(op, IRVariable):
+                break
+            inst = self.dfg.get_producing_instruction(op)
+            if inst is None or inst.opcode != "iszero":
+                break
+            op = inst.operands[0]
+            chain.append(inst)
+
+        chain.reverse()
+        return chain
+
+    def _handle_offset(self):
+        for bb in self.function.get_basic_blocks():
+            for inst in bb.instructions:
+                if (
+                    inst.opcode == "add"
+                    and self._is_lit(inst.operands[0])
+                    and isinstance(inst.operands[1], IRLabel)
+                ):
+                    inst.opcode = "offset"
+
+    def _is_lit(self, operand: IROperand) -> bool:
+        return isinstance(operand, IRLiteral)
+
+    def _extract_value_and_literal_operands(
+        self, inst: IRInstruction
+    ) -> tuple[IROperand | None, IRLiteral | None]:
+        value_op = None
+        literal_op = None
+        for op in inst.operands:
+            if self._is_lit(op):
+                if literal_op is not None:
+                    return None, None
+                literal_op = op
+            else:
+                value_op = op
+        assert isinstance(literal_op, IRLiteral) or literal_op is None  # help mypy
+        return value_op, literal_op
+
+    def _flip_inst(self, inst: IRInstruction):
+        ops = inst.operands
+        # improve code. this seems like it should be properly handled by
+        # better heuristics in DFT pass.
+        if inst.flippable and self._is_lit(ops[0]) and not self._is_lit(ops[1]):
+            inst.flip()
 
     def _optimize_comparator_instruction(self, inst, prefer_iszero):
         opcode, operands = inst.opcode, inst.operands

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -229,6 +229,12 @@ class AlgebraicOptimizationPass(IRPass):
         if base == imm_base:
             return False
 
+        # Don't fold through multi-use intermediates — this destroys
+        # CSE opportunities for shared base pointers (e.g. alloca+64
+        # used by multiple mcopy destinations).
+        if isinstance(imm_base, IRVariable) and not self.dfg.is_single_use(imm_base):
+            return False
+
         if offset == 0:
             self.updater.mk_assign(inst, base)
             return True

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -156,6 +156,16 @@ class AlgebraicOptimizationPass(IRPass):
                 self._rewrite_inst(inst)
                 self._flip_inst(inst)
 
+    def _chain_valid(self, chain: tuple[IROperand, ...]) -> bool:
+        """Verify iszero chain is still intact (not mutated by mid-pass rewrites)."""
+        for var in chain[1:]:  # chain[0] is the root, skip it
+            if not isinstance(var, IRVariable):
+                return False
+            prod = self.dfg.get_producing_instruction(var)
+            if prod is None or prod.opcode != "iszero":
+                return False
+        return True
+
     def _rewrite_iszero_uses(self, inst: IRInstruction):
         """Shorten iszero chains at use sites via forward-computed targets."""
         if inst.opcode == "iszero":
@@ -177,7 +187,7 @@ class AlgebraicOptimizationPass(IRPass):
             else:
                 keep = 2 - depth % 2
 
-            if keep < depth:
+            if keep < depth and self._chain_valid(chain):
                 replacements[op] = chain[keep]
 
         if len(replacements) > 0:

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -42,12 +42,7 @@ class VarInfo:
     iszero_depth: int  # number of iszero applications (0 = not in a chain)
 
     @classmethod
-    def of(
-        cls,
-        base: IROperand | None,
-        offset: int = 0,
-        iszero_depth: int = 0,
-    ) -> "VarInfo":
+    def of(cls, base: IROperand | None, offset: int = 0, iszero_depth: int = 0) -> "VarInfo":
         return cls(base=base, offset=wrap256(offset), iszero_depth=iszero_depth)
 
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -40,19 +40,12 @@ class VarInfo:
 
     @classmethod
     def unknown(cls, producer: str | None = None) -> "VarInfo":
-        return cls(
-            _kind=VarInfoKind.UNKNOWN, _base=None, _offset=0, _producer=producer
-        )
+        return cls(_kind=VarInfoKind.UNKNOWN, _base=None, _offset=0, _producer=producer)
 
     @classmethod
-    def affine(
-        cls, base: IROperand | None, offset: int, producer: str | None = None
-    ) -> "VarInfo":
+    def affine(cls, base: IROperand | None, offset: int, producer: str | None = None) -> "VarInfo":
         return cls(
-            _kind=VarInfoKind.AFFINE,
-            _base=base,
-            _offset=wrap256(offset),
-            _producer=producer,
+            _kind=VarInfoKind.AFFINE, _base=base, _offset=wrap256(offset), _producer=producer
         )
 
     @property
@@ -83,27 +76,19 @@ def transfer_add(lhs: VarInfo, rhs: VarInfo, out: IRVariable) -> VarInfo:
     """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for add."""
     if lhs.is_affine and rhs.is_affine:
         if lhs._base is None:
-            return VarInfo.affine(
-                rhs._base, rhs._offset + lhs._offset, producer="add"
-            )
+            return VarInfo.affine(rhs._base, rhs._offset + lhs._offset, producer="add")
         if rhs._base is None:
-            return VarInfo.affine(
-                lhs._base, lhs._offset + rhs._offset, producer="add"
-            )
+            return VarInfo.affine(lhs._base, lhs._offset + rhs._offset, producer="add")
     return VarInfo.affine(out, 0, producer="add")
 
 
-def transfer_sub(
-    minuend: VarInfo, subtrahend: VarInfo, out: IRVariable
-) -> VarInfo:
+def transfer_sub(minuend: VarInfo, subtrahend: VarInfo, out: IRVariable) -> VarInfo:
     """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for sub
     (minuend - subtrahend)."""
     if minuend.is_affine and subtrahend.is_affine:
         if subtrahend._base is None:
             return VarInfo.affine(
-                minuend._base,
-                minuend._offset - subtrahend._offset,
-                producer="sub",
+                minuend._base, minuend._offset - subtrahend._offset, producer="sub"
             )
     return VarInfo.affine(out, 0, producer="sub")
 
@@ -160,17 +145,11 @@ class AlgebraicOptimizationPass(IRPass):
                     # sub computes operands[1] - operands[0]
                     minuend = _lookup(inst.operands[1], info)
                     subtrahend = _lookup(inst.operands[0], info)
-                    info[inst.output] = transfer_sub(
-                        minuend, subtrahend, inst.output
-                    )
+                    info[inst.output] = transfer_sub(minuend, subtrahend, inst.output)
                 elif inst.opcode == "assign":
-                    info[inst.output] = transfer_assign(
-                        _lookup(inst.operands[0], info)
-                    )
+                    info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
                 else:
-                    info[inst.output] = VarInfo.affine(
-                        inst.output, 0, producer=inst.opcode
-                    )
+                    info[inst.output] = VarInfo.affine(inst.output, 0, producer=inst.opcode)
         return info
 
     # --- Rewrite phase (imperative shell) ---

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -44,17 +44,14 @@ class VarInfo:
     _kind: VarInfoKind
     _base: IROperand | None  # for AFFINE: the root variable (None = pure constant)
     _offset: int  # for AFFINE: the constant offset (wrap256)
-    _producer: str | None  # opcode that produced this value
 
     @classmethod
-    def unknown(cls, producer: str | None = None) -> "VarInfo":
-        return cls(_kind=VarInfoKind.UNKNOWN, _base=None, _offset=0, _producer=producer)
+    def unknown(cls) -> "VarInfo":
+        return cls(_kind=VarInfoKind.UNKNOWN, _base=None, _offset=0)
 
     @classmethod
-    def affine(cls, base: IROperand | None, offset: int, producer: str | None = None) -> "VarInfo":
-        return cls(
-            _kind=VarInfoKind.AFFINE, _base=base, _offset=wrap256(offset), _producer=producer
-        )
+    def affine(cls, base: IROperand | None, offset: int) -> "VarInfo":
+        return cls(_kind=VarInfoKind.AFFINE, _base=base, _offset=wrap256(offset))
 
     @property
     def is_affine(self) -> bool:
@@ -84,10 +81,10 @@ def transfer_add(lhs: VarInfo, rhs: VarInfo, out: IRVariable) -> VarInfo:
     """Pure: (VarInfo, VarInfo, output_var) -> VarInfo for add."""
     if lhs.is_affine and rhs.is_affine:
         if lhs._base is None:
-            return VarInfo.affine(rhs._base, rhs._offset + lhs._offset, producer="add")
+            return VarInfo.affine(rhs._base, rhs._offset + lhs._offset)
         if rhs._base is None:
-            return VarInfo.affine(lhs._base, lhs._offset + rhs._offset, producer="add")
-    return VarInfo.affine(out, 0, producer="add")
+            return VarInfo.affine(lhs._base, lhs._offset + rhs._offset)
+    return VarInfo.affine(out, 0)
 
 
 def transfer_sub(minuend: VarInfo, subtrahend: VarInfo, out: IRVariable) -> VarInfo:
@@ -96,14 +93,14 @@ def transfer_sub(minuend: VarInfo, subtrahend: VarInfo, out: IRVariable) -> VarI
     if minuend.is_affine and subtrahend.is_affine:
         if subtrahend._base is None:
             return VarInfo.affine(
-                minuend._base, minuend._offset - subtrahend._offset, producer="sub"
+                minuend._base, minuend._offset - subtrahend._offset
             )
-    return VarInfo.affine(out, 0, producer="sub")
+    return VarInfo.affine(out, 0)
 
 
 def transfer_assign(src: VarInfo) -> VarInfo:
     """Pure: VarInfo -> VarInfo (inherit)."""
-    return VarInfo(src._kind, src._base, src._offset, _producer="assign")
+    return VarInfo(src._kind, src._base, src._offset)
 
 
 class AlgebraicOptimizationPass(IRPass):
@@ -157,7 +154,7 @@ class AlgebraicOptimizationPass(IRPass):
                 elif inst.opcode == "assign":
                     info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
                 else:
-                    info[inst.output] = VarInfo.affine(inst.output, 0, producer=inst.opcode)
+                    info[inst.output] = VarInfo.affine(inst.output, 0)
         return info
 
     # --- Rewrite phase (imperative shell) ---

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -105,6 +105,10 @@ class AlgebraicOptimizationPass(IRPass):
     updater: InstUpdater
     range_analysis: VariableRangeAnalysis
     var_info: dict[IRVariable, VarInfo]
+    # forward-computed targets for iszero chain shortening.
+    # maps each iszero chain output to (root, first_output, second_output, ...)
+    # so the rewrite can index by `keep` without walking the DFG backward.
+    iszero_targets: dict[IRVariable, tuple[IROperand, ...]]
 
     def run_pass(self):
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
@@ -112,15 +116,18 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater = InstUpdater(self.dfg)
         self._handle_offset()
 
-        self.var_info = self._compute_var_info()
+        self.var_info, self.iszero_targets = self._compute_var_info()
         self._rewrite_all()
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
 
     # --- Forward propagation (imperative shell) ---
 
-    def _compute_var_info(self) -> dict[IRVariable, VarInfo]:
+    def _compute_var_info(
+        self,
+    ) -> tuple[dict[IRVariable, VarInfo], dict[IRVariable, tuple[IROperand, ...]]]:
         info: dict[IRVariable, VarInfo] = {}
+        targets: dict[IRVariable, tuple[IROperand, ...]] = {}
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
                 if inst.num_outputs != 1:
@@ -139,9 +146,17 @@ class AlgebraicOptimizationPass(IRPass):
                 elif inst.opcode == "iszero":
                     src = _lookup(inst.operands[0], info)
                     info[inst.output] = transfer_iszero(src)
+                    # build chain targets forward: (root, 1st output, 2nd, ...)
+                    inp = inst.operands[0]
+                    if isinstance(inp, IRVariable) and inp in targets:
+                        prev = targets[inp]
+                    else:
+                        # new chain, root is the input operand
+                        prev = (inp,)
+                    targets[inst.output] = prev + (inst.output,)
                 else:
                     info[inst.output] = VarInfo.of(inst.output)
-        return info
+        return info, targets
 
     # --- Rewrite phase (imperative shell) ---
 
@@ -174,20 +189,11 @@ class AlgebraicOptimizationPass(IRPass):
             if keep >= depth:
                 continue
 
-            # walk back (depth - keep) iszero producers from op.
-            # bail if the chain no longer matches — mid-pass rewrites
-            # (e.g. comparator handler) can change opcodes, making
-            # the pre-computed iszero_depth stale.
-            target: IROperand = op
-            for _ in range(depth - keep):
-                if not isinstance(target, IRVariable):
-                    break
-                prod = self.dfg.get_producing_instruction(target)
-                if prod is None or prod.opcode != "iszero":
-                    break
-                target = prod.operands[0]
-            else:
-                replacements[op] = target
+            # index into forward-computed targets: targets[keep] is the
+            # operand to use when keeping `keep` iszeros from the root.
+            chain = self.iszero_targets.get(op)
+            if chain is not None and keep < len(chain):
+                replacements[op] = chain[keep]
 
         if len(replacements) > 0:
             self.updater.update_operands(inst, replacements)

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -39,11 +39,10 @@ def _push_size(value: int) -> int:
 class VarInfo:
     base: IROperand | None  # root variable, or None for pure constant
     offset: int  # constant offset (wrap256)
-    iszero_depth: int  # number of iszero applications (0 = not in a chain)
 
     @classmethod
-    def of(cls, base: IROperand | None, offset: int = 0, iszero_depth: int = 0) -> "VarInfo":
-        return cls(base=base, offset=wrap256(offset), iszero_depth=iszero_depth)
+    def of(cls, base: IROperand | None, offset: int = 0) -> "VarInfo":
+        return cls(base=base, offset=wrap256(offset))
 
 
 # --- Pure transfer functions (module-level, no self) ---
@@ -84,11 +83,6 @@ def transfer_assign(src: VarInfo) -> VarInfo:
     return src
 
 
-def transfer_iszero(src: VarInfo) -> VarInfo:
-    """Pure: extend or start an iszero chain."""
-    return VarInfo.of(None, iszero_depth=src.iszero_depth + 1)
-
-
 class AlgebraicOptimizationPass(IRPass):
     """
     This pass reduces algebraic evaluatable expressions.
@@ -105,9 +99,7 @@ class AlgebraicOptimizationPass(IRPass):
     updater: InstUpdater
     range_analysis: VariableRangeAnalysis
     var_info: dict[IRVariable, VarInfo]
-    # forward-computed targets for iszero chain shortening.
-    # maps each iszero chain output to (root, first_output, second_output, ...)
-    # so the rewrite can index by `keep` without walking the DFG backward.
+    # (root, 1st_iszero_out, 2nd, ...) per chain output, built forward
     iszero_targets: dict[IRVariable, tuple[IROperand, ...]]
 
     def run_pass(self):
@@ -144,16 +136,14 @@ class AlgebraicOptimizationPass(IRPass):
                 elif inst.opcode == "assign":
                     info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
                 elif inst.opcode == "iszero":
-                    src = _lookup(inst.operands[0], info)
-                    info[inst.output] = transfer_iszero(src)
-                    # build chain targets forward: (root, 1st output, 2nd, ...)
+                    # build iszero chain targets forward: (root, 1st, 2nd, ...)
                     inp = inst.operands[0]
                     if isinstance(inp, IRVariable) and inp in targets:
                         prev = targets[inp]
                     else:
-                        # new chain, root is the input operand
                         prev = (inp,)
                     targets[inst.output] = prev + (inst.output,)
+                    info[inst.output] = VarInfo.of(inst.output)
                 else:
                     info[inst.output] = VarInfo.of(inst.output)
         return info, targets
@@ -168,7 +158,7 @@ class AlgebraicOptimizationPass(IRPass):
                 self._flip_inst(inst)
 
     def _rewrite_iszero_uses(self, inst: IRInstruction):
-        """Use lattice iszero_depth to shorten iszero chains at use sites."""
+        """Shorten iszero chains at use sites via forward-computed targets."""
         if inst.opcode == "iszero":
             return  # iszero-to-iszero links are left alone
 
@@ -176,23 +166,19 @@ class AlgebraicOptimizationPass(IRPass):
         for op in inst.operands:
             if not isinstance(op, IRVariable):
                 continue
-            vi = self.var_info.get(op)
-            if vi is None or vi.iszero_depth == 0:
+            chain = self.iszero_targets.get(op)
+            if chain is None:
                 continue
 
-            depth = vi.iszero_depth
+            # chain = (root, 1st_iszero_out, 2nd, ..., op)
+            # depth = len(chain) - 1 (root is not an iszero)
+            depth = len(chain) - 1
             if inst.opcode in ("jnz", "assert", "assert_unreachable"):
                 keep = depth % 2
             else:
                 keep = 2 - depth % 2
 
-            if keep >= depth:
-                continue
-
-            # index into forward-computed targets: targets[keep] is the
-            # operand to use when keeping `keep` iszeros from the root.
-            chain = self.iszero_targets.get(op)
-            if chain is not None and keep < len(chain):
+            if keep < depth:
                 replacements[op] = chain[keep]
 
         if len(replacements) > 0:

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -138,7 +138,11 @@ class AlgebraicOptimizationPass(IRPass):
                     if inst.opcode == "iszero":
                         # build iszero chain targets: (root, 1st, 2nd, ...)
                         inp = inst.operands[0]
-                        prev = targets[inp] if isinstance(inp, IRVariable) and inp in targets else (inp,)
+                        prev = (
+                            targets[inp]
+                            if isinstance(inp, IRVariable) and inp in targets
+                            else (inp,)
+                        )
                         targets[inst.output] = prev + (inst.output,)
                     info[inst.output] = VarInfo.of(inst.output)
         return info, targets
@@ -277,204 +281,189 @@ class AlgebraicOptimizationPass(IRPass):
     # --- Local peephole rules ---
 
     def _rewrite_local(self, inst: IRInstruction):
-        operands = inst.operands
-        inst_out = inst.output
-
-        # TODO nice to have rules:
-        # -1 * x => 0 - x
-        # x // -1 => 0 - x (?)
-        # x + (-1) => x - 1  # save codesize, maybe for all negative numbers)
-        # 1 // x => x == 1(?)
-        # 1 % x => x > 1(?)
-        # !!x => x > 0  # saves 1 gas as of shanghai
-
-        # make logic easier for commutative instructions.
-        if inst.flippable and self._is_lit(operands[1]) and not self._is_lit(operands[0]):
+        # normalize: literal to operands[0] for commutative ops
+        if inst.flippable and self._is_lit(inst.operands[1]) and not self._is_lit(inst.operands[0]):
             inst.flip()
-            operands = inst.operands
 
-        if inst.opcode in {"shl", "shr", "sar"}:
-            # (x >> 0) == (x << 0) == x
-            if lit_eq(operands[1], 0):
-                self.updater.mk_assign(inst, operands[0])
-                return
-            # no more cases for these instructions
-            return
-
-        if inst.opcode == "signextend":
-            # text: signextend n, x -> operands[-1]=n (bytes), operands[-2]=x (value)
-            n_op = operands[-1]  # byte count
-            x_op = operands[-2]  # value
-
-            # signextend(n, x) where n >= 31 is always a no-op
-            if self._is_lit(n_op) and n_op.value >= 31:
-                self.updater.mk_assign(inst, x_op)
-                return
-
-            # Range-based elimination: if x is already in the valid signed range
-            # for (n+1) bytes, signextend is a no-op
-            if self._is_lit(n_op):
-                n = n_op.value
-                if 0 <= n < 31:
-                    x_range = self.range_analysis.get_range(x_op, inst)
-                    if not x_range.is_top:
-                        # Compute valid signed range for (n+1) bytes
-                        bits = 8 * (n + 1)
-                        signed_min = -(1 << (bits - 1))
-                        signed_max = (1 << (bits - 1)) - 1
-                        # If x is already in valid range, signextend is no-op
-                        if x_range.lo >= signed_min and x_range.hi <= signed_max:
-                            self.updater.mk_assign(inst, x_op)
-                            return
-            return
-
-        if inst.opcode == "exp":
-            # x ** 0 -> 1
-            if lit_eq(operands[0], 0):
-                self.updater.mk_assign(inst, IRLiteral(1))
-                return
-
-            # 1 ** x -> 1
-            if lit_eq(operands[1], 1):
-                self.updater.mk_assign(inst, IRLiteral(1))
-                return
-
-            # 0 ** x -> iszero x
-            if lit_eq(operands[1], 0):
-                self.updater.update(inst, "iszero", [operands[0]])
-                return
-
-            # x ** 1 -> x
-            if lit_eq(operands[0], 1):
-                self.updater.mk_assign(inst, operands[1])
-                return
-
-            # no more cases for this instruction
-            return
-
-        if inst.opcode == "gep":
-            if lit_eq(inst.operands[1], 0):
-                self.updater.mk_assign(inst, inst.operands[0])
-            return
-
-        if inst.opcode in {"add", "sub", "xor"}:
-            # (x - x) == (x ^ x) == 0
-            if inst.opcode in ("xor", "sub") and operands[0] == operands[1]:
-                self.updater.mk_assign(inst, IRLiteral(0))
-                return
-
-            # (x + 0) == (0 + x)  -> x
-            # x - 0 -> x
-            # (x ^ 0) == (0 ^ x)  -> x
-            if lit_eq(operands[0], 0):
-                self.updater.mk_assign(inst, operands[1])
-                return
-
-            # (-1) - x -> ~x
-            # from two's complement
-            if inst.opcode == "sub" and lit_eq(operands[1], -1):
-                self.updater.update(inst, "not", [operands[0]])
-                return
-
-            # x ^ 0xFFFF..FF -> ~x
-            if inst.opcode == "xor" and lit_eq(operands[0], -1):
-                self.updater.update(inst, "not", [operands[1]])
-                return
-
-            return
-
-        # x & 0xFF..FF -> x
-        if inst.opcode == "and" and lit_eq(operands[0], -1):
-            self.updater.mk_assign(inst, operands[1])
-            return
-
-        if inst.opcode in ("mul", "and", "div", "sdiv", "mod", "smod"):
-            # (x * 0) == (x & 0) == (x // 0) == (x % 0) -> 0
-            if any(lit_eq(op, 0) for op in operands):
-                self.updater.mk_assign(inst, IRLiteral(0))
-                return
-
-        if inst.opcode in {"mul", "div", "sdiv", "mod", "smod"}:
-            if inst.opcode in ("mod", "smod") and lit_eq(operands[0], 1):
-                # x % 1 -> 0
-                self.updater.mk_assign(inst, IRLiteral(0))
-                return
-
-            # (x * 1) == (1 * x) == (x // 1)  -> x
-            if inst.opcode in ("mul", "div", "sdiv") and lit_eq(operands[0], 1):
-                self.updater.mk_assign(inst, operands[1])
-                return
-
-            if self._is_lit(operands[0]) and is_power_of_two(operands[0].value):
-                val = operands[0].value
-                # x % (2^n) -> x & (2^n - 1)
-                if inst.opcode == "mod":
-                    self.updater.update(inst, "and", [IRLiteral(val - 1), operands[1]])
-                    return
-                # x / (2^n) -> x >> n
-                if inst.opcode == "div":
-                    self.updater.update(inst, "shr", [operands[1], IRLiteral(int_log2(val))])
-                    return
-                # x * (2^n) -> x << n
-                if inst.opcode == "mul":
-                    self.updater.update(inst, "shl", [operands[1], IRLiteral(int_log2(val))])
-                    return
-            return
-
-        uses = self.dfg.get_uses(inst_out)
-
-        is_truthy = all(i.opcode in TRUTHY_INSTRUCTIONS for i in uses)
-        prefer_iszero = all(i.opcode in ("assert", "iszero") for i in uses)
-
-        # TODO rules like:
-        # not x | not y => not (x & y)
-        # x | not y => not (not x & y)
-
-        if inst.opcode == "or":
-            # x | 0xff..ff == 0xff..ff
-            if any(lit_eq(op, SizeLimits.MAX_UINT256) for op in operands):
-                self.updater.mk_assign(inst, IRLiteral(SizeLimits.MAX_UINT256))
-                return
-
-            # x | n -> 1 in truthy positions (if n is non zero)
-            if is_truthy and self._is_lit(operands[0]) and operands[0].value != 0:
-                self.updater.mk_assign(inst, IRLiteral(1))
-                return
-
-            # x | 0 -> x
-            if lit_eq(operands[0], 0):
-                self.updater.mk_assign(inst, operands[1])
-                return
-
-        if inst.opcode == "eq":
-            # x == x -> 1
-            if operands[0] == operands[1]:
-                self.updater.mk_assign(inst, IRLiteral(1))
-                return
-
-            # x == 0 -> iszero x
-            if lit_eq(operands[0], 0):
-                self.updater.update(inst, "iszero", [operands[1]])
-                return
-
-            # eq x -1 -> iszero(~x)
-            # (saves codesize, not gas)
-            if lit_eq(operands[0], -1):
-                var = self.updater.add_before(inst, "not", [operands[1]])
-                assert var is not None  # help mypy
-                self.updater.update(inst, "iszero", [var])
-                return
-
-            if prefer_iszero:
-                # (eq x y) has the same truthyness as (iszero (xor x y))
-                tmp = self.updater.add_before(inst, "xor", [operands[0], operands[1]])
-
-                assert tmp is not None  # help mypy
-                self.updater.update(inst, "iszero", [tmp])
-                return
-
-        if inst.opcode in COMPARATOR_INSTRUCTIONS:
+        opcode = inst.opcode
+        if opcode in ("shl", "shr", "sar"):
+            self._rule_shift(inst)
+        elif opcode == "signextend":
+            self._rule_signextend(inst)
+        elif opcode == "exp":
+            self._rule_exp(inst)
+        elif opcode == "gep":
+            self._rule_gep(inst)
+        elif opcode in ("add", "sub", "xor"):
+            self._rule_additive(inst)
+        elif opcode == "and":
+            self._rule_and(inst)
+        elif opcode in ("mul", "div", "sdiv", "mod", "smod"):
+            self._rule_multiplicative(inst)
+        elif opcode == "or":
+            self._rule_or(inst)
+        elif opcode == "eq":
+            self._rule_eq(inst)
+        elif opcode in COMPARATOR_INSTRUCTIONS:
+            uses = self.dfg.get_uses(inst.output)
+            prefer_iszero = all(i.opcode in ("assert", "iszero") for i in uses)
             self._optimize_comparator_instruction(inst, prefer_iszero)
+
+    # --- Per-opcode rewrite rules ---
+
+    def _rule_shift(self, inst: IRInstruction):
+        # (x >> 0) == (x << 0) == x
+        if lit_eq(inst.operands[1], 0):
+            self.updater.mk_assign(inst, inst.operands[0])
+
+    def _rule_signextend(self, inst: IRInstruction):
+        n_op = inst.operands[-1]  # byte count
+        x_op = inst.operands[-2]  # value
+
+        # signextend(n, x) where n >= 31 is always a no-op
+        if self._is_lit(n_op) and n_op.value >= 31:
+            self.updater.mk_assign(inst, x_op)
+            return
+
+        # range-based: if x is in the valid signed range for (n+1) bytes,
+        # signextend is a no-op
+        if not self._is_lit(n_op):
+            return
+        n = n_op.value
+        if not (0 <= n < 31):
+            return
+        x_range = self.range_analysis.get_range(x_op, inst)
+        if x_range.is_top:
+            return
+        bits = 8 * (n + 1)
+        if x_range.lo >= -(1 << (bits - 1)) and x_range.hi <= (1 << (bits - 1)) - 1:
+            self.updater.mk_assign(inst, x_op)
+
+    def _rule_exp(self, inst: IRInstruction):
+        ops = inst.operands
+        # x ** 0 -> 1
+        if lit_eq(ops[0], 0):
+            self.updater.mk_assign(inst, IRLiteral(1))
+        # 1 ** x -> 1
+        elif lit_eq(ops[1], 1):
+            self.updater.mk_assign(inst, IRLiteral(1))
+        # 0 ** x -> iszero x
+        elif lit_eq(ops[1], 0):
+            self.updater.update(inst, "iszero", [ops[0]])
+        # x ** 1 -> x
+        elif lit_eq(ops[0], 1):
+            self.updater.mk_assign(inst, ops[1])
+
+    def _rule_gep(self, inst: IRInstruction):
+        if lit_eq(inst.operands[1], 0):
+            self.updater.mk_assign(inst, inst.operands[0])
+
+    def _rule_additive(self, inst: IRInstruction):
+        ops = inst.operands
+        opcode = inst.opcode
+
+        # (x - x) == (x ^ x) == 0
+        if opcode in ("xor", "sub") and ops[0] == ops[1]:
+            self.updater.mk_assign(inst, IRLiteral(0))
+            return
+
+        # x + 0, x - 0, x ^ 0 -> x
+        if lit_eq(ops[0], 0):
+            self.updater.mk_assign(inst, ops[1])
+            return
+
+        # (-1) - x -> ~x
+        if opcode == "sub" and lit_eq(ops[1], -1):
+            self.updater.update(inst, "not", [ops[0]])
+            return
+
+        # x ^ -1 -> ~x
+        if opcode == "xor" and lit_eq(ops[0], -1):
+            self.updater.update(inst, "not", [ops[1]])
+
+    def _rule_and(self, inst: IRInstruction):
+        ops = inst.operands
+        # x & -1 -> x
+        if lit_eq(ops[0], -1):
+            self.updater.mk_assign(inst, ops[1])
+            return
+        # x & 0 -> 0
+        if any(lit_eq(op, 0) for op in ops):
+            self.updater.mk_assign(inst, IRLiteral(0))
+
+    def _rule_multiplicative(self, inst: IRInstruction):
+        ops = inst.operands
+        opcode = inst.opcode
+
+        # x * 0, x / 0, x % 0 -> 0
+        if any(lit_eq(op, 0) for op in ops):
+            self.updater.mk_assign(inst, IRLiteral(0))
+            return
+
+        # x % 1 -> 0
+        if opcode in ("mod", "smod") and lit_eq(ops[0], 1):
+            self.updater.mk_assign(inst, IRLiteral(0))
+            return
+
+        # x * 1, x / 1 -> x
+        if opcode in ("mul", "div", "sdiv") and lit_eq(ops[0], 1):
+            self.updater.mk_assign(inst, ops[1])
+            return
+
+        # power-of-two strength reduction
+        if not (self._is_lit(ops[0]) and is_power_of_two(ops[0].value)):
+            return
+        val = ops[0].value
+        if opcode == "mod":
+            self.updater.update(inst, "and", [IRLiteral(val - 1), ops[1]])
+        elif opcode == "div":
+            self.updater.update(inst, "shr", [ops[1], IRLiteral(int_log2(val))])
+        elif opcode == "mul":
+            self.updater.update(inst, "shl", [ops[1], IRLiteral(int_log2(val))])
+
+    def _rule_or(self, inst: IRInstruction):
+        ops = inst.operands
+        # x | -1 -> -1
+        if any(lit_eq(op, SizeLimits.MAX_UINT256) for op in ops):
+            self.updater.mk_assign(inst, IRLiteral(SizeLimits.MAX_UINT256))
+            return
+
+        # x | n -> 1 in truthy positions (if n != 0)
+        uses = self.dfg.get_uses(inst.output)
+        is_truthy = all(i.opcode in TRUTHY_INSTRUCTIONS for i in uses)
+        if is_truthy and self._is_lit(ops[0]) and ops[0].value != 0:
+            self.updater.mk_assign(inst, IRLiteral(1))
+            return
+
+        # x | 0 -> x
+        if lit_eq(ops[0], 0):
+            self.updater.mk_assign(inst, ops[1])
+
+    def _rule_eq(self, inst: IRInstruction):
+        ops = inst.operands
+        # x == x -> 1
+        if ops[0] == ops[1]:
+            self.updater.mk_assign(inst, IRLiteral(1))
+            return
+
+        # x == 0 -> iszero x
+        if lit_eq(ops[0], 0):
+            self.updater.update(inst, "iszero", [ops[1]])
+            return
+
+        # eq x -1 -> iszero(~x)
+        if lit_eq(ops[0], -1):
+            var = self.updater.add_before(inst, "not", [ops[1]])
+            assert var is not None
+            self.updater.update(inst, "iszero", [var])
+            return
+
+        # in prefer_iszero context: eq x y -> iszero(xor x y)
+        uses = self.dfg.get_uses(inst.output)
+        if all(i.opcode in ("assert", "iszero") for i in uses):
+            tmp = self.updater.add_before(inst, "xor", [ops[0], ops[1]])
+            assert tmp is not None
+            self.updater.update(inst, "iszero", [tmp])
 
     # --- Unchanged methods ---
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -56,7 +56,7 @@ def _lookup(op: IROperand, info: dict[IRVariable, VarInfo]) -> VarInfo:
         return VarInfo.of(op)
     if isinstance(op, IRLiteral):
         return VarInfo.of(None, op.value)
-    # IRLabel — not trackable
+    # IRLabel — tracked as opaque base (not decomposable)
     return VarInfo.of(op)
 
 
@@ -169,6 +169,8 @@ class AlgebraicOptimizationPass(IRPass):
         base = vi.base
         offset = vi.offset
         if base == inst.output:
+            return False
+        if isinstance(base, IRLabel):
             return False
 
         # Find the immediate variable operand and current literal

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -210,6 +210,12 @@ class AlgebraicOptimizationPass(IRPass):
         if base == imm_base:
             return False
 
+        # Only fold through single-use intermediates — folding through
+        # multi-use doesn't eliminate instructions and the variable
+        # reference change can increase DUP depth in codegen
+        if isinstance(imm_base, IRVariable) and not self.dfg.is_single_use(imm_base):
+            return False
+
         if offset == 0:
             self.updater.mk_assign(inst, base)
             return True

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -39,10 +39,20 @@ def _push_size(value: int) -> int:
 class VarInfo:
     base: IROperand | None  # root variable, or None for pure constant
     offset: int  # constant offset (wrap256)
+    iszero_depth: int  # number of iszero applications from iszero_root
+    iszero_root: IROperand | None  # operand at the base of the iszero chain
 
     @classmethod
-    def of(cls, base: IROperand | None, offset: int = 0) -> "VarInfo":
-        return cls(base=base, offset=wrap256(offset))
+    def of(
+        cls,
+        base: IROperand | None,
+        offset: int = 0,
+        iszero_depth: int = 0,
+        iszero_root: IROperand | None = None,
+    ) -> "VarInfo":
+        return cls(
+            base=base, offset=wrap256(offset), iszero_depth=iszero_depth, iszero_root=iszero_root
+        )
 
 
 # --- Pure transfer functions (module-level, no self) ---
@@ -82,6 +92,15 @@ def transfer_assign(src: VarInfo) -> VarInfo:
     return src
 
 
+def transfer_iszero(src: VarInfo, op: IROperand) -> VarInfo:
+    """Pure: extend or start an iszero chain."""
+    if src.iszero_depth > 0:
+        # extend existing chain
+        return VarInfo.of(None, iszero_depth=src.iszero_depth + 1, iszero_root=src.iszero_root)
+    # start new chain — root is the operand fed into this iszero
+    return VarInfo.of(None, iszero_depth=1, iszero_root=op)
+
+
 class AlgebraicOptimizationPass(IRPass):
     """
     This pass reduces algebraic evaluatable expressions.
@@ -105,12 +124,6 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater = InstUpdater(self.dfg)
         self._handle_offset()
 
-        # Two passes: iszero chain optimization can expose new affine
-        # folding opportunities (e.g. removing iszero nodes that were
-        # blocking chain traversal), so we recompute and rewrite after.
-        self.var_info = self._compute_var_info()
-        self._rewrite_all()
-        self._optimize_iszero_chains()
         self.var_info = self._compute_var_info()
         self._rewrite_all()
 
@@ -135,6 +148,9 @@ class AlgebraicOptimizationPass(IRPass):
                     info[inst.output] = transfer_sub(minuend, subtrahend, inst.output)
                 elif inst.opcode == "assign":
                     info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
+                elif inst.opcode == "iszero":
+                    src = _lookup(inst.operands[0], info)
+                    info[inst.output] = transfer_iszero(src, inst.operands[0])
                 else:
                     info[inst.output] = VarInfo.of(inst.output)
         return info
@@ -144,8 +160,42 @@ class AlgebraicOptimizationPass(IRPass):
     def _rewrite_all(self):
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
+                self._rewrite_iszero_uses(inst)
                 self._rewrite_inst(inst)
                 self._flip_inst(inst)
+
+    def _rewrite_iszero_uses(self, inst: IRInstruction):
+        """Use lattice iszero_depth to shorten iszero chains at use sites."""
+        if inst.opcode == "iszero":
+            return  # iszero-to-iszero links are left alone
+
+        replacements: dict[IROperand, IROperand] = {}
+        for op in inst.operands:
+            if not isinstance(op, IRVariable):
+                continue
+            vi = self.var_info.get(op)
+            if vi is None or vi.iszero_depth == 0:
+                continue
+
+            depth = vi.iszero_depth
+            if inst.opcode in ("jnz", "assert", "assert_unreachable"):
+                keep = depth % 2
+            else:
+                keep = 2 - depth % 2
+
+            if keep >= depth:
+                continue
+
+            # walk back (depth - keep) iszero producers from op
+            target: IROperand = op
+            for _ in range(depth - keep):
+                prod = self.dfg.get_producing_instruction(target)
+                assert prod is not None and prod.opcode == "iszero"
+                target = prod.operands[0]
+            replacements[op] = target
+
+        if len(replacements) > 0:
+            self.updater.update_operands(inst, replacements)
 
     def _rewrite_inst(self, inst: IRInstruction):
         if inst.num_outputs != 1:
@@ -440,55 +490,6 @@ class AlgebraicOptimizationPass(IRPass):
 
     # --- Unchanged methods ---
 
-    def _optimize_iszero_chains(self) -> None:
-        fn = self.function
-        for bb in fn.get_basic_blocks():
-            for inst in bb.instructions:
-                if inst.opcode != "iszero":
-                    continue
-
-                iszero_chain = self._get_iszero_chain(inst.operands[0])
-                iszero_count = len(iszero_chain)
-                if iszero_count == 0:
-                    continue
-
-                inst_out = inst.output
-                for use_inst in self.dfg.get_uses(inst_out).copy():
-                    opcode = use_inst.opcode
-
-                    if opcode == "iszero":
-                        # We keep iszero instuctions as is
-                        continue
-                    if opcode in ("jnz", "assert", "assert_unreachable"):
-                        # instructions that accept a truthy value as input:
-                        # we can remove up to all the iszero instructions
-                        keep_count = 1 - iszero_count % 2
-                    else:
-                        # all other instructions:
-                        # we need to keep at least one or two iszero instructions
-                        keep_count = 1 + iszero_count % 2
-
-                    if keep_count >= iszero_count:
-                        continue
-
-                    out_var = iszero_chain[keep_count].operands[0]
-                    self.updater.update_operands(use_inst, {inst_out: out_var})
-
-    def _get_iszero_chain(self, op: IROperand) -> list[IRInstruction]:
-        chain: list[IRInstruction] = []
-
-        while True:
-            if not isinstance(op, IRVariable):
-                break
-            inst = self.dfg.get_producing_instruction(op)
-            if inst is None or inst.opcode != "iszero":
-                break
-            op = inst.operands[0]
-            chain.append(inst)
-
-        chain.reverse()
-        return chain
-
     def _handle_offset(self):
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
@@ -638,14 +639,33 @@ class AlgebraicOptimizationPass(IRPass):
 
         if lit_eq(operands[0], almost_never):
             # (lt x 1), (gt x (MAX_UINT256 - 1)), (slt x (MIN_INT256 + 1))
-
+            if never == 0:
+                # eq x 0 => iszero x
+                self.updater.update(inst, "iszero", [operands[1]])
+                return
+            if wrap256(never) == wrap256(-1):
+                # eq x -1 => iszero(not x)
+                var = self.updater.add_before(inst, "not", [operands[1]])
+                assert var is not None
+                self.updater.update(inst, "iszero", [var])
+                return
             self.updater.update(inst, "eq", [operands[1], IRLiteral(never)])
             return
 
         # rewrites. in positions where iszero is preferred, (gt x 5) => (ge x 6)
         if prefer_iszero and lit_eq(operands[0], almost_always):
             # e.g. gt x 0, slt x MAX_INT256
-            tmp = self.updater.add_before(inst, "eq", operands)
+            # produce iszero(iszero(xor x N)) directly, with
+            # xor x 0 = x and xor x -1 = not x as special cases
+            val = operands[0].value
+            x = operands[1]
+            if val == 0:
+                inner = x
+            elif wrap256(val) == wrap256(-1):
+                inner = self.updater.add_before(inst, "not", [x])
+            else:
+                inner = self.updater.add_before(inst, "xor", [operands[0], x])
+            tmp = self.updater.add_before(inst, "iszero", [inner])
             self.updater.update(inst, "iszero", [tmp])
             return
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -129,22 +129,17 @@ class AlgebraicOptimizationPass(IRPass):
                     rhs = _lookup(inst.operands[0], info)
                     info[inst.output] = transfer_add(lhs, rhs, inst.output)
                 elif inst.opcode == "sub":
-                    # sub computes operands[1] - operands[0]
                     minuend = _lookup(inst.operands[1], info)
                     subtrahend = _lookup(inst.operands[0], info)
                     info[inst.output] = transfer_sub(minuend, subtrahend, inst.output)
                 elif inst.opcode == "assign":
                     info[inst.output] = transfer_assign(_lookup(inst.operands[0], info))
-                elif inst.opcode == "iszero":
-                    # build iszero chain targets forward: (root, 1st, 2nd, ...)
-                    inp = inst.operands[0]
-                    if isinstance(inp, IRVariable) and inp in targets:
-                        prev = targets[inp]
-                    else:
-                        prev = (inp,)
-                    targets[inst.output] = prev + (inst.output,)
-                    info[inst.output] = VarInfo.of(inst.output)
                 else:
+                    if inst.opcode == "iszero":
+                        # build iszero chain targets: (root, 1st, 2nd, ...)
+                        inp = inst.operands[0]
+                        prev = targets[inp] if isinstance(inp, IRVariable) and inp in targets else (inp,)
+                        targets[inst.output] = prev + (inst.output,)
                     info[inst.output] = VarInfo.of(inst.output)
         return info, targets
 
@@ -493,7 +488,8 @@ class AlgebraicOptimizationPass(IRPass):
                 ):
                     inst.opcode = "offset"
 
-    def _is_lit(self, operand: IROperand) -> bool:
+    @staticmethod
+    def _is_lit(operand: IROperand) -> bool:
         return isinstance(operand, IRLiteral)
 
     def _extract_value_and_literal_operands(
@@ -518,6 +514,59 @@ class AlgebraicOptimizationPass(IRPass):
         if inst.flippable and self._is_lit(ops[0]) and not self._is_lit(ops[1]):
             inst.flip()
 
+    def _try_range_cmp(
+        self, inst: IRInstruction, operands: list, is_gt: bool, signed: bool
+    ) -> int | None:
+        """Try to resolve a comparison to a constant using range analysis.
+        Returns 0 or 1 if resolved, None otherwise."""
+        a_op = operands[-1]  # first in text
+        b_op = operands[-2]  # second in text
+
+        # identify which operand is the literal and which is the variable
+        if self._is_lit(a_op) and not self._is_lit(b_op):
+            lit_val, var_op = a_op.value, b_op
+            lit_is_first = True
+        elif self._is_lit(b_op) and not self._is_lit(a_op):
+            lit_val, var_op = b_op.value, a_op
+            lit_is_first = False
+        else:
+            return None
+
+        var_range = self.range_analysis.get_range(var_op, inst)
+        if var_range.is_top or var_range.is_empty:
+            return None
+
+        # normalize literal to match range representation
+        if signed:
+            if var_range.hi > SizeLimits.MAX_INT256:
+                return None
+            lit_val = wrap256(lit_val, signed=True)
+        else:
+            if var_range.lo < 0:
+                return None
+            lit_val = wrap256(lit_val)
+
+        # determine effective comparison direction:
+        # lit_is_first with is_gt means "lit > var"
+        # lit_is_first without is_gt means "lit < var"
+        # flipping lit_is_first flips the direction
+        lit_gt_var = is_gt == lit_is_first
+
+        if lit_gt_var:
+            # lit > var: always true if lit > var.hi, always false if lit <= var.lo
+            if lit_val > var_range.hi:
+                return 1
+            if lit_val <= var_range.lo:
+                return 0
+        else:
+            # var > lit: always true if var.lo > lit, always false if var.hi <= lit
+            if var_range.lo > lit_val:
+                return 1
+            if var_range.hi <= lit_val:
+                return 0
+
+        return None
+
     def _optimize_comparator_instruction(self, inst, prefer_iszero):
         opcode, operands = inst.opcode, inst.operands
         assert opcode in COMPARATOR_INSTRUCTIONS  # sanity
@@ -531,80 +580,13 @@ class AlgebraicOptimizationPass(IRPass):
         is_gt = "g" in opcode
         signed = "s" in opcode
 
-        # Range-based comparison optimization
-        # Semantics: lt a, b computes a < b; gt a, b computes a > b
-        # operands[-1] = a (first in text), operands[-2] = b (second in text)
-        # We can optimize when one operand is a literal and we have range info for the other
-        a_op = operands[-1]  # first in text
-        b_op = operands[-2]  # second in text
-
-        if self._is_lit(a_op) and not self._is_lit(b_op):
-            # a is literal, b is variable: comparing lit <?> var
-            lit = a_op.value
-            var_range = self.range_analysis.get_range(b_op, inst)
-            if not var_range.is_top and not var_range.is_empty:
-                if signed:
-                    if var_range.hi <= SizeLimits.MAX_INT256:
-                        lit = wrap256(lit, signed=True)
-                    else:
-                        lit = None
-                else:
-                    if var_range.lo >= 0:
-                        lit = wrap256(lit)
-                    else:
-                        lit = None
-
-                if lit is not None:
-                    if is_gt:
-                        # lit > var: always true if lit > var.hi, always false if lit <= var.lo
-                        if lit > var_range.hi:
-                            self.updater.mk_assign(inst, IRLiteral(1))
-                            return
-                        if lit <= var_range.lo:
-                            self.updater.mk_assign(inst, IRLiteral(0))
-                            return
-                    else:
-                        # lit < var: always true if lit < var.lo, always false if lit >= var.hi
-                        if lit < var_range.lo:
-                            self.updater.mk_assign(inst, IRLiteral(1))
-                            return
-                        if lit >= var_range.hi:
-                            self.updater.mk_assign(inst, IRLiteral(0))
-                            return
-
-        elif self._is_lit(b_op) and not self._is_lit(a_op):
-            # a is variable, b is literal: comparing var <?> lit
-            lit = b_op.value
-            var_range = self.range_analysis.get_range(a_op, inst)
-            if not var_range.is_top and not var_range.is_empty:
-                if signed:
-                    if var_range.hi <= SizeLimits.MAX_INT256:
-                        lit = wrap256(lit, signed=True)
-                    else:
-                        lit = None
-                else:
-                    if var_range.lo >= 0:
-                        lit = wrap256(lit)
-                    else:
-                        lit = None
-
-                if lit is not None:
-                    if is_gt:
-                        # var > lit: always true if var.lo > lit, always false if var.hi <= lit
-                        if var_range.lo > lit:
-                            self.updater.mk_assign(inst, IRLiteral(1))
-                            return
-                        if var_range.hi <= lit:
-                            self.updater.mk_assign(inst, IRLiteral(0))
-                            return
-                    else:
-                        # var < lit: always true if var.hi < lit, always false if var.lo >= lit
-                        if var_range.hi < lit:
-                            self.updater.mk_assign(inst, IRLiteral(1))
-                            return
-                        if var_range.lo >= lit:
-                            self.updater.mk_assign(inst, IRLiteral(0))
-                            return
+        # Range-based comparison optimization.
+        # Try to resolve comparisons with one literal operand using
+        # range analysis on the other.
+        result = self._try_range_cmp(inst, operands, is_gt, signed)
+        if result is not None:
+            self.updater.mk_assign(inst, IRLiteral(result))
+            return
 
         lo, hi = int_bounds(bits=256, signed=signed)
 

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -112,12 +112,8 @@ class AlgebraicOptimizationPass(IRPass):
         self.updater = InstUpdater(self.dfg)
         self._handle_offset()
 
-        # two iterations: the first pass may create new iszero chains
-        # (e.g. comparator rewrites) or change operands (iszero shortening)
-        # that expose new folding opportunities in the second pass.
-        for _ in range(2):
-            self.var_info = self._compute_var_info()
-            self._rewrite_all()
+        self.var_info = self._compute_var_info()
+        self._rewrite_all()
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
 
@@ -178,19 +174,13 @@ class AlgebraicOptimizationPass(IRPass):
             if keep >= depth:
                 continue
 
-            # walk back (depth - keep) iszero producers from op.
-            # the chain may not match if prior rewrites changed opcodes,
-            # in which case we bail out for this operand.
+            # walk back (depth - keep) iszero producers from op
             target: IROperand = op
             for _ in range(depth - keep):
-                if not isinstance(target, IRVariable):
-                    break
                 prod = self.dfg.get_producing_instruction(target)
-                if prod is None or prod.opcode != "iszero":
-                    break
+                assert prod is not None and prod.opcode == "iszero"
                 target = prod.operands[0]
-            else:
-                replacements[op] = target
+            replacements[op] = target
 
         if len(replacements) > 0:
             self.updater.update_operands(inst, replacements)


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
the algebraic optimization pass mixed two separate concerns — affine
chain folding and iszero chain shortening — with the iszero logic doing
its own full iteration over the IR, separate from the lattice-driven
rewrite loop. this made the pass harder to reason about and blocked
formal verification: the iszero chain walker re-derived structural
information that a forward analysis had already computed.

refactor to unify both concerns into a single forward-pass architecture:

- the affine lattice (`VarInfo`) is now purely about `base + offset`
  tracking. iszero chain information is computed separately in a
  forward-built target table (`iszero_targets`) during the same analysis
  pass. each chain output maps to `(root, 1st_iszero_out, 2nd, ...)`, so
  the rewrite phase can index by `keep` count directly — no backward DFG
  walk needed.

- the monolithic `_rewrite_local` (200+ lines of nested if/elif) is
  factored into independent per-opcode rule methods (`_rule_shift`,
  `_rule_exp`, `_rule_additive`, `_rule_eq`, etc.), each self-contained
  and independently provable. the dispatch is a clean opcode match.

- the duplicated comparator range analysis (~60 lines of near-identical
  code for the two operand orderings) is unified into a single
  `_try_range_cmp` pure function.

- the comparator handler's `almost_never` and `almost_always` cases now
  produce their final forms directly (`iszero`, `iszero(not x)`,
  `iszero(iszero(xor x N))`) instead of creating intermediate `eq`
  instructions that relied on a second pass to simplify.

a `_chain_valid` check guards against a subtle semantic bug: when the
comparator handler absorbs an iszero (converting it to assign), the pre-
computed chain targets become stale — the root's semantics are inverted
but the chain still claims the original depth. without validation, the
chain shortener would redirect a `jnz` to the inverted root, flipping
the branch direction.

adds a single-use guard to `_rewrite_affine` to prevent folding through
multi-use intermediates, which destroyed CSE opportunities for shared
base pointers (e.g., alloca+64 used by multiple mcopy destinations).
this recovers ~18 bytes on contracts with repeated buffer access
patterns.

bytecode impact vs master: O2 improves significantly (-30 to -366 bytes
across contracts). O3/Os show small regressions (+1 to +11 bytes) due to
different IR patterns interacting with downstream passes — these are
pass-ordering artifacts, not correctness issues.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
