### PR TITLE
fix[venom]: avoid address attr lowering for struct fields

### DIFF
--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -30,6 +30,30 @@ def slice_tower_test(inp1: Bytes[50]) -> Bytes[50]:
     assert x == b"klmnopqrst", x
 
 
+def test_slice_struct_field_named_code(get_contract, env):
+    code = """
+struct Account:
+    code: Bytes[10]
+
+accounts: HashMap[address, Account]
+
+@external
+def set_code(owner: address, code: Bytes[10]):
+    self.accounts[owner].code = code
+
+@external
+@view
+def get_prefix(owner: address) -> Bytes[3]:
+    return slice(self.accounts[owner].code, 0, 3)
+    """
+
+    c = get_contract(code)
+    owner = env.accounts[1]
+    c.set_code(owner, b"abcdef")
+
+    assert c.get_prefix(owner) == b"abc"
+
+
 # note: optimization boundaries at 32, 64 and 320 depending on mode
 _draw_1024 = st.integers(min_value=0, max_value=1024)
 _draw_1024_1 = st.integers(min_value=1, max_value=1024)

--- a/tests/functional/codegen/storage_variables/test_setters.py
+++ b/tests/functional/codegen/storage_variables/test_setters.py
@@ -148,6 +148,84 @@ def gop() -> int128:
     assert c.gop() == 87198763254321
 
 
+def test_struct_field_names_shadow_address_attrs(get_contract, env):
+    code = """
+struct Account:
+    balance: uint256
+    codesize: uint256
+    is_contract: bool
+    codehash: bytes32
+
+accounts: HashMap[address, Account]
+
+@external
+def set_account(owner: address, codehash: bytes32):
+    self.accounts[owner] = Account(
+        balance=100,
+        codesize=200,
+        is_contract=True,
+        codehash=codehash
+    )
+
+@external
+def bump_balance(owner: address, amount: uint256):
+    self.accounts[owner].balance += amount
+
+@external
+def set_codesize(owner: address, new_codesize: uint256):
+    self.accounts[owner].codesize = new_codesize
+
+@external
+def set_is_contract(owner: address, new_is_contract: bool):
+    self.accounts[owner].is_contract = new_is_contract
+
+@external
+def set_codehash(owner: address, new_codehash: bytes32):
+    self.accounts[owner].codehash = new_codehash
+
+@external
+@view
+def get_balance(owner: address) -> uint256:
+    return self.accounts[owner].balance
+
+@external
+@view
+def get_codesize(owner: address) -> uint256:
+    return self.accounts[owner].codesize
+
+@external
+@view
+def get_is_contract(owner: address) -> bool:
+    return self.accounts[owner].is_contract
+
+@external
+@view
+def get_codehash(owner: address) -> bytes32:
+    return self.accounts[owner].codehash
+    """
+
+    c = get_contract(code)
+    owner = env.accounts[1]
+    codehash = b"\x12" * 32
+    new_codehash = b"\x34" * 32
+
+    c.set_account(owner, codehash)
+    assert c.get_balance(owner) == 100
+    assert c.get_codesize(owner) == 200
+    assert c.get_is_contract(owner) is True
+    assert c.get_codehash(owner) == codehash
+
+    c.bump_balance(owner, 23)
+    c.set_codesize(owner, 456)
+    c.set_is_contract(owner, False)
+    c.set_codehash(owner, new_codehash)
+
+    assert c.get_balance(owner) == 123
+    assert c.get_codesize(owner) == 456
+    assert c.get_is_contract(owner) is False
+    assert c.get_codehash(owner) == new_codehash
+
+
 def test_struct_assignment_order(get_contract, assert_compile_failed):
     code = """
 struct Foo:

--- a/tests/functional/syntax/test_code_size.py
+++ b/tests/functional/syntax/test_code_size.py
@@ -44,3 +44,23 @@ def bar() -> uint256:
 @pytest.mark.parametrize("good_code", valid_list)
 def test_block_success(good_code):
     assert compiler.compile_code(good_code) is not None
+
+
+def test_self_codesize_in_constructor(get_contract):
+    code = """
+stored: public(uint256)
+
+@deploy
+def __init__():
+    self.stored = self.codesize
+
+@external
+@view
+def live() -> uint256:
+    return self.codesize
+    """
+
+    c = get_contract(code)
+
+    assert c.stored() > 0
+    assert c.live() > 0

--- a/vyper/codegen_venom/builtins/bytes.py
+++ b/vyper/codegen_venom/builtins/bytes.py
@@ -183,7 +183,7 @@ def _is_adhoc_slice(node: vy_ast.VyperNode) -> bool:
             return True
 
     # <addr>.code
-    if node.attr == "code":
+    if node.attr == "code" and isinstance(node.value._metadata.get("type"), AddressT):
         return True
 
     return False

--- a/vyper/codegen_venom/builtins/bytes.py
+++ b/vyper/codegen_venom/builtins/bytes.py
@@ -183,7 +183,7 @@ def _is_adhoc_slice(node: vy_ast.VyperNode) -> bool:
             return True
 
     # <addr>.code
-    if node.attr == "code" and isinstance(node.value._metadata.get("type"), AddressT):
+    if node.attr == "code" and isinstance(node.value._metadata["type"], AddressT):
         return True
 
     return False

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -634,8 +634,14 @@ class Expr:
                 value = 2**flag_id  # 0 => 1, 1 => 2, 2 => 4, etc.
                 return VyperValue.from_stack_op(IRLiteral(value), typ)
 
-        # Case 2: Address properties
         attr = node.attr
+        sub_typ = node.value._metadata.get("type")
+
+        # Case 2: Struct field access (point.x)
+        if isinstance(sub_typ, StructT) and attr in sub_typ.member_types:
+            return self._lower_struct_field()
+
+        # Case 3: Address properties
         if attr == "balance":
             sub = Expr(node.value, self.ctx).lower_value()
             return VyperValue.from_stack_op(self.builder.balance(sub), UINT256_T)
@@ -660,11 +666,11 @@ class Expr:
         ):  # pragma: nocover
             raise CompilerPanic(".code requires slice() context")
 
-        # Case 3: Environment variables (msg.*, block.*, tx.*, chain.*)
+        # Case 4: Environment variables (msg.*, block.*, tx.*, chain.*)
         if isinstance(node.value, vy_ast.Name) and node.value.id in ENVIRONMENT_VARIABLES:
             return VyperValue.from_stack_op(self._lower_environment_attr(), typ)
 
-        # Case 4: State variables (self.x)
+        # Case 5: State variables (self.x)
         varinfo = node._expr_info.var_info
         if varinfo is not None:
             # Constant state variable - evaluate the constant expression
@@ -683,14 +689,9 @@ class Expr:
             ptr = Ptr(operand=IRLiteral(slot), location=varinfo.location)
             return VyperValue.from_ptr(ptr, typ)
 
-        # Case 5: Interface address (x.address where x is an interface)
-        sub_typ = node.value._metadata.get("type")
+        # Case 6: Interface address (x.address where x is an interface)
         if isinstance(sub_typ, InterfaceT) and attr == "address":
             return VyperValue.from_stack_op(Expr(node.value, self.ctx).lower_value(), AddressT())
-
-        # Case 6: Struct field access (point.x)
-        if isinstance(sub_typ, StructT) and attr in sub_typ.member_types:
-            return self._lower_struct_field()
 
         raise CompilerPanic(f"Unsupported attribute access: {node.attr}")  # pragma: nocover
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -635,7 +635,7 @@ class Expr:
                 return VyperValue.from_stack_op(IRLiteral(value), typ)
 
         attr = node.attr
-        sub_typ = node.value._metadata.get("type")
+        sub_typ = node.value._metadata["type"]
 
         # Case 2: Struct field access (point.x)
         if isinstance(sub_typ, StructT) and attr in sub_typ.member_types:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -647,6 +647,8 @@ class Expr:
             return VyperValue.from_stack_op(self.builder.balance(sub), UINT256_T)
 
         if attr == "codesize":
+            if isinstance(node.value, vy_ast.Name) and node.value.id == "self":
+                return VyperValue.from_stack_op(self.builder.codesize(), UINT256_T)
             sub = Expr(node.value, self.ctx).lower_value()
             return VyperValue.from_stack_op(self.builder.extcodesize(sub), UINT256_T)
 


### PR DESCRIPTION
### What I did

Fix three Venom lowering paths where address-specific attribute handling could beat the ordinary source semantics:

- direct struct fields named `balance`, `codesize`, `codehash`, or `is_contract`
- `slice()` sources named `code`
- `self.codesize` in constructor/runtime code

### Bug description

Venom lowered some attributes by checking the attribute name before checking whether the base expression was a struct. That made legal struct fields collide with address pseudo-attributes.

For read-only access, this could compile to the wrong EVM operation. A struct field read such as `return self.accounts[owner].balance` could emit `BALANCE` instead of loading the `balance` member from storage. The same name-resolution problem applied to fields named `codesize`, `codehash`, and `is_contract`.

For writes and augmented assignments, the same misclassification surfaced as a compiler panic. Assignment lowering needs a pointer for the target field, but address pseudo-attribute lowering returns a stack value. For example, `self.accounts[owner].balance += amount` attempted to call `.ptr()` on the stack result and failed with `CompilerPanic: cannot get ptr from stack value`.

The second issue was in the Venom `slice()` builtin. Its ad-hoc `<address>.code` recognizer matched any attribute named `code`, regardless of the base type. A source like `slice(self.accounts[owner].code, 0, 3)`, where `code` is a `Bytes[10]` struct field, was lowered as an `EXTCODECOPY` path instead of an ordinary bytes slice.

The third issue is also in address pseudo-attribute lowering. Legacy codegen treats `self.codesize` specially and emits `CODESIZE`; Venom emitted `EXTCODESIZE(ADDRESS())` for all `.codesize` expressions. Those are not equivalent in initcode: during deployment, `EXTCODESIZE(self)` returns zero because the account code is not installed yet, while `CODESIZE` returns the current initcode size.

### Before/after lowering evidence

Minimal struct-field read reproducer:

```vyper
struct Account:
    balance: uint256

accounts: HashMap[address, Account]

@external
@view
def get_balance(owner: address) -> uint256:
    return self.accounts[owner].balance
```

Before this change, Venom IR lowered the final field access as an address balance operation:

```text
%23 = balance %46
mstore 0, %23
return 0, 32
```

After this change, the same getter lowers as a storage lookup:

```text
%20 = sha3 0, 64
%22 = sload %20
mstore 0, %22
return 0, 32
```

For the write reproducer, the old lowering failed before useful IR could be emitted:

```vyper
@external
def bump_balance(owner: address, amount: uint256):
    self.accounts[owner].balance += amount
```

```text
vyper.exceptions.CompilerPanic: cannot get ptr from stack value
```

The additional `slice()` reproducer:

```vyper
struct Account:
    code: Bytes[10]

accounts: HashMap[address, Account]

@external
@view
def get_prefix(owner: address) -> Bytes[3]:
    return slice(self.accounts[owner].code, 0, 3)
```

Before this change, the Venom runtime path contained `EXTCODESIZE`/`EXTCODECOPY`. After this change, it uses normal storage-to-memory copying and bytes slicing for the struct field.

The `self.codesize` reproducer:

```vyper
stored: public(uint256)

@deploy
def __init__():
    self.stored = self.codesize

@external
@view
def live() -> uint256:
    return self.codesize
```

Observed locally before the fix:

```text
legacy: stored=165 live=89
venom:  stored=0   live=70
```

The constructor value is the important regression. Venom emitted `ADDRESS EXTCODESIZE` where legacy emits `CODESIZE`. Venom's optimizer already documents that `EXTCODESIZE(ADDRESS()) -> CODESIZE` is not safe in initcode.

### How I did it

Resolve struct fields before address pseudo-attributes in `Expr.lower_Attribute`, preserving pointer semantics for storage and memory struct access.

Require the `slice()` ad-hoc `.code` path to have an address-typed base expression, so struct fields named `code` are handled by the normal bytes slicing path.

Special-case `self.codesize` in Venom attribute lowering to emit `CODESIZE`, matching legacy codegen.

### How to verify it

- `uv run --python 3.12 pytest tests/functional/codegen/storage_variables/test_setters.py -k struct_field_names_shadow_address_attrs -q`
- `uv run --python 3.12 pytest tests/functional/codegen/storage_variables/test_setters.py -k struct_field_names_shadow_address_attrs --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/builtins/codegen/test_slice.py -q`
- `uv run --python 3.12 pytest tests/functional/builtins/codegen/test_slice.py --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/syntax/test_code_size.py -q`
- `uv run --python 3.12 pytest tests/functional/syntax/test_code_size.py --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/syntax/test_self_balance.py --experimental-codegen -q`
- `uv run --python 3.12 black --check vyper/codegen_venom/expr.py vyper/codegen_venom/builtins/bytes.py tests/functional/codegen/storage_variables/test_setters.py tests/functional/builtins/codegen/test_slice.py tests/functional/syntax/test_code_size.py`
- `uv run --python 3.12 flake8 vyper/codegen_venom/expr.py vyper/codegen_venom/builtins/bytes.py tests/functional/codegen/storage_variables/test_setters.py tests/functional/builtins/codegen/test_slice.py tests/functional/syntax/test_code_size.py`

### Description for the changelog

Fix Venom codegen for struct fields named like address pseudo-attributes and for `self.codesize`.
