### PR TITLE
fix[docs]: add blank line after code block

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -96,6 +96,7 @@ Internal functions (optionally marked with the ``@internal`` decorator) are only
 Or for internal functions which are defined in :ref:`imported modules <modules>`, they are invoked by prefixing the name of the module to the function name:
 
 .. code-block:: vyper
+
     import calculator_library
 
     @external

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -188,6 +188,7 @@ Therefore, a module encapsulates
 Modules can be added to contracts by importing them from a ``.vy`` file. Any ``.vy`` file is a valid module which can be imported into another contract! This is a very powerful feature which allows you to assemble contracts via other contracts as building blocks.
 
 .. code-block:: vyper
+
     # my_module.vy
 
     def perform_some_computation() -> uint256:
@@ -198,6 +199,7 @@ Modules can be added to contracts by importing them from a ``.vy`` file. Any ``.
         return 6
 
 .. code-block:: vyper
+
     import my_module
 
     exports: my_module.some_external_function


### PR DESCRIPTION
### What I did

Fix the build warnings "maximum 1 argument(s) allowed, X supplied" raised by the `.. code-block:: vyper` directive.

### How I did it

Add a blank line after the `.. code-block:: vyper` directive.

### How to verify it

```bash
sphinx-build -b html docs docs/_build
```

### Commit message

```
fix[docs]: add blank line after code block

Add a blank line after the `.. code-block:: vyper` directives.

Otherwise, Sphinx parsed the first code line as extra directive
arguments and raised "maximum 1 argument(s) allowed, X supplied".

This prevents the parser from misinterpreting the code block and
fixes the documentation build warnings.
```