### PR TITLE
fix[venom]: fix `raw_call` kwarg evaluation order

### DIFF
--- a/tests/functional/builtins/codegen/test_raw_call.py
+++ b/tests/functional/builtins/codegen/test_raw_call.py
@@ -601,6 +601,40 @@ def bar(f: uint256) -> Bytes[100]:
     )
 
 
+def test_raw_call_msg_data_kwarg_evaluation_order(get_contract, experimental_codegen):
+    code = """
+identity: constant(address) = 0x0000000000000000000000000000000000000004
+
+marker: public(uint256)
+
+@internal
+def set_value() -> uint256:
+    self.marker = 1
+    return 0
+
+@internal
+def set_gas() -> uint256:
+    self.marker = 2
+    return msg.gas
+
+@external
+def value_then_gas() -> uint256:
+    raw_call(identity, msg.data, value=self.set_value(), gas=self.set_gas())
+    return self.marker
+
+@external
+def gas_then_value() -> uint256:
+    raw_call(identity, msg.data, gas=self.set_gas(), value=self.set_value())
+    return self.marker
+    """
+    c = get_contract(code)
+
+    assert c.value_then_gas() == 2
+    # Legacy codegen evaluates raw_call kwargs in operand order; #2863 tracks
+    # fixing it to source order.
+    assert c.gas_then_value() == (1 if experimental_codegen else 2)
+
+
 uncompilable_code = [
     (
         """

--- a/tests/functional/builtins/codegen/test_raw_call.py
+++ b/tests/functional/builtins/codegen/test_raw_call.py
@@ -632,7 +632,11 @@ def gas_then_value() -> uint256:
     assert c.value_then_gas() == 2
     # Legacy codegen evaluates raw_call kwargs in operand order; #2863 tracks
     # fixing it to source order.
-    assert c.gas_then_value() == (1 if experimental_codegen else 2)
+    gas_then_value = c.gas_then_value()
+    if experimental_codegen:
+        assert gas_then_value == 1
+    else:
+        assert gas_then_value == 2
 
 
 uncompilable_code = [

--- a/vyper/codegen_venom/builtins/system.py
+++ b/vyper/codegen_venom/builtins/system.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from vyper import ast as vy_ast
 from vyper.codegen_venom.value import VyperValue
-from vyper.exceptions import ArgumentException, StateAccessViolation
+from vyper.exceptions import ArgumentException, CompilerPanic, StateAccessViolation
 from vyper.semantics.types import BytesT, TupleT
 from vyper.semantics.types.shortcuts import BYTES32_T, UINT256_T
 from vyper.venom.basicblock import IRLiteral, IROperand, IRVariable
@@ -126,6 +126,13 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
             gas = Expr(kw.value, ctx).lower_value()
         elif kw.arg == "value":
             value = Expr(kw.value, ctx).lower_value()
+        elif kw.arg not in (
+            "max_outsize",
+            "is_delegate_call",
+            "is_static_call",
+            "revert_on_failure",
+        ):
+            raise CompilerPanic(f"unexpected raw_call kwarg: {kw.arg}", kw)
     if gas is None:
         gas = b.gas()
 

--- a/vyper/codegen_venom/builtins/system.py
+++ b/vyper/codegen_venom/builtins/system.py
@@ -118,21 +118,16 @@ def lower_raw_call(node: vy_ast.Call, ctx: VenomCodegenContext) -> Union[IROpera
         data_len = b.mload(data)
         data_ptr = b.add(data, IRLiteral(32))
 
-    # Handle gas kwarg - defaults to remaining gas
-    gas_node = _get_kwarg_value(node, "gas")
-    gas: IROperand
-    if gas_node is None:
-        gas = b.gas()
-    else:
-        gas = Expr(gas_node, ctx).lower_value()
-
-    # Handle value kwarg - only for regular call
-    value_node = _get_kwarg_value(node, "value")
     value: IROperand
-    if value_node is None:
-        value = IRLiteral(0)
-    else:
-        value = Expr(value_node, ctx).lower_value()
+    gas: Optional[IROperand] = None
+    value = IRLiteral(0)
+    for kw in node.keywords:
+        if kw.arg == "gas":
+            gas = Expr(kw.value, ctx).lower_value()
+        elif kw.arg == "value":
+            value = Expr(kw.value, ctx).lower_value()
+    if gas is None:
+        gas = b.gas()
 
     # Allocate output buffer if needed
     out_val: Optional["VyperValue"]


### PR DESCRIPTION
### What I did

Fixed Venom `raw_call` lowering so side-effectful `value=` and `gas=` keyword arguments are evaluated in source order.

### How I did it

Changed Venom `raw_call` lowering to walk `node.keywords` and materialize `gas=` / `value=` in the order written by the user.

The patch keeps the existing behavior that copies `msg.data` only after kwarg evaluation, so scratch memory is not clobbered before the call.

Legacy codegen currently evaluates this class of call kwargs in operand order; the regression test documents that legacy behavior against #2863 while requiring source-order behavior for Venom.

### How to verify it

- `uv run --python 3.12 pytest tests/functional/builtins/codegen/test_raw_call.py::test_raw_call_msg_data_kwarg_evaluation_order -q`
- `uv run --python 3.12 pytest tests/functional/builtins/codegen/test_raw_call.py::test_raw_call_msg_data_kwarg_evaluation_order --experimental-codegen -q`
- `uv run --python 3.12 ruff check vyper/codegen_venom/builtins/system.py tests/functional/builtins/codegen/test_raw_call.py`

### Commit message

```
the Venom `raw_call` lowering evaluated `gas=` before `value=`
unconditionally, regardless of the order the user wrote them. When
either kwarg has side effects (e.g. `value=self.set_value()`,
`gas=self.set_gas()`), the observable evaluation order was wrong — Vyper
requires left-to-right evaluation.

walk `node.keywords` in source order and materialize `gas=` / `value=`
as encountered, deferring the gas default to after the loop. also guard
against unexpected kwargs with a `CompilerPanic`.

the regression test documents that legacy codegen still evaluates kwargs
in operand order (GH 2863 tracks fixing that) while requiring source-
order for Venom.
```

### Description for the changelog

Fix Venom `raw_call` keyword-argument evaluation order.
