### PR TITLE
fix[docs]: fix docs CI build

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -96,6 +96,7 @@ Internal functions (optionally marked with the ``@internal`` decorator) are only
 Or for internal functions which are defined in :ref:`imported modules <modules>`, they are invoked by prefixing the name of the module to the function name:
 
 .. code-block:: vyper
+
     import calculator_library
 
     @external

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -26,7 +26,7 @@ Date released: 2025-06-19
 
 v0.4.3 introduces the ``@raw_return`` decorator which allows contracts to return bytes directly without ABI-encoding, which enables new proxy contract use cases. The default EVM version has been updated to ``prague``, and several improvements have been made to the Venom optimizer pipeline.
 
-Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_June_2025_limited_review.pdf>`_,  `Anatomist <https://github.com/vyperlang/audits/blob/master/audits/Anatomist_Vyper_April_2025.pdf>`_
+Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_June_2025_limited_review.pdf>`__,  `Anatomist <https://github.com/vyperlang/audits/blob/master/audits/Anatomist_Vyper_April_2025.pdf>`__
 
 Breaking changes
 ----------------
@@ -73,7 +73,7 @@ Additionally, Venom has undergone more improvements, including a CSE elimination
 
 Two low severity GHSAs have been patched in this release.
 
-Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_April_2025.pdf>`_,  `Anatomist <https://github.com/vyperlang/audits/blob/master/audits/Anatomist_Vyper_April_2025.pdf>`_
+Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_April_2025.pdf>`__,  `Anatomist <https://github.com/vyperlang/audits/blob/master/audits/Anatomist_Vyper_April_2025.pdf>`__
 
 
 Breaking and notable changes
@@ -294,7 +294,7 @@ Venom improvements
 * feat[venom]: make dft-pass commutative aware (`#4358 <https://github.com/vyperlang/vyper/pull/4358>`_)
 * perf[venom]: add ``OrderedSet.last()`` (`#4236 <https://github.com/vyperlang/vyper/pull/4236>`_)
 * feat[venom]: improve liveness computation time (`#4086 <https://github.com/vyperlang/vyper/pull/4086>`_)
-* fix[venom]: fix invalid ``phi``s after SCCP (`#4181 <https://github.com/vyperlang/vyper/pull/4181>`_)
+* fix[venom]: fix invalid ``phi``\s after SCCP (`#4181 <https://github.com/vyperlang/vyper/pull/4181>`_)
 * fix[venom]: clean up sccp pass (`#4261 <https://github.com/vyperlang/vyper/pull/4261>`_)
 * refactor[venom]: remove ``dup_requirements`` analysis (`#4262 <https://github.com/vyperlang/vyper/pull/4262>`_)
 * fix[venom]: remove duplicate volatile instructions (`#4263 <https://github.com/vyperlang/vyper/pull/4263>`_)
@@ -389,7 +389,7 @@ Date released: 2024-06-20
 
 v0.4.0 represents a major overhaul to the Vyper language. Notably, it overhauls the import system and adds support for code reuse. It also adds a new, experimental backend to Vyper which lays the foundation for improved analysis, optimization and integration with third party tools.
 
-Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_December_2023_limited_review.pdf>`_, `ChainSecurity 2nd audit <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_February_2024_limited_review.pdf>`_, `ChainSecurity 3rd audit <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_April_2024_limited_review.pdf>`_,  `Statemind <https://github.com/vyperlang/audits/blob/master/audits/Statemind_Vyper_June_2024_audit.pdf>`_, `OtterSec <https://github.com/vyperlang/audits/blob/master/audits/OtterSec_Vyper_November_2023_audit.pdf>`_, `OtterSec 2nd audit <https://github.com/vyperlang/audits/blob/master/audits/OtterSec_Vyper_June_2024.pdf>`_
+Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_December_2023_limited_review.pdf>`__, `ChainSecurity 2nd audit <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_February_2024_limited_review.pdf>`__, `ChainSecurity 3rd audit <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_April_2024_limited_review.pdf>`__,  `Statemind <https://github.com/vyperlang/audits/blob/master/audits/Statemind_Vyper_June_2024_audit.pdf>`__, `OtterSec <https://github.com/vyperlang/audits/blob/master/audits/OtterSec_Vyper_November_2023_audit.pdf>`__, `OtterSec 2nd audit <https://github.com/vyperlang/audits/blob/master/audits/OtterSec_Vyper_June_2024.pdf>`__
 
 Breaking Changes
 ----------------
@@ -699,7 +699,7 @@ Date released: 2023-10-04
 
 v0.3.10 is a performance focused release that additionally ships numerous bugfixes. It adds a ``codesize`` optimization mode (`#3493 <https://github.com/vyperlang/vyper/pull/3493>`_), adds new vyper-specific ``#pragma`` directives  (`#3493 <https://github.com/vyperlang/vyper/pull/3493>`_), uses Cancun's ``MCOPY`` opcode for some compiler generated code (`#3483 <https://github.com/vyperlang/vyper/pull/3483>`_), and generates selector tables which now feature O(1) performance (`#3496 <https://github.com/vyperlang/vyper/pull/3496>`_).
 
-Audits: `OtterSec <https://github.com/vyperlang/audits/blob/master/audits/OtterSec_Vyper_September_2023_audit.pdf>`_, `CodeHawks <https://github.com/vyperlang/audits/blob/master/audits/CodeHawks_Vyper_September_2023_competitive_audit.md>`_, `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_September_2023_limited_review.pdf>`_
+Audits: `OtterSec <https://github.com/vyperlang/audits/blob/master/audits/OtterSec_Vyper_September_2023_audit.pdf>`__, `CodeHawks <https://github.com/vyperlang/audits/blob/master/audits/CodeHawks_Vyper_September_2023_competitive_audit.md>`__, `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_September_2023_limited_review.pdf>`__
 
 Breaking changes:
 -----------------
@@ -756,7 +756,7 @@ Date released: 2023-05-29
 
 This is a patch release fix for v0.3.8. @bout3fiddy discovered a codesize regression for blueprint contracts in v0.3.8 which is fixed in this release. @bout3fiddy also discovered a runtime performance (gas) regression for default functions in v0.3.8 which is fixed in this release.
 
-Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_May_2023_limited_review.pdf>`_
+Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_May_2023_limited_review.pdf>`__
 
 Fixes:
 
@@ -769,7 +769,7 @@ v0.3.8
 
 Date released: 2023-05-23
 
-Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_January_2023_limited_review.pdf>`_, `ChainSecurity 2nd audit <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_March_2023_limited_review.pdf>`_
+Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_January_2023_limited_review.pdf>`__, `ChainSecurity 2nd audit <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_March_2023_limited_review.pdf>`__
 
 Non-breaking changes and improvements:
 
@@ -944,7 +944,7 @@ v0.3.4
 
 Date released: 2022-07-27
 
-Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_July_2022_limited_review.pdf>`_
+Audits: `ChainSecurity <https://github.com/vyperlang/audits/blob/master/audits/ChainSecurity_Vyper_July_2022_limited_review.pdf>`__
 
 Non-breaking changes and improvements:
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -55,7 +55,7 @@ EVM Version
 The EVM version can be set with the ``evm-version`` pragma, which is documented in :ref:`evm-version`.
 
 Experimental Code Generation
------------------
+----------------------------
 The new experimental code generation feature can be activated using the following directive:
 
 .. code-block:: vyper
@@ -231,7 +231,7 @@ Events provide an interface for the EVM's logging facilities. Events may be logg
 
 See the :ref:`Event <event-logging>` documentation for more information.
 
-.. _interfaces:
+.. _structure-interfaces:
 
 Interfaces
 ==========

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -188,6 +188,7 @@ Therefore, a module encapsulates
 Modules can be added to contracts by importing them from a ``.vy`` file. Any ``.vy`` file is a valid module which can be imported into another contract! This is a very powerful feature which allows you to assemble contracts via other contracts as building blocks.
 
 .. code-block:: vyper
+
     # my_module.vy
 
     def perform_some_computation() -> uint256:
@@ -198,6 +199,7 @@ Modules can be added to contracts by importing them from a ``.vy`` file. Any ``.
         return 6
 
 .. code-block:: vyper
+
     import my_module
 
     exports: my_module.some_external_function

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+Pygments<2.19
 shibuya==2024.1.17
 sphinx==7.2.6
 sphinx-copybutton==0.5.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-Pygments<2.19
+Pygments==2.18.0
 shibuya==2024.1.17
 sphinx==7.2.6
 sphinx-copybutton==0.5.2

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -44,7 +44,7 @@ implementation paragraph here...
 EOF
 
 # 2. Format it (wraps at 72 chars, preserves lists/code blocks)
-python fmt_commit_msg.py   # reads and overwrites commitmsg.txt
+python fmt_commit_msg.py   # reads/overwrites commitmsg.txt, prints result to stdout
 
 # 3. Get the current PR body
 gh pr view <N> --json body -q .body > /tmp/pr_body.md

--- a/skills/contributing.md
+++ b/skills/contributing.md
@@ -69,6 +69,8 @@ The body is the most important part. It should answer:
 Don't enumerate every file touched or mechanically list what each function does — that's the diff.
 Do explain the *reasoning* behind structural decisions, the bug mechanism, or the design rationale.
 
+Commit messages should not be tied to a particular issue tracker. Use `GH 1234` instead of `#1234` — the `#` syntax is GitHub-specific and creates links that are meaningless outside GitHub.
+
 ### Good Example (from recent history)
 
 ```


### PR DESCRIPTION
_co-authored by claude opus 4.6_

### What I did

Fix the docs CI build which is currently failing with `AttributeError: 'int' object has no attribute 'replace'`. Supersedes #4902 (includes those changes plus additional fixes).

### How I did it

- **Pin `Pygments==2.18.0`**: `pygments>=2.19` changed `linespans` to require strings, which crashes with `shibuya==2024.1.17`. This is the root cause of the CI failure.
- **Add blank lines after `code-block` directives** (from #4902): missing blank lines caused sphinx to treat code as directive arguments.
- **Use anonymous refs (`` >`__ ``)** for audit links in `release-notes.rst`: repeated named targets like `ChainSecurity` caused duplicate target warnings.
- **Fix inline literal**: `` ``phi``s `` → `` ``phi``\s `` to avoid "start-string without end-string" warning.
- **Fix title underline length** in `structure-of-a-contract.rst` for "Experimental Code Generation" section.
- **Rename duplicate label**: `.. _interfaces:` in `structure-of-a-contract.rst` → `.. _structure-interfaces:` to avoid conflict with `interfaces.rst`.
- **Update skills/contributing.md**: note that `fmt_commit_msg.py` prints to stdout, and that commit messages should not use issue-tracker-specific syntax.

### How to verify it

CI docs job should pass.

### Commit message

```
fix[docs]: fix docs CI build

the docs CI build crashes with `AttributeError: 'int' object has no
attribute 'replace'` due to pygments>=2.19 passing an int for
`linespans` which shibuya==2024.1.17 doesn't handle. pin
Pygments==2.18.0 as a stopgap.

also fix several rst warnings that were already present: duplicate named
targets for audit links (use anonymous refs), an inline literal without
end-string, a title underline that was too short, and a duplicate `..
_interfaces:` label.

also update skills/contributing.md to note that fmt_commit_msg.py prints
to stdout, and that commit messages should not use issue-tracker-
specific syntax (use `GH 1234` not `#1234`).
```

### Description for the changelog

n/a

### Cute Animal Picture

![capybara](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Capybara_%28Hydrochoerus_hydrochaeris%29.JPG/1280px-Capybara_%28Hydrochoerus_hydrochaeris%29.JPG)





