### PR TITLE
feat(parser): collect all syntax errors before raising

### DIFF
--- a/tests/functional/syntax/test_multi_error.py
+++ b/tests/functional/syntax/test_multi_error.py
@@ -62,12 +62,7 @@ if True
 
 def test_multi_syntax_errors_include_resolved_path():
     path = Path("/tmp/multi_error_path_check.vy")
-    file_input = FileInput(
-        source_id=1,
-        path=path,
-        resolved_path=path,
-        contents=MULTI_ERROR_CODE,
-    )
+    file_input = FileInput(source_id=1, path=path, resolved_path=path, contents=MULTI_ERROR_CODE)
 
     with pytest.raises(VyperException) as exc_info:
         compiler.compile_from_file_input(file_input)

--- a/tests/functional/syntax/test_multi_error.py
+++ b/tests/functional/syntax/test_multi_error.py
@@ -1,12 +1,14 @@
+from pathlib import Path
+
 import pytest
 
 from vyper import compiler
+from vyper.compiler.input_bundle import FileInput
 from vyper.exceptions import SyntaxException, VyperException
 
-# Code with 3 syntax errors on 3 different lines:
+# Code with 2 recoverable syntax errors on 2 different lines:
 # 1. Incomplete assignment `x =`
 # 2. Missing colon after `if True`
-# 3. Invalid function name (missing parenthesis)
 MULTI_ERROR_CODE = """
 @external
 def foo():
@@ -16,12 +18,58 @@ def foo():
 """
 
 
-def test_multi_syntax_errors():
+def test_multi_syntax_errors_are_reported_in_source_order():
     """Multiple syntax errors are collected and raised together."""
     with pytest.raises(VyperException) as exc_info:
         compiler.compile_code(MULTI_ERROR_CODE)
 
     msg = str(exc_info.value)
     assert "Compilation failed with the following errors:" in msg
-    # Should contain at least 2 SyntaxException entries
-    assert msg.count("SyntaxException") >= 2
+    assert msg.count("SyntaxException") == 2
+    assert msg.index("line 4:7") < msg.index("line 5:11")
+    assert "invalid syntax" in msg
+    assert "expected ':'" in msg
+
+
+def test_syntax_recovery_stops_when_no_progress_is_possible():
+    code = """
+@external
+def foo():
+    x =
+"""
+
+    with pytest.raises(SyntaxException) as exc_info:
+        compiler.compile_code(code)
+
+    msg = str(exc_info.value)
+    assert "invalid syntax" in msg
+    assert "expected an indented block" not in msg
+
+
+def test_syntax_recovery_skips_indentation_cascade_errors():
+    code = """
+if True
+    pass
+"""
+
+    with pytest.raises(SyntaxException) as exc_info:
+        compiler.compile_code(code)
+
+    msg = str(exc_info.value)
+    assert "expected ':'" in msg
+    assert "unexpected indent" not in msg
+
+
+def test_multi_syntax_errors_include_resolved_path():
+    path = Path("/tmp/multi_error_path_check.vy")
+    file_input = FileInput(
+        source_id=1,
+        path=path,
+        resolved_path=path,
+        contents=MULTI_ERROR_CODE,
+    )
+
+    with pytest.raises(VyperException) as exc_info:
+        compiler.compile_from_file_input(file_input)
+
+    assert "multi_error_path_check.vy:4" in str(exc_info.value)

--- a/tests/functional/syntax/test_multi_error.py
+++ b/tests/functional/syntax/test_multi_error.py
@@ -1,0 +1,27 @@
+import pytest
+
+from vyper import compiler
+from vyper.exceptions import SyntaxException, VyperException
+
+# Code with 3 syntax errors on 3 different lines:
+# 1. Incomplete assignment `x =`
+# 2. Missing colon after `if True`
+# 3. Invalid function name (missing parenthesis)
+MULTI_ERROR_CODE = """
+@external
+def foo():
+    x =
+    if True
+        pass
+"""
+
+
+def test_multi_syntax_errors():
+    """Multiple syntax errors are collected and raised together."""
+    with pytest.raises(VyperException) as exc_info:
+        compiler.compile_code(MULTI_ERROR_CODE)
+
+    msg = str(exc_info.value)
+    assert "Compilation failed with the following errors:" in msg
+    # Should contain at least 2 SyntaxException entries
+    assert msg.count("SyntaxException") >= 2

--- a/tests/functional/syntax/test_multi_error.py
+++ b/tests/functional/syntax/test_multi_error.py
@@ -17,6 +17,14 @@ def foo():
         pass
 """
 
+THREE_ERROR_CODE = """
+@external
+def foo():
+    x =
+    y =
+    z =
+"""
+
 
 def test_multi_syntax_errors_are_reported_in_source_order():
     """Multiple syntax errors are collected and raised together."""
@@ -29,6 +37,98 @@ def test_multi_syntax_errors_are_reported_in_source_order():
     assert msg.index("line 4:7") < msg.index("line 5:11")
     assert "invalid syntax" in msg
     assert "expected ':'" in msg
+
+
+def test_three_syntax_errors_are_reported_in_source_order():
+    with pytest.raises(VyperException) as exc_info:
+        compiler.compile_code(THREE_ERROR_CODE)
+
+    msg = str(exc_info.value)
+    assert msg.count("SyntaxException") == 3
+    assert msg.index("line 4:7") < msg.index("line 5:7") < msg.index("line 6:7")
+    assert "expected an indented block" not in msg
+
+
+@pytest.mark.parametrize(
+    "code, expected_lines, expected_errors",
+    [
+        (
+            """
+@external
+def foo():
+    x =
+    pass
+
+@external
+def bar:
+    pass
+""",
+            ("line 4:7", "line 8:7"),
+            ("invalid syntax", "expected '('"),
+        ),
+        (
+            """
+@external
+def foo():
+    x =
+    pass
+
+@external
+def bar():
+    y =
+    pass
+""",
+            ("line 4:7", "line 9:7"),
+            ("invalid syntax", "invalid syntax"),
+        ),
+        (
+            """
+@external
+def foo():
+    x +=
+    y =
+    pass
+""",
+            ("line 4:8", "line 5:7"),
+            ("invalid syntax", "invalid syntax"),
+        ),
+        (
+            """
+@external
+def foo():
+    assert
+    y =
+    pass
+""",
+            ("line 4:10", "line 5:7"),
+            ("invalid syntax", "invalid syntax"),
+        ),
+        (
+            """
+import
+
+@external
+def foo():
+    y =
+    pass
+""",
+            ("line 2:6", "line 6:7"),
+            ("invalid syntax", "invalid syntax"),
+        ),
+    ],
+)
+def test_recoverable_syntax_errors_are_collected(code, expected_lines, expected_errors):
+    with pytest.raises(VyperException) as exc_info:
+        compiler.compile_code(code)
+
+    msg = str(exc_info.value)
+    assert msg.count("SyntaxException") == len(expected_lines)
+    for line in expected_lines:
+        assert line in msg
+    for first_line, second_line in zip(expected_lines, expected_lines[1:]):
+        assert msg.index(first_line) < msg.index(second_line)
+    for error in expected_errors:
+        assert error in msg
 
 
 def test_syntax_recovery_stops_when_no_progress_is_possible():
@@ -46,10 +146,103 @@ def foo():
     assert "expected an indented block" not in msg
 
 
-def test_syntax_recovery_skips_indentation_cascade_errors():
-    code = """
+@pytest.mark.parametrize(
+    "code, expected_error, rejected_errors",
+    [
+        (
+            """
+@external
+def foo:
+    pass
+""",
+            "expected '('",
+            ("SyntaxException:", "expected an indented block"),
+        ),
+        (
+            """
+@external
+def 123foo():
+    pass
+""",
+            "invalid decimal literal",
+            ("SyntaxException:", "unexpected indent"),
+        ),
+        (
+            """
 if True
     pass
+
+if False
+    pass
+""",
+            "expected ':'",
+            ("SyntaxException:", "unexpected indent"),
+        ),
+        (
+            """
+@external
+def foo() -> uint256:
+    return
+    x =
+    pass
+""",
+            "invalid syntax",
+            ("SyntaxException:", "expected an indented block"),
+        ),
+    ],
+)
+def test_unrecoverable_syntax_errors_stop_before_downstream_noise(
+    code, expected_error, rejected_errors
+):
+    with pytest.raises(SyntaxException) as exc_info:
+        compiler.compile_code(code)
+
+    msg = str(exc_info.value)
+    assert expected_error in msg
+    for rejected_error in rejected_errors:
+        assert rejected_error not in msg
+
+
+@pytest.mark.parametrize(
+    "code, primary_error, cascade_error",
+    [
+        (
+            """
+if True
+    pass
+""",
+            "expected ':'",
+            "unexpected indent",
+        ),
+        (
+            """
+@external
+def foo():
+    if True
+        pass
+    if False
+        pass
+""",
+            "expected ':'",
+            "unindent does not match any outer indentation level",
+        ),
+    ],
+)
+def test_syntax_recovery_skips_indentation_cascade_errors(code, primary_error, cascade_error):
+    with pytest.raises(SyntaxException) as exc_info:
+        compiler.compile_code(code)
+
+    msg = str(exc_info.value)
+    assert primary_error in msg
+    assert cascade_error not in msg
+
+
+def test_syntax_recovery_raises_before_orphaned_pre_parser_metadata_asserts():
+    code = """
+@external
+def foo():
+    for i: uint256 in range(10)
+        pass
 """
 
     with pytest.raises(SyntaxException) as exc_info:
@@ -57,7 +250,7 @@ if True
 
     msg = str(exc_info.value)
     assert "expected ':'" in msg
-    assert "unexpected indent" not in msg
+    assert "AssertionError" not in msg
 
 
 def test_multi_syntax_errors_include_resolved_path():
@@ -68,3 +261,21 @@ def test_multi_syntax_errors_include_resolved_path():
         compiler.compile_from_file_input(file_input)
 
     assert "multi_error_path_check.vy:4" in str(exc_info.value)
+
+
+def test_multi_syntax_error_hints_are_preserved():
+    code = """
+from ethereum.ercs import IERC20Detailed
+
+@external
+def foo():
+    x =
+    staticcall ERC20(msg.sender).transfer(msg.sender, staticall IERC20Detailed(msg.sender).decimals())
+"""
+
+    with pytest.raises(VyperException) as exc_info:
+        compiler.compile_code(code)
+
+    msg = str(exc_info.value)
+    assert msg.count("SyntaxException") == 2
+    assert "did you mean `staticcall`?" in msg

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -111,6 +111,15 @@ def _parse_to_ast(
                 lines[e.lineno - 1] = ""
             code = "\n".join(lines)
 
+    # If we collected syntax errors during parsing, raise them before
+    # AST annotation. Otherwise, blanked lines may leave unconsumed
+    # pre-parser metadata (e.g. for_loop_annotations) that would cause
+    # an internal AssertionError instead of the intended diagnostics.
+    if errors:
+        err_list = ExceptionList()
+        err_list.extend(errors)
+        err_list.raise_if_not_empty()
+
     annotate_python_ast(
         py_ast,
         vyper_source,
@@ -133,12 +142,6 @@ def _parse_to_ast(
     module.is_interface = is_interface
 
     module.settings = pre_parser.settings
-
-    # If we collected errors along the way, raise them now
-    if errors:
-        err_list = ExceptionList()
-        err_list.extend(errors)
-        err_list.raise_if_not_empty()
 
     return module
 

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.pre_parser import PreParser
-from vyper.exceptions import CompilerPanic, ParserException, SyntaxException
+from vyper.exceptions import CompilerPanic, ExceptionList, ParserException, SyntaxException
 from vyper.utils import sha256sum
 from vyper.warnings import Deprecation, vyper_warn
 
@@ -76,29 +76,40 @@ def _parse_to_ast(
     pre_parser = PreParser(is_interface)
     pre_parser.parse(vyper_source)
 
-    try:
-        py_ast = python_ast.parse(pre_parser.reformatted_code)
-    except SyntaxError as e:
-        offset = e.offset
-        if offset is not None:
-            # SyntaxError offset is 1-based, not 0-based (see:
-            # https://docs.python.org/3/library/exceptions.html#SyntaxError.offset)
-            offset -= 1
+    errors: list[SyntaxException] = []
+    code = pre_parser.reformatted_code
 
-            # adjust the column of the error if it was modified by the pre-parser
-            if e.lineno is not None:  # help mypy
-                offset += pre_parser.adjustments.get((e.lineno, offset), 0)
+    while True:
+        try:
+            py_ast = python_ast.parse(code)
+            break
+        except SyntaxError as e:
+            offset = e.offset
+            if offset is not None:
+                # SyntaxError offset is 1-based, not 0-based (see:
+                # https://docs.python.org/3/library/exceptions.html#SyntaxError.offset)
+                offset -= 1
 
-        new_e = SyntaxException(str(e), vyper_source, e.lineno, offset)
+                # adjust the column of the error if it was modified by the pre-parser
+                if e.lineno is not None:  # help mypy
+                    offset += pre_parser.adjustments.get((e.lineno, offset), 0)
 
-        likely_errors = ("staticall", "staticcal")
-        tmp = str(new_e)
-        for s in likely_errors:
-            if s in tmp:
-                new_e._hint = "did you mean `staticcall`?"
-                break
+            new_e = SyntaxException(str(e), vyper_source, e.lineno, offset)
 
-        raise new_e from None
+            likely_errors = ("staticall", "staticcal")
+            tmp = str(new_e)
+            for s in likely_errors:
+                if s in tmp:
+                    new_e._hint = "did you mean `staticcall`?"
+                    break
+
+            errors.append(new_e)
+
+            # Blank the error line in the reformatted code to recover
+            lines = code.split("\n")
+            if e.lineno is not None and 1 <= e.lineno <= len(lines):
+                lines[e.lineno - 1] = ""
+            code = "\n".join(lines)
 
     annotate_python_ast(
         py_ast,
@@ -122,6 +133,12 @@ def _parse_to_ast(
     module.is_interface = is_interface
 
     module.settings = pre_parser.settings
+
+    # If we collected errors along the way, raise them now
+    if errors:
+        err_list = ExceptionList()
+        err_list.extend(errors)
+        err_list.raise_if_not_empty()
 
     return module
 
@@ -324,6 +341,14 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         annotation_tokens = self._pre_parser.for_loop_annotations.pop(key)
 
         if not annotation_tokens:
+            if not isinstance(node.target, python_ast.Name):
+                raise SyntaxException(
+                    "invalid for loop syntax: not a name",
+                    self._source_code,
+                    node.target.lineno,
+                    node.target.col_offset,
+                )
+
             # a common case for people migrating to 0.4.0, provide a more
             # specific error message than "invalid type annotation"
             raise SyntaxException(

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -76,7 +76,7 @@ def _parse_to_ast(
     pre_parser = PreParser(is_interface)
     pre_parser.parse(vyper_source)
 
-    errors: list[SyntaxException] = []
+    errors = ExceptionList()
     code = pre_parser.reformatted_code
 
     while True:
@@ -84,6 +84,16 @@ def _parse_to_ast(
             py_ast = python_ast.parse(code)
             break
         except SyntaxError as e:
+            if errors and (
+                e.msg.startswith("expected an indented block")
+                or e.msg
+                in (
+                    "unexpected indent",
+                    "unindent does not match any outer indentation level",
+                )
+            ):
+                errors.raise_if_not_empty()
+
             offset = e.offset
             if offset is not None:
                 # SyntaxError offset is 1-based, not 0-based (see:
@@ -95,6 +105,7 @@ def _parse_to_ast(
                     offset += pre_parser.adjustments.get((e.lineno, offset), 0)
 
             new_e = SyntaxException(str(e), vyper_source, e.lineno, offset)
+            new_e.resolved_path = resolved_path
 
             likely_errors = ("staticall", "staticcal")
             tmp = str(new_e)
@@ -103,12 +114,16 @@ def _parse_to_ast(
                     new_e._hint = "did you mean `staticcall`?"
                     break
 
-            errors.append(new_e)
+            errors.insert(0, new_e)
 
             # Blank the error line in the reformatted code to recover
             lines = code.split("\n")
             if e.lineno is not None and 1 <= e.lineno <= len(lines):
+                if lines[e.lineno - 1] == "":
+                    errors.raise_if_not_empty()
                 lines[e.lineno - 1] = ""
+            else:
+                errors.raise_if_not_empty()
             code = "\n".join(lines)
 
     # If we collected syntax errors during parsing, raise them before
@@ -116,9 +131,7 @@ def _parse_to_ast(
     # pre-parser metadata (e.g. for_loop_annotations) that would cause
     # an internal AssertionError instead of the intended diagnostics.
     if errors:
-        err_list = ExceptionList()
-        err_list.extend(errors)
-        err_list.raise_if_not_empty()
+        errors.raise_if_not_empty()
 
     annotate_python_ast(
         py_ast,

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -87,10 +87,7 @@ def _parse_to_ast(
             if errors and (
                 e.msg.startswith("expected an indented block")
                 or e.msg
-                in (
-                    "unexpected indent",
-                    "unindent does not match any outer indentation level",
-                )
+                in ("unexpected indent", "unindent does not match any outer indentation level")
             ):
                 errors.raise_if_not_empty()
 


### PR DESCRIPTION
### What I did

Wired the existing ExceptionList mechanism into the parser so it collects all syntax errors in a single pass instead of stopping at the first one.

### How I did it

In _parse_to_ast, replaced the try/except/raise with a while True loop. On each SyntaxError, the offending line is blanked in the reformatted code and the parse is retried. After the parse succeeds, all collected errors are raised at once via ExceptionList.

### How to verify it

 Run the new test:
    
 ```bash
 pytest tests/functional/syntax/test_multi_error.py -v
 ```   
    
 Or compile any Vyper file with multiple syntax errors. All of them should appear in the output.

### Commit message

```
feat(parser): collect all syntax errors before raising
```

### Description for the changelog

Report all syntax errors at once instead of stopping at the first one.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/post-the-best-cat-memes-you-got-in-the-comments-please-v0-kg82lbnu0ste1.png?auto=webp&s=e6f9eee86484f5de3f4e31f3c33b2d07fb982bd5)
