### PR TITLE
refactor[test]: demote `StaticAssertionException` in oob tests

### DIFF
--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -565,9 +565,7 @@ def do_slice():
 
 
 @pytest.mark.parametrize("bad_code", oob_fail_list)
-def test_slice_buffer_oob_reverts(bad_code, get_contract, tx_failed):
-    compiler_settings = get_global_settings()
-    assert compiler_settings is not None
+def test_slice_buffer_oob_reverts(bad_code, get_contract, tx_failed, compiler_settings):
     compiler_settings = dataclasses.replace(compiler_settings, disable_static_exceptions=True)
     c = get_contract(bad_code, compiler_settings=compiler_settings)
     with tx_failed():

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -1,11 +1,13 @@
+import dataclasses
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
+from vyper.compiler.settings import get_global_settings
 
 from vyper.compiler import compile_code
 from vyper.compiler.settings import OptimizationLevel, Settings
 from vyper.evm.opcodes import version_check
-from vyper.exceptions import ArgumentException, StaticAssertionException, TypeMismatch
+from vyper.exceptions import ArgumentException, TypeMismatch
 
 _fun_bytes32_bounds = [(0, 32), (3, 29), (27, 5), (0, 5), (5, 3), (30, 2)]
 
@@ -564,15 +566,12 @@ def do_slice():
 
 @pytest.mark.parametrize("bad_code", oob_fail_list)
 def test_slice_buffer_oob_reverts(bad_code, get_contract, tx_failed):
-    try:
-        c = get_contract(bad_code)
-        with tx_failed():
-            c.do_slice()
-    except StaticAssertionException:
-        # it should be ok if we
-        # catch the assert in compile time
-        # since it supposed to be revert
-        pass
+    compiler_settings = get_global_settings()
+    assert compiler_settings is not None
+    compiler_settings = dataclasses.replace(compiler_settings, disable_static_exceptions=True)
+    c = get_contract(bad_code, compiler_settings=compiler_settings)
+    with tx_failed():
+        c.do_slice()
 
 
 # tests all 3 adhoc locations: `msg.data`, `self.code`, `<address>.code`

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -5,7 +5,7 @@ import pytest
 from hypothesis import given, settings
 
 from vyper.compiler import compile_code
-from vyper.compiler.settings import OptimizationLevel, Settings, get_global_settings
+from vyper.compiler.settings import OptimizationLevel, Settings
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import ArgumentException, TypeMismatch
 

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -1,11 +1,11 @@
 import dataclasses
+
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
-from vyper.compiler.settings import get_global_settings
 
 from vyper.compiler import compile_code
-from vyper.compiler.settings import OptimizationLevel, Settings
+from vyper.compiler.settings import OptimizationLevel, Settings, get_global_settings
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import ArgumentException, TypeMismatch
 

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 import pytest
 
 from tests.utils import check_precompile_asserts, decimal_to_int
-from vyper.compiler import compile_code, settings
+from vyper.compiler import compile_code
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
     ArgumentException,

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -1,11 +1,12 @@
 import contextlib
+import dataclasses
 import itertools
 from typing import Any, Callable
 
 import pytest
 
 from tests.utils import check_precompile_asserts, decimal_to_int
-from vyper.compiler import compile_code
+from vyper.compiler import compile_code, settings
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
     ArgumentException,
@@ -14,7 +15,6 @@ from vyper.exceptions import (
     ImmutableViolation,
     OverflowException,
     StateAccessViolation,
-    StaticAssertionException,
     TypeMismatch,
 )
 
@@ -1864,16 +1864,12 @@ def should_revert() -> DynArray[String[65], 2]:
 @pytest.mark.parametrize("code", dynarray_length_no_clobber_cases)
 def test_dynarray_length_no_clobber(get_contract, tx_failed, code):
     # check that length is not clobbered before dynarray data copy happens
-    try:
-        c = get_contract(code)
-        with tx_failed():
-            c.should_revert()
-    except StaticAssertionException:
-        # this test should create
-        # assert error so if it is
-        # detected in compile time
-        # we can continue
-        pass
+    compiler_settings = settings.get_global_settings()
+    assert compiler_settings is not None
+    compiler_settings = dataclasses.replace(compiler_settings, disable_static_exceptions=True)
+    c = get_contract(code, compiler_settings=compiler_settings)
+    with tx_failed():
+        c.should_revert()
 
 
 def test_dynarray_make_setter_overlap(get_contract):

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -1862,10 +1862,8 @@ def should_revert() -> DynArray[String[65], 2]:
 
 
 @pytest.mark.parametrize("code", dynarray_length_no_clobber_cases)
-def test_dynarray_length_no_clobber(get_contract, tx_failed, code):
+def test_dynarray_length_no_clobber(get_contract, tx_failed, code, compiler_settings):
     # check that length is not clobbered before dynarray data copy happens
-    compiler_settings = settings.get_global_settings()
-    assert compiler_settings is not None
     compiler_settings = dataclasses.replace(compiler_settings, disable_static_exceptions=True)
     c = get_contract(code, compiler_settings=compiler_settings)
     with tx_failed():


### PR DESCRIPTION
### What I did

Replaced the try/except `StaticAssertionException` pattern in `test_slice_buffer_oob_reverts` and `test_dynarray_length_no_clobber` with `compiler_settings = dataclasses.replace(compiler_settings, disable_static_exceptions=True)` (added in GH 4862), demoting the compile-time errors to runtime reverts explicitly so we can verify the runtime behavior directly.

### How I did it

In both test functions, removed the `try/except StaticAssertionException` wrapper and instead pass `disable_static_exceptions=True` via the `compiler_settings` fixture. Removed the `StaticAssertionException` import from both files. Added `import dataclasses`.

### How to verify it

```bash
uv run pytest tests/functional/builtins/codegen/test_slice.py::test_slice_buffer_oob_reverts -x
uv run pytest tests/functional/codegen/types/test_dynamic_array.py::test_dynarray_length_no_clobber -x
```

### Commit message

```
a couple of tests intentionally demoted compile-time
StaticAssertionException errors to runtime reverts by catching the
compile-time exception and passing. now that GH 4862 added
--disable-static-exceptions, we can demote them explicitly via the
compiler setting and verify the runtime revert behavior directly.
```

### Description for the changelog

N/A — test-only change

### Cute Animal Picture

![A sleepy red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Red_panda_%28il%29.jpg/440px-Red_panda_%28il%29.jpg)


