### PR TITLE
fix[ux]: fix panic in pow folding

### DIFF
--- a/tests/unit/ast/nodes/test_fold_binop_int.py
+++ b/tests/unit/ast/nodes/test_fold_binop_int.py
@@ -131,3 +131,32 @@ def foo({input_value}) -> int128:
     else:
         with tx_failed():
             contract.foo(*values)
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("(-2) ** 2", 4),
+        ("(-2) ** 3", -8),
+        ("(-1) ** 100", 1),
+        ("(-1) ** 101", -1),
+        ("0 ** 0", 1),
+        ("1 ** 99", 1),
+    ],
+)
+def test_binop_pow_degenerate_base(expr, expected):
+    # Negative bases (and 0/1 bases) used to trip the log-based overflow
+    # heuristic in Pow._op, which called math.log on Decimal(left).
+    vyper_ast = parse_and_fold(expr)
+    folded = vyper_ast.body[0].value.get_folded_value()
+    assert folded.value == expected
+
+
+@pytest.mark.parametrize("expr", ["(-2) ** 1000", "(-3) ** 500"])
+def test_binop_pow_negative_base_overflow(expr):
+    # Bases with magnitude > 1 must still be caught by the log-based bound.
+    from vyper.exceptions import InvalidLiteral
+
+    with pytest.raises(InvalidLiteral):
+        vyper_ast = parse_and_fold(expr)
+        vyper_ast.body[0].value.get_folded_value()

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1136,7 +1136,11 @@ class Pow(Operator):
         # l**r > 2**256
         # r * ln(l) > ln(2 ** 256)
         # r > ln(2 ** 256) / ln(l)
-        if right > math.log(decimal.Decimal(2**257)) / math.log(decimal.Decimal(left)):
+        # math.log is undefined for left <= 0 and zero for left == 1; use the
+        # base magnitude so |left| > 1 still gets the early bound check.
+        if abs(left) > 1 and right > math.log(decimal.Decimal(2**257)) / math.log(
+            decimal.Decimal(abs(left))
+        ):
             raise InvalidLiteral("Out of bounds", self)
 
         return int(left**right)

--- a/vyper/ast/nodes.py
+++ b/vyper/ast/nodes.py
@@ -1133,14 +1133,16 @@ class Pow(Operator):
         # stage since we are just trying to filter out inputs which can cause
         # the compiler to hang. the others will get caught during constant
         # folding or codegen.
+        # |left| <= 1 can never overflow (result magnitude stays <= 1), so
+        # fast-path it before the log-based heuristic. math.log is undefined
+        # for left <= 0 and zero for left == 1, so the log check below would
+        # also be ill-defined for those cases.
+        if abs(left) <= 1:
+            return int(left**right)
         # l**r > 2**256
         # r * ln(l) > ln(2 ** 256)
         # r > ln(2 ** 256) / ln(l)
-        # math.log is undefined for left <= 0 and zero for left == 1; use the
-        # base magnitude so |left| > 1 still gets the early bound check.
-        if abs(left) > 1 and right > math.log(decimal.Decimal(2**257)) / math.log(
-            decimal.Decimal(abs(left))
-        ):
+        if right > math.log(decimal.Decimal(2**257)) / math.log(decimal.Decimal(abs(left))):
             raise InvalidLiteral("Out of bounds", self)
 
         return int(left**right)


### PR DESCRIPTION
### What I did

Fix #4980: a negative base in a literal `**` expression aborts the compiler with `ValueError: math domain error` (now `expected a positive input`) because `Pow._op` calls `math.log(decimal.Decimal(left))` in the overflow heuristic without guarding the base sign. Skipping the heuristic for `left <= 1` also fixes the related `0 ** 0` and `1 ** N` crashes since the exact fold handles those exactly.

### How I did it

Guarded the log-based overflow estimate with `left > 1` in `vyper/ast/nodes.py` so non-positive and unit bases fall through to `int(left**right)`.

### How to verify it

`uv run pytest tests/unit/ast/nodes/test_fold_binop_int.py::test_binop_pow_degenerate_base` covers `(-2)**2`, `(-2)**3`, `(-1)**100`, `(-1)**101`, `0**0`, `1**99`.

### Commit message

```
The constant-fold path for `**` in `Pow._op` calls
`math.log(decimal.Decimal(left))` to estimate whether `l**r` would
overflow `2**256` and result in a compiler hang or crash. The estimate
is only defined for `left > 1`; for any negative base it raises
`ValueError`, denying valid in-range expressions such as
`(-2) ** 2 == 4` and `(-1) ** 100 == 1`. The same math.log call also
crashes on `0 ** 0` and `1 ** N`.

Guard the heuristic with `left > 1` so degenerate bases skip the
estimate and fall through to the exact `int(left**right)` fold, which
already handles them correctly.
```

### Description for the changelog

Fix uncaught `ValueError` when constant-folding `**` with a non-positive base.

### Cute Animal Picture

![](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/640px-Cat03.jpg)






