### PR TITLE
chore[docs]: document @abstract and @override decorators

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -309,6 +309,8 @@ Decorator                       Description
 ``@payable``                    Function is able to receive Ether
 ``@nonreentrant``               Function cannot be called back into during an external call
 ``@raw_return``                 Function returns raw bytes without ABI-encoding (``@external`` functions only)
+``@abstract``                   Function body must be ``...``; an ``@override`` must provide the implementation (see :ref:`abstract-methods`)
+``@override(module)``           Function provides the implementation for an ``@abstract`` function in ``module`` (see :ref:`abstract-methods`)
 =============================== ===========================================================
 
 Raw Return

--- a/docs/solidity-differences.rst
+++ b/docs/solidity-differences.rst
@@ -98,6 +98,8 @@ Three declarations manage module relationships: ``initializes`` (this contract m
 
 A contract can be understood by reading one file and its direct imports; dependencies and what is exposed in the external function table are explicit.
 
+Solidity's ``abstract contract`` and ``virtual`` / ``override`` keywords belong to its inheritance model. Vyper's ``@abstract`` and ``@override`` decorators apply only to internal module functions and are resolved at compile time against a single initializing module, so there is no virtual dispatch and no method-resolution order. See :ref:`abstract-methods` for details.
+
 No Inline Assembly
 ==================
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -208,7 +208,7 @@ Modules can be added to contracts by importing them from a ``.vy`` file. Any ``.
     def foo() -> uint256:
         return my_module.perform_some_computation()
 
-Modules are opt-in by design. That is, any operations involving state or exposing external functions must be explicitly opted into using the ``exports``, ``uses`` or ``initializes`` keywords. See the :ref:`Modules <modules>` documentation for more information.
+Modules are opt-in by design. That is, any operations involving state or exposing external functions must be explicitly opted into using the ``exports``, ``uses`` or ``initializes`` keywords. A module can also declare internal functions whose bodies another module must supply, using the :ref:`@abstract and @override decorators <abstract-methods>`. See the :ref:`Modules <modules>` documentation for more information.
 
 Events
 ======

--- a/docs/using-modules.rst
+++ b/docs/using-modules.rst
@@ -189,6 +189,92 @@ Sometimes, you may encounter a module which itself ``uses`` other modules. Vyper
 .. warning::
     In normal usage, you should make sure that ``__init__()`` functions are called in dependency order. In the above example, you can get unexpected behavior if ``ownable_2step.__init__()`` is called before ``ownable.__init__()``! The compiler may enforce this behavior in the future.
 
+.. _abstract-methods:
+
+Abstract methods and overrides
+==============================
+
+A module can declare an **internal** function whose body another module must supply. The declaration uses the ``@abstract`` decorator and leaves the body as ``...``. A concrete function in the module that initializes the abstract's module supplies the body, marked with ``@override``. Every call to an abstract function is resolved to its concrete override at compile time; there is no runtime dispatch table.
+
+The following module declares a transfer hook and calls it from its own code:
+
+.. code-block:: vyper
+
+    # hook.vy
+
+    event Transfer:
+        sender: indexed(address)
+        recipient: indexed(address)
+        amount: uint256
+
+    @external
+    def transfer(to: address, amount: uint256):
+        # ... transfer logic
+        self._on_transfer(to, amount)
+
+    @abstract
+    def _on_transfer(to: address, amount: uint256): ...
+
+A module that initializes ``hook`` must provide ``_on_transfer``:
+
+.. code-block:: vyper
+
+    # token.vy
+
+    import hook
+
+    initializes: hook
+
+    exports: hook.transfer
+
+    @override(hook)
+    def _on_transfer(to: address, amount: uint256):
+        log hook.Transfer(sender=msg.sender, recipient=to, amount=amount)
+
+The call to ``self._on_transfer`` inside ``hook.transfer`` resolves at compile time to the concrete body in ``token``. Compiling ``token.vy`` produces a contract whose ``transfer`` entry runs the override's body.
+
+Rules
+-----
+
+* ``@abstract`` and ``@override`` apply only to internal functions. They are rejected on ``@external``, on ``@deploy``, and in ``.vyi`` interface files.
+* An ``@abstract`` function's body must be ``...``. A leading docstring is allowed.
+* A module that declares ``@override(M)`` must also declare ``initializes: M``.
+* A module that initializes another module which contains abstract functions must provide exactly one override for each of them. Zero overrides raise ``Abstract function was not overridden``. A duplicate override raises ``... was already overridden in ...``.
+* A single function may carry several ``@override(...)`` decorators to override abstracts from multiple modules, as long as the containing module initializes each one. The overriding function's name must match the abstract's name in every listed module; a mismatch is reported as ``Tried to override M.name, but it does not exist``.
+* Abstract functions can only live in imported modules. A top-level contract that declares ``@abstract`` has no module above it to supply the override, so it fails the override-coverage rule with ``Abstract function was not overridden`` pointing at the abstract's own line.
+
+Signature compatibility
+-----------------------
+
+The compiler checks each override's signature against the abstract's:
+
+* Parameter names must match, in order.
+* For parameters whose type takes a size (``String[N]``, ``Bytes[N]``, ``DynArray[_, N]``), the override's ``N`` must be greater than or equal to the abstract's. For other parameter types the two must be the same.
+* The return type must match, or for sized types the override's ``N`` must be less than or equal to the abstract's.
+* Mutability on the override may be the same or stricter, in the order ``payable > nonpayable > view > pure``.
+* ``@nonreentrant`` must be present on both or on neither.
+* Default values: if the abstract writes ``...`` as the default, the override may supply any concrete default; if the abstract writes a concrete default, the override's must be the same expression. The override may add a default where the abstract had none. The override may not remove a default the abstract declared.
+
+When a signature fails these rules, the compiler reports ``Override parameter mismatch: Got X, but expected Y (or more general)``.
+
+Dispatch and call paths
+-----------------------
+
+Calls to an abstract function resolve at compile time to the concrete override. There is no virtual dispatch.
+
+To call an abstract function from a module other than the one that declared it, add ``uses:`` for that module at the top of the calling file. Omitting this raises ``Cannot access abstract methods of 'X'`` with the hint ``add 'uses: X' as a top-level statement to your contract``. If a shorter path to the override is already reachable from the caller (through ``self``, or through a module the caller has initialized), the compiler requires that shorter path instead and reports ``Abstract method `X` is overridden by `Y`, call that instead.``
+
+Call sites see the **abstract's** signature, not the override's. An abstract declared without ``@view`` cannot be called from a ``@view`` caller, even when the concrete override happens to be ``@view``. Mark the abstract with the mutability its call sites require.
+
+The compiler tracks an override's side effects. Events declared in a module that contains abstract functions and emitted only inside an override still appear in the compiled contract's ABI. Reads and writes performed by an override count as accesses on the initializing module.
+
+An overriding function may itself be marked ``@abstract``, stacking ``@abstract`` with ``@override(parent)``. The concrete body then lives in a further module down the import tree. This is a niche pattern; typical code provides a concrete override directly.
+
+Abstract methods versus ``.vyi`` interfaces
+-------------------------------------------
+
+A ``.vyi`` file describes an external ABI for calls between deployed contracts. ``@abstract`` describes a function another module in the same compilation target must define. Use ``.vyi`` for external call surfaces. Use ``@abstract`` for internal hooks inside a module tree.
+
 .. _exporting-functions:
 
 Exporting functions


### PR DESCRIPTION
### What I did

Documented the `@abstract` and `@override` decorators added in [GH 4875](https://github.com/vyperlang/vyper/pull/4875). The feature landed without user-facing docs; this adds a new "Abstract methods and overrides" section in `using-modules.rst` and cross-references it from three adjacent pages.

### How I did it

- New section in `docs/using-modules.rst` placed between *Initializing a module with dependencies* and *Exporting functions*. Opens with a worked two-module example (`hook.vy` + `token.vy`), then four subsections: Rules, Signature compatibility, Dispatch and call paths, Abstract methods versus `.vyi` interfaces.
- Two rows added to the Decorators Reference table in `docs/control-structures.rst`.
- One sentence appended to the Modules subsection of `docs/structure-of-a-contract.rst` pointing to the new section.
- Two-sentence entry added under *No Class Inheritance* in `docs/solidity-differences.rst` contrasting with Solidity's `abstract contract` / `virtual` / `override`.

### How to verify it

```bash
# Sphinx build produces no new warnings on the edited files
uv run --with-requirements requirements-docs.txt \
  sphinx-build -b html docs /tmp/vyper-docs

# The worked example compiles as-is
mkdir -p /tmp/docs-ex
# (copy hook.vy and token.vy from the new section into /tmp/docs-ex/)
vyper /tmp/docs-ex/token.vy -p /tmp/docs-ex
```

### Commit message

```
GH 4875 merged the @abstract and @override decorators without user-
facing documentation. Add a new "Abstract methods and overrides" section
in using-modules.rst covering syntax, the override-coverage and
initialization rules, signature compatibility (parameter names and
sizes, return type, mutability ordering, @nonreentrant, default values),
compile-time dispatch with the shortest-reachable-path rule, and the
distinction from .vyi external interfaces. The worked example compiles
as-is.

Add cross-references from the Decorators Reference table in control-
structures.rst, the Modules subsection of structure-of-a-contract.rst,
and the No Class Inheritance section of solidity-differences.rst so
readers arriving from those entry points land in the new section.
```

### Description for the changelog

Documented the `@abstract` and `@override` decorators.