### PR TITLE
fix[lang]: forbid docstring-only function body

### DIFF
--- a/tests/functional/codegen/features/test_comments.py
+++ b/tests/functional/codegen/features/test_comments.py
@@ -9,3 +9,20 @@ def foo() -> int128:
     c = get_contract(comment_test)
     assert c.foo() == 3
     print("Passed comment test")
+
+
+def test_docstring_only_function_body(get_contract):
+    # a function whose body is only a docstring should compile (not IndexError)
+    code = """
+@external
+def foo():
+    "notice me"
+
+@external
+def bar() -> int128:
+    "another docstring"
+    return 3
+    """
+
+    c = get_contract(code)
+    assert c.bar() == 3

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -344,6 +344,9 @@ def parse_stmt(stmt, context):
 # it ends with an if/else and both branches are terminated.
 # (if not, we need to insert a terminator so that the IR is well-formed)
 def _is_terminated(code):
+    if not code:
+        return False
+
     last_stmt = code[-1]
 
     if last_stmt.is_terminus:


### PR DESCRIPTION
### What I did

Fixes #4965. A Vyper function whose body consists of only a docstring crashes the compiler with a bare `IndexError: list index out of range`.

### How I did it

The function-level docstring is consumed during parsing, leaving an empty body list for codegen. `_is_terminated` in `vyper/codegen/stmt.py` then does `code[-1]` on the empty list. Added an empty-list guard that returns `False`, so a terminator is inserted normally (same as a body with no terminating statement).

### How to verify it

```vyper
@external
def f():
    "notice me"
```

Previously raised `IndexError`; now compiles. Added a regression test in `tests/functional/codegen/features/test_comments.py`.

### Commit message

fix[codegen]: handle docstring-only function body

### Description for the changelog

Fix `IndexError` when compiling a function whose body is only a docstring.

### Cute Animal Picture

![](https://placekitten.com/400/300)