### PR TITLE
fix[venom]: add missing scalar conversion validation

### DIFF
--- a/tests/functional/builtins/codegen/test_as_wei_value.py
+++ b/tests/functional/builtins/codegen/test_as_wei_value.py
@@ -90,6 +90,18 @@ def foo(a: {data_type}) -> uint256:
         c.foo(value)
 
 
+def test_negative_int_wei_reverts(get_contract, tx_failed):
+    code = """
+@external
+def foo(a: int128) -> uint256:
+    return as_wei_value(a, "wei")
+    """
+
+    c = get_contract(code)
+    with tx_failed():
+        c.foo(-1)
+
+
 @pytest.mark.parametrize("denom,multiplier", wei_denoms.items())
 @pytest.mark.parametrize("data_type", ["decimal", "int128", "uint256"])
 def test_zero_value(get_contract, tx_failed, denom, multiplier, data_type):

--- a/tests/functional/builtins/codegen/test_convert.py
+++ b/tests/functional/builtins/codegen/test_convert.py
@@ -9,6 +9,7 @@ import pytest
 
 from tests.utils import decimal_to_int
 from vyper.compiler import compile_code
+from vyper.compiler.settings import Settings
 from vyper.exceptions import InvalidLiteral, InvalidType, TypeMismatch
 from vyper.semantics.types import AddressT, BoolT, BytesM_T, BytesT, DecimalT, IntegerT, StringT
 from vyper.semantics.types.shortcuts import BYTES20_T, BYTES32_T, UINT, UINT160_T, UINT256_T
@@ -720,6 +721,32 @@ def foo(bar: {i_typ}) -> {o_typ}:
         input_val = decimal_to_int(input_val)
     with tx_failed():
         c3.foo(input_val)
+
+
+@pytest.mark.parametrize(
+    "bad_code",
+    [
+        """
+@external
+def foo(x: uint256) -> bytes1:
+    return convert(x, bytes1)
+        """,
+        """
+@external
+def foo(x: int128) -> address:
+    return convert(x, address)
+        """,
+        """
+@external
+def foo(x: address) -> int256:
+    return convert(x, int256)
+        """,
+    ],
+)
+def test_venom_bytecode_output_rejects_invalid_conversions(bad_code):
+    settings = Settings(experimental_codegen=True)
+    with pytest.raises(TypeMismatch):
+        compile_code(bad_code, output_formats=["bytecode"], settings=settings)
 
 
 @pytest.mark.parametrize(

--- a/vyper/codegen_venom/builtins/convert.py
+++ b/vyper/codegen_venom/builtins/convert.py
@@ -147,6 +147,9 @@ def _to_address(
     From signed integers: disallowed (type checker handles this)
     From bytes: right-shift if needed, clamp to 160 bits
     """
+    if isinstance(in_t, IntegerT) and in_t.is_signed:
+        raise TypeMismatch(f"Can't convert {in_t} to address", arg_node)
+
     # Use _to_int to get uint160, which handles clamping
     result = _to_int(val, in_t, UINT160_T, arg_node, ctx)
     return result
@@ -226,6 +229,8 @@ def _to_int(
 
     # From address: treat as uint160
     if in_t == AddressT():
+        if out_t.is_signed:
+            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
         # Can only go to unsigned types >= 160 bits
         if out_t.bits < 160:
             val = _int_clamp(val, out_t, ctx)
@@ -329,6 +334,16 @@ def _to_bytes_m(
             return val
         # Widening is no-op (already left-aligned)
         return val
+
+    if isinstance(in_t, IntegerT):
+        if out_t.m_bits < in_t.bits:
+            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
+    elif in_t == AddressT():
+        if out_t.m_bits < 160:
+            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
+    elif isinstance(in_t, DecimalT):
+        if out_t.m_bits < in_t.bits:
+            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
 
     # From integer/address/decimal: left-shift to align
     shift_bits = (32 - out_t.m) * 8

--- a/vyper/codegen_venom/builtins/misc.py
+++ b/vyper/codegen_venom/builtins/misc.py
@@ -20,7 +20,7 @@ from vyper.codegen_venom.abi.abi_encoder import abi_encode_to_buf
 from vyper.codegen_venom.constants import BLOCKHASH_LOOKBACK_LIMIT, ECRECOVER_PRECOMPILE
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import EvmVersionException
-from vyper.semantics.types import BytesT, DecimalT, StringT, TupleT
+from vyper.semantics.types import BytesT, DecimalT, IntegerT, StringT, TupleT
 from vyper.utils import DECIMAL_DIVISOR, method_id_int
 from vyper.venom.basicblock import IRLiteral, IROperand, IRVariable
 
@@ -304,8 +304,10 @@ def lower_as_wei_value(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand
             is_non_negative = b.iszero(b.slt(value, IRLiteral(0)))
             b.assert_(is_non_negative)
             return b.div(value, IRLiteral(DECIMAL_DIVISOR))
-        else:
-            return value
+        if isinstance(typ, IntegerT) and typ.is_signed:
+            is_non_negative = b.iszero(b.slt(value, IRLiteral(0)))
+            b.assert_(is_non_negative)
+        return value
 
     if isinstance(typ, DecimalT):
         # Decimal: check non-negative, multiply, then divide by DECIMAL_DIVISOR


### PR DESCRIPTION
### What I did

Added missing Venom validation for scalar conversion paths:

- `as_wei_value(int*, "wei")` now rejects negative signed values
- signed integer to `address` conversion is rejected
- `address` to signed integer conversion is rejected
- integer/address/decimal to too-small `bytesM` conversion is rejected before Venom bytecode generation

### How I did it

Mirrored the scalar validation already enforced by legacy codegen and ABI-oriented compile paths before Venom bytecode lowering accepts these conversions.

Also added the runtime clamp for the `as_wei_value(a: int*, "wei")` fast path, where Venom previously returned the raw signed word for denominator `1` and allowed `-1` to become `2**256 - 1`.

### How to verify it

- `uv run --python 3.12 pytest tests/functional/builtins/codegen/test_as_wei_value.py tests/functional/builtins/codegen/test_convert.py::test_venom_bytecode_output_rejects_invalid_conversions --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/builtins/codegen/test_as_wei_value.py::test_negative_int_wei_reverts tests/functional/builtins/codegen/test_convert.py::test_venom_bytecode_output_rejects_invalid_conversions -q`

### Commit message

```
the venom codegen path for convert() and as_wei_value() was missing
validation that the legacy pipeline and type checker enforce for other
compilation targets.

three gaps in convert.py:

- signed integer to address: _to_address did not reject signed inputs,
  allowing negative values through as garbled addresses.
- address to signed integer: _to_int allowed the conversion, which is
  semantically invalid (addresses are unsigned 160-bit values).
- integer/address/decimal to bytesM: _to_bytes_m did not check that the
  source width fits in the target, so narrowing conversions silently
  truncated.

additionally, lower_as_wei_value had a fast-path bug: when the
denominator is 1 (e.g. as_wei_value(a: int128, "wei")), the signed value
was returned unclamped. a negative input like -1 would be interpreted as
2**256 - 1 in the unsigned return type. add a non-negative assertion for
signed integers in the fast path, matching the existing clamp in the
general (non-denominator-1) branch.
```

### Description for the changelog

Fix Venom validation for invalid scalar conversions and negative signed `as_wei_value(..., "wei")` inputs.
