### PR TITLE
fix[venom]: don't fold affine chains through multi-use intermediates

### DIFF
--- a/tests/unit/compiler/venom/test_algebraic_optimizer.py
+++ b/tests/unit/compiler/venom/test_algebraic_optimizer.py
@@ -275,6 +275,30 @@ def test_fold_add_chain_multi_use_stops():
     _check_pre_post(pre, post)
 
 
+def test_fold_stops_at_multi_use_intermediate():
+    """Don't fold past a multi-use intermediate deeper in the chain.
+    %a has multiple uses so it should be preserved as the base, even
+    though the lattice flattens all the way to %x."""
+    pre = """
+    main:
+        %x = source
+        %a = add 3, %x
+        %b = add 5, %a
+        %out = add 7, %b
+        sink %out, %a
+    """
+    # %a is multi-use (sink + %b). %b is single-use.
+    # The walk stops at %a: %out = %a + 12, not %x + 15.
+    post = """
+    main:
+        %x = source
+        %a = add 3, %x
+        %out = add 12, %a
+        sink %out, %a
+    """
+    _check_pre_post(pre, post)
+
+
 def test_fold_add_chain_three_deep():
     """add(add(add(x, 1), 2), 3) => add(x, 6)"""
     pre = """

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -248,6 +248,8 @@ class AlgebraicOptimizationPass(IRPass):
         if eff_base == base:
             eff_offset = offset
         else:
+            if not isinstance(eff_base, IRVariable):
+                return False
             vi_eff = self.var_info.get(eff_base)
             if vi_eff is None or vi_eff.base != base:
                 return False

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -237,22 +237,55 @@ class AlgebraicOptimizationPass(IRPass):
         if base == imm_base:
             return False
 
-        # Don't fold through multi-use intermediates — this destroys
-        # CSE opportunities for shared base pointers (e.g. alloca+64
-        # used by multiple mcopy destinations).
-        if isinstance(imm_base, IRVariable) and not self.dfg.is_single_use(imm_base):
+        # Walk from imm_base toward lattice base, stopping at the first
+        # multi-use intermediate. This preserves shared base pointers
+        # for CSE/DFT (e.g. alloca+64 used by multiple mcopy destinations).
+        eff_base = self._effective_affine_base(imm_base, base)
+        if eff_base == imm_base:
             return False
 
-        if offset == 0:
-            self.updater.mk_assign(inst, base)
+        # compute offset relative to effective base
+        if eff_base == base:
+            eff_offset = offset
+        else:
+            vi_eff = self.var_info.get(eff_base)
+            if vi_eff is None or vi_eff.base != base:
+                return False
+            eff_offset = wrap256(offset - vi_eff.offset)
+
+        if eff_offset == 0:
+            self.updater.mk_assign(inst, eff_base)
             return True
 
         # Don't rewrite if it would increase literal byte width
-        if _push_size(offset) > _push_size(curr_lit):
+        if _push_size(eff_offset) > _push_size(curr_lit):
             return False
 
-        self.updater.update(inst, "add", [base, IRLiteral(offset)])
+        self.updater.update(inst, "add", [eff_base, IRLiteral(eff_offset)])
         return True
+
+    def _effective_affine_base(self, imm_base: IROperand, lattice_base: IROperand) -> IROperand:
+        """Walk producers from imm_base toward lattice_base, return the
+        deepest reachable base without crossing multi-use intermediates."""
+        current = imm_base
+        while current != lattice_base:
+            if not isinstance(current, IRVariable):
+                return current
+            if not self.dfg.is_single_use(current):
+                return current
+            prod = self.dfg.get_producing_instruction(current)
+            if prod is None:
+                return current
+            if prod.opcode == "assign":
+                current = prod.operands[0]
+            elif prod.opcode == "add":
+                val_op, lit_op = self._extract_value_and_literal_operands(prod)
+                if val_op is None or lit_op is None:
+                    return current
+                current = val_op
+            else:
+                return current
+        return lattice_base
 
     def _rewrite_or_skip_producer(self, inst: IRInstruction) -> bool:
         """Producer-based pattern rewrites. Returns True if a rewrite was


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
the lattice-driven affine rewriter (`_rewrite_affine`) flattens add/sub
chains to the deepest base, but the single-use guard only checked the
immediate operand — not intermediates the lattice looked through. in a
chain like `%a = add 3, %x; sink %a; %b = add 5, %a; %out = add 7, %b`,
the lattice computes `%out = %x + 15` and since `%b` is single-use, it
rewrites to `add 15, %x`. but `%a` is multi-use and should be preserved
as a shared base — folding past it duplicates the pointer arithmetic on
every downstream use, regressing codesize and stack pressure on shared
alloca/GEP patterns.

replace the single-use guard with `_effective_affine_base`, which walks
the producer chain from the immediate operand toward the lattice base,
stopping at the first multi-use variable. the effective base becomes
that variable, and the offset is recomputed relative to it. in the
example above, the walk stops at `%a` and rewrites to `add 12, %a`
instead of `add 15, %x`.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
