### PR TITLE
fix[venom]: guard copy-forwarding against deep-callee gas bombs

### DIFF
--- a/tests/unit/compiler/venom/test_invoke_arg_copy_forwarding.py
+++ b/tests/unit/compiler/venom/test_invoke_arg_copy_forwarding.py
@@ -224,6 +224,77 @@ def test_readonly_forwarding_allows_retained_copy_comparison_from_invoke_arg():
     assert all(inst.opcode != "mcopy" for inst in insts)
 
 
+def test_readonly_forwarding_rejects_param_source_with_huge_callee_frame():
+    # Source is a function param (unresolved alloca). The callee transitively
+    # holds two ABI-encode-scale buffers (totaling >8MB) — after inlining the
+    # param could resolve to a small caller alloca that gets forced to a high
+    # address by the conflict graph, producing a quadratic memory-expansion
+    # gas bomb. Forwarding must bail out.
+    src = """
+    function caller {
+    caller:
+        %arg = param
+        %retpc = param
+        %tmp = alloca 4128
+        mcopy %tmp, %arg, 4128
+        invoke @callee, %tmp
+        ret %retpc
+    }
+
+    function callee {
+    callee:
+        %a = param
+        %retpc = param
+        %buf1 = alloca 4195552
+        %buf2 = alloca 4195424
+        mload %a
+        ret %retpc
+    }
+    """
+
+    ctx = _run_copy_forwarding(src)
+    caller = ctx.get_function(IRLabel("caller"))
+    insts = [inst for bb in caller.get_basic_blocks() for inst in bb.instructions]
+
+    mcopy = next(inst for inst in insts if inst.opcode == "mcopy")
+    invoke = next(inst for inst in insts if inst.opcode == "invoke")
+
+    assert invoke.operands[1] == mcopy.operands[2]
+
+
+def test_readonly_forwarding_allows_param_source_with_small_callee_frame():
+    # Source is a function param but the callee's transitive frame is tiny —
+    # any post-inlining placement is cheap, so forwarding wins.
+    src = """
+    function caller {
+    caller:
+        %arg = param
+        %retpc = param
+        %tmp = alloca 1056
+        mcopy %tmp, %arg, 1056
+        invoke @callee, %tmp
+        ret %retpc
+    }
+
+    function callee {
+    callee:
+        %a = param
+        %retpc = param
+        %frame = alloca 64
+        mload %a
+        ret %retpc
+    }
+    """
+
+    ctx = _run_copy_forwarding(src)
+    caller = ctx.get_function(IRLabel("caller"))
+    insts = [inst for bb in caller.get_basic_blocks() for inst in bb.instructions]
+
+    invoke = next(inst for inst in insts if inst.opcode == "invoke")
+    assert invoke.operands[1] == IRVariable("%arg")
+    assert all(inst.opcode != "mcopy" for inst in insts)
+
+
 def test_readonly_forwarding_rejects_larger_source_liveness_extension():
     src = """
     function caller {

--- a/vyper/venom/passes/copy_forwarding.py
+++ b/vyper/venom/passes/copy_forwarding.py
@@ -340,8 +340,7 @@ class CopyForwardingPolicy:
                     if inst.opcode != "invoke":
                         continue
                     target = inst.operands[0]
-                    if not isinstance(target, IRLabel):
-                        continue
+                    assert isinstance(target, IRLabel)
                     sub_callee = self.function.ctx.functions.get(target)
                     if sub_callee is None:
                         continue

--- a/vyper/venom/passes/copy_forwarding.py
+++ b/vyper/venom/passes/copy_forwarding.py
@@ -25,6 +25,12 @@ class CopyForwardingPolicy:
     # the one-byte MCOPY opcode from deployed bytecode.
     CODE_DEPOSIT_GAS_PER_BYTE: int = 200
     MIN_ELIDED_MCOPY_BYTES: int = 1
+    # When the copy source can't be resolved to an alloca, only block
+    # forwarding for catastrophic memory-expansion penalties (millions of
+    # gas, e.g. ABI-encode buffers of dynamic-array args). Moderate
+    # penalties (a few KB of frame growth) can still be outweighed by the
+    # forwarding win across many invocations.
+    UNRESOLVED_SOURCE_PENALTY_THRESHOLD: int = 1_000_000
 
     function: IRFunction
     dfg: DFGAnalysis
@@ -78,7 +84,28 @@ class CopyForwardingPolicy:
         dst_alloca: Allocation,
     ) -> bool:
         src_alloca = self._copy_source_alloca(copy_inst)
+
+        copy_size = self.copy_size(copy_inst)
+        if copy_size is None:
+            copy_size = dst_alloca.alloca_size
+
         if src_alloca is None:
+            # Source can't be resolved to an alloca — typically a function
+            # `param`. After inlining the param will resolve to a caller
+            # alloca whose write history is invisible here. If forwarding
+            # would extend that future liveness across a callee whose
+            # transitive frame would force the source to a catastrophic
+            # high address, the quadratic memory-expansion gas can dwarf
+            # any forwarding win. Use a high absolute penalty threshold
+            # so small-frame forwardings still win (~hundreds of gas) but
+            # ABI-encode-buffer-scale frames (megabytes → millions of gas)
+            # are caught.
+            for invoke_inst, _ in rewrite_sites:
+                penalty = self._memory_expansion_penalty_across_callee(invoke_inst, copy_size)
+                if penalty is None:
+                    continue
+                if penalty > self.UNRESOLVED_SOURCE_PENALTY_THRESHOLD:
+                    return True
             return False
 
         has_read_access, has_write_access = self._alloca_has_accesses_that_can_skip_copy(
@@ -86,10 +113,6 @@ class CopyForwardingPolicy:
         )
         if not has_read_access and not has_write_access:
             return False
-
-        copy_size = self.copy_size(copy_inst)
-        if copy_size is None:
-            copy_size = dst_alloca.alloca_size
 
         for invoke_inst, _ in rewrite_sites:
             if self._alloca_has_read_after(src_alloca, invoke_inst):
@@ -285,18 +308,45 @@ class CopyForwardingPolicy:
                 if alloca in allocator.allocated
             ]
 
+        # Allocator hasn't run yet (first, pre-inline forwarding pass).
+        # Walk transitive callees to estimate the frame footprint —
+        # local-only would miss deep ABI-encode buffers and the cost
+        # check would let through forwardings that become quadratic
+        # memory-expansion bombs after inlining.
         intervals: list[tuple[int, int]] = []
         ptr = 0
-        for bb in callee.get_basic_blocks():
-            for inst in bb.instructions:
-                if inst.opcode != "alloca":
-                    continue
-                size = inst.operands[0]
-                assert isinstance(size, IRLiteral)
-                intervals.append((ptr, size.value))
-                ptr += size.value
+        for alloca_size in self._collect_transitive_alloca_sizes(callee):
+            intervals.append((ptr, alloca_size))
+            ptr += alloca_size
 
         return intervals
+
+    def _collect_transitive_alloca_sizes(self, callee: IRFunction) -> list[int]:
+        sizes: list[int] = []
+        visited: set[IRFunction] = set()
+        stack: list[IRFunction] = [callee]
+        while len(stack) > 0:
+            fn = stack.pop()
+            if fn in visited:
+                continue
+            visited.add(fn)
+            for bb in fn.get_basic_blocks():
+                for inst in bb.instructions:
+                    if inst.opcode == "alloca":
+                        size_op = inst.operands[0]
+                        assert isinstance(size_op, IRLiteral)
+                        sizes.append(size_op.value)
+                        continue
+                    if inst.opcode != "invoke":
+                        continue
+                    target = inst.operands[0]
+                    if not isinstance(target, IRLabel):
+                        continue
+                    sub_callee = self.function.ctx.functions.get(target)
+                    if sub_callee is None:
+                        continue
+                    stack.append(sub_callee)
+        return sizes
 
     def _get_invoke_callee(self, invoke_inst: IRInstruction) -> IRFunction:
         target = invoke_inst.operands[0]


### PR DESCRIPTION
### What I did

Hardened `CopyForwardingPolicy` against quadratic memory-expansion gas bombs when the mcopy source operand can't be resolved to an alloca (typically a function `param`). On master alone, no contract in the snekmate corpus currently triggers this shape, but it materializes on branches whose inlining decisions are less aggressive  (observed at ~135M gas per call on snekmate ERC1155 batch revert paths).

### How I did it

Two structural changes in `vyper/venom/passes/copy_forwarding.py`:

- `_callee_reserved_intervals` now walks transitive callees in its pre-allocator fallback. The previous local-only walk silently missed deeper allocas, which is a precision bug independent of the bomb scenario.
- `should_block_forwarding` now has an explicit branch for unresolved sources. It estimates the per-invoke memory-expansion penalty using the copy size as a proxy and bails when the penalty exceeds an absolute 1M-gas threshold. Small-frame forwardings still win (hundreds of gas); ABI-encode-buffer-scale frames (megabytes -> millions of gas) are blocked.

An alternative defer all unresolved-source forwarding decisions to the post-inline per-function pass (was evaluated and rejected). It eliminates the magic number but loses ~67 forwarding wins across the snekmate corpus, because non-inlined functions with `param` sources keep `src=None` in both passes and the post-inline pass can't tell "never-inlined" apart from "will-be-inlined."

### How to verify it

### Commit message

```
`CopyForwardingPolicy.should_block_forwarding` previously returned False
unconditionally when the mcopy source couldn't be resolved to an alloca
(typically a function `param`). That's a soundness gap: if the enclosing
function gets inlined later, the param resolves to a caller alloca whose
liveness now extends across the deep invoke. The conflict graph can
force that caller alloca above the callee's transitive pinned set, and
on snekmate ERC1155 batch revert paths under inlining shapes that expose
this pattern, the resulting quadratic memory-expansion gas is ~135M per
call.

Two changes plug the gap. `_callee_reserved_intervals` now walks
transitive callees in its pre-allocator fallback -- the old local-only
walk silently missed deeper allocas, a precision bug in its own right.
And `should_block_forwarding` now estimates the per-invoke memory-
expansion penalty even when the source is unresolved, using the copy
size as a proxy, and bails when the penalty exceeds an absolute 1M-gas
threshold. Small-frame forwardings still win (hundreds of gas); ABI-
encode-buffer-scale frames (megabytes -> millions of gas) are caught.

A defer-to-post-inline-pass alternative was evaluated and rejected. It
removes the magic number but loses ~67 forwarding wins across the
snekmate corpus: non-inlined functions with `param` sources have
src=None in both passes, so the post-inline pass can't tell "never-
inlined" apart from "will-be-inlined" and conservatively keeps the
mcopy.
```

### Description for the changelog

### Cute Animal Picture

![]()
