### PR TITLE
fix: treat venom gas as ordered

### DIFF
--- a/tests/functional/codegen/features/test_gas.py
+++ b/tests/functional/codegen/features/test_gas.py
@@ -1,3 +1,7 @@
+from vyper.compiler import compile_code
+from vyper.compiler.settings import Settings
+
+
 def test_gas_call(get_contract):
     gas_call = """
 @external
@@ -9,3 +13,41 @@ def foo() -> uint256:
 
     assert c.foo(gas=50000) < 50000
     assert c.foo(gas=50000) > 25000
+
+
+def test_msg_gas_reads_are_not_removed():
+    code = """
+@external
+def foo() -> uint256:
+    g: uint256 = msg.gas
+    return msg.gas
+    """
+
+    out = compile_code(
+        code,
+        output_formats=["opcodes_runtime"],
+        settings=Settings(experimental_codegen=True),
+    )
+
+    assert out["opcodes_runtime"].split().count("GAS") == 2
+
+
+def test_msg_gas_read_order_is_preserved():
+    code = """
+x: public(uint256)
+
+@external
+def foo() -> uint256:
+    g: uint256 = msg.gas
+    y: uint256 = self.x
+    return unsafe_add(g, y)
+    """
+
+    out = compile_code(
+        code,
+        output_formats=["opcodes_runtime"],
+        settings=Settings(experimental_codegen=True),
+    )
+    opcodes = out["opcodes_runtime"].split()
+
+    assert opcodes.index("GAS") < opcodes.index("SLOAD")

--- a/vyper/venom/analysis/available_expression.py
+++ b/vyper/venom/analysis/available_expression.py
@@ -29,11 +29,12 @@ for opcode, eff in effects.writes.items():
 # staticcall doesn't have external effects, but it is not idempotent since
 # it can depend on gas
 _nonidempotent_insts.append("staticcall")
+_nonidempotent_insts.append("gas")
 
 NONIDEMPOTENT_INSTRUCTIONS = frozenset(_nonidempotent_insts)
 
 # sanity
-for opcode in ("call", "create", "staticcall", "delegatecall", "create2"):
+for opcode in ("call", "create", "staticcall", "delegatecall", "create2", "gas"):
     assert opcode in NONIDEMPOTENT_INSTRUCTIONS
 
 

--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -40,6 +40,7 @@ VOLATILE_INSTRUCTIONS = frozenset(
         "returndatacopy",
         "codecopy",
         "dloadbytes",
+        "gas",
         "return",
         "ret",
         "sink",

--- a/vyper/venom/passes/dft.py
+++ b/vyper/venom/passes/dft.py
@@ -8,6 +8,9 @@ from vyper.venom.function import IRFunction
 from vyper.venom.passes.base_pass import IRPass
 
 
+ORDERED_INSTRUCTIONS = frozenset(["gas"])
+
+
 class DFTPass(IRPass):
     function: IRFunction
     data_offspring: dict[IRInstruction, OrderedSet[IRInstruction]]
@@ -146,13 +149,23 @@ class DFTPass(IRPass):
         #
         last_write_effects: dict[effects.Effects, IRInstruction] = {}
         all_read_effects: dict[effects.Effects, list[IRInstruction]] = defaultdict(list)
+        last_ordered_instruction: IRInstruction | None = None
+        previous_instructions: OrderedSet[IRInstruction] = OrderedSet()
 
         for inst in non_phis:
+            if last_ordered_instruction is not None:
+                self.eda[inst].add(last_ordered_instruction)
+
             if inst.is_bb_terminator:
                 for var in self.order:
                     dep = self.dfg.get_producing_instruction(var)
                     if dep is not None and dep.parent == bb:
                         self.dda[inst].add(dep)
+
+            if inst.opcode in ORDERED_INSTRUCTIONS:
+                self.eda[inst] |= previous_instructions
+                last_ordered_instruction = inst
+
             for op in inst.operands:
                 dep = self.dfg.get_producing_instruction(op)
                 if dep is not None and dep.parent == bb:
@@ -178,6 +191,8 @@ class DFTPass(IRPass):
                 if read_effect in last_write_effects and last_write_effects[read_effect] != inst:
                     self.eda[inst].add(last_write_effects[read_effect])
                 all_read_effects[read_effect].append(inst)
+
+            previous_instructions.add(inst)
 
     def _calculate_data_offspring(self, inst: IRInstruction):
         if inst in self.data_offspring:


### PR DESCRIPTION
### What I did

Treated Venom `gas` instructions as non-removable, non-substitutable, and ordered inside DFT.

### How I did it

Updated the Venom optimizer model so `gas` behaves like an ordered observation of the current execution point:

- marked `gas` volatile so remove-unused-vars does not delete it
- excluded `gas` from available-expression substitution
- made DFT preserve instruction order across `gas` reads

`GAS` observes remaining gas at its exact program point. Removing an unused `msg.gas` read or moving independent work such as `SLOAD` across it can change later gas observations.

### How to verify it

- `uv run --python 3.12 pytest tests/functional/codegen/features/test_gas.py --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/codegen/features/test_gas.py -q`
- `uv run --python 3.12 pytest tests/unit/compiler/venom/test_common_subexpression_elimination.py -q`
- `uv run --python 3.12 ruff check vyper/venom/basicblock.py vyper/venom/passes/dft.py vyper/venom/analysis/available_expression.py tests/functional/codegen/features/test_gas.py`

### Commit message

fix: treat Venom gas as ordered

### Description for the changelog

Fix Venom optimizer handling of `msg.gas` so gas reads are preserved and remain ordered.