### PR TITLE
fix[venom]: invalidate returndata copy facts

### DIFF
--- a/tests/unit/compiler/venom/test_memory_copy_elision.py
+++ b/tests/unit/compiler/venom/test_memory_copy_elision.py
@@ -202,6 +202,21 @@ def test_no_repeated_mcopy_elision_when_dest_modified():
     _check_no_change(pre)
 
 
+def test_returndatacopy_not_forwarded_across_create():
+    pre = """
+    _global:
+        %src = alloca 32
+        %dst = alloca 32
+        %code = alloca 1
+        returndatacopy %src, 0, 32
+        %addr = create 0, %code, 1
+        mcopy %dst, %src, 32
+        %1 = mload %dst
+        sink %1
+    """
+    _check_no_change(pre)
+
+
 def test_no_elision_with_intermediate_write():
     """
     Test that copy elision doesn't happen if there's an intermediate write

--- a/vyper/venom/passes/memory_copy_elision.py
+++ b/vyper/venom/passes/memory_copy_elision.py
@@ -137,6 +137,8 @@ class MemoryCopyElisionPass(IRPass):
                     self.copies[write_loc] = inst
 
             else:
+                if Effects.RETURNDATA in inst.get_write_effects():
+                    self._invalidate_returndata_copies()
                 if Effects.MEMORY in inst.get_write_effects():
                     self.copies.clear()
                     self.loads[Effects.MEMORY].clear()
@@ -151,6 +153,15 @@ class MemoryCopyElisionPass(IRPass):
             self.bb_copies[bb] = self.copies.copy()
             return True
         return False
+
+    def _invalidate_returndata_copies(self):
+        to_remove = [
+            mem_loc
+            for mem_loc, copy_inst in self.copies.items()
+            if copy_inst.opcode == "returndatacopy"
+        ]
+        for mem_loc in to_remove:
+            del self.copies[mem_loc]
 
     def _invalidate(self, write_loc: MemoryLocation, eff: Effects):
         if not write_loc.is_fixed and Effects.MEMORY in eff:

--- a/vyper/venom/passes/memory_copy_elision.py
+++ b/vyper/venom/passes/memory_copy_elision.py
@@ -158,7 +158,7 @@ class MemoryCopyElisionPass(IRPass):
         to_remove = [
             mem_loc
             for mem_loc, copy_inst in self.copies.items()
-            if copy_inst.opcode == "returndatacopy"
+            if Effects.RETURNDATA in copy_inst.get_read_effects()
         ]
         for mem_loc in to_remove:
             del self.copies[mem_loc]


### PR DESCRIPTION
### What I did

Invalidated `returndatacopy`-sourced memory copy facts when an instruction writes `RETURNDATA`.

### How I did it

Changed `MemoryCopyElisionPass` to clear copy facts derived from `returndatacopy` across instructions that can replace RETURNDATA, such as `CREATE` and `CREATE2`.

The old pass tracked fixed-size `returndatacopy` results like `calldatacopy` and `codecopy`. That is only safe while RETURNDATA is unchanged. Without invalidation, the pass could rewrite a later memory copy into a second `returndatacopy` and read post-`CREATE` returndata instead of the bytes already copied into memory.

### How to verify it

- `uv run --python 3.12 pytest tests/unit/compiler/venom/test_memory_copy_elision.py::test_returndatacopy_not_forwarded_across_create -q`
- `uv run --python 3.12 pytest tests/unit/compiler/venom/test_memory_copy_elision.py -q`
- `uv run --python 3.12 ruff check vyper/venom/passes/memory_copy_elision.py tests/unit/compiler/venom/test_memory_copy_elision.py`

### Commit message

```
the MemoryCopyElisionPass tracked returndatacopy results as copy facts
alongside calldatacopy and codecopy. that is only valid while RETURNDATA
remains unchanged. instructions like CREATE and CREATE2 replace
RETURNDATA with the deployed contract's return data, so copy facts
derived from a prior returndatacopy become stale.

without invalidation, the pass could rewrite a later mcopy into a second
returndatacopy and read post-CREATE returndata instead of the bytes
already present in memory.

add _invalidate_returndata_copies to drop any copy facts whose source
instruction reads RETURNDATA when an instruction that writes RETURNDATA
is encountered.
```

### Description for the changelog

Fix Venom memory copy elision across instructions that replace RETURNDATA.
