### PR TITLE
feat[docs]: add deep verification section

### DIFF
--- a/docs/deep-verification.rst
+++ b/docs/deep-verification.rst
@@ -1,0 +1,69 @@
+.. _vyper-deep-verification:
+
+##################
+Deep Verification
+##################
+
+Formal verification is becoming substantially more practical for smart contracts. Better tooling and accessible machine-checked semantics now make it feasible to prove properties on production code that were previously out of reach.
+
+Formal verification proves that a program satisfies a specified property within a formal model. In practice, however, most verification work establishes that property at only one layer of the stack. The remaining layers (from source semantics through the compiler to the EVM execution model) are taken on trust.
+
+This distance between what is formally proved and what actually executes on chain is the **verification gap**.
+
+**Deep verification** is the discipline of reducing that gap by formally bridging as many layers as possible. The fewer unverified assumptions remain in the chain, the stronger the resulting guarantee.
+
+Verification Depth and Breadth
+==============================
+
+Two concepts help clarify the verification gap:
+
+* **Verification depth** — how far the proof carries through the stack, from a high-level security property through source semantics and compiler correctness down to the EVM execution model.
+* **Verification breadth** — how much of the contract’s actual behavior is covered: which functions, which properties, which sequences of operations, and which environment assumptions.
+
+Every verification effort has some gap. Deep verification is the discipline of reducing it to its irreducible minimum.
+
+The Layers
+==========
+
+::
+
+        High-level properties
+                │
+                ▼
+          Source semantics
+                │
+                ▼
+         Compiler correctness
+                │
+                ▼
+           EVM semantics
+                │
+                ▼
+          Deployed bytecode
+
+A source-level proof establishes a property under the language’s formal semantics. A bytecode-level proof establishes the analogous statement against a formal EVM model. A verified compiler connects the two. The fewer layers a guarantee skips by assumption, the smaller the verification gap.
+
+The Technical Foundation
+========================
+
+Two of those layers already exist as public, machine-checked artifacts developed in the Verifereum project using HOL4:
+
+* A formal semantics for the Vyper source language.
+* A formal semantics for the EVM.
+
+Together they provide the mathematical foundation against which source-level and bytecode-level proofs about Vyper programs can be stated. The work is fully open and available in the `vyper-hol <https://github.com/verifereum/vyper-hol>`_ repository.
+
+Current Status
+==============
+
+Source-level verification on Vyper contracts and libraries is available today. Compiler verification (the critical link that connects source semantics to deployed bytecode) is in active development, with substantial proof engineering already underway.
+
+No complete deep verification pipeline exists yet for any widely deployed smart-contract language. Vyper is one of the places where the pieces are actively being assembled, and the stack is already in place for meaningful source-level work.
+
+.. seealso::
+
+   `vyper-hol on GitHub <https://github.com/verifereum/vyper-hol>`_
+      The open-source repository containing the formal semantics for Vyper and the EVM.
+
+   `Verifereum project <https://verifereum.org>`_
+      The project developing the HOL4 semantics and compiler verification work.

--- a/docs/deep-verification.rst
+++ b/docs/deep-verification.rst
@@ -6,7 +6,7 @@ Deep Verification
 
 Formal verification is becoming substantially more practical for smart contracts. Better tooling and accessible machine-checked semantics now make it feasible to prove properties on production code that were previously out of reach.
 
-Formal verification proves that a program satisfies a specified property within a formal model. In practice, however, most verification work establishes that property at only one layer of the stack. The remaining layers (from source semantics through the compiler to the EVM execution model) are taken on trust.
+However, formal verification only proves that a program satisfies a specified property *within its formal model*. In practice, most verification work today establishes that property at only one layer of the stack. Everything else (from the accuracy and completeness of the model itself, through the compiler, to the EVM execution semantics), is taken on trust.
 
 This distance between what is formally proved and what actually executes on chain is the **verification gap**.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,6 +67,13 @@ Vyper eliminates entire vulnerability classes by excluding features that enable 
 
 These constraints mean developers cannot accidentally introduce dangerous patterns, even under time pressure or with limited blockchain experience.
 
+Deep Verification
+=================
+
+Vyper’s design makes **deep verification** practical on a production smart-contract language.
+
+See :doc:`deep-verification` for the full discussion of verification depth, verification gap, and the current state of Vyper’s formal semantics and compiler verification work.
+
 Decimal Fixed Point
 ===================
 

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -48,6 +48,7 @@ Vyper
     :maxdepth: 2
 
     resources
+    deep-verification.rst
     release-notes.rst
     contributing.rst
     style-guide.rst


### PR DESCRIPTION
### What I did
Added a new "Deep Verification" page to the docs explaining verification depth/breadth, the verification gap, and the current state of Vyper's formal semantics work (Verifereum / vyper-hol). Linked from the docs landing page.

### How I did it
- New `docs/deep-verification.rst` with the full discussion
-Short teaser section + link added to `docs/index.rst`
- Added entry to `docs/toctree.rst`

### How to verify it

Build the docs locally and confirm the page renders and the cross-link from the index works.

### Commit message

```
add a docs page describing "deep verification" — reducing the
verification gap by formally bridging as many layers of the stack as
possible (high-level properties → source semantics → compiler
correctness → EVM semantics → deployed bytecode).

vyper's design (simple semantics, no inline assembly, bounded execution)
makes deep verification practical on a production smart-contract
language. the page explains the concept, the existing technical
foundation via the verifereum project (HOL4 semantics for both vyper
source and the EVM), and the current status of source-level vs compiler-
level verification.

link from the docs landing page and add to the toctree so the page is
reachable from navigation.

```
 