### PR TITLE
fix[tool]: serialize symbolic lengths in metadata

### DIFF
--- a/vyper/semantics/types/bytestrings.py
+++ b/vyper/semantics/types/bytestrings.py
@@ -2,7 +2,7 @@ from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Bytes, ABI_String, ABIType
 from vyper.exceptions import CodegenPanic, StructureException, UnexpectedNodeType, UnexpectedValue
 from vyper.semantics.types.base import VyperType
-from vyper.semantics.types.infinity import INF, WILDCARD, LengthUpperBound
+from vyper.semantics.types.infinity import INF, WILDCARD, LengthUpperBound, length_to_json
 from vyper.semantics.types.utils import get_index_value
 from vyper.utils import ceil32
 
@@ -35,7 +35,7 @@ class _BytestringT(VyperType):
         return f"{self._id}[{self.length}]"
 
     def _addl_dict_fields(self):
-        return {"length": self.length}
+        return {"length": length_to_json(self.length)}
 
     @property
     def length(self) -> LengthUpperBound:

--- a/vyper/semantics/types/infinity.py
+++ b/vyper/semantics/types/infinity.py
@@ -37,3 +37,10 @@ LengthUpperBound: TypeAlias = int | Inf | Wildcard
 def is_bounded_length(_lengthval: LengthUpperBound) -> TypeGuard[int]:
     """Return True if val is a concrete int (not INF or WILDCARD)."""
     return _lengthval is not INF and _lengthval is not WILDCARD
+
+
+def length_to_json(length: LengthUpperBound) -> int | str:
+    """Return a JSON-serializable representation of a length value."""
+    if length is INF or length is WILDCARD:
+        return str(length)
+    return length

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -5,7 +5,13 @@ from vyper.abi_types import ABI_DynamicArray, ABI_StaticArray, ABI_Tuple, ABITyp
 from vyper.exceptions import ArrayIndexException, CodegenPanic, InvalidType, StructureException
 from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.types.base import VyperType
-from vyper.semantics.types.infinity import INF, WILDCARD, LengthUpperBound, is_bounded_length
+from vyper.semantics.types.infinity import (
+    INF,
+    WILDCARD,
+    LengthUpperBound,
+    is_bounded_length,
+    length_to_json,
+)
 from vyper.semantics.types.primitives import IntegerT
 from vyper.semantics.types.shortcuts import UINT256_T
 from vyper.semantics.types.utils import get_index_value, type_from_annotation
@@ -282,6 +288,11 @@ class DArrayT(_SequenceT):
         # modify the child name in place.
         ret["type"] += "[]"
         return _set_first_key(ret, "name", name)
+
+    def _addl_dict_fields(self):
+        ret = super()._addl_dict_fields()
+        ret["length"] = length_to_json(self.length)
+        return ret
 
     # TODO rename me to memory_bytes_required
     @property


### PR DESCRIPTION
### What I did

Made symbolic type lengths JSON-serializable in compiler metadata.

### How I did it

Added a small helper for serializing `INF` and wildcard length sentinels,
and used it when bytestring and dynamic-array types emit `to_dict()`
metadata. Numeric bounds are still emitted as integers.

### How to verify it

Export test JSON for cases involving unbounded or wildcard lengths, or
check that annotated type dictionaries containing `String[INF]`,
`Bytes[INF]`, or `DynArray[..., INF]` can be passed through
`json.dumps()`.

### Commit message

```
symbolic length sentinels introduced for unbounded and wildcard types
can flow into annotated type dictionaries. those dictionaries are
expected to be JSON-serializable, but the raw enum members for INF and
wildcard are not, causing JSON export of compiled test metadata to fail
during final serialization.

serialize symbolic lengths at the same boundary as other AST/type
metadata: keep bounded lengths as integers, but emit INF and wildcard as
their source-level string forms. this mirrors the existing Ellipsis
serialization behavior and avoids changing the runtime sentinel objects
or adding broad exporter-specific fallback handling.
```

### Description for the changelog

Fix JSON serialization of compiler metadata for symbolic type lengths.

### Cute Animal Picture

![quokka](https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Quokka_at_Rottnest_Island.jpg/640px-Quokka_at_Rottnest_Island.jpg)
