### PR TITLE
fix[venom]: keep storage writes before selfdestruct

### DIFF
--- a/tests/functional/codegen/features/test_selfdestruct.py
+++ b/tests/functional/codegen/features/test_selfdestruct.py
@@ -67,6 +67,25 @@ def refund():
     check_selfdestruct_warning(w)
 
 
+def test_selfdestruct_preserves_prior_storage_writes(get_contract):
+    contract = """
+x: public(uint256)
+
+@external
+def boom():
+    self.x = 1
+    selfdestruct(msg.sender)
+    """
+
+    with warnings.catch_warnings(record=True) as w:
+        c = get_contract(contract)
+
+    c.boom()
+    assert c.x() == 1
+
+    check_selfdestruct_warning(w)
+
+
 def check_selfdestruct_warning(w):
     expected = "`selfdestruct` is deprecated!"
     expected += " The opcode is no longer recommended for use."

--- a/tests/unit/compiler/venom/test_dead_store_elimination.py
+++ b/tests/unit/compiler/venom/test_dead_store_elimination.py
@@ -1189,6 +1189,20 @@ def test_storage_basic_dead_store(addr_space):
     _check_pre_post_generic(pre, post, addr_space)
 
 
+def test_storage_store_before_selfdestruct():
+    pre = """
+        _global:
+            sstore 0, 1
+            selfdestruct 0
+    """
+    post = """
+        _global:
+            sstore 0, 1
+            selfdestruct 0
+    """
+    _check_pre_post_generic(pre, post, STORAGE)
+
+
 @pytest.mark.parametrize("addr_space", _persistent_address_spaces)
 def test_storage_basic_dead_store_clobbered(addr_space):
     pre = f"""

--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -236,7 +236,7 @@ class BasePtrAnalysis(IRAnalysis):
             return MemoryLocation.UNDEFINED
         elif opcode in ("create", "create2"):
             return MemoryLocation.UNDEFINED
-        elif opcode in ("return", "stop", "sink"):
+        elif opcode in ("return", "stop", "sink", "selfdestruct"):
             # these opcodes terminate execution and commit to (persistent)
             # storage, resulting in storage writes escaping our control.
             # returning `MemoryLocation.UNDEFINED` represents "future" reads


### PR DESCRIPTION
### What I did

Made Venom storage DSE treat `selfdestruct` as a storage-escaping terminator, like `return`, `stop`, and `sink`.

### How I did it

Updated storage base-pointer analysis so storage writes before `selfdestruct` are considered observable and cannot be removed as dead stores.

Under current EVM semantics for an existing contract, `selfdestruct` does not erase prior storage writes in the same call. Before this patch, Venom storage DSE could remove a preceding `self.x = 1` and leave `self.x == 0` after the call.

### How to verify it

- `uv run --python 3.12 pytest tests/unit/compiler/venom/test_dead_store_elimination.py::test_storage_store_before_selfdestruct tests/functional/codegen/features/test_selfdestruct.py::test_selfdestruct_preserves_prior_storage_writes --experimental-codegen -q`
- `uv run --python 3.12 pytest tests/functional/codegen/features/test_selfdestruct.py::test_selfdestruct_preserves_prior_storage_writes -q`
- `uv run --python 3.12 ruff check vyper/venom/analysis/base_ptr_analysis.py tests/unit/compiler/venom/test_dead_store_elimination.py tests/functional/codegen/features/test_selfdestruct.py`

### Commit message

fix: keep storage writes before selfdestruct

### Description for the changelog

Fix Venom storage DSE so storage writes before `selfdestruct` are preserved.