### PR TITLE
fix[parser]: reject non-name for-loop targets early

### DIFF
--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -483,6 +483,7 @@ def bar():
             """
 @external
 def bar():
+    # Tuple targets are invalid Vyper syntax, but should raise SyntaxException.
     for i, j in [(1, 2)]:
         pass
     """,

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -487,7 +487,7 @@ def bar():
     for i, j in [(1, 2)]:
         pass
     """,
-            "missing type annotation",
+            "invalid for loop syntax: not a name",
         ),
         (
             """

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -483,7 +483,7 @@ def bar():
             """
 @external
 def bar():
-    for i, j in range(0, 1):
+    for i, j in [(1, 2)]:
         pass
     """,
             "missing type annotation",

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -483,6 +483,15 @@ def bar():
             """
 @external
 def bar():
+    for i, j in range(0, 1):
+        pass
+    """,
+            "missing type annotation",
+        ),
+        (
+            """
+@external
+def bar():
     for i: in range(0, 1):
         pass
     """,

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -326,10 +326,15 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         if not annotation_tokens:
             # a common case for people migrating to 0.4.0, provide a more
             # specific error message than "invalid type annotation"
+            msg = "missing type annotation"
+            if isinstance(node.target, python_ast.Name):
+                msg += (
+                    "\n\n"
+                    "  (hint: did you mean something like "
+                    f"`for {node.target.id}: uint256 in ...`?)"
+                )
             raise SyntaxException(
-                "missing type annotation\n\n"
-                "  (hint: did you mean something like "
-                f"`for {node.target.id}: uint256 in ...`?)",
+                msg,
                 self._source_code,
                 node.lineno,
                 node.col_offset,

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -324,17 +324,20 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         annotation_tokens = self._pre_parser.for_loop_annotations.pop(key)
 
         if not annotation_tokens:
+            if not isinstance(node.target, python_ast.Name):
+                raise SyntaxException(
+                    "invalid for loop syntax: not a name",
+                    self._source_code,
+                    node.target.lineno,
+                    node.target.col_offset,
+                )
+
             # a common case for people migrating to 0.4.0, provide a more
             # specific error message than "invalid type annotation"
-            msg = "missing type annotation"
-            if isinstance(node.target, python_ast.Name):
-                msg += (
-                    "\n\n"
-                    "  (hint: did you mean something like "
-                    f"`for {node.target.id}: uint256 in ...`?)"
-                )
             raise SyntaxException(
-                msg,
+                "missing type annotation\n\n"
+                "  (hint: did you mean something like "
+                f"`for {node.target.id}: uint256 in ...`?)",
                 self._source_code,
                 node.lineno,
                 node.col_offset,


### PR DESCRIPTION
### What I did

Fixed a parser crash when a `for` loop uses an invalid tuple target, such as:

```vyper
for i, j in [(1, 2)]:
    pass
```

This is intentionally invalid Vyper syntax. The fix is that it now raises a clearer `SyntaxException`:

```text
invalid for loop syntax: not a name
```

instead of leaking an internal `AttributeError`.

### How I did it

The parser now rejects non-name loop targets explicitly before constructing the missing type annotation hint. Simple name targets still use the existing missing-annotation diagnostic.

### How to verify it

```bash
uv run --no-dev python -m py_compile vyper/ast/parse.py tests/functional/syntax/test_for_range.py
```

I also ran a focused compiler smoke check for the invalid tuple-target case:

```vyper
for i, j in [(1, 2)]:
    pass
```

### Commit message

```text
Reject non-name for-loop targets before constructing the missing type
annotation hint.

Add syntax coverage for tuple targets so this path raises a clear
SyntaxException instead of leaking AttributeError.
```

### Description for the changelog

Fixed an internal parser error for `for` loops with tuple targets.

### Cute Animal Picture

![red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Endangered_Red_Panda.jpg/640px-Endangered_Red_Panda.jpg)
