### PR TITLE
feat[venom]: gas bench

### DIFF
--- a/.github/scripts/compare_gas.py
+++ b/.github/scripts/compare_gas.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Compare gas usage between base and head and generate markdown report."""
+
+import json
+import sys
+
+
+def fmt_row(test, base_entry, head_entry):
+    # returns (display_row, delta_for_sorting, kind) where kind in
+    # {"new", "deleted", "broke", "fixed", "regression", "improvement", "unchanged"}
+    base_gas = base_entry.get("gas") if base_entry else None
+    head_gas = head_entry.get("gas") if head_entry else None
+    base_status = base_entry.get("status") if base_entry else None
+    head_status = head_entry.get("status") if head_entry else None
+
+    if base_entry is None and head_entry is not None:
+        return f"| {test} | - | ➕ **{head_gas}** | new |", 0, "new"
+    if base_entry is not None and head_entry is None:
+        return f"| {test} | **{base_gas}** | - | 🗑️ |", 0, "deleted"
+    # status flips: forge marks suite-level breakage at the test level too
+    if base_status == "Success" and head_status != "Success":
+        return f"| {test} | **{base_gas}** | 💥 | failing ({head_status}) |", 0, "broke"
+    if base_status != "Success" and head_status == "Success":
+        return f"| {test} | ❌ | 🔧 **{head_gas}** | fixed |", 0, "fixed"
+    if base_gas is None or head_gas is None:
+        return None
+    if base_gas == head_gas:
+        return None
+    delta = head_gas - base_gas
+    sign = "+" if delta > 0 else ""
+    icon = "🔴" if delta > 0 else "🟢"
+    return (
+        f"| {test} | **{base_gas}** | **{head_gas}** | {icon}{sign}{delta} |",
+        delta,
+        ("regression" if delta > 0 else "improvement"),
+    )
+
+
+def generate_report(base_path, head_path):
+    with open(base_path) as f:
+        base = json.load(f)["tests"]
+    with open(head_path) as f:
+        head = json.load(f)["tests"]
+
+    all_tests = sorted(set(base.keys()) | set(head.keys()))
+    rows = []
+    regressions = []
+    improvements = []
+    new_count = 0
+    deleted_count = 0
+    broke_count = 0
+    fixed_count = 0
+
+    for test in all_tests:
+        result = fmt_row(test, base.get(test), head.get(test))
+        if result is None:
+            continue
+        row, delta, kind = result
+        rows.append((row, delta, kind, test))
+        if kind == "regression":
+            regressions.append((test, delta))
+        elif kind == "improvement":
+            improvements.append((test, delta))
+        elif kind == "new":
+            new_count += 1
+        elif kind == "deleted":
+            deleted_count += 1
+        elif kind == "broke":
+            broke_count += 1
+        elif kind == "fixed":
+            fixed_count += 1
+
+    rows.sort(key=lambda r: abs(r[1]), reverse=True)
+
+    header = "| Test | Base Gas | Head Gas | Delta |"
+    sep = "|---|---|---|---|"
+
+    if rows:
+        body = "## Gas Changes\n\n" + header + "\n" + sep + "\n" + "\n".join(r[0] for r in rows)
+    else:
+        body = "## Gas Changes\n\nNo changes detected."
+
+    total = len(set(base.keys()) | set(head.keys()))
+    changed = len(rows)
+    top_reg = max(regressions, key=lambda r: r[1]) if regressions else None
+    top_imp = min(improvements, key=lambda r: r[1]) if improvements else None
+
+    body += "\n\n## Summary\n\n"
+    body += f"- Total tests measured: {total}\n"
+    body += f"- Changed: {changed}\n"
+    body += f"- Regressions (gas up): {len(regressions)}\n"
+    body += f"- Improvements (gas down): {len(improvements)}\n"
+    body += f"- New tests: {new_count}\n"
+    body += f"- Deleted tests: {deleted_count}\n"
+    body += f"- Newly failing: {broke_count}\n"
+    body += f"- Newly passing: {fixed_count}\n"
+    if top_reg:
+        body += f"- Top regression: `{top_reg[0]}` (+{top_reg[1]})\n"
+    if top_imp:
+        body += f"- Top improvement: `{top_imp[0]}` ({top_imp[1]})\n"
+
+    return body
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <base.json> <head.json>", file=sys.stderr)
+        sys.exit(1)
+    print(generate_report(sys.argv[1], sys.argv[2]))

--- a/.github/scripts/compare_gas.py
+++ b/.github/scripts/compare_gas.py
@@ -13,7 +13,11 @@ def fmt_row(test, base_entry, head_entry):
     base_status = base_entry.get("status") if base_entry else None
     head_status = head_entry.get("status") if head_entry else None
 
+    # a brand-new test that fails on head must surface as a failure, not a benign add,
+    # otherwise the "Newly failing" summary count under-reports regressions
     if base_entry is None and head_entry is not None:
+        if head_status != "Success":
+            return f"| {test} | - | 💥 | new failing ({head_status}) |", 0, "broke"
         return f"| {test} | - | ➕ **{head_gas}** | new |", 0, "new"
     if base_entry is not None and head_entry is None:
         return f"| {test} | **{base_gas}** | - | 🗑️ |", 0, "deleted"

--- a/.github/scripts/measure_gas.py
+++ b/.github/scripts/measure_gas.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Measure gas usage of snekmate's foundry test suite under the Venom backend.
+
+Usage:
+    python .github/scripts/measure_gas.py --snekmate-dir /path/to/snekmate
+    python .github/scripts/measure_gas.py --snekmate-dir /path/to/snekmate --include-fuzz
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def extract_gas(kind):
+    # forge --json reports kind as {"Unit": {"gas": N}} | {"Fuzz": {"median_gas": N, ...}} |
+    # {"Invariant": {...}}; pick the one numeric field that represents this run's gas
+    if not isinstance(kind, dict):
+        return None
+    for v in kind.values():
+        if not isinstance(v, dict):
+            continue
+        if "gas" in v:
+            return v["gas"]
+        # fuzz/invariant have no scalar gas; median is the most stable representative
+        if "median_gas" in v:
+            return v["median_gas"]
+    return None
+
+
+def run_forge(snekmate_dir):
+    env = os.environ.copy()
+    # default-venom is snekmate's profile that enables experimental_codegen=True (Venom backend)
+    env["FOUNDRY_PROFILE"] = "default-venom"
+    # pin fuzz/invariant seeds: identical compiled code must produce identical
+    # gas across runs, otherwise the diff drowns in fuzzer-input noise
+    env["FOUNDRY_FUZZ_SEED"] = "0x1"
+    env["FOUNDRY_INVARIANT_SEED"] = "0x1"
+    proc = subprocess.run(
+        ["forge", "test", "--json"], cwd=snekmate_dir, env=env, capture_output=True, text=True
+    )
+    return proc
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snekmate-dir", required=True, help="Path to snekmate checkout")
+    parser.add_argument(
+        "--include-fuzz", action="store_true", help="Include testFuzz_/invariant_ tests (noisy)"
+    )
+    args = parser.parse_args()
+
+    print(f"Running forge test in {args.snekmate_dir}...", file=sys.stderr)
+    proc = run_forge(args.snekmate_dir)
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        print("forge produced no parseable JSON on stdout", file=sys.stderr)
+        print("--- stderr ---", file=sys.stderr)
+        print(proc.stderr, file=sys.stderr)
+        print("--- stdout (head) ---", file=sys.stderr)
+        print(proc.stdout[:2000], file=sys.stderr)
+        sys.exit(proc.returncode if proc.returncode != 0 else 1)
+
+    tests = {}
+    total = 0
+    passing = 0
+    failing = 0
+    skipped_fuzz = 0
+    failing_names = []
+
+    for suite_path, suite in data.items():
+        contract_name = suite_path.split(":", 1)[1] if ":" in suite_path else suite_path
+        for test_name, result in suite.get("test_results", {}).items():
+            total += 1
+            base_name = test_name.split("(", 1)[0]
+            if not args.include_fuzz and (
+                base_name.startswith("testFuzz_") or base_name.startswith("invariant_")
+            ):
+                skipped_fuzz += 1
+                continue
+            status = result.get("status", "Unknown")
+            full_name = f"{contract_name}:{test_name}"
+            if status != "Success":
+                failing += 1
+                failing_names.append(full_name)
+                tests[full_name] = {"gas": None, "status": status}
+                continue
+            gas = extract_gas(result.get("kind"))
+            tests[full_name] = {"gas": gas, "status": status}
+            passing += 1
+
+    output = {
+        "tests": tests,
+        "metadata": {
+            "total_tests_seen": total,
+            "passing": passing,
+            "failing": failing,
+            "skipped_fuzz": skipped_fuzz,
+            "failing_tests": failing_names,
+        },
+    }
+
+    if proc.returncode != 0:
+        print(f"forge exited {proc.returncode}; reporting {failing} failing tests", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/measure_gas.py
+++ b/.github/scripts/measure_gas.py
@@ -37,8 +37,15 @@ def run_forge(snekmate_dir):
     # gas across runs, otherwise the diff drowns in fuzzer-input noise
     env["FOUNDRY_FUZZ_SEED"] = "0x1"
     env["FOUNDRY_INVARIANT_SEED"] = "0x1"
+    # --force clears cache/out: forge keys its build cache on source hash, not
+    # on the vyper version, so back-to-back runs against different vyper installs
+    # would otherwise reuse the first run's bytecode for unchanged .vy sources
     proc = subprocess.run(
-        ["forge", "test", "--json"], cwd=snekmate_dir, env=env, capture_output=True, text=True
+        ["forge", "test", "--force", "--json"],
+        cwd=snekmate_dir,
+        env=env,
+        capture_output=True,
+        text=True,
     )
     return proc
 

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -1,0 +1,140 @@
+name: Gas Benchmark Report
+
+on:
+  pull_request:
+    branches: [master]
+  pull_request_target:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gas-bench:
+    # pull_request: untrusted contributors only (step summary, no comment)
+    # pull_request_target: trusted contributors only (step summary + comment)
+    if: |
+      (github.event_name == 'pull_request' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      (github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invalidate existing comment
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- gas-bench-report -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (!existing) return;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body: marker + '\n\n⏳ **Recalculating gas benchmark...**'
+            });
+
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          path: head
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Copy scripts to base
+        run: cp -r head/.github/scripts base/.github/
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Checkout snekmate
+        uses: actions/checkout@v4
+        with:
+          repository: pcaversaccio/snekmate
+          ref: 37e1513dcb993dcc7e58f8c56aaeaaa14f8d8be8
+          submodules: recursive
+          path: snekmate
+
+      - name: Install vyper (base)
+        working-directory: base
+        run: pip install .
+
+      - name: Measure base gas
+        working-directory: base
+        run: python .github/scripts/measure_gas.py --snekmate-dir ../snekmate > ../base-gas.json
+
+      - name: Install vyper (merge)
+        working-directory: head
+        run: pip install .
+
+      - name: Measure merge gas
+        working-directory: head
+        run: python .github/scripts/measure_gas.py --snekmate-dir ../snekmate > ../head-gas.json
+
+      - name: Generate report
+        id: report
+        run: |
+          python3 head/.github/scripts/compare_gas.py base-gas.json head-gas.json > report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo 'REPORT<<EOF'
+            cat report.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- gas-bench-report -->';
+            const body = marker + '\n\n' + process.env.REPORT;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              return github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: body
+            });
+        env:
+          REPORT: ${{ steps.report.outputs.REPORT }}
+
+      - name: Upload gas data
+        uses: actions/upload-artifact@v4
+        with:
+          name: gas-results
+          path: |
+            base-gas.json
+            head-gas.json

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Invalidate existing comment
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- gas-bench-report -->';
@@ -40,7 +40,7 @@ jobs:
             });
 
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           path: head
@@ -48,7 +48,7 @@ jobs:
           fetch-tags: true
 
       - name: Checkout base
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
           path: base
@@ -59,15 +59,17 @@ jobs:
         run: cp -r head/.github/scripts base/.github/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+            version: nightly
 
       - name: Checkout snekmate
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pcaversaccio/snekmate
           ref: main
@@ -103,7 +105,7 @@ jobs:
 
       - name: Post or update PR comment
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- gas-bench-report -->';
@@ -132,7 +134,7 @@ jobs:
           REPORT: ${{ steps.report.outputs.REPORT }}
 
       - name: Upload gas data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gas-results
           path: |

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: pcaversaccio/snekmate
-          ref: 37e1513dcb993dcc7e58f8c56aaeaaa14f8d8be8
+          ref: main
           submodules: recursive
           path: snekmate
 


### PR DESCRIPTION
### What I did

Added a CI gas benchmark workflow that measures gas usage of the snekmate test suite under the Venom backend on every PR. The workflow compares gas between the base branch and the PR's merge commit, then posts a markdown report as a PR comment (trusted contributors) or step summary (untrusted contributors).

### How I did it

Three new files:

- **`.github/scripts/measure_gas.py`** — Runs `forge test --force --json` against a snekmate checkout using the `default-venom` foundry profile. Pins fuzz/invariant seeds for deterministic results. Excludes fuzz/invariant tests by default (`--include-fuzz` to opt in). Outputs structured JSON with per-test gas and status.

- **`.github/scripts/compare_gas.py`** — Takes two gas JSON files (base and head), diffs them, and generates a markdown report table sorted by absolute delta. Classifies changes as regression/improvement/new/deleted/broke/fixed. Includes summary counts and top regression/improvement.

- **`.github/workflows/gas-bench.yml`** — Dual-trigger workflow:
  - `pull_request`: runs for untrusted contributors, results in step summary only
  - `pull_request_target`: runs for OWNER/MEMBER/COLLABORATOR, posts results as a PR comment (idempotent — updates existing comment on re-runs)

  Steps: check out both base and merge commit, install vyper from each, checkout snekmate, measure gas with both versions, generate and post report. Scripts are copied from head to base so both vyper installs use the same measurement code.

### How to verify it

- Push a PR targeting master and observe the workflow run
- Check the step summary for the gas diff table
- For trusted contributors: verify the PR comment is posted and updated on re-runs
- Run `measure_gas.py` locally: `python .github/scripts/measure_gas.py --snekmate-dir /path/to/snekmate`
- Run `compare_gas.py` locally on two gas JSON files

### Commit message

```
add a CI gas benchmark that measures snekmate test suite gas usage
under the Venom backend on every PR.

the workflow (gas-bench.yml) triggers on both pull_request (for
untrusted contributors) and pull_request_target (for trusted
contributors). it checks out both the base and merge commit, installs
vyper from each, and measures gas using snekmate's foundry test suite
via the `default-venom` profile.

measure_gas.py wraps `forge test --force --json`, pinning fuzz seeds
for deterministic results and excluding noisy testFuzz_/invariant_
tests by default. it outputs structured JSON with per-test gas and
pass/fail status.

compare_gas.py diffs two gas JSON files and generates a markdown
report table sorted by absolute delta, classifying changes as
regression, improvement, new, deleted, broke, or fixed, with summary
counts.

for trusted contributors, the report is posted as a PR comment
(idempotent via an HTML marker). for untrusted contributors (fork
PRs), the report appears only in the step summary since the workflow
token lacks comment permissions.
```

### Description for the changelog

Add CI gas benchmark workflow measuring snekmate gas usage on PRs

### Cute Animal Picture

![A sleepy capybara](https://upload.wikimedia.org/wikipedia/commons/thumb/1/10/Capybara_%2826059686052%29.jpg/320px-Capybara_%2826059686052%29.jpg)
