### PR TITLE
fix[ci]: enable decimals in bytecode measurement script

### DIFF
--- a/.github/scripts/measure_bytecode.py
+++ b/.github/scripts/measure_bytecode.py
@@ -32,7 +32,7 @@ def get_example_vy_filenames(limit: int | None = None):
 def compile_one(source_code: str, opt_level: OptimizationLevel, experimental: bool) -> tuple[int | None, str | None]:
     """Compile with given settings. Returns (size, error)."""
     try:
-        settings = Settings(experimental_codegen=experimental, optimize=opt_level)
+        settings = Settings(experimental_codegen=experimental, optimize=opt_level, enable_decimals=True)
         result = compiler.compile_code(source_code, settings=settings, output_formats=["bytecode"])
         bytecode = result.get("bytecode", "")
         size = (len(bytecode) - 2) // 2 if bytecode.startswith("0x") else len(bytecode) // 2


### PR DESCRIPTION
### What I did
Fixed the `measure_bytecode.py` script which failed to compile example contracts that use `isqrt`.

### How I did it
Added `enable_decimals=True` to the `Settings` constructor in `compile_one()`. The `isqrt` builtin requires decimal mode, and some thirdparty example contracts use it.

### How to verify it
Run `python .github/scripts/measure_bytecode.py --limit 5` — contracts using `isqrt` no longer produce compilation errors.

### Commit message

```
the measure_bytecode.py script omitted enable_decimals from its Settings
construction, causing compilation of example contracts that use isqrt
(which requires decimal mode) to fail. add enable_decimals=True so the
benchmark script can compile all thirdparty examples without errors.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
