### PR TITLE
chore[venom]: remove `IRParameter`

### DIFF
--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import textwrap
-from collections import defaultdict
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, Optional
 
 from vyper.codegen.ir_node import IRnode
@@ -12,18 +10,6 @@ if TYPE_CHECKING:
     from vyper.venom.context import IRContext
 
 
-@dataclass(frozen=True)
-class IRParameter:
-    name: str
-    index: int  # needed?
-    offset: int  # needed?
-    size: int  # needed?
-    id_: int
-    call_site_var: Optional[IRVariable]  # needed?
-    func_var: IRVariable
-    addr_var: Optional[IRVariable]  # needed?
-
-
 class IRFunction:
     """
     Function that contains basic blocks.
@@ -31,7 +17,6 @@ class IRFunction:
 
     name: IRLabel  # symbol name
     ctx: IRContext
-    args: list
     last_variable: int
     _basic_block_dict: dict[str, IRBasicBlock]
 
@@ -48,7 +33,6 @@ class IRFunction:
     def __init__(self, name: IRLabel, ctx: IRContext = None):
         self.ctx = ctx  # type: ignore
         self.name = name
-        self.args = []
         self._basic_block_dict = {}
 
         self.last_variable = 0
@@ -114,24 +98,6 @@ class IRFunction:
     def get_last_variable(self) -> str:
         return f"%{self.last_variable}"
 
-    def freshen_varnames(self) -> None:
-        """
-        Reset `self.last_variable`, and regenerate all variable names.
-        Helpful for debugging.
-        So fresh, so clean!
-        """
-        self.last_variable = 0
-        varmap: dict[IRVariable, IRVariable] = defaultdict(self.get_next_variable)
-        for bb in self.get_basic_blocks():
-            for inst in bb.instructions:
-                if inst.has_outputs:
-                    inst.set_outputs([varmap[o] for o in inst.get_outputs()])
-
-                for i, op in enumerate(inst.operands):
-                    if not isinstance(op, IRVariable):
-                        continue
-                    inst.operands[i] = varmap[op]
-
     def push_source(self, ir):
         if isinstance(ir, IRnode):
             self._ast_source_stack.append(ir.ast_source)
@@ -151,20 +117,6 @@ class IRFunction:
         self._ast_source_stack.pop()
         assert len(self._error_msg_stack) > 0, "Empty error stack"
         self._error_msg_stack.pop()
-
-    def get_param_by_id(self, id_: int) -> Optional[IRParameter]:
-        for param in self.args:
-            if param.id_ == id_:
-                return param
-        return None
-
-    def get_param_by_name(self, var: IRVariable | str) -> Optional[IRParameter]:
-        if isinstance(var, str):
-            var = IRVariable(var)
-        for param in self.args:
-            if f"%{param.name}" == var.name:
-                return param
-        return None
 
     @property
     def ast_source(self) -> Optional[IRnode]:


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
Remove the unused `IRParameter` dataclass and associated `IRFunction`                                                                                                                                                                                                                       
methods (`freshen_varnames`, `get_param_by_id`, `get_param_by_name`)                                                                                                                                                                                                                        
and the `args` field, which are no longer referenced after the alloca_id                                                                                                                                                                                                                    
cleanup.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
