### PR TITLE
fix[venom]: fix `raw_call` kwarg evaluation order

### DIFF
--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -2450,19 +2450,21 @@ def bar(foo: Foo):
     c.bar(bad_2.address)
 
 
-def test_default_return_value_reads_storage_after_call(get_contract, experimental_codegen):
+def test_default_return_value_reads_storage_before_empty_returndata_call(
+    get_contract, experimental_codegen
+):
     callee_code = """
 interface Caller:
     def set_x(v: uint256): nonpayable
 
 @external
-def poke(c: address):
+def set_x_without_return(c: address):
     extcall Caller(c).set_x(99)
     """
 
     caller_code = """
 interface Callee:
-    def poke(c: address) -> uint256: nonpayable
+    def set_x_without_return(c: address) -> uint256: nonpayable
 
 x: public(uint256)
 
@@ -2473,7 +2475,7 @@ def set_x(v: uint256):
 @external
 def run(callee: address) -> uint256:
     self.x = 7
-    return extcall Callee(callee).poke(self, default_return_value=self.x)
+    return extcall Callee(callee).set_x_without_return(self, default_return_value=self.x)
     """
 
     callee = get_contract(callee_code)

--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -2450,7 +2450,7 @@ def bar(foo: Foo):
     c.bar(bad_2.address)
 
 
-def test_default_return_value_reads_storage_after_call(get_contract):
+def test_default_return_value_reads_storage_after_call(get_contract, experimental_codegen):
     callee_code = """
 interface Caller:
     def set_x(v: uint256): nonpayable
@@ -2479,7 +2479,11 @@ def run(callee: address) -> uint256:
     callee = get_contract(callee_code)
     caller = get_contract(caller_code)
 
-    assert caller.run(callee.address) == 99
+    output = caller.run(callee.address)
+    if experimental_codegen:
+        assert output == 7
+    else:
+        assert output == 99
     assert caller.x() == 99
 
 
@@ -2510,9 +2514,13 @@ def run() -> uint256:
     c = get_contract(code)
     env.set_balance(env.deployer, 10**18)
 
-    # Legacy codegen evaluates call kwargs in operand order; #2863 tracks
-    # fixing it to source order.
-    assert c.run(value=10) == (20 if experimental_codegen else 10)
+    output = c.run(value=10)
+    if experimental_codegen:
+        assert output == 20
+    else:
+        # Legacy codegen evaluates call kwargs in operand order; #2863 tracks
+        # fixing it to source order.
+        assert output == 10
     assert c.counter() == 2
 
 

--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -2450,6 +2450,72 @@ def bar(foo: Foo):
     c.bar(bad_2.address)
 
 
+def test_default_return_value_reads_storage_after_call(get_contract):
+    callee_code = """
+interface Caller:
+    def set_x(v: uint256): nonpayable
+
+@external
+def poke(c: address):
+    extcall Caller(c).set_x(99)
+    """
+
+    caller_code = """
+interface Callee:
+    def poke(c: address) -> uint256: nonpayable
+
+x: public(uint256)
+
+@external
+def set_x(v: uint256):
+    self.x = v
+
+@external
+def run(callee: address) -> uint256:
+    self.x = 7
+    return extcall Callee(callee).poke(self, default_return_value=self.x)
+    """
+
+    callee = get_contract(callee_code)
+    caller = get_contract(caller_code)
+
+    assert caller.run(callee.address) == 99
+    assert caller.x() == 99
+
+
+def test_external_call_kwarg_source_order(env, get_contract, experimental_codegen):
+    code = """
+interface Foo:
+    def pay() -> uint256: payable
+
+counter: public(uint256)
+
+@internal
+def bump() -> uint256:
+    self.counter += 1
+    return self.counter
+
+@external
+@payable
+def pay() -> uint256:
+    return msg.value * 10
+
+@external
+@payable
+def run() -> uint256:
+    self.counter = 0
+    return extcall Foo(self).pay(gas=50000 + self.bump(), value=self.bump())
+    """
+
+    c = get_contract(code)
+    env.set_balance(env.deployer, 10**18)
+
+    # Legacy codegen evaluates call kwargs in operand order; #2863 tracks
+    # fixing it to source order.
+    assert c.run(value=10) == (20 if experimental_codegen else 10)
+    assert c.counter() == 2
+
+
 def test_contract_address_evaluation(get_contract):
     callee_code = """
 # implements: Foo

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -155,6 +155,18 @@ class VenomCodegenContext:
         """Store a VyperValue into memory, preserving its source layout."""
         self.store_memory(self.unwrap(vv), ptr, typ, src_typ=vv.typ)
 
+    def materialize_value(
+        self, vv: VyperValue, typ: Optional[VyperType] = None, annotation: Optional[str] = None
+    ) -> VyperValue:
+        """Copy a VyperValue into a fresh memory temporary."""
+        if typ is None:
+            typ = vv.typ
+
+        ret = self.new_temporary_value(typ, annotation=annotation)
+        assert isinstance(ret.operand, IRVariable)
+        self.store_vyper_value(vv, ret.operand, typ)
+        return ret
+
     def bytes_data_ptr(self, vv: VyperValue) -> IROperand:
         """Get pointer to bytestring data (skipping length word).
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -61,7 +61,7 @@ class _CallKwargs:
     value: IROperand  # ETH value to send (CALL only)
     gas: IROperand  # Gas limit for the call
     skip_contract_check: bool  # Skip extcodesize check
-    default_return_value: Optional[vy_ast.VyperNode]  # Default if returndatasize==0
+    default_return_value: Optional[VyperValue]  # Default if returndatasize==0
 
 
 # Environment variable prefixes for attribute access
@@ -1656,7 +1656,7 @@ class Expr:
         value: IROperand = IRLiteral(0)
         gas: Optional[IROperand] = None
         skip_contract_check = False
-        default_return_value: Optional[vy_ast.VyperNode] = None
+        default_return_value: Optional[VyperValue] = None
 
         for kw in call_node.keywords:
             if kw.arg == "value":
@@ -1670,7 +1670,14 @@ class Expr:
                     raise CompilerPanic(f"Expected IRLiteral for keyword, got {type(kw_val)}")
                 skip_contract_check = bool(kw_val.value)
             elif kw.arg == "default_return_value":
-                default_return_value = kw.value
+                default_vv = Expr(kw.value, self.ctx).lower()
+                if default_vv.location is not None and default_vv.location in (
+                    DataLocation.STORAGE,
+                    DataLocation.TRANSIENT,
+                ):
+                    materialized = self.ctx.unwrap(default_vv)
+                    default_vv = VyperValue.from_stack_op(materialized, default_vv.typ)
+                default_return_value = default_vv
             else:  # pragma: nocover
                 raise CompilerPanic(f"Unexpected keyword argument: {kw.arg}")
 
@@ -1841,9 +1848,8 @@ class Expr:
             b.set_block(default_bb)
 
             # Store default value
-            default_node = call_kwargs.default_return_value
-            assert default_node is not None
-            default_vv = Expr(default_node, self.ctx).lower()
+            default_vv = call_kwargs.default_return_value
+            assert default_vv is not None
             self.ctx.store_vyper_value(default_vv, result_val.operand, return_t)
 
             # Check extcodesize if not skipped (contract might have selfdestructed)

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1671,13 +1671,10 @@ class Expr:
                 skip_contract_check = bool(kw_val.value)
             elif kw.arg == "default_return_value":
                 default_vv = Expr(kw.value, self.ctx).lower()
-                if default_vv.location is not None and default_vv.location in (
-                    DataLocation.STORAGE,
-                    DataLocation.TRANSIENT,
-                ):
-                    materialized = self.ctx.unwrap(default_vv)
-                    default_vv = VyperValue.from_stack_op(materialized, default_vv.typ)
-                default_return_value = default_vv
+                # Freeze the expression here; the default block runs after the external call.
+                default_return_value = VyperValue.from_stack_op(
+                    self.ctx.unwrap(default_vv), default_vv.typ
+                )
             else:  # pragma: nocover
                 raise CompilerPanic(f"Unexpected keyword argument: {kw.arg}")
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1671,10 +1671,18 @@ class Expr:
                 skip_contract_check = bool(kw_val.value)
             elif kw.arg == "default_return_value":
                 default_vv = Expr(kw.value, self.ctx).lower()
-                # Freeze the expression here; the default block runs after the external call.
-                default_return_value = VyperValue.from_stack_op(
-                    self.ctx.unwrap(default_vv), default_vv.typ
-                )
+                # Freeze the expression here; the default block runs after the
+                # external call. Primitive values can stay on the stack, but
+                # composite values need a fresh memory copy instead of a
+                # pointer to a source location that later code may mutate.
+                if default_vv.typ._is_prim_word:
+                    default_return_value = VyperValue.from_stack_op(
+                        self.ctx.unwrap(default_vv), default_vv.typ
+                    )
+                else:
+                    default_return_value = self.ctx.materialize_value(
+                        default_vv, annotation="external call default_return_value"
+                    )
             else:  # pragma: nocover
                 raise CompilerPanic(f"Unexpected keyword argument: {kw.arg}")
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -61,7 +61,7 @@ class _CallKwargs:
     value: IROperand  # ETH value to send (CALL only)
     gas: IROperand  # Gas limit for the call
     skip_contract_check: bool  # Skip extcodesize check
-    default_return_value: Optional[VyperValue]  # Default if returndatasize==0
+    default_return_value: Optional[vy_ast.VyperNode]  # Default if returndatasize==0
 
 
 # Environment variable prefixes for attribute access
@@ -1653,39 +1653,29 @@ class Expr:
         Args:
             call_node: The Call AST node (from ExtCall.value or StaticCall.value)
         """
-        # Default values
         value: IROperand = IRLiteral(0)
-        gas: IROperand = self.builder.gas()
+        gas: Optional[IROperand] = None
         skip_contract_check = False
-        default_return_value: Optional[VyperValue] = None
+        default_return_value: Optional[vy_ast.VyperNode] = None
 
         for kw in call_node.keywords:
-            if kw.arg == "default_return_value":
-                drv_vv = Expr(kw.value, self.ctx).lower()
-                # Eagerly materialize mutable-location values so the read
-                # happens before CALL, not in the post-call default block
-                # (avoids reentrancy-dependent fallback semantics).
-                if drv_vv.location is not None and drv_vv.location in (
-                    DataLocation.STORAGE,
-                    DataLocation.TRANSIENT,
-                ):
-                    materialized = self.ctx.unwrap(drv_vv)
-                    drv_vv = VyperValue.from_stack_op(materialized, drv_vv.typ)
-                default_return_value = drv_vv
-                continue
-
-            kw_val = Expr(kw.value, self.ctx).lower_value()
             if kw.arg == "value":
-                value = kw_val
+                value = Expr(kw.value, self.ctx).lower_value()
             elif kw.arg == "gas":
-                gas = kw_val
+                gas = Expr(kw.value, self.ctx).lower_value()
             elif kw.arg == "skip_contract_check":
+                kw_val = Expr(kw.value, self.ctx).lower_value()
                 # Must be a literal True/False
                 if not isinstance(kw_val, IRLiteral):  # pragma: nocover
                     raise CompilerPanic(f"Expected IRLiteral for keyword, got {type(kw_val)}")
                 skip_contract_check = bool(kw_val.value)
+            elif kw.arg == "default_return_value":
+                default_return_value = kw.value
             else:  # pragma: nocover
                 raise CompilerPanic(f"Unexpected keyword argument: {kw.arg}")
+
+        if gas is None:
+            gas = self.builder.gas()
 
         return _CallKwargs(
             value=value,
@@ -1851,8 +1841,9 @@ class Expr:
             b.set_block(default_bb)
 
             # Store default value
-            default_vv = call_kwargs.default_return_value
-            assert default_vv is not None
+            default_node = call_kwargs.default_return_value
+            assert default_node is not None
+            default_vv = Expr(default_node, self.ctx).lower()
             self.ctx.store_vyper_value(default_vv, result_val.operand, return_t)
 
             # Check extcodesize if not skipped (contract might have selfdestructed)


### PR DESCRIPTION
_co-authored by chatgpt_

### What I did

Fixed two Venom external-call lowering issues:

- evaluate side-effectful call kwargs in source order
- freeze `default_return_value` before the external call, including
  composite defaults that need a stable memory copy

### How I did it

Changed external call kwarg parsing to walk `node.keywords` directly,
materializing `value=`, `gas=`, and `skip_contract_check=` in the order
written by the user.

`default_return_value` follows the same source-order rule: it is
materialized when its keyword is encountered, before the external call.
Because the fallback is only consumed later, after empty returndata is
observed, primitive defaults stay on the stack and composite defaults are
copied to a fresh temporary so the call or later memory writes cannot
mutate the fallback.

The regression tests cover both source-order kwarg side effects and the
empty-returndata fallback timing. Legacy codegen still documents its
operand-order behavior pending GH 2863.

### How to verify it

- `uv run --python 3.12 pytest tests/functional/codegen/calling_convention/test_external_contract_calls.py::test_default_return_value_reads_storage_before_empty_returndata_call tests/functional/codegen/calling_convention/test_external_contract_calls.py::test_external_call_kwarg_source_order --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/codegen/calling_convention/test_external_contract_calls.py::test_default_return_value_reads_storage_before_empty_returndata_call tests/functional/codegen/calling_convention/test_external_contract_calls.py::test_external_call_kwarg_source_order -q`
- `uv run --python 3.12 ruff check vyper/codegen_venom/expr.py tests/functional/codegen/calling_convention/test_external_contract_calls.py`

### Commit message

```
Venom lowered external call keyword arguments in a way that did not
match Vyper's source-order evaluation rules. `gas=` and `value=` were
materialized by keyword kind rather than in the order written, so side
effects in one kwarg could change the value observed by another.

The same source-order rule applies to `default_return_value`: the
expression must be evaluated when its keyword is encountered, before the
external call. Because the fallback value is only consumed later, after
empty returndata is observed, the evaluated value must also be frozen so
the call or subsequent memory writes cannot change it.

Parse external call kwargs by walking the AST keyword list, materialize
`default_return_value` at that point, and copy composite defaults into a
fresh temporary so the empty-returndata block reads the source-order
value.
```

### Description for the changelog

Fix Venom external-call keyword argument evaluation order and stabilize
`default_return_value` fallback values.

