### PR TITLE
refactor[venom]: sunset msize instruction

### DIFF
--- a/tests/unit/compiler/venom/test_alloca_in_loop.py
+++ b/tests/unit/compiler/venom/test_alloca_in_loop.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for alloca behavior in loop CFGs.
+
+These tests pin down the current (static) alloca-in-loop invariants before
+dynamic-alloca support is added. They exercise the three cooperating parts
+of the pipeline:
+
+1. MemLivenessAnalysis — extends an alloca's live range across loop
+   back-edges via its fixpoint propagation, so allocas used in a loop body
+   are live for the entire loop.
+2. ConcretizeMemLocPass + MemoryAllocator — must NOT reuse a slot between
+   two allocas both live in the same loop, but MAY reuse it between
+   disjoint branches within a loop, and between allocas whose lifetimes
+   are disjoint with respect to the loop.
+3. Mem2Var + MakeSSA — a loop-body mload/mstore pair on a 32-byte alloca
+   is promoted to SSA, and MakeSSA then inserts the expected loop-header
+   phi for the loop-carried value.
+
+The direct test coverage for these cases was previously limited to
+incidental functional tests; see tests/functional/codegen/features/
+test_alloca_loop_param_init.py (PR #4840 regression). These unit-level
+tests catch regressions in the analysis layer itself.
+"""
+
+from tests.venom_utils import parse_from_basic_block
+from vyper.venom.analysis import IRAnalysesCache
+from vyper.venom.passes import ConcretizeMemLocPass, MakeSSA
+from vyper.venom.passes.mem2var import Mem2Var
+
+
+def _concretize(pre: str):
+    ctx = parse_from_basic_block(pre)
+    fn = next(iter(ctx.functions.values()))
+    ac = IRAnalysesCache(fn)
+    ConcretizeMemLocPass(ac, fn).run_pass()
+    return ctx, fn
+
+
+def _positions_by_var(ctx):
+    """Map alloca output variable name -> concrete offset."""
+    allocator = ctx.mem_allocator
+    result = {}
+    for alloca, pos in allocator.allocated.items():
+        name = alloca.inst.output.value
+        result[name] = pos
+    return result
+
+
+# --------------------------------------------------------------------------
+# MemLivenessAnalysis + ConcretizeMemLocPass: slot reuse under loops
+# --------------------------------------------------------------------------
+
+
+def test_two_allocas_in_same_loop_body_no_overlap():
+    """
+    Two allocas are both accessed inside the same loop body. The liveness
+    fixpoint propagates across the back-edge, so both allocas are live for
+    the entire loop body — they must NOT share a memory slot.
+    """
+    pre = """
+    main:
+        %buf_a = alloca 32
+        %buf_b = alloca 32
+        jmp @loop_header
+    loop_header:
+        %i = source
+        %cond = iszero %i
+        jnz %cond, @exit, @loop_body
+    loop_body:
+        mstore %buf_a, 11
+        mstore %buf_b, 22
+        %va = mload %buf_a
+        %vb = mload %buf_b
+        jmp @loop_header
+    exit:
+        sink %va, %vb
+    """
+    ctx, _ = _concretize(pre)
+
+    positions = _positions_by_var(ctx)
+    assert positions["%buf_a"] != positions["%buf_b"], (
+        f"two allocas in the same loop body must not share a slot: {positions}"
+    )
+
+
+def test_alloca_defined_before_loop_used_in_loop():
+    """
+    An alloca defined before the loop and accessed inside the loop must
+    be live for the entire loop. Another alloca whose lifetime is strictly
+    after the loop can reuse the slot.
+    """
+    pre = """
+    main:
+        %loop_buf = alloca 64
+        jmp @loop_header
+    loop_header:
+        %i = source
+        %cond = iszero %i
+        jnz %cond, @after_loop, @loop_body
+    loop_body:
+        calldatacopy %loop_buf, 0, 64
+        %v = mload %loop_buf
+        jmp @loop_header
+    after_loop:
+        %post_buf = alloca 64
+        calldatacopy %post_buf, 100, 64
+        %w = mload %post_buf
+        sink %v, %w
+    """
+    ctx, _ = _concretize(pre)
+
+    positions = _positions_by_var(ctx)
+    # %loop_buf is only used in the loop, %post_buf only after — their
+    # live ranges should be disjoint, so they can share the same slot.
+    assert positions["%loop_buf"] == positions["%post_buf"], (
+        f"allocas with disjoint lifetimes should share a slot: {positions}"
+    )
+
+
+def test_allocas_in_disjoint_branches_within_loop():
+    """
+    Two allocas on mutually exclusive branches inside a loop can still
+    share a slot — their live ranges don't overlap at any instruction,
+    even after the back-edge propagates liveness.
+
+    This is the loop analog of the existing test_venom_allocation_branches
+    test in test_concretize_mem.py.
+    """
+    pre = """
+    main:
+        jmp @loop_header
+    loop_header:
+        %cond = source
+        jnz %cond, @then, @else
+    then:
+        %buf_t = alloca 32
+        calldatacopy %buf_t, 0, 32
+        %vt = mload %buf_t
+        jmp @join
+    else:
+        %buf_e = alloca 32
+        calldatacopy %buf_e, 100, 32
+        %ve = mload %buf_e
+        jmp @join
+    join:
+        %done = source
+        jnz %done, @exit, @loop_header
+    exit:
+        stop
+    """
+    ctx, _ = _concretize(pre)
+
+    positions = _positions_by_var(ctx)
+    assert positions["%buf_t"] == positions["%buf_e"], (
+        f"allocas on disjoint branches within a loop should share: {positions}"
+    )
+
+
+def test_alloca_in_nested_loops_no_overlap():
+    """
+    Two allocas, each accessed in its own nested loop, must not share
+    a slot when the inner loop runs inside the outer loop's body (so the
+    outer alloca is live across the entire inner loop via the fixpoint).
+    """
+    pre = """
+    main:
+        %outer_buf = alloca 32
+        %inner_buf = alloca 32
+        jmp @outer_header
+    outer_header:
+        %o = source
+        %oc = iszero %o
+        jnz %oc, @exit, @outer_body
+    outer_body:
+        mstore %outer_buf, 1
+        jmp @inner_header
+    inner_header:
+        %i = source
+        %ic = iszero %i
+        jnz %ic, @outer_tail, @inner_body
+    inner_body:
+        mstore %inner_buf, 2
+        %iv = mload %inner_buf
+        jmp @inner_header
+    outer_tail:
+        %ov = mload %outer_buf
+        jmp @outer_header
+    exit:
+        stop
+    """
+    ctx, _ = _concretize(pre)
+
+    positions = _positions_by_var(ctx)
+    assert positions["%outer_buf"] != positions["%inner_buf"], (
+        f"nested-loop allocas whose live ranges overlap must not share: {positions}"
+    )
+
+
+def test_trivial_self_loop_alloca_liveness():
+    """
+    A self-looping basic block containing an alloca access still has the
+    alloca marked live everywhere in the loop. The fixpoint must converge
+    on the self-edge.
+    """
+    pre = """
+    main:
+        %buf = alloca 32
+        jmp @loop
+    loop:
+        mstore %buf, 7
+        %v = mload %buf
+        %cond = source
+        jnz %cond, @loop, @exit
+    exit:
+        sink %v
+    """
+    ctx, _ = _concretize(pre)
+
+    # Single alloca, it should be at position 0.
+    positions = _positions_by_var(ctx)
+    assert positions == {"%buf": 0}, positions
+
+
+# --------------------------------------------------------------------------
+# Mem2Var + MakeSSA: loop-carried value via promoted alloca
+# --------------------------------------------------------------------------
+
+
+def _count_opcodes(fn, opcode):
+    return sum(
+        1 for bb in fn.get_basic_blocks() for inst in bb.instructions
+        if inst.opcode == opcode
+    )
+
+
+def _find_insts(fn, opcode):
+    return [
+        inst for bb in fn.get_basic_blocks() for inst in bb.instructions
+        if inst.opcode == opcode
+    ]
+
+
+def test_mem2var_promotes_alloca_with_loop_body_access():
+    """
+    A 32-byte alloca whose entire use-set is mload/mstore inside a loop
+    body is promoted to SSA by Mem2Var. The subsequent MakeSSA pass must
+    then insert a phi node at the loop header for the loop-carried value.
+
+    Mem2Var itself is loop-unaware — the test verifies the cooperation
+    between Mem2Var (which mechanically rewrites memory ops to assigns)
+    and MakeSSA (which inserts the necessary phis).
+    """
+    pre = """
+    main:
+        %ptr = alloca 32
+        mstore %ptr, 0
+        jmp @loop
+    loop:
+        %cur = mload %ptr
+        %next = add %cur, 1
+        mstore %ptr, %next
+        %cond = source
+        jnz %cond, @loop, @exit
+    exit:
+        %final = mload %ptr
+        sink %final
+    """
+
+    ctx = parse_from_basic_block(pre)
+    fn = next(iter(ctx.functions.values()))
+    ac = IRAnalysesCache(fn)
+
+    # Mem2Var is run in an SSA sandwich: MakeSSA → Mem2Var → MakeSSA.
+    MakeSSA(ac, fn).run_pass()
+    Mem2Var(ac, fn).run_pass()
+    MakeSSA(ac, fn).run_pass()
+
+    # After the sandwich, every mload and mstore on the promoted alloca
+    # should be gone (the alloca has no remaining memory uses).
+    assert _count_opcodes(fn, "mload") == 0, (
+        "mem2var should have removed all mloads on the promoted alloca"
+    )
+    assert _count_opcodes(fn, "mstore") == 0, (
+        "mem2var should have removed all mstores on the promoted alloca"
+    )
+
+    # MakeSSA must insert a phi at the loop header for the loop-carried
+    # value. There is exactly one loop in this CFG and one loop-carried
+    # value, so exactly one phi is expected.
+    phis = _find_insts(fn, "phi")
+    assert len(phis) == 1, f"expected exactly one phi, got {len(phis)}: {phis}"
+
+    # The phi must live in the @loop block (the loop header).
+    loop_bb = next(
+        bb for bb in fn.get_basic_blocks() if bb.label.value == "loop"
+    )
+    assert phis[0].parent is loop_bb, (
+        f"phi should be at the loop header, found in {phis[0].parent.label}"
+    )
+
+
+def test_mem2var_skips_alloca_with_non_memory_use():
+    """
+    Mem2Var must NOT promote an alloca whose pointer escapes to a non
+    mload/mstore/return use, even if the alloca is inside a loop. Here
+    calldatacopy uses the pointer, which is not in mem2var's accepted
+    opcode set.
+    """
+    pre = """
+    main:
+        %ptr = alloca 32
+        jmp @loop
+    loop:
+        mstore %ptr, 42
+        calldatacopy %ptr, 0, 32
+        %v = mload %ptr
+        %cond = source
+        jnz %cond, @loop, @exit
+    exit:
+        sink %v
+    """
+
+    ctx = parse_from_basic_block(pre)
+    fn = next(iter(ctx.functions.values()))
+    ac = IRAnalysesCache(fn)
+
+    MakeSSA(ac, fn).run_pass()
+    Mem2Var(ac, fn).run_pass()
+    MakeSSA(ac, fn).run_pass()
+
+    # The alloca must survive — its pointer is used by calldatacopy,
+    # which is not in mem2var's accepted opcode set.
+    allocas = _find_insts(fn, "alloca")
+    assert len(allocas) == 1, f"alloca should be preserved, got {allocas}"
+    # The mload/mstore should also survive since promotion was skipped.
+    assert _count_opcodes(fn, "mload") >= 1
+    assert _count_opcodes(fn, "mstore") >= 1

--- a/tests/unit/compiler/venom/test_alloca_in_loop.py
+++ b/tests/unit/compiler/venom/test_alloca_in_loop.py
@@ -78,9 +78,9 @@ def test_two_allocas_in_same_loop_body_no_overlap():
     ctx, _ = _concretize(pre)
 
     positions = _positions_by_var(ctx)
-    assert positions["%buf_a"] != positions["%buf_b"], (
-        f"two allocas in the same loop body must not share a slot: {positions}"
-    )
+    assert (
+        positions["%buf_a"] != positions["%buf_b"]
+    ), f"two allocas in the same loop body must not share a slot: {positions}"
 
 
 def test_alloca_defined_before_loop_used_in_loop():
@@ -112,9 +112,9 @@ def test_alloca_defined_before_loop_used_in_loop():
     positions = _positions_by_var(ctx)
     # %loop_buf is only used in the loop, %post_buf only after — their
     # live ranges should be disjoint, so they can share the same slot.
-    assert positions["%loop_buf"] == positions["%post_buf"], (
-        f"allocas with disjoint lifetimes should share a slot: {positions}"
-    )
+    assert (
+        positions["%loop_buf"] == positions["%post_buf"]
+    ), f"allocas with disjoint lifetimes should share a slot: {positions}"
 
 
 def test_allocas_in_disjoint_branches_within_loop():
@@ -151,9 +151,9 @@ def test_allocas_in_disjoint_branches_within_loop():
     ctx, _ = _concretize(pre)
 
     positions = _positions_by_var(ctx)
-    assert positions["%buf_t"] == positions["%buf_e"], (
-        f"allocas on disjoint branches within a loop should share: {positions}"
-    )
+    assert (
+        positions["%buf_t"] == positions["%buf_e"]
+    ), f"allocas on disjoint branches within a loop should share: {positions}"
 
 
 def test_alloca_in_nested_loops_no_overlap():
@@ -191,9 +191,9 @@ def test_alloca_in_nested_loops_no_overlap():
     ctx, _ = _concretize(pre)
 
     positions = _positions_by_var(ctx)
-    assert positions["%outer_buf"] != positions["%inner_buf"], (
-        f"nested-loop allocas whose live ranges overlap must not share: {positions}"
-    )
+    assert (
+        positions["%outer_buf"] != positions["%inner_buf"]
+    ), f"nested-loop allocas whose live ranges overlap must not share: {positions}"
 
 
 def test_trivial_self_loop_alloca_liveness():
@@ -228,15 +228,13 @@ def test_trivial_self_loop_alloca_liveness():
 
 def _count_opcodes(fn, opcode):
     return sum(
-        1 for bb in fn.get_basic_blocks() for inst in bb.instructions
-        if inst.opcode == opcode
+        1 for bb in fn.get_basic_blocks() for inst in bb.instructions if inst.opcode == opcode
     )
 
 
 def _find_insts(fn, opcode):
     return [
-        inst for bb in fn.get_basic_blocks() for inst in bb.instructions
-        if inst.opcode == opcode
+        inst for bb in fn.get_basic_blocks() for inst in bb.instructions if inst.opcode == opcode
     ]
 
 
@@ -277,12 +275,12 @@ def test_mem2var_promotes_alloca_with_loop_body_access():
 
     # After the sandwich, every mload and mstore on the promoted alloca
     # should be gone (the alloca has no remaining memory uses).
-    assert _count_opcodes(fn, "mload") == 0, (
-        "mem2var should have removed all mloads on the promoted alloca"
-    )
-    assert _count_opcodes(fn, "mstore") == 0, (
-        "mem2var should have removed all mstores on the promoted alloca"
-    )
+    assert (
+        _count_opcodes(fn, "mload") == 0
+    ), "mem2var should have removed all mloads on the promoted alloca"
+    assert (
+        _count_opcodes(fn, "mstore") == 0
+    ), "mem2var should have removed all mstores on the promoted alloca"
 
     # MakeSSA must insert a phi at the loop header for the loop-carried
     # value. There is exactly one loop in this CFG and one loop-carried
@@ -291,12 +289,10 @@ def test_mem2var_promotes_alloca_with_loop_body_access():
     assert len(phis) == 1, f"expected exactly one phi, got {len(phis)}: {phis}"
 
     # The phi must live in the @loop block (the loop header).
-    loop_bb = next(
-        bb for bb in fn.get_basic_blocks() if bb.label.value == "loop"
-    )
-    assert phis[0].parent is loop_bb, (
-        f"phi should be at the loop header, found in {phis[0].parent.label}"
-    )
+    loop_bb = next(bb for bb in fn.get_basic_blocks() if bb.label.value == "loop")
+    assert (
+        phis[0].parent is loop_bb
+    ), f"phi should be at the loop header, found in {phis[0].parent.label}"
 
 
 def test_mem2var_skips_alloca_with_non_memory_use():

--- a/tests/unit/compiler/venom/test_common_subexpression_elimination.py
+++ b/tests/unit/compiler/venom/test_common_subexpression_elimination.py
@@ -210,27 +210,6 @@ def test_cse_effect_mstore():
     _check_pre_post(pre, post)
 
 
-def test_cse_effect_mstore_with_msize():
-    """
-    Test that checks that msize is handled correctly
-    """
-    pre = """
-    main:
-        %1 = 10
-        mstore 0, %1
-        %mload1 = mload 0
-        %2 = 10
-        mstore 0, %1
-        %mload2 = mload 0
-        %msize = msize
-        %res1 = add %mload1, %msize
-        %res2 = add %mload2, %msize
-        sink %res1, %res2
-    """
-
-    _check_no_change(pre)
-
-
 def test_cse_different_branches_cannot_optimize():
     """
     Test of inter basicblock analysis which would require

--- a/tests/unit/compiler/venom/test_memmerging.py
+++ b/tests/unit/compiler/venom/test_memmerging.py
@@ -208,60 +208,6 @@ def test_memmerging_imposs_unkown_place():
     _check_no_change(pre)
 
 
-def test_memmerging_imposs_msize():
-    """
-    Test case of impossible merge
-    Impossible because of the msize barier
-    """
-    if not version_check(begin="cancun"):
-        return
-
-    pre = """
-    _global:
-        %1 = mload 0
-        %2 = msize  ; BARRIER
-        %3 = mload 32
-        %4 = mload 64
-        mstore 1000, %1
-        mstore 1032, %3
-        %5 = msize  ; BARRIER
-        mstore 1064, %4
-        return %2, %5
-    """
-    _check_no_change(pre)
-
-
-def test_memmerging_partial_msize():
-    """
-    Only partial merge possible
-    because of the msize barier
-    """
-    if not version_check(begin="cancun"):
-        return
-
-    pre = """
-    _global:
-        %1 = mload 0
-        %2 = mload 32
-        %3 = mload 64
-        mstore 1000, %1
-        mstore 1032, %2
-        %4 = msize  ; BARRIER
-        mstore 1064, %3
-        return %4
-    """
-
-    post = """
-    _global:
-        %3 = mload 64
-        mcopy 1000, 0, 64
-        %4 = msize
-        mstore 1064, %3
-        return %4
-    """
-    _check_pre_post(pre, post)
-
-
 def test_memmerging_partial_overlap():
     """
     Two different copies from overlapping

--- a/tests/unit/compiler/venom/test_memory_copy_elision.py
+++ b/tests/unit/compiler/venom/test_memory_copy_elision.py
@@ -24,8 +24,7 @@ def _check_pre_post_with_unused_var_removal(pre, post, hevm: bool = True):
     """Like _check_pre_post but also runs RemoveUnusedVariablesPass.
 
     This is needed for tests involving load-store elision where the load
-    becomes unused after the store is nop'd. RemoveUnusedVariablesPass
-    has proper MSIZE fence handling to preserve loads that affect msize.
+    becomes unused after the store is nop'd.
     """
     pre_ctx, post_ctx = _checker.run_passes(pre, post)
     for fn in pre_ctx.functions.values():
@@ -71,7 +70,7 @@ def test_redundant_copy_elimination():
     """
 
     # After MemoryCopyElisionPass: store is nop'd, load remains
-    # After RemoveUnusedVariablesPass: load is also removed (no msize downstream), nops cleared
+    # After RemoveUnusedVariablesPass: load is also removed, nops cleared
     post = """
     _global:
         stop
@@ -788,36 +787,6 @@ def test_mem_elision_load_needed_not_precise():
     """
 
     _check_pre_post(pre, post)
-
-
-def test_mem_elision_msize():
-    """
-    Test that mload is preserved when msize is read downstream.
-
-    MemoryCopyElisionPass only nops the store. RemoveUnusedVariablesPass
-    would normally remove the unused load, but it correctly preserves it
-    because there's an msize instruction downstream (msize fence).
-    """
-    pre = """
-    main:
-        ; you cannot nop both of
-        ; them since you need correct
-        ; msize (currently it does that)
-        %1 = mload 100
-        mstore 100, %1
-        %2 = msize
-        sink %2
-    """
-
-    # After MemoryCopyElisionPass: store is nop'd
-    # After RemoveUnusedVariablesPass: load is KEPT (msize fence), nops cleared
-    post = """
-    main:
-        %1 = mload 100
-        %2 = msize
-        sink %2
-    """
-    _check_pre_post_with_unused_var_removal(pre, post)
 
 
 def test_remove_unused_writes():

--- a/tests/unit/compiler/venom/test_memory_copy_elision.py
+++ b/tests/unit/compiler/venom/test_memory_copy_elision.py
@@ -60,7 +60,7 @@ def test_redundant_copy_elimination():
     Test that copying to the same location is eliminated entirely.
 
     MemoryCopyElisionPass only nops the store. The load is removed by
-    RemoveUnusedVariablesPass (which has proper MSIZE fence handling).
+    RemoveUnusedVariablesPass.
     """
     pre = """
     _global:

--- a/tests/unit/compiler/venom/test_memtop.py
+++ b/tests/unit/compiler/venom/test_memtop.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for the `memtop` Venom instruction.
+
+`memtop` returns a pointer past all currently-used memory (the EVM `MSIZE`
+high-water mark). It is used by builtins (`raw_call(msg.data)`,
+`create_copy_of`, `create_from_blueprint`) to obtain runtime-sized scratch
+above the static frame and any spill slots.
+
+Semantics:
+1. Lowers to a single `MSIZE` byte at assembly time.
+2. Has a `MEMORY` read effect — depends on all prior memory writes.
+3. CSE may merge two `memtop` instructions only when no memory write
+   separates them.
+4. DFT must not reorder `memtop` past a memory write.
+"""
+
+from tests.venom_utils import assert_ctx_eq, parse_from_basic_block
+from vyper.venom.analysis.analysis import IRAnalysesCache
+from vyper.venom.parser import parse_venom
+from vyper.venom.passes.common_subexpression_elimination import CSE
+from vyper.venom.venom_to_assembly import VenomCompiler
+
+
+# --------------------------------------------------------------------------
+# Lowering: memtop -> MSIZE
+# --------------------------------------------------------------------------
+
+
+def test_memtop_lowers_to_msize():
+    """
+    A `memtop` instruction must lower to the EVM `MSIZE` opcode.
+    """
+    code = """
+    function foo {
+        main:
+            %1 = memtop
+            mstore 0, %1
+            stop
+    }
+    """
+    ctx = parse_venom(code)
+    asm = VenomCompiler(ctx).generate_evm_assembly()
+    # The exact stack layout depends on the scheduler; the only
+    # guarantee we care about is that an MSIZE opcode is emitted.
+    assert "MSIZE" in asm, asm
+
+
+def test_memtop_only_emits_msize_byte():
+    """
+    Two memtop instructions in sequence (with no memory write between)
+    should each be free to lower to MSIZE — and CSE should be free to
+    merge them. Either way, MSIZE appears at least once.
+    """
+    code = """
+    function foo {
+        main:
+            %1 = memtop
+            %2 = memtop
+            mstore 0, %1
+            mstore 32, %2
+            stop
+    }
+    """
+    ctx = parse_venom(code)
+    asm = VenomCompiler(ctx).generate_evm_assembly()
+    assert asm.count("MSIZE") >= 1, asm
+
+
+# --------------------------------------------------------------------------
+# CSE: memtop is mergeable when no memory write separates two uses,
+# and NOT mergeable when one does.
+# --------------------------------------------------------------------------
+
+
+def _run_cse(pre: str):
+    ctx = parse_from_basic_block(pre)
+    for fn in ctx.functions.values():
+        ac = IRAnalysesCache(fn)
+        CSE(ac, fn).run_pass()
+    return ctx
+
+
+def test_cse_does_not_merge_memtop_across_memory_write():
+    """
+    Regression: with the `MEMORY` read effect, an `mstore` between two
+    `memtop` instructions invalidates the first one in the available
+    expressions, so CSE must NOT replace the second with the first.
+    Without this effect, both `memtop` ops would compute as the same
+    expression and CSE would incorrectly merge them — but at runtime
+    the mstore advances MSIZE, so the second memtop would return a
+    different value.
+    """
+    pre = """
+    main:
+        %1 = memtop
+        mstore %1, 42
+        %2 = memtop
+        sink %1, %2
+    """
+    ctx = _run_cse(pre)
+
+    # The pass must NOT have collapsed %2 into an alias of %1.
+    fn = next(iter(ctx.functions.values()))
+    memtops = [
+        inst
+        for bb in fn.get_basic_blocks()
+        for inst in bb.instructions
+        if inst.opcode == "memtop"
+    ]
+    assert len(memtops) == 2, (
+        f"CSE must not merge memtops across a memory write, "
+        f"got {len(memtops)} memtop(s)"
+    )
+
+
+def test_cse_merges_memtop_without_memory_write():
+    """
+    Two consecutive `memtop` instructions with no intervening memory
+    write are equivalent and CSE may merge them. (At runtime MSIZE
+    has not advanced, so both return the same value.)
+    """
+    pre = """
+    main:
+        %1 = memtop
+        %2 = memtop
+        sink %1, %2
+    """
+    post = """
+    main:
+        %1 = memtop
+        %2 = %1
+        sink %1, %2
+    """
+    ctx_pre = _run_cse(pre)
+    assert_ctx_eq(ctx_pre, parse_from_basic_block(post))
+
+
+# --------------------------------------------------------------------------
+# DFT scheduling: memtop must not be reordered past a memory write
+# --------------------------------------------------------------------------
+
+
+def test_memtop_emission_respects_memory_write_ordering():
+    """
+    A function that writes memory then reads `memtop` must produce
+    assembly where MSIZE is emitted *after* MSTORE — the MEMORY read
+    effect on memtop creates an effect dependency that prevents DFT
+    from reordering the memtop before the mstore.
+    """
+    code = """
+    function foo {
+        main:
+            mstore 0, 99
+            %1 = memtop
+            mstore 32, %1
+            stop
+    }
+    """
+    ctx = parse_venom(code)
+    asm = VenomCompiler(ctx).generate_evm_assembly()
+
+    # Locate the first MSTORE and the MSIZE; MSIZE must come AFTER
+    # the first MSTORE so that it observes the memory growth.
+    msize_idx = asm.index("MSIZE")
+    first_mstore_idx = asm.index("MSTORE")
+    assert first_mstore_idx < msize_idx, (
+        f"MSIZE must come after the prior MSTORE, "
+        f"got asm={asm}"
+    )

--- a/tests/unit/compiler/venom/test_memtop.py
+++ b/tests/unit/compiler/venom/test_memtop.py
@@ -20,7 +20,6 @@ from vyper.venom.parser import parse_venom
 from vyper.venom.passes.common_subexpression_elimination import CSE
 from vyper.venom.venom_to_assembly import VenomCompiler
 
-
 # --------------------------------------------------------------------------
 # Lowering: memtop -> MSIZE
 # --------------------------------------------------------------------------
@@ -102,14 +101,10 @@ def test_cse_does_not_merge_memtop_across_memory_write():
     # The pass must NOT have collapsed %2 into an alias of %1.
     fn = next(iter(ctx.functions.values()))
     memtops = [
-        inst
-        for bb in fn.get_basic_blocks()
-        for inst in bb.instructions
-        if inst.opcode == "memtop"
+        inst for bb in fn.get_basic_blocks() for inst in bb.instructions if inst.opcode == "memtop"
     ]
     assert len(memtops) == 2, (
-        f"CSE must not merge memtops across a memory write, "
-        f"got {len(memtops)} memtop(s)"
+        f"CSE must not merge memtops across a memory write, " f"got {len(memtops)} memtop(s)"
     )
 
 
@@ -164,6 +159,5 @@ def test_memtop_emission_respects_memory_write_ordering():
     msize_idx = asm.index("MSIZE")
     first_mstore_idx = asm.index("MSTORE")
     assert first_mstore_idx < msize_idx, (
-        f"MSIZE must come after the prior MSTORE, "
-        f"got asm={asm}"
+        f"MSIZE must come after the prior MSTORE, " f"got asm={asm}"
     )

--- a/tests/unit/compiler/venom/test_removeunused.py
+++ b/tests/unit/compiler/venom/test_removeunused.py
@@ -1,24 +1,19 @@
-from tests.venom_utils import assert_ctx_eq, parse_from_basic_block, parse_venom
+from tests.venom_utils import assert_ctx_eq, parse_from_basic_block
 from vyper.venom.analysis.analysis import IRAnalysesCache
 from vyper.venom.passes import RemoveUnusedVariablesPass
 
 
-def _check_pre_post(pre, post, scope="basicblock"):
-    if scope == "basicblock":
-        parse = parse_from_basic_block
-    else:
-        parse = parse_venom
-
-    ctx = parse(pre)
+def _check_pre_post(pre, post):
+    ctx = parse_from_basic_block(pre)
     for fn in ctx.functions.values():
         ac = IRAnalysesCache(fn)
         RemoveUnusedVariablesPass(ac, fn).run_pass()
 
-    assert_ctx_eq(ctx, parse(post))
+    assert_ctx_eq(ctx, parse_from_basic_block(post))
 
 
-def _check_no_change(pre, scope="basicblock"):
-    _check_pre_post(pre, pre, scope=scope)
+def _check_no_change(pre):
+    _check_pre_post(pre, pre)
 
 
 def test_removeunused_basic():
@@ -86,126 +81,5 @@ def test_removeunused_loop():
         %2 = add %p, 1
         mstore 10, %2
         jmp @after
-    """
-    _check_pre_post(pre, post)
-
-
-def test_removeunused_mload_basic():
-    pre = """
-    main:
-        %a = mload 32
-        %b = msize
-        %c_unused = mload 64  # safe to remove
-        return %b, %b
-    """
-    post = """
-    main:
-        %a = mload 32
-        %b = msize
-        return %b, %b
-    """
-    _check_pre_post(pre, post)
-
-
-def test_removeunused_mload_two_msizes():
-    pre = """
-    main:
-        %a = mload 32
-        %b = msize
-        %c = mload 64  # not safe to remove - has MSIZE effect
-        %d = msize
-        return %b, %d
-    """
-    _check_no_change(pre)
-
-
-def test_removeunused_msize_loop():
-    pre = """
-    main:
-        %1 = msize
-
-        # not safe to remove because the previous instruction is
-        # still reachable
-        %2 = mload %1
-
-        jmp @main
-    """
-    _check_no_change(pre)
-
-
-def test_removeunused_msize_reachable():
-    pre = """
-    main:
-        # not safe to remove because there is an msize in a reachable
-        # basic block
-        %1 = mload 0
-
-        jmp @next
-    next:
-        jmp @last
-    last:
-        %2 = msize
-        return %2, %2
-    """
-    _check_no_change(pre)
-
-
-def test_removeunused_msize_branches():
-    """
-    Test that mload removal is blocked by msize in a downstream basic
-    block
-    """
-    pre = """
-    function global {
-        main:
-            %1 = source
-            %2 = mload 10  ; looks unused, but has MSIZE effect
-            jnz %1, @branch1, @branch2
-        branch1:
-            %3 = msize  ; blocks removal of `%2 = mload 10`
-            mstore 10, %3
-            jmp @end
-        branch2:
-            jmp @end
-        end:
-            stop
-    }
-    """
-    _check_no_change(pre, scope="function")
-
-
-def test_remove_unused_mload_msize_chain():
-    """
-    Test effect chain removal - remove mload which is initially blocked by
-    an msize but is free to be removed after the msize is removed.
-    """
-    pre = """
-    main:
-        %1_unused = mload 10
-        %2_unused = msize
-        stop
-    """
-    post = """
-    main:
-        stop
-    """
-    _check_pre_post(pre, post)
-
-
-def test_remove_unused_mload_msize_chain_loop():
-    """
-    Test effect chain removal - remove mload which is initially blocked by
-    an msize but is free to be removed after the msize is removed.
-    Loop version.
-    """
-    pre = """
-    main:
-        %1_unused = msize
-        %2_unused = mload 10
-        jmp @main
-    """
-    post = """
-    main:
-        jmp @main
     """
     _check_pre_post(pre, post)

--- a/vyper/codegen_venom/builtins/create.py
+++ b/vyper/codegen_venom/builtins/create.py
@@ -409,8 +409,7 @@ def lower_create_copy_of(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROpera
     shifted_codesize = b.shl(IRLiteral(shl_bits), codesize)
     preamble_with_size = b.or_(IRLiteral(preamble_base), shifted_codesize)
 
-    # Get scratch space past all static allocations
-    mem_ofst = b.alloca_top()
+    mem_ofst = ctx.allocate_dyn()
 
     # Store preamble at mem_ofst (will be stored as 32-byte word)
     b.mstore(mem_ofst, preamble_with_size)
@@ -533,8 +532,7 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
         args_len = IRLiteral(0)
         args_ptr = IRLiteral(0)
 
-    # Get scratch space past all static allocations
-    mem_ofst = b.alloca_top()
+    mem_ofst = ctx.allocate_dyn()
 
     # Copy blueprint code (skipping preamble) to memory
     b.extcodecopy(target, mem_ofst, code_offset, codesize)

--- a/vyper/codegen_venom/builtins/create.py
+++ b/vyper/codegen_venom/builtins/create.py
@@ -385,8 +385,6 @@ def lower_create_copy_of(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROpera
     else:
         value = IRLiteral(0)
 
-    # Evaluate salt BEFORE msize() to ensure any memory allocations
-    # (e.g., from keccak256(_abi_encode(x))) don't overwrite the initcode buffer
     salt: Optional[IROperand] = None
     if salt_node is not None:
         salt = Expr(salt_node, ctx).lower_value()
@@ -411,8 +409,8 @@ def lower_create_copy_of(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROpera
     shifted_codesize = b.shl(IRLiteral(shl_bits), codesize)
     preamble_with_size = b.or_(IRLiteral(preamble_base), shifted_codesize)
 
-    # Get current memory size as buffer start
-    mem_ofst = b.msize()
+    # Get scratch space past all static allocations
+    mem_ofst = b.alloca_top()
 
     # Store preamble at mem_ofst (will be stored as 32-byte word)
     b.mstore(mem_ofst, preamble_with_size)
@@ -473,8 +471,6 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
     else:
         value = IRLiteral(0)
 
-    # Evaluate salt BEFORE msize() to ensure any memory allocations
-    # (e.g., from keccak256(_abi_encode(x))) don't overwrite the initcode
     salt: Optional[IROperand] = None
     if salt_node is not None:
         salt = Expr(salt_node, ctx).lower_value()
@@ -497,8 +493,6 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
     b.assert_(has_code)
 
     # Handle constructor arguments
-    # NOTE: ALL memory allocations (including ABI encoding) MUST happen BEFORE
-    # calling msize(). This ensures msize() returns a value past all alloca buffers.
     args_len: IROperand
     args_ptr: IROperand
 
@@ -513,8 +507,6 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
         args_len = b.mload(raw_arg)
         args_ptr = b.add(raw_arg, IRLiteral(32))
     elif len(ctor_arg_nodes) > 0:
-        # ABI-encode constructor arguments BEFORE calling msize()
-        # This ensures all alloca buffers are written to before msize() is evaluated
         ctor_arg_types = [arg._metadata["type"] for arg in ctor_arg_nodes]
         ctor_tuple_typ = TupleT(tuple(ctor_arg_types))
         ctor_abi_size = ctor_tuple_typ.abi_type.size_bound()
@@ -534,7 +526,6 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
             ctx.store_vyper_value(vv, dst, arg_t)
             offset += arg_t.memory_bytes_required
 
-        # ABI encode from ctor_args_src to args_buf (BEFORE msize!)
         args_len = abi_encode_to_buf(ctx, args_buf._ptr, ctor_args_src.operand, ctor_tuple_typ)
         args_ptr = args_buf._ptr
     else:
@@ -542,9 +533,8 @@ def lower_create_from_blueprint(node: vy_ast.Call, ctx: VenomCodegenContext) -> 
         args_len = IRLiteral(0)
         args_ptr = IRLiteral(0)
 
-    # Get current memory size as buffer start
-    # This is called AFTER all memory allocations to ensure msize() is past all alloca buffers
-    mem_ofst = b.msize()
+    # Get scratch space past all static allocations
+    mem_ofst = b.alloca_top()
 
     # Copy blueprint code (skipping preamble) to memory
     b.extcodecopy(target, mem_ofst, code_offset, codesize)

--- a/vyper/codegen_venom/builtins/system.py
+++ b/vyper/codegen_venom/builtins/system.py
@@ -145,7 +145,7 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
     # Copy msg.data to scratch AFTER all kwarg evaluation, so nothing
     # else overwrites the alloca_top scratch region before the call.
     if use_msg_data:
-        data_ptr = b.alloca_top()
+        data_ptr = ctx.allocate_dyn()
         data_len = b.calldatasize()
         b.calldatacopy(data_ptr, IRLiteral(0), data_len)
 

--- a/vyper/codegen_venom/builtins/system.py
+++ b/vyper/codegen_venom/builtins/system.py
@@ -143,7 +143,7 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
         out_ptr = IRLiteral(0)
 
     # Copy msg.data to scratch AFTER all kwarg evaluation, so nothing
-    # else overwrites the alloca_top scratch region before the call.
+    # else overwrites the memtop scratch region before the call.
     if use_msg_data:
         data_ptr = ctx.allocate_dyn()
         data_len = b.calldatasize()

--- a/vyper/codegen_venom/builtins/system.py
+++ b/vyper/codegen_venom/builtins/system.py
@@ -106,18 +106,12 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
             node,
         )
 
-    # Handle msg.data specially - it needs to copy calldata to memory
+    # Evaluate data argument
     data_node = node.args[1]
-    if _is_msg_data(data_node):
-        # Get scratch space past all static allocations
-        data_ptr = b.alloca_top()
-        data_len = b.calldatasize()
-        # Copy entire calldata to scratch memory
-        b.calldatacopy(data_ptr, IRLiteral(0), data_len)
-    else:
+    use_msg_data = _is_msg_data(data_node)
+    if not use_msg_data:
         data_vv = Expr(data_node, ctx).lower()
         data = ctx.unwrap(data_vv)  # Copies storage/transient to memory
-        # Get input data pointer and length
         # Bytes layout: [32-byte length][data...]
         data_len = b.mload(data)
         data_ptr = b.add(data, IRLiteral(32))
@@ -147,6 +141,13 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
     else:
         out_val = None
         out_ptr = IRLiteral(0)
+
+    # Copy msg.data to scratch AFTER all kwarg evaluation, so nothing
+    # else overwrites the alloca_top scratch region before the call.
+    if use_msg_data:
+        data_ptr = b.alloca_top()
+        data_len = b.calldatasize()
+        b.calldatacopy(data_ptr, IRLiteral(0), data_len)
 
     # Build the call instruction
     if is_delegate:

--- a/vyper/codegen_venom/builtins/system.py
+++ b/vyper/codegen_venom/builtins/system.py
@@ -107,13 +107,12 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
         )
 
     # Handle msg.data specially - it needs to copy calldata to memory
-    # This must be done before other memory allocations to use msize correctly
     data_node = node.args[1]
     if _is_msg_data(data_node):
-        # Get msize first - this is where we'll copy calldata
-        data_ptr = b.msize()
+        # Get scratch space past all static allocations
+        data_ptr = b.alloca_top()
         data_len = b.calldatasize()
-        # Copy entire calldata to memory at msize
+        # Copy entire calldata to scratch memory
         b.calldatacopy(data_ptr, IRLiteral(0), data_len)
     else:
         data_vv = Expr(data_node, ctx).lower()

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -660,7 +660,7 @@ class VenomCodegenContext:
 
         Lowers to EVM MSIZE at assembly time.
         """
-        return self.builder.alloca_top()
+        return self.builder.memtop()
 
     # === Storage Operations ===
 

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -650,6 +650,18 @@ class VenomCodegenContext:
         ptr = self.builder.alloca(size)
         return Buffer(_ptr=ptr, size=size, annotation=annotation)
 
+    def allocate_dyn(self) -> "IRVariable":
+        """Get a pointer to scratch memory for runtime-sized data.
+
+        Returns an address past all static allocations and any prior memory
+        use. The caller may write arbitrary data at this address; the region
+        is untracked and must be consumed (e.g. by CALL/CREATE) before any
+        other code that could also call allocate_dyn().
+
+        Lowers to EVM MSIZE at assembly time.
+        """
+        return self.builder.alloca_top()
+
     # === Storage Operations ===
 
     # Storage is word-addressed (word_scale=1): slot N is at slot N, not byte N*32.

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -1398,12 +1398,6 @@ def _generate_constructor(
         # never reuses this region for temporary allocas.
         builder.ctx.mem_allocator.add_global(imm_alloc)
 
-        # Force msize to be past immutables region (like legacy's GH issue 3101 fix)
-        # This ensures builtins using msize() don't clobber immutables
-        # mload X touches bytes X to X+32, so touch the last word
-        touch_offset = max(0, immutables_len - 32)
-        builder.mload(IRLiteral(touch_offset))
-
     # Register constructor args from DATA section (not calldata)
     # Constructor args are appended to the deploy code
     _register_constructor_args(codegen_ctx, func_t)

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -427,7 +427,6 @@ Instructions have the same effects.
 - `sgt`
 - `create`
 - `create2`
-- `msize`
 - `balance`
 - `call`
 - `staticcall`

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -198,7 +198,15 @@ Assembly can be inspected with `-f asm`, whereas an opcode view of the final byt
   - Allocates an abstract memory region of a given `size`.
   - The output is a pointer to the allocated region (concretized to an offset by `ConcretizeMemLocPass`).
   - Because the SSA form does not allow changing values of registers, handling mutable variables can be tricky. The `alloca` instruction is meant to simplify that.
-  
+
+- `memtop`
+  - ```
+    %out = memtop
+    ```
+  - Returns a pointer past all currently used memory. Lowers to the EVM `MSIZE` opcode at assembly time.
+  - Reads `MEMORY` (so CSE will not merge two `memtop` instructions across a memory write, and DFT will not reorder it past one).
+  - Used by builtins (`raw_call(msg.data, ...)`, `create_copy_of`, `create_from_blueprint`) to obtain runtime-sized scratch above the static frame and any spill slots. The caller writes data starting at the returned address and immediately consumes it via `CALL`/`CREATE` — the region is untracked by the allocator.
+
 - `iload`
   - ```
     %out = iload offset

--- a/vyper/venom/analysis/available_expression.py
+++ b/vyper/venom/analysis/available_expression.py
@@ -39,29 +39,23 @@ for opcode in ("call", "create", "staticcall", "delegatecall", "create2"):
 
 # flag bitwise operations are somehow a perf bottleneck, cache them
 @lru_cache
-def _get_read_effects(opcode, ignore_msize):
-    ret = effects.reads.get(opcode, effects.EMPTY)
-    if ignore_msize:
-        ret &= ~Effects.MSIZE
-    return ret
+def _get_read_effects(opcode):
+    return effects.reads.get(opcode, effects.EMPTY)
 
 
 @lru_cache
-def _get_write_effects(opcode, ignore_msize):
-    ret = effects.writes.get(opcode, effects.EMPTY)
-    if ignore_msize:
-        ret &= ~Effects.MSIZE
-    return ret
+def _get_write_effects(opcode):
+    return effects.writes.get(opcode, effects.EMPTY)
 
 
 @lru_cache
-def _get_overlap_effects(opcode, ignore_msize):
-    return _get_read_effects(opcode, ignore_msize) & _get_write_effects(opcode, ignore_msize)
+def _get_overlap_effects(opcode):
+    return _get_read_effects(opcode) & _get_write_effects(opcode)
 
 
 @lru_cache
-def _get_effects(opcode, ignore_msize):
-    return _get_read_effects(opcode, ignore_msize) | _get_write_effects(opcode, ignore_msize)
+def _get_effects(opcode):
+    return _get_read_effects(opcode) | _get_write_effects(opcode)
 
 
 @dataclass
@@ -173,12 +167,12 @@ class _AvailableExpressions:
             mt[expr].append(src_inst)
             self.exprs = mt.finish()
 
-    def remove_effect(self, effect: Effects, ignore_msize):
+    def remove_effect(self, effect: Effects):
         if effect == effects.EMPTY:
             return
         to_remove = set()
         for expr in self.exprs.keys():
-            op_effect = _get_effects(expr.opcode, ignore_msize)
+            op_effect = _get_effects(expr.opcode)
             if op_effect & effect != effects.EMPTY:
                 to_remove.add(expr)
 
@@ -240,8 +234,6 @@ class AvailableExpressionAnalysis(IRAnalysis):
     bb_ins: dict[IRBasicBlock, _AvailableExpressions]
     bb_outs: dict[IRBasicBlock, _AvailableExpressions]
 
-    ignore_msize: bool
-
     def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction):
         super().__init__(analyses_cache, function)
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
@@ -252,8 +244,6 @@ class AvailableExpressionAnalysis(IRAnalysis):
         self.bb_ins = dict()
         self.bb_outs = dict()
 
-        self.ignore_msize = not self._contains_msize()
-
     def analyze(self):
         worklist = deque()
         worklist.append(self.function.entry)
@@ -261,17 +251,6 @@ class AvailableExpressionAnalysis(IRAnalysis):
             bb: IRBasicBlock = worklist.popleft()
             if self._handle_bb(bb):
                 worklist.extend(self.cfg.cfg_out(bb))
-
-    # msize effect should be only necessery
-    # to be handled when there is a possibility
-    # of msize read otherwise it should not make difference
-    # for this analysis
-    def _contains_msize(self) -> bool:
-        for bb in self.function.get_basic_blocks():
-            for inst in bb.instructions:
-                if inst.opcode == "msize":
-                    return True
-        return False
 
     def _handle_bb(self, bb: IRBasicBlock) -> bool:
         preds = self.cfg.cfg_in(bb)
@@ -304,8 +283,8 @@ class AvailableExpressionAnalysis(IRAnalysis):
 
             self._update_expr(inst, expr)
 
-            write_effects = _get_write_effects(expr.opcode, self.ignore_msize)
-            available_exprs.remove_effect(write_effects, self.ignore_msize)
+            write_effects = _get_write_effects(expr.opcode)
+            available_exprs.remove_effect(write_effects)
 
             # nonidempotent instructions affect other instructions,
             # but since it cannot be substituted it should not be
@@ -313,7 +292,7 @@ class AvailableExpressionAnalysis(IRAnalysis):
             if inst.opcode in NONIDEMPOTENT_INSTRUCTIONS:
                 continue
 
-            expr_effects = _get_overlap_effects(expr.opcode, self.ignore_msize)
+            expr_effects = _get_overlap_effects(expr.opcode)
             if expr_effects == effects.EMPTY:
                 available_exprs.add(expr, inst)
 

--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -197,7 +197,7 @@ class BasePtrAnalysis(IRAnalysis):
             return MemoryLocation.UNDEFINED
         if inst.opcode == "ret":
             return MemoryLocation.UNDEFINED
-        if inst.opcode == "alloca_top":
+        if inst.opcode == "memtop":
             return MemoryLocation.UNDEFINED
 
         if inst.get_read_effects() & effects.MEMORY == effects.EMPTY:

--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -197,6 +197,8 @@ class BasePtrAnalysis(IRAnalysis):
             return MemoryLocation.UNDEFINED
         if inst.opcode == "ret":
             return MemoryLocation.UNDEFINED
+        if inst.opcode == "alloca_top":
+            return MemoryLocation.UNDEFINED
 
         if inst.get_read_effects() & effects.MEMORY == effects.EMPTY:
             return MemoryLocation.EMPTY

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -426,6 +426,8 @@ class IRInstruction:
             return 0
         if self.opcode in ("assign", "alloca"):
             return 1
+        if self.opcode == "memtop":
+            return 1  # lowers to single MSIZE byte
         return 2
 
     def get_ast_source(self) -> Optional[IRnode]:

--- a/vyper/venom/builder.py
+++ b/vyper/venom/builder.py
@@ -160,13 +160,13 @@ class VenomBuilder:
         """Allocate abstract memory. Returns pointer. (IR-specific)"""
         return self._emit1("alloca", size)
 
-    def alloca_top(self) -> IRVariable:
+    def memtop(self) -> IRVariable:
         """Get address past all memory (scratch space start).
 
         Lowered to EVM MSIZE at assembly time. Use for untracked scratch
         buffers above the static frame and any spill slots.
         """
-        return self._emit1("alloca_top")
+        return self._emit1("memtop")
 
     # === Storage ===
     def sload(self, slot: Operand) -> IRVariable:

--- a/vyper/venom/builder.py
+++ b/vyper/venom/builder.py
@@ -156,12 +156,18 @@ class VenomBuilder:
         """Copy size bytes from memory[src] to memory[dst]."""
         self._emit_evm("mcopy", dst, src, size)
 
-    def msize(self) -> IRVariable:
-        return self._emit1_evm("msize")
-
     def alloca(self, size: int) -> IRVariable:
         """Allocate abstract memory. Returns pointer. (IR-specific)"""
         return self._emit1("alloca", size)
+
+    def alloca_top(self) -> IRVariable:
+        """Get address past all static memory allocations (scratch space start).
+
+        Resolved by ConcretizeMemLocPass to a literal equal to the function's
+        end-of-memory offset. Use for untracked scratch buffers above the
+        static frame (replaces the old msize-based pattern).
+        """
+        return self._emit1("alloca_top")
 
     # === Storage ===
     def sload(self, slot: Operand) -> IRVariable:

--- a/vyper/venom/builder.py
+++ b/vyper/venom/builder.py
@@ -161,11 +161,10 @@ class VenomBuilder:
         return self._emit1("alloca", size)
 
     def alloca_top(self) -> IRVariable:
-        """Get address past all static memory allocations (scratch space start).
+        """Get address past all memory (scratch space start).
 
-        Resolved by ConcretizeMemLocPass to a literal equal to the function's
-        end-of-memory offset. Use for untracked scratch buffers above the
-        static frame (replaces the old msize-based pattern).
+        Lowered to EVM MSIZE at assembly time. Use for untracked scratch
+        buffers above the static frame and any spill slots.
         """
         return self._emit1("alloca_top")
 

--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -84,6 +84,7 @@ _reads = {
     "revert": MEMORY,
     "sha3": MEMORY,
     "return": MEMORY,
+    "alloca_top": MEMORY,  # lowers to MSIZE; depends on all prior memory writes
 }
 
 reads = _reads.copy()

--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -8,7 +8,6 @@ class Effects(Flag):
     STORAGE = auto()
     TRANSIENT = auto()
     MEMORY = auto()
-    MSIZE = auto()
     IMMUTABLES = auto()
     RETURNDATA = auto()
     LOG = auto()
@@ -31,13 +30,12 @@ ALL = ~EMPTY
 STORAGE = Effects.STORAGE
 TRANSIENT = Effects.TRANSIENT
 MEMORY = Effects.MEMORY
-MSIZE = Effects.MSIZE
 IMMUTABLES = Effects.IMMUTABLES
 RETURNDATA = Effects.RETURNDATA
 LOG = Effects.LOG
 BALANCE = Effects.BALANCE
 EXTCODE = Effects.EXTCODE
-NON_MEMORY_EFFECTS = ~(Effects.MEMORY | Effects.MSIZE)
+NON_MEMORY_EFFECTS = ~Effects.MEMORY
 NON_STORAGE_EFFECTS = ~Effects.STORAGE
 NON_TRANSIENT_EFFECTS = ~Effects.TRANSIENT
 
@@ -85,19 +83,8 @@ _reads = {
     "log": MEMORY,
     "revert": MEMORY,
     "sha3": MEMORY,
-    "msize": MSIZE,
     "return": MEMORY,
 }
 
 reads = _reads.copy()
 writes = _writes.copy()
-
-for k, v in reads.items():
-    if MEMORY in v or IMMUTABLES in v:
-        if k not in writes:
-            writes[k] = EMPTY
-        writes[k] |= MSIZE
-
-for k, v in writes.items():
-    if MEMORY in v or IMMUTABLES in v:
-        writes[k] |= MSIZE

--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -84,7 +84,7 @@ _reads = {
     "revert": MEMORY,
     "sha3": MEMORY,
     "return": MEMORY,
-    "alloca_top": MEMORY,  # lowers to MSIZE; depends on all prior memory writes
+    "memtop": MEMORY,  # lowers to MSIZE; depends on all prior memory writes
 }
 
 reads = _reads.copy()

--- a/vyper/venom/passes/common_subexpression_elimination.py
+++ b/vyper/venom/passes/common_subexpression_elimination.py
@@ -31,7 +31,6 @@ UNINTERESTING_OPCODES = frozenset(
         "basefee",
         "blobbasefee",
         "pc",
-        "msize",
     ]
 )
 # instruction that are not useful to be # substituted

--- a/vyper/venom/passes/concretize_mem_loc.py
+++ b/vyper/venom/passes/concretize_mem_loc.py
@@ -1,6 +1,6 @@
 from vyper.utils import OrderedSet
 from vyper.venom.analysis import BasePtrAnalysis, DFGAnalysis, MemLivenessAnalysis
-from vyper.venom.basicblock import IRBasicBlock
+from vyper.venom.basicblock import IRBasicBlock, IRLiteral
 from vyper.venom.passes.base_pass import IRPass
 from vyper.venom.passes.machinery.inst_updater import InstUpdater
 
@@ -43,6 +43,9 @@ class ConcretizeMemLocPass(IRPass):
 
         self.allocator.reserve_all()
 
+        # Compute end-of-memory before the BB walk so alloca_top can use it.
+        self.fn_eom = self.allocator.compute_fn_eom()
+
         for bb in self.function.get_basic_blocks():
             self._handle_bb(bb)
 
@@ -62,3 +65,5 @@ class ConcretizeMemLocPass(IRPass):
                 ), f"alloca not allocated by livesets: {inst}"
                 concrete = self.allocator.get_concrete(base_ptr)
                 self.updater.replace(inst, "assign", [concrete])
+            elif inst.opcode == "alloca_top":
+                self.updater.replace(inst, "assign", [IRLiteral(self.fn_eom)])

--- a/vyper/venom/passes/concretize_mem_loc.py
+++ b/vyper/venom/passes/concretize_mem_loc.py
@@ -1,6 +1,6 @@
 from vyper.utils import OrderedSet
 from vyper.venom.analysis import BasePtrAnalysis, DFGAnalysis, MemLivenessAnalysis
-from vyper.venom.basicblock import IRBasicBlock, IRLiteral
+from vyper.venom.basicblock import IRBasicBlock
 from vyper.venom.passes.base_pass import IRPass
 from vyper.venom.passes.machinery.inst_updater import InstUpdater
 
@@ -43,9 +43,6 @@ class ConcretizeMemLocPass(IRPass):
 
         self.allocator.reserve_all()
 
-        # Compute end-of-memory before the BB walk so alloca_top can use it.
-        self.fn_eom = self.allocator.compute_fn_eom()
-
         for bb in self.function.get_basic_blocks():
             self._handle_bb(bb)
 
@@ -65,5 +62,3 @@ class ConcretizeMemLocPass(IRPass):
                 ), f"alloca not allocated by livesets: {inst}"
                 concrete = self.allocator.get_concrete(base_ptr)
                 self.updater.replace(inst, "assign", [concrete])
-            elif inst.opcode == "alloca_top":
-                self.updater.replace(inst, "assign", [IRLiteral(self.fn_eom)])

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -167,7 +167,7 @@ class DFTPass(IRPass):
                     for read_inst in all_read_effects[write_effect]:
                         self.eda[inst].add(read_inst)
                 # prevent reordering write-after-write for the same effect
-                if (write_effect & ~effects.Effects.MSIZE) in last_write_effects:
+                if write_effect in last_write_effects:
                     self.eda[inst].add(last_write_effects[write_effect])
                 last_write_effects[write_effect] = inst
                 # clear previous read effects after a write

--- a/vyper/venom/passes/mem2var.py
+++ b/vyper/venom/passes/mem2var.py
@@ -45,12 +45,15 @@ class Mem2Var(IRPass):
         assert len(alloca_inst.operands) == 1, (alloca_inst, alloca_inst.parent)
 
         size_lit = alloca_inst.operands[0]
+        if not isinstance(size_lit, IRLiteral):
+            # dynamic (runtime-sized) alloca
+            return
+
         uses = dfg.get_uses(alloca_inst.output)
 
         if not all2(inst.opcode in ["mstore", "mload", "return"] for inst in uses):
             return
 
-        assert isinstance(size_lit, IRLiteral)
         size = size_lit.value
         var = IRVariable(self._mk_varname(var.value))
 

--- a/vyper/venom/passes/memmerging.py
+++ b/vyper/venom/passes/memmerging.py
@@ -457,4 +457,4 @@ class MemMergePass(IRPass):
 
 def _volatile_memory(inst):
     inst_effects = inst.get_read_effects() | inst.get_write_effects()
-    return Effects.MEMORY in inst_effects or Effects.MSIZE in inst_effects
+    return Effects.MEMORY in inst_effects

--- a/vyper/venom/passes/memory_copy_elision.py
+++ b/vyper/venom/passes/memory_copy_elision.py
@@ -267,9 +267,9 @@ class MemoryCopyElisionPass(IRPass):
         uses = self.dfg.get_uses(load_inst.output)
         if len(uses) > 1:
             return
-        # Only nop the store here. The load may still be needed for MSIZE
-        # side effects. Let RemoveUnusedVariablesPass decide if the load
-        # can be removed (it has proper msize fence handling).
+        # Only nop the store here. The load may still be needed by other
+        # users. Let RemoveUnusedVariablesPass decide if the load can be
+        # removed.
         self.updater.nop(inst)
 
 

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -1,9 +1,6 @@
-from collections import defaultdict
-
 from vyper.utils import OrderedSet, uniq
-from vyper.venom import effects
-from vyper.venom.analysis import DFGAnalysis, LivenessAnalysis, ReachableAnalysis
-from vyper.venom.basicblock import IRBasicBlock, IRInstruction
+from vyper.venom.analysis import DFGAnalysis, LivenessAnalysis
+from vyper.venom.basicblock import IRInstruction
 from vyper.venom.passes.base_pass import IRPass
 
 
@@ -14,27 +11,9 @@ class RemoveUnusedVariablesPass(IRPass):
 
     dfg: DFGAnalysis
     work_list: OrderedSet[IRInstruction]
-    _msizes: dict[IRBasicBlock, list]
 
     def run_pass(self):
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
-        self.reachable = self.analyses_cache.request_analysis(ReachableAnalysis).reachable
-
-        self._msizes = defaultdict(list)
-        self._blocked_by_msize: OrderedSet[IRInstruction] = OrderedSet()
-
-        # map instructions to their indexes in the basic block.
-        # although the basic block can be updated during this pass,
-        # instruction_ordering only needs to be able to give us a total
-        # ordering of effects.
-        self.instruction_ordering: dict[IRInstruction, int] = {}
-
-        for bb in self.function.get_basic_blocks():
-            for idx, inst in enumerate(bb.instructions):
-                inst = bb.instructions[idx]
-                self.instruction_ordering[inst] = idx
-                if inst.opcode == "msize":
-                    self._msizes[bb].append(idx)
 
         work_list = OrderedSet()
         self.work_list = work_list
@@ -51,38 +30,11 @@ class RemoveUnusedVariablesPass(IRPass):
 
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
 
-    def has_msize(self, bb):
-        return len(self._msizes[bb]) > 0
-
-    def get_last_msize(self, bb):
-        msizes = self._msizes[bb]
-        if len(msizes) == 0:
-            return None
-        return max(msizes)
-
-    def msize_fence(self, inst):
-        # return true if there is an msize after memory touch
-        bb = inst.parent
-
-        for next_bb in self._msizes:
-            if next_bb in self.reachable[bb] and self.has_msize(next_bb):
-                return True
-
-        if not self.has_msize(bb):
-            return False
-
-        return self.instruction_ordering[inst] < self.get_last_msize(bb)
-
     def _process_instruction(self, inst):
         outputs = inst.get_outputs()
         if len(outputs) == 0:
             return
         if inst.is_volatile or inst.is_bb_terminator:
-            return
-
-        bb = inst.parent
-        if effects.MSIZE in inst.get_write_effects() and self.msize_fence(inst):
-            self._blocked_by_msize.add(inst)
             return
 
         # Check if ANY output has uses
@@ -95,12 +47,5 @@ class RemoveUnusedVariablesPass(IRPass):
             self.dfg.remove_use(operand, inst)
             new_uses = self.dfg.get_uses(operand)
             self.work_list.addmany(new_uses)
-
-        # if we remove an msize, update the index and revisit all visited
-        # memory instructions since they might now be free to be removed.
-        if inst.opcode == "msize":
-            self._msizes[bb].remove(self.instruction_ordering[inst])
-            self.work_list.addmany(self._blocked_by_msize)
-            self._blocked_by_msize.clear()
 
         inst.make_nop()

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -579,7 +579,7 @@ class VenomCompiler:
             assembly.append(opcode.upper())
         elif opcode == "alloca":
             pass
-        elif opcode == "alloca_top":
+        elif opcode == "memtop":
             assembly.append("MSIZE")
         elif opcode == "param":
             pass

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -94,7 +94,6 @@ _ONE_TO_ONE_INSTRUCTIONS = frozenset(
         "sgt",
         "create",
         "create2",
-        "msize",
         "balance",
         "call",
         "staticcall",
@@ -578,7 +577,7 @@ class VenomCompiler:
         # Step 5: Emit the EVM instruction(s)
         if opcode in _ONE_TO_ONE_INSTRUCTIONS:
             assembly.append(opcode.upper())
-        elif opcode == "alloca":
+        elif opcode in ("alloca", "alloca_top"):
             pass
         elif opcode == "param":
             pass

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -577,8 +577,10 @@ class VenomCompiler:
         # Step 5: Emit the EVM instruction(s)
         if opcode in _ONE_TO_ONE_INSTRUCTIONS:
             assembly.append(opcode.upper())
-        elif opcode in ("alloca", "alloca_top"):
+        elif opcode == "alloca":
             pass
+        elif opcode == "alloca_top":
+            assembly.append("MSIZE")
         elif opcode == "param":
             pass
         elif opcode == "assign":


### PR DESCRIPTION
### What I did

Removed the `msize` instruction and its `MSIZE` effect flag from Venom IR. The flag was load-bearing for five passes (RemoveUnusedVariables fence, AvailableExpressionAnalysis `ignore_msize`, CSE skip-list, DFT mask, memmerging volatile check) and forced a constructor `mload` touch in `codegen_venom/module.py` — all of it existing only so the optimizer could see `msize`.

Replaced with `memtop`, an instruction that lowers to a single `MSIZE` byte at assembly time and carries only a `MEMORY` read effect (enough to prevent CSE merging across memory writes and DFT reordering past them, while still letting two consecutive memtops merge). The three call sites that need runtime-sized scratch (`raw_call(msg.data, ...)`, `create_copy_of`, `create_from_blueprint`) now go through a new `ctx.allocate_dyn()` helper, mirroring the existing `allocate_buffer` API for static buffers.

Drive-bys:
- Fixed an aliasing bug in `raw_call(msg.data)`: the calldatacopy ran before kwarg evaluation, so any nested expression that wrote to scratch could clobber the calldata buffer. Deferred the calldatacopy to immediately before the call.
- Guarded `Mem2Var` against non-literal alloca sizes (one-line `IRLiteral` check) so a future dynamic alloca cannot be silently mis-promoted to SSA.
- Added the first direct unit tests for `MemLivenessAnalysis` + `ConcretizeMemLocPass` over loop CFGs (existing coverage was incidental functional tests), plus a `test_memtop.py` covering `memtop` lowering, CSE merge/no-merge, and DFT scheduling.

### How I did it

### How to verify it

### Commit message

```
The msize Venom instruction carried a dedicated MSIZE effect flag that
effects.py propagated to every memory-touching opcode, so the optimizer
could honor the implicit "any memory touch advances msize" semantics.
That single flag was load-bearing for five separate code paths — a fence
worklist in RemoveUnusedVariables, the ignore_msize shortcut in
AvailableExpressionAnalysis, a CSE skip-list entry, the `& ~MSIZE` mask
in DFT scheduling, and a volatile-memory check in memmerging — plus a
constructor mload touch in codegen_venom/module.py to advance msize past
the immutables region. All of that machinery existed solely so the
optimizer could see msize at all.

Replace msize with memtop, which lowers to a single MSIZE byte at
assembly emission time and carries only a MEMORY read effect. That
effect is the minimal constraint needed to prevent CSE from merging two
memtops across a memory write and to give DFT an edge that keeps memtop
ordered after prior writes; consecutive memtops with no intervening
write remain mergeable. The three callers that need runtime-sized
scratch (raw_call(msg.data), create_copy_of, create_from_blueprint) now
go through a new codegen_venom/context.py::allocate_dyn() helper,
mirroring the existing allocate_buffer API for static buffers.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
