### PR TITLE
chore[tool]: remove redundant logic from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,10 @@
-SHELL := /bin/bash
-
-ifeq (, $(shell which pip3))
-	pip := $(shell which pip3)
-else
-	pip := $(shell which pip)
-endif
-
 .PHONY: test dev-deps lint clean clean-pyc clean-build clean-test docs
 
 init:
 	python setup.py install
 
 dev-init:
-	${pip} install .[dev]
+	pip install .[dev]
 
 test:
 	pytest


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
the pip logic was inverted: it was meant to use pip3 if available
otherwise pip. but instead it used pip if pip3 was available and
otherwise failed. since there have been no issues with this faulty
logic, it implies everyone had pip as an alias for pip3, so the dispatch
is not needed. the 'which' in that logic was the last remaining bash-ism
in the makefile, so the SHELL variable is no longer needed.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
