### PR TITLE
fix[venom]: align print selector storage

### DIFF
--- a/tests/functional/syntax/test_print.py
+++ b/tests/functional/syntax/test_print.py
@@ -105,6 +105,9 @@ def foo(x: uint256):
     opcodes = out["opcodes_runtime"]
     selector = method_id_int(signature)
 
+    # This is intentionally a narrow opcode regression and is brittle to
+    # unrelated codegen changes. If it starts failing from harmless lowering
+    # churn, replace it with functional console-precompile instrumentation.
     assert f"PUSH4 0x{selector:08X}" in opcodes
     assert f"PUSH32 0x{selector:08X}{'0' * 56}" not in opcodes
 

--- a/tests/functional/syntax/test_print.py
+++ b/tests/functional/syntax/test_print.py
@@ -1,6 +1,8 @@
 import pytest
 
 from vyper import compiler
+from vyper.compiler.settings import Settings
+from vyper.utils import method_id_int
 
 valid_list = [
     """
@@ -79,3 +81,29 @@ def foo():
 @pytest.mark.parametrize("good_code", valid_list)
 def test_print_syntax(good_code):
     assert compiler.compile_code(good_code) is not None
+
+
+@pytest.mark.parametrize(
+    "print_call,signature",
+    [
+        ("print(x)", "log(string,bytes)"),
+        ("print(x, hardhat_compat=True)", "log(uint256)"),
+    ],
+)
+def test_venom_print_selector_stored_at_call_offset(print_call, signature):
+    code = f"""
+@external
+def foo(x: uint256):
+    {print_call}
+    """
+
+    out = compiler.compile_code(
+        code,
+        output_formats=["opcodes_runtime"],
+        settings=Settings(debug=True, experimental_codegen=True),
+    )
+    opcodes = out["opcodes_runtime"]
+    selector = method_id_int(signature)
+
+    assert f"PUSH4 0x{selector:08X}" in opcodes
+    assert f"PUSH32 0x{selector:08X}{'0' * 56}" not in opcodes

--- a/tests/functional/syntax/test_print.py
+++ b/tests/functional/syntax/test_print.py
@@ -85,10 +85,7 @@ def test_print_syntax(good_code):
 
 @pytest.mark.parametrize(
     "print_call,signature",
-    [
-        ("print(x)", "log(string,bytes)"),
-        ("print(x, hardhat_compat=True)", "log(uint256)"),
-    ],
+    [("print(x)", "log(string,bytes)"), ("print(x, hardhat_compat=True)", "log(uint256)")],
 )
 def test_venom_print_selector_stored_at_call_offset(print_call, signature):
     code = f"""

--- a/vyper/codegen_venom/builtins/misc.py
+++ b/vyper/codegen_venom/builtins/misc.py
@@ -468,9 +468,8 @@ def lower_print(node: vy_ast.Call, ctx: "VenomCodegenContext") -> IROperand:
         # Allocate buffer: [32 bytes padding for method_id alignment] | [data]
         buf = ctx.allocate_buffer(buflen)
 
-        # Store method_id at buf (shifted left to align in word)
-        method_id_word = mid << 224
-        b.mstore(buf._ptr, IRLiteral(method_id_word))
+        # Store method_id so buf+28 starts at the 4-byte selector.
+        b.mstore(buf._ptr, IRLiteral(mid))
 
         # Create tuple in memory and encode starting at buf + 32
         if len(args) > 0:
@@ -540,9 +539,8 @@ def lower_print(node: vy_ast.Call, ctx: "VenomCodegenContext") -> IROperand:
         final_buflen = 32 + outer_abi_size
         buf = ctx.allocate_buffer(final_buflen)
 
-        # Store method_id
-        method_id_word = mid << 224
-        b.mstore(buf._ptr, IRLiteral(method_id_word))
+        # Store method_id so buf+28 starts at the 4-byte selector.
+        b.mstore(buf._ptr, IRLiteral(mid))
 
         # Encode outer tuple
         data_dst = b.add(buf._ptr, IRLiteral(32))


### PR DESCRIPTION
### What I did

Fixed Venom lowering for the debug-only `print()` builtin so the console selector is stored at the offset used by the subsequent `staticcall`.

This applies to both default `log(string,bytes)` mode and `hardhat_compat=True` direct `log(...)` mode.

### How I did it

Stored the unshifted 4-byte method selector at `buf`, matching the legacy IR layout for calls that start calldata at `buf + 28`.

Before this patch, Venom stored `method_id << 224` at `buf`. That places the selector at `buf..buf+3`, while the call starts at `buf+28`, so the call sent zeroes as the selector. Storing the unshifted selector puts it at `buf+28..buf+31`, so calldata starts with the intended selector.

### How to verify it

- `uv run --python 3.12 pytest tests/functional/syntax/test_print.py -q`
- `uv run --python 3.12 ruff check vyper/codegen_venom/builtins/misc.py tests/functional/syntax/test_print.py`

### Commit message

```
venom stored `method_id << 224` (left-aligned in word) at `buf`, placing
the 4-byte selector at `buf..buf+3`. but the `staticcall` for the
console precompile starts calldata at `buf + 28`, so the call sent
zeroes as the method selector. store the unshifted `method_id` at `buf`
instead, which places the selector at `buf+28..buf+31` where the call
reads it.

applies to both default `log(string,bytes)` mode and
`hardhat_compat=True` direct `log(...)` mode.
```

### Description for the changelog

Fix Venom debug `print()` console selector encoding.
