### PR TITLE
fix[lang]: allow unused decimals without --allow-decimals

### DIFF
--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -339,6 +339,7 @@ def foo(x: decimal):
     finally:
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
 
+
 def test_decimals_blocked_in_struct():
     code = """
 struct MyStruct:
@@ -568,9 +569,6 @@ def foo() -> uint256:
     try:
         assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
         compiler_settings.DEFAULT_ENABLE_DECIMALS = False
-        compile_code(
-            code,
-            input_bundle=input_bundle,
-        )
+        compile_code(code, input_bundle=input_bundle)
     finally:
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -339,6 +339,44 @@ def foo(x: decimal):
     finally:
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
 
+def test_decimals_blocked_in_struct():
+    code = """
+struct MyStruct:
+    x: decimal
+
+@external
+def foo(s: MyStruct):
+    pass
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_blocked_in_event():
+    code = """
+event MyEvent:
+    x: decimal
+
+@external
+def foo():
+    log MyEvent(1.0)
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
 def test_unused_math_allowed_with_decimals_disabled():
     code = """
 import math

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -377,6 +377,114 @@ def foo():
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
 
 
+def test_decimals_blocked_in_state_variable():
+    code = """
+x: decimal
+
+@external
+def foo() -> decimal:
+    return self.x
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_blocked_in_constant():
+    code = """
+X: constant(decimal) = 1.0
+
+@external
+def foo() -> decimal:
+    return X
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_blocked_in_immutable():
+    code = """
+X: immutable(decimal)
+
+@deploy
+def __init__():
+    X = 1.0
+
+@external
+def foo() -> decimal:
+    return X
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_blocked_in_state_variable_nested():
+    code = """
+x: DynArray[decimal, 10]
+
+@external
+def foo() -> DynArray[decimal, 10]:
+    return self.x
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_unused_decimal_state_variable_allowed():
+    code = """
+x: decimal
+
+@external
+def foo() -> uint256:
+    return 1
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        compile_code(code)
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_unused_decimal_constant_allowed():
+    code = """
+X: constant(decimal) = 1.0
+
+@external
+def foo() -> uint256:
+    return 1
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        compile_code(code)
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
 def test_unused_math_allowed_with_decimals_disabled():
     code = """
 import math

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -497,6 +497,60 @@ import math
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
 
 
+def test_decimals_blocked_in_hashmap_value():
+    code = """
+x: HashMap[address, decimal]
+
+@external
+def foo() -> decimal:
+    return self.x[msg.sender]
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_blocked_in_hashmap_key():
+    code = """
+x: HashMap[decimal, uint256]
+
+@external
+def foo() -> uint256:
+    return self.x[1.0]
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_blocked_in_nested_hashmap():
+    code = """
+x: HashMap[address, HashMap[address, decimal]]
+
+@external
+def foo() -> decimal:
+    return self.x[msg.sender][msg.sender]
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
 def test_unused_imported_decimal_function_allowed_with_decimals_disabled(make_input_bundle):
     lib = """
 @internal

--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -338,3 +338,39 @@ def foo(x: decimal):
         assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
     finally:
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+def test_unused_math_allowed_with_decimals_disabled():
+    code = """
+import math
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        compile_code(code)
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_unused_imported_decimal_function_allowed_with_decimals_disabled(make_input_bundle):
+    lib = """
+@internal
+def f() -> decimal:
+    return 1.0
+    """
+    code = """
+import lib
+
+@external
+def foo() -> uint256:
+    return 1
+    """
+    input_bundle = make_input_bundle({"lib.vy": lib})
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        compile_code(
+            code,
+            input_bundle=input_bundle,
+        )
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True

--- a/tests/functional/codegen/types/numbers/test_isqrt.py
+++ b/tests/functional/codegen/types/numbers/test_isqrt.py
@@ -53,6 +53,7 @@ def test(a: uint256) -> uint256:
     assert c.test(val) == math.isqrt(val)
     assert c.test(0) == 0
 
+
 def test_isqrt_compiles_with_decimals_disabled():
     code = """
 import math
@@ -67,7 +68,6 @@ def test(a: uint256) -> uint256:
         compile_code(code)
     finally:
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
-
 
 
 def test_isqrt_internal_variable(get_contract):

--- a/tests/functional/codegen/types/numbers/test_isqrt.py
+++ b/tests/functional/codegen/types/numbers/test_isqrt.py
@@ -3,6 +3,7 @@ import math
 import hypothesis
 import pytest
 
+import vyper.compiler.settings as compiler_settings
 from vyper.compiler import compile_code
 from vyper.exceptions import UnimplementedException
 from vyper.utils import SizeLimits
@@ -51,6 +52,22 @@ def test(a: uint256) -> uint256:
     val = 10**17
     assert c.test(val) == math.isqrt(val)
     assert c.test(0) == 0
+
+def test_isqrt_compiles_with_decimals_disabled():
+    code = """
+import math
+
+@external
+def test(a: uint256) -> uint256:
+    return math.isqrt(a)
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        compile_code(code)
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
 
 
 def test_isqrt_internal_variable(get_contract):

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -5,12 +5,14 @@ from typing import Optional
 
 from vyper import ast as vy_ast
 from vyper.evm.opcodes import version_check
+from vyper.compiler.settings import get_global_settings
 from vyper.exceptions import (
     BorrowException,
     CallViolation,
     CompilerPanic,
     EvmVersionException,
     ExceptionList,
+    FeatureException,
     FunctionDeclarationException,
     ImmutableViolation,
     InitializerException,
@@ -95,6 +97,14 @@ def analyze_modules(imports: ImportAnalyzer) -> ModuleT:
     # (needs to be after reachable set with overrides computation since used_events depends on it)
     for module_ast in modules:
         module_ast._metadata["type"].validate_used_events()
+
+    root_module_t = root_module_ast._metadata["type"]
+
+    # Errors out if decimals are used, but not enabled
+    settings = get_global_settings()
+    if settings and not settings.get_enable_decimals():
+        if any(func_t.uses_decimal() for func_t in root_module_t.reachable_functions):
+            raise FeatureException("decimals are not allowed unless `--enable-decimals` is set")
 
     return ret
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -4,8 +4,8 @@ from itertools import zip_longest
 from typing import Optional
 
 from vyper import ast as vy_ast
-from vyper.evm.opcodes import version_check
 from vyper.compiler.settings import get_global_settings
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
     BorrowException,
     CallViolation,

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -869,6 +869,12 @@ class ContractFunctionT(VyperType):
                 if _contains_decimal(typ):
                     return True
 
+        # body variable accesses
+        for var_access in self.get_variable_accesses():
+            if _contains_decimal(var_access.variable.typ):
+                return True
+
+
         # emitted events
         for event_t in self._emitted_events:
             for member_t in event_t.arguments.values():

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -869,6 +869,12 @@ class ContractFunctionT(VyperType):
                 if _contains_decimal(typ):
                     return True
 
+        # emitted events
+        for event_t in self._emitted_events:
+            for member_t in event_t.arguments.values():
+                if _contains_decimal(member_t):
+                    return True
+
         return False
 
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -36,7 +36,7 @@ from vyper.semantics.analysis.utils import (
 from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.types.base import KwargSettings, VyperType
 from vyper.semantics.types.bytestrings import BytesT
-from vyper.semantics.types.primitives import BoolT
+from vyper.semantics.types.primitives import BoolT, DecimalT
 from vyper.semantics.types.shortcuts import UINT256_T
 from vyper.semantics.types.subscriptable import TupleT
 from vyper.semantics.types.user import EventT
@@ -851,6 +851,41 @@ class ContractFunctionT(VyperType):
     def abi_signature_for_kwargs(self, kwargs: list[KeywordArg]) -> str:
         args = self.positional_args + kwargs  # type: ignore
         return self.name + "(" + ",".join([arg.typ.abi_type.selector_name() for arg in args]) + ")"
+
+    def uses_decimal(self) -> bool:
+        # param types
+        for param_t in self.argument_types:
+            if _contains_decimal(param_t):
+                return True
+
+        # return type
+        if self.return_type is not None and _contains_decimal(self.return_type):
+            return True
+
+        # body type annotations
+        if self.ast_def is not None and isinstance(self.ast_def, vy_ast.FunctionDef):
+            for node in self.ast_def.get_descendants(vy_ast.AnnAssign):
+                typ = type_from_annotation(node.annotation, DataLocation.MEMORY)
+                if _contains_decimal(typ):
+                    return True
+
+        return False
+
+
+def _contains_decimal(typ: VyperType) -> bool:
+    if isinstance(typ, DecimalT):
+        return True
+    if hasattr(typ, "value_type"):
+        if _contains_decimal(typ.value_type):
+            return True
+    if hasattr(typ, "member_types"):
+        member_types = typ.member_types
+        if isinstance(member_types, dict):
+            member_types = member_types.values()
+        for member_t in member_types:
+            if _contains_decimal(member_t):
+                return True
+    return False
 
 
 def is_ellipsis_body(body: list[vy_ast.VyperNode]) -> bool:

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -874,7 +874,6 @@ class ContractFunctionT(VyperType):
             if _contains_decimal(var_access.variable.typ):
                 return True
 
-
         # emitted events
         for event_t in self._emitted_events:
             for member_t in event_t.arguments.values():

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -887,6 +887,9 @@ class ContractFunctionT(VyperType):
 def _contains_decimal(typ: VyperType) -> bool:
     if isinstance(typ, DecimalT):
         return True
+    if hasattr(typ, "key_type"):
+        if _contains_decimal(typ.key_type):
+            return True
     if hasattr(typ, "value_type"):
         if _contains_decimal(typ.value_type):
             return True

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -1,9 +1,7 @@
 from vyper import ast as vy_ast
-from vyper.compiler.settings import get_global_settings
 from vyper.exceptions import (
     ArrayIndexException,
     CompilerPanic,
-    FeatureException,
     InstantiationException,
     InvalidType,
     StructureException,

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -91,15 +91,6 @@ def type_from_annotation(
         location_str = "" if location is DataLocation.UNSET else f"in {location.name.lower()}"
         raise InstantiationException(f"{typ} is not instantiable {location_str}", node)
 
-    # TODO: cursed import cycle!
-    from vyper.semantics.types.primitives import DecimalT
-
-    if isinstance(typ, DecimalT):
-        # is there a better place to put this check?
-        settings = get_global_settings()
-        if settings and not settings.get_enable_decimals():
-            raise FeatureException("decimals are not allowed unless `--enable-decimals` is set")
-
     return typ
 
 


### PR DESCRIPTION
### What I did

Fix #4580

Fix tests failing

Always allow decimals if they are unreachable

### How I did it

Add new pass in module analysis which checks no reachable function uses `decimal`

### How to verify it

### Commit message

```
move the decimal check from type resolution time to `analyze_modules`,
where it inspects only `reachable_functions`. done through helper
`ContractFunctionT.uses_decimal()` which walks param types, return type,
and body annotations to detect actual decimal usage in a function. 
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
