### PR TITLE
chore[venom]: remove references to `sha3_64`

### DIFF
--- a/tests/unit/compiler/venom/test_builder.py
+++ b/tests/unit/compiler/venom/test_builder.py
@@ -301,11 +301,5 @@ def test_builder_crypto_ops():
     size = b.calldataload(32)
     hash_result = b.sha3(ptr, size)
 
-    a = b.calldataload(64)
-    b_val = b.calldataload(96)
-    hash_64 = b.sha3_64(a, b_val)
-    b.stop()
-
     instrs = fn.entry.instructions
     assert instrs[2].opcode == "sha3"
-    assert instrs[5].opcode == "sha3_64"

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -277,18 +277,6 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
     ```
   - Similar to `stop`, but used for constructor exit. The assembler is expected to jump to a special initcode sequence which returns the runtime code.
   - Might translate to something like  `_sym__ctor_exit JUMP`.
-- `sha3_64`
-  - ```
-    %out = sha3_64 x, y
-    ```
-  - Shortcut to access the `SHA3` EVM opcode where `%out` is the result.
-  - Essentially translates to
-    ```
-    PUSH y PUSH FREE_VAR_SPACE MSTORE
-    PUSH x PUSH FREE_VAR_SPACE2 MSTORE
-    PUSH 64 PUSH FREE_VAR_SPACE SHA3
-    ```
-    where `FREE_VAR_SPACE` and `FREE_VAR_SPACE2` are locations reserved by the compiler, set to 0 and 32 respectively.
 
 - `assert`
   - ```

--- a/vyper/venom/builder.py
+++ b/vyper/venom/builder.py
@@ -370,10 +370,6 @@ class VenomBuilder:
     def sha3(self, ptr: Operand, size: Operand) -> IRVariable:
         return self._emit1_evm("sha3", ptr, size)
 
-    def sha3_64(self, a: Operand, b: Operand) -> IRVariable:
-        """Hash two 32-byte values (optimized keccak). (IR-specific)"""
-        return self._emit1("sha3_64", a, b)
-
     # === Data Copy ===
     def calldatacopy(self, dst: Operand, src: Operand, size: Operand) -> None:
         """Copy size bytes from calldata[src] to memory[dst]."""


### PR DESCRIPTION
### What I did
The `sha3_64` is not used in codegen venom but there is some scaffolding for it so I removed it.

### How I did it

### How to verify it

### Commit message
```
Remove sha3_64 from venom builder since it is no longer used
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
