### PR TITLE
refactor[venom]: sunset `gep`

### DIFF
--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -74,9 +74,9 @@ Do explain the *reasoning* behind structural decisions, the bug mechanism, or th
 ```
 fix[venom]: fix allocation in ternary fall through (#4846)
 
-`Mem2Var._fix_adds` converts `add` instructions on alloca pointers into
-`gep` (get-element-pointer) so that `BasePtrAnalysis` can track pointer
-provenance through arithmetic. When a ternary expression merges two
+`Mem2Var._fix_adds` ensures `add` instructions on alloca pointers are
+recognized by `BasePtrAnalysis` so it can track pointer provenance
+through arithmetic. When a ternary expression merges two
 pointer paths via a `phi` node, the `add` sits downstream of the phi
 rather than as a direct use of the alloca — so `_fix_adds` never saw it.
 

--- a/tests/unit/compiler/venom/test_base_ptr_analysis.py
+++ b/tests/unit/compiler/venom/test_base_ptr_analysis.py
@@ -10,10 +10,10 @@ def test_base_ptr_basic():
     code = """
     main:
         %alloca1 = alloca 256
-        %2 = gep 32, %alloca1
+        %2 = add 32, %alloca1
         %random = mload 123
-        %3 = gep %random, %alloca1
-        %4 = gep 32, %2
+        %3 = add %random, %alloca1
+        %4 = add 32, %2
         stop
     """
 

--- a/tests/unit/compiler/venom/test_memory_copy_elision.py
+++ b/tests/unit/compiler/venom/test_memory_copy_elision.py
@@ -1665,11 +1665,11 @@ def test_interleaved_copies_different_regions():
     _check_pre_post(pre, post)
 
 
-def test_cross_bb_copy_with_gep_different_geps():
+def test_cross_bb_copy_with_add_different_adds():
     """
-    Two paths with different gep instructions that compute same value.
-    Should NOT optimize because gep results are different variables,
-    and _traverse_assign_chain stops at gep (not assign).
+    Two paths with different add instructions that compute same value.
+    Should NOT optimize because add results are different variables,
+    and _traverse_assign_chain stops at add (not assign).
     """
     if not version_check(begin="cancun"):
         return
@@ -1681,14 +1681,14 @@ def test_cross_bb_copy_with_gep_different_geps():
         jnz %cond, @path1, @path2
 
     path1:
-        %gep1 = gep 32, %base
-        %x = assign %gep1
+        %add1 = add 32, %base
+        %x = assign %add1
         calldatacopy 100, %x, 32
         jmp @merge
 
     path2:
-        %gep2 = gep 32, %base
-        %y = assign %gep2
+        %add2 = add 32, %base
+        %y = assign %add2
         calldatacopy 100, %y, 32
         jmp @merge
 
@@ -1698,14 +1698,14 @@ def test_cross_bb_copy_with_gep_different_geps():
         sink %1
     """
 
-    # mcopy should NOT be optimized - different geps break equivalence
+    # mcopy should NOT be optimized - different adds break equivalence
     _check_no_change(pre)
 
 
-def test_cross_bb_copy_with_gep_in_dominator():
+def test_cross_bb_copy_with_add_in_dominator():
     """
-    Single gep in common dominator, assign chains through it.
-    SHOULD optimize because the gep dominates merge point.
+    Single add in common dominator, assign chains through it.
+    SHOULD optimize because the add dominates merge point.
     """
     if not version_check(begin="cancun"):
         return
@@ -1714,16 +1714,16 @@ def test_cross_bb_copy_with_gep_in_dominator():
     _global:
         %cond = param
         %base = alloca 256
-        %gep = gep 32, %base
+        %add = add 32, %base
         jnz %cond, @path1, @path2
 
     path1:
-        %x = assign %gep
+        %x = assign %add
         calldatacopy 100, %x, 32
         jmp @merge
 
     path2:
-        %y = assign %gep
+        %y = assign %add
         calldatacopy 100, %y, 32
         jmp @merge
 
@@ -1737,31 +1737,31 @@ def test_cross_bb_copy_with_gep_in_dominator():
     _global:
         %cond = param
         %base = alloca 256
-        %gep = gep 32, %base
+        %add = add 32, %base
         jnz %cond, @path1, @path2
 
     path1:
-        %x = assign %gep
+        %x = assign %add
         nop  ; calldatacopy 100, %x, 32 [dead store - overwritten at merge]
         jmp @merge
 
     path2:
-        %y = assign %gep
+        %y = assign %add
         nop  ; calldatacopy 100, %y, 32 [dead store - overwritten at merge]
         jmp @merge
 
     merge:
-        calldatacopy 200, %gep, 32
+        calldatacopy 200, %add, 32
         %1 = mload 200
         sink %1
     """
     _check_pre_post(pre, post)
 
 
-def test_cross_bb_copy_with_longer_assign_chain_through_gep():
+def test_cross_bb_copy_with_longer_assign_chain_through_add():
     """
-    Longer assign chain that goes through a gep in dominator.
-    Should optimize - the gep dominates merge point.
+    Longer assign chain that goes through a add in dominator.
+    Should optimize - the add dominates merge point.
     """
     if not version_check(begin="cancun"):
         return
@@ -1770,17 +1770,17 @@ def test_cross_bb_copy_with_longer_assign_chain_through_gep():
     _global:
         %cond = param
         %base = alloca 256
-        %gep = gep 32, %base
+        %add = add 32, %base
         jnz %cond, @path1, @path2
 
     path1:
-        %a = assign %gep
+        %a = assign %add
         %b = assign %a
         calldatacopy 100, %b, 32
         jmp @merge
 
     path2:
-        %c = assign %gep
+        %c = assign %add
         %d = assign %c
         calldatacopy 100, %d, 32
         jmp @merge
@@ -1795,33 +1795,33 @@ def test_cross_bb_copy_with_longer_assign_chain_through_gep():
     _global:
         %cond = param
         %base = alloca 256
-        %gep = gep 32, %base
+        %add = add 32, %base
         jnz %cond, @path1, @path2
 
     path1:
-        %a = assign %gep
+        %a = assign %add
         %b = assign %a
         nop  ; calldatacopy [dead store]
         jmp @merge
 
     path2:
-        %c = assign %gep
+        %c = assign %add
         %d = assign %c
         nop  ; calldatacopy [dead store]
         jmp @merge
 
     merge:
-        calldatacopy 200, %gep, 32
+        calldatacopy 200, %add, 32
         %1 = mload 200
         sink %1
     """
     _check_pre_post(pre, post)
 
 
-def test_cross_bb_copy_with_nested_gep_different_inner_geps():
+def test_cross_bb_copy_with_nested_add_different_inner_adds():
     """
-    Nested gep (gep of gep) with different inner gep instructions in each path.
-    Should NOT optimize - the inner geps are different variables.
+    Nested add (add of add) with different inner add instructions in each path.
+    Should NOT optimize - the inner adds are different variables.
     """
     if not version_check(begin="cancun"):
         return
@@ -1830,17 +1830,17 @@ def test_cross_bb_copy_with_nested_gep_different_inner_geps():
     _global:
         %cond = param
         %base = alloca 256
-        %gep = gep 32, %base
+        %add = add 32, %base
         jnz %cond, @path1, @path2
 
     path1:
-        %inner1 = gep 64, %gep
+        %inner1 = add 64, %add
         %a = assign %inner1
         calldatacopy 100, %a, 32
         jmp @merge
 
     path2:
-        %inner2 = gep 64, %gep
+        %inner2 = add 64, %add
         %b = assign %inner2
         calldatacopy 100, %b, 32
         jmp @merge
@@ -1851,5 +1851,5 @@ def test_cross_bb_copy_with_nested_gep_different_inner_geps():
         sink %1
     """
 
-    # mcopy should NOT be optimized - different inner geps break equivalence
+    # mcopy should NOT be optimized - different inner adds break equivalence
     _check_no_change(pre)

--- a/tests/unit/compiler/venom/test_readonly_memory_args_analysis.py
+++ b/tests/unit/compiler/venom/test_readonly_memory_args_analysis.py
@@ -28,13 +28,13 @@ def test_analysis_returns_indices_without_mutating_functions():
     assert not hasattr(fn, "_readonly_memory_invoke_arg_idxs")
 
 
-def test_gep_write_marks_param_mutable():
+def test_add_write_marks_param_mutable():
     src = """
     function f {
     f:
         %arg = param
         %retpc = param
-        %ptr = gep 32, %arg
+        %ptr = add 32, %arg
         mstore %ptr, 1
         ret %retpc
     }
@@ -45,13 +45,13 @@ def test_gep_write_marks_param_mutable():
     assert readonly_analysis.get_readonly_invoke_arg_idxs(fn) == ()
 
 
-def test_gep_read_keeps_param_readonly():
+def test_add_read_keeps_param_readonly():
     src = """
     function f {
     f:
         %arg = param
         %retpc = param
-        %ptr = gep 32, %arg
+        %ptr = add 32, %arg
         %val = mload %ptr
         ret %retpc
     }

--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -30,7 +30,7 @@ from vyper.venom.memory_location import (
 @dataclass(frozen=True)
 class Ptr:
     """
-    class representing an offset (gep) into an Allocation
+    class representing an offset into an Allocation
     """
 
     base_alloca: Allocation
@@ -52,7 +52,7 @@ class BasePtrAnalysis(IRAnalysis):
     """
     Analysis to get every possible base pointer for variables.
     The alloca is the source of base pointer and other instructions
-    (gep/assign) are used to manipulate these base pointers
+    (add/assign) are used to manipulate these base pointers
     """
 
     var_to_mem: dict[IRVariable, set[Ptr]]
@@ -83,14 +83,6 @@ class BasePtrAnalysis(IRAnalysis):
         opcode = inst.opcode
         if opcode == "alloca":
             self.var_to_mem[inst.output] = set([Ptr.from_alloca(inst)])
-
-        elif opcode == "gep":
-            assert isinstance(inst.operands[0], IRVariable), inst.parent
-            offset = None
-            if isinstance(inst.operands[1], IRLiteral):
-                offset = inst.operands[1].value
-            ptrs = self.get_possible_ptrs(inst.operands[0])
-            self.var_to_mem[inst.output] = set(ptr.offset_by(offset) for ptr in ptrs)
 
         elif opcode in ("add", "sub"):
             rhs, lhs = inst.operands

--- a/vyper/venom/analysis/readonly_memory_args.py
+++ b/vyper/venom/analysis/readonly_memory_args.py
@@ -167,9 +167,6 @@ class ReadonlyMemoryArgsGlobalAnalysis(IRGlobalAnalysis):
                 return root_param_indices_var(src)
             return frozenset()
 
-        if op == "gep":
-            return self._root_from_gep(inst, root_param_indices_var)
-
         if op == "add":
             return self._root_from_add(inst, root_param_indices_var)
 
@@ -203,13 +200,3 @@ class ReadonlyMemoryArgsGlobalAnalysis(IRGlobalAnalysis):
             roots.update(root_param_indices_var(b))
         return frozenset(roots)
 
-    def _root_from_gep(self, inst: IRInstruction, root_param_indices_var) -> frozenset[int]:
-        if len(inst.operands) != 2:
-            return frozenset()
-        base, offset = inst.operands
-        roots: set[int] = set()
-        if isinstance(base, IRVariable):
-            roots.update(root_param_indices_var(base))
-        if isinstance(offset, IRVariable):
-            roots.update(root_param_indices_var(offset))
-        return frozenset(roots)

--- a/vyper/venom/analysis/readonly_memory_args.py
+++ b/vyper/venom/analysis/readonly_memory_args.py
@@ -199,4 +199,3 @@ class ReadonlyMemoryArgsGlobalAnalysis(IRGlobalAnalysis):
         if isinstance(b, IRVariable):
             roots.update(root_param_indices_var(b))
         return frozenset(roots)
-

--- a/vyper/venom/builder.py
+++ b/vyper/venom/builder.py
@@ -163,13 +163,6 @@ class VenomBuilder:
         """Allocate abstract memory. Returns pointer. (IR-specific)"""
         return self._emit1("alloca", size)
 
-    def gep(self, ptr: Operand, offset: Operand) -> IRVariable:
-        """Get element pointer into memory region. (IR-specific)
-
-        Used for accessing elements within abstract memory (e.g., immutables).
-        """
-        return self._emit1("gep", ptr, offset)
-
     # === Storage ===
     def sload(self, slot: Operand) -> IRVariable:
         return self._emit1_evm("sload", slot)

--- a/vyper/venom/passes/algebraic_optimization.py
+++ b/vyper/venom/passes/algebraic_optimization.py
@@ -162,8 +162,6 @@ class AlgebraicOptimizationPass(IRPass):
             self._rule_signextend(inst)
         elif opcode == "exp":
             self._rule_exp(inst)
-        elif opcode == "gep":
-            self._rule_gep(inst)
         elif opcode in ("add", "sub", "xor"):
             self._rule_additive(inst)
         elif opcode == "and":
@@ -223,10 +221,6 @@ class AlgebraicOptimizationPass(IRPass):
         # x ** 1 -> x
         elif lit_eq(ops[0], 1):
             self.updater.mk_assign(inst, ops[1])
-
-    def _rule_gep(self, inst: IRInstruction):
-        if lit_eq(inst.operands[1], 0):
-            self.updater.mk_assign(inst, inst.operands[0])
 
     def _rule_additive(self, inst: IRInstruction):
         ops = inst.operands

--- a/vyper/venom/passes/concretize_mem_loc.py
+++ b/vyper/venom/passes/concretize_mem_loc.py
@@ -62,5 +62,3 @@ class ConcretizeMemLocPass(IRPass):
                 ), f"alloca not allocated by livesets: {inst}"
                 concrete = self.allocator.get_concrete(base_ptr)
                 self.updater.replace(inst, "assign", [concrete])
-            if inst.opcode == "gep":
-                inst.opcode = "add"

--- a/vyper/venom/passes/fix_mem_locations.py
+++ b/vyper/venom/passes/fix_mem_locations.py
@@ -54,14 +54,14 @@ class FixMemLocationsPass(IRPass):
                     if in_free_var(MemoryPositions.FREE_VAR_SPACE, write_op.value):
                         offset = write_op.value - MemoryPositions.FREE_VAR_SPACE
                         ptr = self.updater.add_before(
-                            inst, "gep", [self.free_ptr1, IRLiteral(offset)]
+                            inst, "add", [self.free_ptr1, IRLiteral(offset)]
                         )
                         assert ptr is not None
                         update_write_location(inst, ptr)
                     elif in_free_var(MemoryPositions.FREE_VAR_SPACE2, write_op.value):
                         offset = write_op.value - MemoryPositions.FREE_VAR_SPACE2
                         ptr = self.updater.add_before(
-                            inst, "gep", [self.free_ptr2, IRLiteral(offset)]
+                            inst, "add", [self.free_ptr2, IRLiteral(offset)]
                         )
                         assert ptr is not None
                         update_write_location(inst, ptr)
@@ -72,12 +72,12 @@ class FixMemLocationsPass(IRPass):
 
                 if in_free_var(MemoryPositions.FREE_VAR_SPACE, read_op.value):
                     offset = read_op.value - MemoryPositions.FREE_VAR_SPACE
-                    ptr = self.updater.add_before(inst, "gep", [self.free_ptr1, IRLiteral(offset)])
+                    ptr = self.updater.add_before(inst, "add", [self.free_ptr1, IRLiteral(offset)])
                     assert ptr is not None
                     update_read_location(inst, ptr)
                 elif in_free_var(MemoryPositions.FREE_VAR_SPACE2, read_op.value):
                     offset = read_op.value - MemoryPositions.FREE_VAR_SPACE2
-                    ptr = self.updater.add_before(inst, "gep", [self.free_ptr2, IRLiteral(offset)])
+                    ptr = self.updater.add_before(inst, "add", [self.free_ptr2, IRLiteral(offset)])
                     assert ptr is not None
                     update_read_location(inst, ptr)
 

--- a/vyper/venom/passes/sccp/sccp.py
+++ b/vyper/venom/passes/sccp/sccp.py
@@ -186,10 +186,6 @@ class SCCP(IRPass):
             out = self._eval_from_lattice(inst.operands[0])
             self._set_lattice(inst.output, out)
             self._add_ssa_work_items(inst)
-        elif opcode == "gep":
-            out = LatticeEnum.BOTTOM
-            self._set_lattice(inst.output, out)
-            self._add_ssa_work_items(inst)
         elif opcode == "jmp":
             target = self.fn.get_basic_block(inst.operands[0].value)
             self.work_list.append(FlowWorkItem(inst.parent, target))


### PR DESCRIPTION
### What I did

Remove the `gep` (get-element-pointer) instruction from the Venom IR. Since `BasePtrAnalysis` was extended to track pointer provenance through `add`/`sub`, `gep` no longer carries information that `add` doesn't.

### How I did it

- `FixMemLocationsPass` now emits `add` instead of `gep`
- Remove `_rule_gep` from algebraic optimization (subsumed by `_rule_additive`)
- Remove `gep→add` lowering in `ConcretizeMemLocPass`
- Remove `gep` case from `BasePtrAnalysis`, SCCP, and readonly memory args analysis
- Remove `builder.gep()` method
- Update test IR and skill docs

### How to verify it

```bash
pytest tests/unit/compiler/venom/ -x
```

Bytecode is identical across all 43 thirdparty contracts at O2, O3, Os.

### Commit message

```
`gep` (get-element-pointer) was an IR-specific opcode for pointer
arithmetic on alloca regions. it existed so `BasePtrAnalysis` could
distinguish pointer offsets from plain integer addition. since c58034a22
extended `BasePtrAnalysis` to track pointer provenance through
`add`/`sub` (by checking whether either operand is a known pointer),
`gep` no longer carries information that `add` doesn't.

replace all `gep` emissions in `FixMemLocationsPass` with `add` and
remove the `gep` handling from every consumer: `_rule_gep` in algebraic
optimization (subsumed by `_rule_additive`), the `gep→add` lowering in
`ConcretizeMemLocPass`, the `gep` case in `BasePtrAnalysis` (the
`add`/`sub` handler covers it), the `gep` branch in SCCP (add is already
in ARITHMETIC_OPS), and `_root_from_gep` in readonly memory args
analysis. remove the `builder.gep()` method.
```

### Description for the changelog

Remove redundant `gep` instruction from Venom IR; `add` now handles all pointer arithmetic.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
