### PR TITLE
fix[lang]: allow decimals in built-ins unconditionally

### DIFF
--- a/tests/functional/codegen/types/numbers/test_decimals.py
+++ b/tests/functional/codegen/types/numbers/test_decimals.py
@@ -338,3 +338,41 @@ def foo(x: decimal):
         assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
     finally:
         compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_allowed_in_builtin():
+    # importing a builtin module that uses decimal (math.sqrt) should
+    # not raise FeatureException even without --enable-decimals
+    code = """
+import math
+
+@external
+def foo() -> uint256:
+    return math.isqrt(4)
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        compile_code(code)
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True
+
+
+def test_decimals_not_silenced_by_builtin():
+    # the builtin loophole should not swallow other uses of decimals
+    code = """
+import math
+
+@external
+def foo():
+
+    x: decimal = 1.0
+    """
+    try:
+        assert compiler_settings.DEFAULT_ENABLE_DECIMALS is True
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = False
+        with pytest.raises(FeatureException) as e:
+            compile_code(code)
+        assert e.value._message == "decimals are not allowed unless `--enable-decimals` is set"
+    finally:
+        compiler_settings.DEFAULT_ENABLE_DECIMALS = True

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -1,4 +1,5 @@
 from vyper import ast as vy_ast
+from vyper.compiler.input_bundle import BUILTIN
 from vyper.compiler.settings import get_global_settings
 from vyper.exceptions import (
     ArrayIndexException,
@@ -94,7 +95,8 @@ def type_from_annotation(
     # TODO: cursed import cycle!
     from vyper.semantics.types.primitives import DecimalT
 
-    if isinstance(typ, DecimalT):
+    # Gate uses of decimal outside of built-ins behind a flag
+    if isinstance(typ, DecimalT) and node.module_node.source_id != BUILTIN:
         # is there a better place to put this check?
         settings = get_global_settings()
         if settings and not settings.get_enable_decimals():


### PR DESCRIPTION
### What I did

Fix https://github.com/vyperlang/vyper/issues/4580

### How I did it

### How to verify it

### Commit message

```
in 318bd1e0342a5b8671d8c32e116f42612c7a245f, 'isqrt' was moved to the
'math' built-in module, this forces users to refactor their code to
import that module. however that module provides 'sqrt' which operates
on decimals, importing it thus forced the use of --enable-decimals. all-
in-all this meant using 'isqrt', which only operates on integers, forced
the use of a flag about decimals. this commit fixes that by ignoring all
built-in modules when checking for uses of decimals.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
