### PR TITLE
chore[ci]: update `actions/checkout` and `actions/setup-python`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
             # grab the commit passed in via `tag`, if any
             ref: ${{ github.event.inputs.tag }}
@@ -41,7 +41,7 @@ jobs:
         run: git rev-parse --short HEAD
 
       - name: Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -67,7 +67,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
             # grab the commit passed in via `tag`, if any
             ref: ${{ github.event.inputs.tag }}
@@ -79,7 +79,7 @@ jobs:
         run: git rev-parse --short HEAD
 
       - name: Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/

--- a/.github/workflows/bytecode-size.yml
+++ b/.github/workflows/bytecode-size.yml
@@ -40,7 +40,7 @@ jobs:
             });
 
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           path: head
@@ -48,7 +48,7 @@ jobs:
           fetch-tags: true
 
       - name: Checkout base
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
           path: base
@@ -59,7 +59,7 @@ jobs:
         run: cp -r head/.github/scripts base/.github/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/era-tester.yml
+++ b/.github/workflows/era-tester.yml
@@ -27,7 +27,7 @@ jobs:
         echo "ERA_VYPER_HASH=$( curl -u "u:${{ github.token }}" https://api.github.com/repos/matter-labs/era-compiler-vyper/git/ref/heads/main | jq .object.sha | tr -d '"' )" >> $GITHUB_ENV
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Rust setup
       uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -35,7 +35,7 @@ jobs:
         toolchain: nightly-2022-11-03
 
     - name: Set up Python ${{ matrix.python-version[0] }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version[0] }}
         cache: "pip"

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
             # need to fetch unshallow so that setuptools_scm can infer the version
             fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install python
         with:
           python-version: "3.11"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -19,7 +19,7 @@ jobs:
     environment: release
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # fetch unshallow so commit hash matches github release.
         # see https://github.com/vyperlang/vyper/blob/8f9a8cac49aafb3fbc9dde78f0f6125c390c32f0/.github/workflows/build.yml#L27-L32
@@ -30,7 +30,7 @@ jobs:
       run: git rev-parse --short HEAD
 
     - name: Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
         cache: "pip"
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -70,10 +70,10 @@ jobs:
     name: symbolic-tests
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
         cache: "pip"
@@ -176,13 +176,13 @@ jobs:
           - os: macos
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
           # need to fetch unshallow so that setuptools_scm can infer the version
           fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version[0] || '3.11' }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version[0] || '3.11' }}
         cache: "pip"
@@ -239,10 +239,10 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
         cache: "pip"
@@ -294,10 +294,10 @@ jobs:
     needs: [tests, fuzzing]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
         cache: "pip"
@@ -342,7 +342,7 @@ jobs:
     needs: [coverage-report]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/download-artifact@v4
       with:
         name: coverage-artifacts

--- a/tests/unit/venom/test_branch_opt_liveness.py
+++ b/tests/unit/venom/test_branch_opt_liveness.py
@@ -4,8 +4,6 @@ def test_branch_optimization_liveness_mutation(get_contract):
     """
 
     code = """
-#pragma version ^0.5.0a1
-
 @external
 def f(a: bool) -> bool:
     self._h()

--- a/tests/unit/venom/test_branch_opt_liveness.py
+++ b/tests/unit/venom/test_branch_opt_liveness.py
@@ -4,7 +4,7 @@ def test_branch_optimization_liveness_mutation(get_contract):
     """
 
     code = """
-#pragma version ^0.4.0
+#pragma version ^0.5.0a1
 
 @external
 def f(a: bool) -> bool:


### PR DESCRIPTION
### What I did

This PR updates the GitHub Action versions of [`actions/checkout`](https://github.com/actions/checkout) and [`actions/setup-python`](https://github.com/actions/setup-python) to their latest versions. To update, I used the following command:

```bash
git grep -lE 'actions/(checkout@v4|setup-python@v5)' -- '*.yml' '*.yaml' |
xargs sed -i \
  -e 's/actions\/checkout@v4/actions\/checkout@v6/g' \
  -e 's/actions\/setup-python@v5/actions\/setup-python@v6/g'
```

### How I did it

Because I'm lazy, I used a `git grep` replace command.

### How to verify it

Obvious.

### Commit message

```
updated the GitHub Action versions of `actions/checkout` and
`actions/setup-python`. also remove an unneeded pragma from a venom test
case.
```

### Description for the changelog

chore[ci]: update `actions/checkout` and `actions/setup-python`

### Cute Animal Picture

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/0aa42fbf-cc1f-4b93-8252-7ab8f922ab89" />