### PR TITLE
fix[venom]: spiller stack invalidation

### DIFF
--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper.ir.compile_ir import Label
-from vyper.venom.basicblock import IRLiteral, IRVariable, IROperand
+from vyper.venom.basicblock import IRLiteral, IROperand, IRVariable
 from vyper.venom.context import IRContext
 from vyper.venom.parser import parse_venom
 from vyper.venom.stack_model import StackModel
@@ -256,6 +256,7 @@ def test_stack_reorder_operand_not_in_stack_but_spilled() -> None:
     # Assembly should contain PUSH and MLOAD to restore
     assert "MLOAD" in assembly
 
+
 def test_stack_spill_stack_invalidation_error():
     dummy_function = """
     function spill_demo {
@@ -273,7 +274,7 @@ def test_stack_spill_stack_invalidation_error():
     stack = StackModel()
     a = IRVariable("%a")
     b = IRVariable("%b")
-    
+
     expected_stack: list[IROperand] = [a, b]
 
     stack.push(b)
@@ -287,4 +288,3 @@ def test_stack_spill_stack_invalidation_error():
 
     # Try to reorder with spilled_var as target (should restore it from memory)
     compiler._stack_reorder(assembly, stack, expected_stack, spilled, dry_run=False)
-

--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper.ir.compile_ir import Label
-from vyper.venom.basicblock import IRLiteral, IRVariable
+from vyper.venom.basicblock import IRLiteral, IRVariable, IROperand
 from vyper.venom.context import IRContext
 from vyper.venom.parser import parse_venom
 from vyper.venom.stack_model import StackModel
@@ -255,3 +255,36 @@ def test_stack_reorder_operand_not_in_stack_but_spilled() -> None:
     assert spilled_var not in spilled  # Should have been removed from spilled dict
     # Assembly should contain PUSH and MLOAD to restore
     assert "MLOAD" in assembly
+
+def test_stack_spill_stack_invalidation_error():
+    dummy_function = """
+    function spill_demo {
+    main:
+        ret 0
+    }
+    """
+
+    ctx = parse_venom(dummy_function)
+    compiler = VenomCompiler(ctx)
+    compiler.dfg = _dummy_dfg()
+    compiler.spiller._current_function = next(ctx.get_functions())
+    compiler.spiller._next_spill_offset = 0x1000
+
+    stack = StackModel()
+    a = IRVariable("%a")
+    b = IRVariable("%b")
+    
+    expected_stack: list[IROperand] = [a, b]
+
+    stack.push(b)
+    for i in range(20):
+        stack.push(IRVariable(f"%{i}"))
+    stack.push(a)
+
+    spilled: dict = {}
+
+    assembly: list = []
+
+    # Try to reorder with spilled_var as target (should restore it from memory)
+    compiler._stack_reorder(assembly, stack, expected_stack, spilled, dry_run=False)
+

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -248,7 +248,6 @@ class VenomCompiler:
             assert depth != StackModel.NOT_IN_STACK
             if depth == final_stack_depth:
                 continue
-            assert depth >= -16, depth
 
             to_swap = stack.peek(final_stack_depth)
             if self.dfg.are_equivalent(op, to_swap):

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -245,7 +245,7 @@ class VenomCompiler:
             final_stack_depth = -(len(stack_ops) - i - 1)
 
             depth = stack.get_depth(op)
-            assert depth_order != StackModel.NOT_IN_STACK
+            assert depth != StackModel.NOT_IN_STACK
             if depth == final_stack_depth:
                 continue
             assert depth >= -16, depth

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -222,30 +222,36 @@ class VenomCompiler:
         ), f"duplicated stack {stack_ops}"  # precondition
 
         cost = 0
-        for i, op in enumerate(stack_ops):
-            final_stack_depth = -(len(stack_ops) - i - 1)
+        
+        # restore spilled ops
+        for op in reversed(stack_ops):
+            if op in spilled:
+                assert isinstance(op, IRVariable)
+                self.spiller.restore_spilled_operand(
+                    assembly, stack, spilled, op, dry_run=dry_run
+                )
+        
+        depth_order = stack_ops.copy()
+        depth_order.sort(key=lambda x: stack.get_depth(x))
 
+        for op in depth_order:
             depth = stack.get_depth(op)
-
-            if depth == StackModel.NOT_IN_STACK:
-                if isinstance(op, IRVariable) and op in spilled:
-                    self.spiller.restore_spilled_operand(
-                        assembly, stack, spilled, op, dry_run=dry_run
-                    )
-                    depth = stack.get_depth(op)
-                else:  # pragma: nocover
-                    raise CompilerPanic(f"Variable {op} not in stack")
-
             if depth < -16:
                 # Try to selectively spill items to bring target within SWAP16
                 # range. If this fails, swap() handles it via bulk spill/restore.
                 self._reduce_depth_via_spill(
                     assembly, stack, spilled, stack_ops, op, depth, dry_run
                 )
-                depth = stack.get_depth(op)
 
+
+        for i, op in enumerate(stack_ops):
+            final_stack_depth = -(len(stack_ops) - i - 1)
+
+            depth = stack.get_depth(op)
+            assert depth_order != StackModel.NOT_IN_STACK
             if depth == final_stack_depth:
                 continue
+            assert depth >= -16, depth
 
             to_swap = stack.peek(final_stack_depth)
             if self.dfg.are_equivalent(op, to_swap):
@@ -562,6 +568,7 @@ class VenomCompiler:
 
         # final step to get the inputs to this instruction ordered
         # correctly on the stack
+
         self._stack_reorder(assembly, stack, operands, spilled)
 
         # some instructions (i.e. invoke) need to do stack manipulations

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -224,7 +224,7 @@ class VenomCompiler:
         cost = 0
         
         # restore spilled ops
-        for op in reversed(stack_ops):
+        for op in stack_ops:
             if op in spilled:
                 assert isinstance(op, IRVariable)
                 self.spiller.restore_spilled_operand(

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -222,15 +222,13 @@ class VenomCompiler:
         ), f"duplicated stack {stack_ops}"  # precondition
 
         cost = 0
-        
+
         # restore spilled ops
         for op in stack_ops:
             if op in spilled:
                 assert isinstance(op, IRVariable)
-                self.spiller.restore_spilled_operand(
-                    assembly, stack, spilled, op, dry_run=dry_run
-                )
-        
+                self.spiller.restore_spilled_operand(assembly, stack, spilled, op, dry_run=dry_run)
+
         depth_order = stack_ops.copy()
         depth_order.sort(key=lambda x: stack.get_depth(x))
 
@@ -242,7 +240,6 @@ class VenomCompiler:
                 self._reduce_depth_via_spill(
                     assembly, stack, spilled, stack_ops, op, depth, dry_run
                 )
-
 
         for i, op in enumerate(stack_ops):
             final_stack_depth = -(len(stack_ops) - i - 1)


### PR DESCRIPTION
### What I did
Fix an error from https://github.com/vyperlang/vyper/issues/4930 it was caused by stack invalidation during the stack spill

### How I did it
Did spilling and stack reordering in distinct parts (not interleaved as it was done)

### How to verify it

### Commit message

```
Fix an error from https://github.com/vyperlang/vyper/issues/4930 it was caused by stack invalidation during the stack spill
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
