### PR TITLE
fix[ci]: fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ WORKDIR /code
 # force repository to be clean so the version string is right
 RUN git reset --hard
 
-# Using "test" optional to include test dependencies in built docker-image
+# Upgrade pip to version compatible with `--group`
+RUN pip install --upgrade pip==25.1.1
+
+# Using "test" group to include test dependencies in built docker-image
 RUN pip install --no-cache-dir . --group test && \
     apt-get purge -y --auto-remove apt-utils gcc libc6-dev libc-dev libssl-dev
 


### PR DESCRIPTION
Was due to using pip version where --group is not supported

### What I did

### How I did it

### How to verify it

### Commit message

```
dockerfile was updated to use dependency groups with --group, but the
installed pip version did not support it. this commit updates the pip
version used in the dockerfile to fix that.
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
