### PR TITLE
chore[ux]: ignore format commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Commits that `git blame` should ignore
+# `git blame` only respects this file if it has been configured to do so, for example by running:
+# `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+
+96daf69740e120cb5af58193db35fc694e3d3e83

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Make sure you have `uv` installed
 3. Run `uv sync`
 4. Run `source .venv/bin/activate` to activate the virtual environment
 5. Run `vyper --version` to verify the setup
+6. (optional) Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to improve `git blame`
 
 #### pip
 
@@ -76,6 +77,7 @@ Make sure you have `pip`, `setuptools`, and `pytest` installed
 5. Run `make init` to install the main dependencies
 6. Run `make dev-init` to install the dev dependencies
 7. Run `vyper --version` to verify the setup
+6. (optional) Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` to improve `git blame`
 
 ### Commands
 


### PR DESCRIPTION
### What I did

Ignore the commit introduced by https://github.com/vyperlang/vyper/pull/4953

### How I did it

Add file to be used as a git blame ignore file

### How to verify it

Lines should point to the latest semantic change, and not to the formatting changes in #4953 

### Commit message

```
this commit adds a .git-blame-ignore-revs file to be used as a filter
for git blame. note that this file is used by default in some software,
including github. this commit also updates the README with instructions
on how to setup this file to be automatically used by git blame.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
