### PR TITLE
fix[lang]: forbid docstring-only function body

### DIFF
--- a/tests/functional/codegen/features/test_comments.py
+++ b/tests/functional/codegen/features/test_comments.py
@@ -9,3 +9,20 @@ def foo() -> int128:
     c = get_contract(comment_test)
     assert c.foo() == 3
     print("Passed comment test")
+
+
+def test_docstring_only_function_body(get_contract):
+    # a function whose body is only a docstring should compile (not IndexError)
+    code = """
+@external
+def foo():
+    "notice me"
+
+@external
+def bar() -> int128:
+    "another docstring"
+    return 3
+    """
+
+    c = get_contract(code)
+    assert c.bar() == 3

--- a/tests/functional/codegen/features/test_comments.py
+++ b/tests/functional/codegen/features/test_comments.py
@@ -1,3 +1,9 @@
+import pytest
+
+from vyper.compiler import compile_code
+from vyper.exceptions import FunctionDeclarationException
+
+
 def test_comment_test(get_contract):
     comment_test = """
 @external
@@ -11,18 +17,25 @@ def foo() -> int128:
     print("Passed comment test")
 
 
-def test_docstring_only_function_body(get_contract):
-    # a function whose body is only a docstring should compile (not IndexError)
+def test_docstring_with_body(get_contract):
     code = """
-@external
-def foo():
-    "notice me"
-
 @external
 def bar() -> int128:
     "another docstring"
     return 3
     """
-
     c = get_contract(code)
     assert c.bar() == 3
+
+
+def test_docstring_without_body_fails():
+    code = """
+@external
+def foo():
+    "notice me"
+    """
+
+    with pytest.raises(FunctionDeclarationException) as e:
+        compile_code(code)
+    assert e.value.message == "Function body cannot consist of only a docstring"
+    assert e.value.hint == "add a `pass` statement to the function body"

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -14,6 +14,7 @@ from vyper.compiler.settings import VYPER_ERROR_CONTEXT_LINES, VYPER_ERROR_LINE_
 from vyper.exceptions import (
     ArgumentException,
     CompilerPanic,
+    FunctionDeclarationException,
     InvalidLiteral,
     InvalidOperation,
     OverflowException,
@@ -666,6 +667,14 @@ class Module(TopLevel):
 
 class FunctionDef(TopLevel):
     __slots__ = ("args", "returns", "decorator_list")
+
+    def validate(self):
+        if not self.body:
+            raise FunctionDeclarationException(
+                "Function body cannot consist of only a docstring",
+                self,
+                hint="add a `pass` statement to the function body",
+            )
 
 
 class DocStr(VyperNode):

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -344,6 +344,9 @@ def parse_stmt(stmt, context):
 # it ends with an if/else and both branches are terminated.
 # (if not, we need to insert a terminator so that the IR is well-formed)
 def _is_terminated(code):
+    if not code:
+        return False
+
     last_stmt = code[-1]
 
     if last_stmt.is_terminus:

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -344,9 +344,6 @@ def parse_stmt(stmt, context):
 # it ends with an if/else and both branches are terminated.
 # (if not, we need to insert a terminator so that the IR is well-formed)
 def _is_terminated(code):
-    if not code:
-        return False
-
     last_stmt = code[-1]
 
     if last_stmt.is_terminus:


### PR DESCRIPTION
### What I did

Fix: #4965

### How I did it

### How to verify it

### Commit message

```
this commits forbids functions which only contain a docstring. the error
message points to using an explicit 'pass' to fix it.
```
### Description for the changelog

Forbid docstring-only functions, must now use `pass` explicitly

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
