### PR TITLE
fix[lang]: fix overly conservative state access simulation for `__at__()`

### DIFF
--- a/tests/functional/syntax/modules/test_initializers.py
+++ b/tests/functional/syntax/modules/test_initializers.py
@@ -9,6 +9,7 @@ main properties to test:
 import pytest
 
 from vyper.compiler import compile_code
+from vyper.compiler.phases import CompilerData
 from vyper.exceptions import (
     BorrowException,
     CallViolation,
@@ -1758,3 +1759,55 @@ def test_foo() -> uint256:
 
     assert "abstract_module.vy` is used but never initialized!" in e.value._message
     assert "add `initializes: abstract_module`" in e.value._hint
+
+
+def test_at_call_does_not_propagate_writes(make_input_bundle):
+    # calling a module's function via __at__ is an external call.
+    # the callee's variable writes should NOT be propagated into
+    # the caller function's _variable_writes.
+    other = """
+counter: uint256
+
+@external
+def increment():
+    self.counter += 1
+    """
+    main = """
+import other
+
+@external
+def foo(addr: address):
+    extcall other.__at__(0x0000000000000000000000000000000000000000).increment()
+    """
+    input_bundle = make_input_bundle({"other.vy": other})
+
+    data = CompilerData(main, input_bundle=input_bundle)
+    foo_t = data.function_signatures["foo"]
+    assert len(foo_t._variable_writes) == 0
+
+
+def test_at_call_does_not_propagate_reads(make_input_bundle):
+    # calling a module's function via __at__ is an external call.
+    # the callee's variable reads should NOT be propagated into
+    # the caller function's _variable_reads.
+    lib = """
+counter: uint256
+
+@external
+@view
+def get_counter() -> uint256:
+    return self.counter
+    """
+    main = """
+import lib
+
+@external
+@view
+def foo() -> uint256:
+    return staticcall lib.__at__(0x0000000000000000000000000000000000000000).get_counter()
+    """
+    input_bundle = make_input_bundle({"lib.vy": lib})
+
+    data = CompilerData(main, input_bundle=input_bundle)
+    foo_t = data.function_signatures["foo"]
+    assert len(foo_t._variable_reads) == 0

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -952,7 +952,10 @@ class ExprVisitor(VyperNodeVisitorBase):
                     hint = f"remove the `{kind}` keyword"
                     raise CallViolation(msg, node.parent, hint=hint)
 
-            if not func_type.from_interface:
+            # methods from other contracts should not have their variable accesses added
+            # note that this logic will be insufficient if we add a way to
+            # internally call external methods
+            if func_type.is_internal:
                 for s in func_type.get_variable_writes():
                     if s.variable.is_state_variable():
                         func_info._writes.add(s)


### PR DESCRIPTION
### What I did

### How I did it

### How to verify it

### Commit message

```
`__at__` calls dispatch to another contract, so the callee's storage
reads and writes should not be tracked as part of the caller's variable
accesses. the existing guard was overly conservative and could throw
false positives for variable/state access protection mechanisms.

Switch the condition to `func_type.is_internal`, which correctly limits
variable-access propagation to internal calls only.
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
