### PR TITLE
fix: reject extcall/staticcall in assert/raise revert reason

### DIFF
--- a/tests/functional/syntax/test_revert_reason_external_calls.py
+++ b/tests/functional/syntax/test_revert_reason_external_calls.py
@@ -1,0 +1,57 @@
+import pytest
+
+from vyper import compiler
+from vyper.exceptions import StructureException
+
+fail_list = [
+    (
+        """
+interface I:
+    def get_msg() -> String[20]: nonpayable
+
+@external
+def f(x: bool, target: address):
+    assert x, extcall I(target).get_msg()
+        """,
+        StructureException,
+    ),
+    (
+        """
+interface I:
+    def get_msg() -> String[20]: nonpayable
+
+@external
+def f(x: bool, target: address):
+    raise extcall I(target).get_msg()
+        """,
+        StructureException,
+    ),
+    (
+        """
+interface I:
+    def get_msg() -> String[20]: nonpayable
+
+@external
+def f(x: bool, target: address):
+    assert x, staticcall I(target).get_msg()
+        """,
+        StructureException,
+    ),
+    (
+        """
+interface I:
+    def get_msg() -> String[20]: nonpayable
+
+@external
+def f(x: bool, target: address):
+    raise staticcall I(target).get_msg()
+        """,
+        StructureException,
+    ),
+]
+
+
+@pytest.mark.parametrize("bad_code,exc", fail_list)
+def test_revert_reason_rejects_external_calls(bad_code, exc):
+    with pytest.raises(exc):
+        compiler.compile_code(bad_code)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -481,6 +481,10 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         self.expr_visitor.visit(node.target, typ)
 
     def _validate_revert_reason(self, msg_node: vy_ast.VyperNode) -> None:
+        if isinstance(msg_node, vy_ast.ExtCall):
+            raise StructureException("Cannot use extcall in revert reason", msg_node)
+        if isinstance(msg_node, vy_ast.StaticCall):
+            raise StructureException("Cannot use staticcall in revert reason", msg_node)
         if isinstance(msg_node, vy_ast.Str):
             if not msg_node.value.strip():
                 raise StructureException("Reason string cannot be empty", msg_node)


### PR DESCRIPTION
## Summary

Using `extcall` (or `staticcall`) as the message argument to `assert` or `raise` crashes the compiler with `CodegenPanic` because the codegen pipeline sets the context to constant mode when evaluating revert reasons, and external calls violate that constraint.

This adds an early guard in `_validate_revert_reason` in the typechecker to reject `ExtCall` and `StaticCall` nodes with a clear `StructureException` before they reach codegen.

## Changes

- `vyper/semantics/analysis/local.py`: Added two type checks at the top of `_validate_revert_reason` to reject `ExtCall` and `StaticCall` nodes
- `tests/functional/syntax/test_revert_reason_external_calls.py`: Added parametrized tests covering `assert` and `raise` with both `extcall` and `staticcall`

## Before

```
CodegenPanic: unhandled exception typechecker missed this, parse_ExtCall
```

## After

```
StructureException: Cannot use extcall in revert reason
  function "f", line 7:14
       6 def f(x: bool, target: address):
  ---> 7     assert x, extcall I(target).get_msg()
```

Fixes #4966