### PR TITLE
feat[lang]: access immutables through `self`

### DIFF
--- a/tests/functional/builtins/codegen/test_concat.py
+++ b/tests/functional/builtins/codegen/test_concat.py
@@ -81,12 +81,12 @@ i: immutable(int256)
 
 @deploy
 def __init__():
-    i = -1
+    self.i = -1
     s: String[2] = concat("a", "b")
 
 @external
 def foo() -> int256:
-    return i
+    return self.i
     """
     c = get_contract(code)
     assert c.foo() == -1

--- a/tests/functional/builtins/codegen/test_create_functions.py
+++ b/tests/functional/builtins/codegen/test_create_functions.py
@@ -282,11 +282,11 @@ BLUEPRINT: immutable(address)
 
 @deploy
 def __init__(blueprint_address: address):
-    BLUEPRINT = blueprint_address
+    self.BLUEPRINT = blueprint_address
 
 @external
 def test(code_ofst: uint256) -> address:
-    return create_from_blueprint(BLUEPRINT, code_offset=code_ofst)
+    return create_from_blueprint(self.BLUEPRINT, code_offset=code_ofst)
     """
 
     initcode_len = 100
@@ -341,16 +341,16 @@ BAR: immutable(Bar)
 
 @deploy
 def __init__(foo: String[128], bar: Bar):
-    FOO = foo
-    BAR = bar
+    self.FOO = foo
+    self.BAR = bar
 
 @external
 def foo() -> String[128]:
-    return FOO
+    return self.FOO
 
 @external
 def bar() -> Bar:
-    return BAR
+    return self.BAR
     """
 
     deployer_code = """

--- a/tests/functional/builtins/codegen/test_ecrecover.py
+++ b/tests/functional/builtins/codegen/test_ecrecover.py
@@ -74,11 +74,11 @@ owner: immutable(address)
 
 @deploy
 def __init__():
-    owner = 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
+    self.owner = 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
 
 @internal
 def get_v() -> uint256:
-    assert owner == owner # force a dload to write at index 0 of memory
+    assert self.owner == self.owner # force a dload to write at index 0 of memory
     return 21
 
 @payable

--- a/tests/functional/builtins/codegen/test_slice.py
+++ b/tests/functional/builtins/codegen/test_slice.py
@@ -111,12 +111,12 @@ IMMUTABLE_SLICE: immutable(Bytes[{length_bound}])
 
 @deploy
 def __init__(inp: Bytes[{length_bound}], start: uint256, length: uint256):
-    IMMUTABLE_BYTES = inp
-    IMMUTABLE_SLICE = slice(IMMUTABLE_BYTES, {_start}, {_length})
+    self.IMMUTABLE_BYTES = inp
+    self.IMMUTABLE_SLICE = slice(self.IMMUTABLE_BYTES, {_start}, {_length})
 
 @external
 def do_splice() -> Bytes[{length_bound}]:
-    return IMMUTABLE_SLICE
+    return self.IMMUTABLE_SLICE
     """
 
     def _get_contract():
@@ -185,10 +185,10 @@ foo: transient(Bytes[{length_bound}])
 IMMUTABLE_BYTES: immutable(Bytes[{length_bound}])
 @deploy
 def __init__(foo: Bytes[{length_bound}]):
-    IMMUTABLE_BYTES = foo
+    self.IMMUTABLE_BYTES = foo
     """
         spliced_code = ""
-        foo = "IMMUTABLE_BYTES"
+        foo = "self.IMMUTABLE_BYTES"
     elif location == "literal":
         spliced_code = ""
         foo = f"{bytesdata}"
@@ -315,11 +315,11 @@ LENGTH: immutable(uint256)
 
 @deploy
 def __init__():
-    LENGTH = 5
+    self.LENGTH = 5
 
 @external
 def do_slice(inp: Bytes[50]) -> Bytes[50]:
-    return slice(inp, 0, LENGTH)
+    return slice(inp, 0, self.LENGTH)
     """
     c = get_contract(code)
     x = c.do_slice(b"abcdefghijklmnopqrstuvwxyz1234")

--- a/tests/functional/codegen/calling_convention/test_new_call_convention.py
+++ b/tests/functional/codegen/calling_convention/test_new_call_convention.py
@@ -24,11 +24,11 @@ a: immutable(uint256)
 
 @deploy
 def __init__():
-    a = 5
+    self.a = 5
 
 @internal
 def get_my_immutable() -> uint256:
-    return a
+    return self.a
 
 @external
 def get_immutable() -> uint256:

--- a/tests/functional/codegen/features/decorators/test_nonreentrant.py
+++ b/tests/functional/codegen/features/decorators/test_nonreentrant.py
@@ -572,7 +572,7 @@ b: public(immutable(uint256))
 
 @deploy
 def __init__():
-    b = 666
+    self.b = 666
 
     """
     main = """

--- a/tests/functional/codegen/features/decorators/test_pure.py
+++ b/tests/functional/codegen/features/decorators/test_pure.py
@@ -93,12 +93,12 @@ COUNTER: immutable(uint256)
 
 @deploy
 def __init__():
-    COUNTER = 1234
+    self.COUNTER = 1234
 
 @pure
 @external
 def foo() -> uint256:
-    return COUNTER
+    return self.COUNTER
     """
     with pytest.raises(StateAccessViolation):
         compile_code(code)
@@ -139,7 +139,7 @@ COUNTER: immutable(uint256)
 
 @deploy
 def __init__():
-    COUNTER = 123
+    self.COUNTER = 123
     """
     code = """
 import lib1

--- a/tests/functional/codegen/features/decorators/test_raw_return.py
+++ b/tests/functional/codegen/features/decorators/test_raw_return.py
@@ -201,7 +201,7 @@ def foo() -> Bytes[32]:
 
 # test raw_return from storage, transient, constant and immutable
 # calldata Bytes[..] need clamp and thus are internally coppied to memory
-@pytest.mark.parametrize("to_ret", ["self.s", "self.t", "c", "i"])
+@pytest.mark.parametrize("to_ret", ["self.s", "self.t", "c", "self.i"])
 def test_raw_return_from_location(env, get_contract, to_ret):
     has_transient = version_check(begin="cancun")
     if to_ret == "self.t" and not has_transient:
@@ -219,7 +219,7 @@ i: immutable(Bytes[32])
 @deploy
 def __init__():
     self.s = b'cow'
-    i = b'cow'
+    self.i = b'cow'
 
 @external
 @raw_return

--- a/tests/functional/codegen/features/test_constructor.py
+++ b/tests/functional/codegen/features/test_constructor.py
@@ -254,7 +254,7 @@ x: public(immutable(uint256))
 
 @deploy
 def __init__(i: uint256):
-    x = self.foo0(i)
+    self.x = self.foo0(i)
 """
     for i in range(16):
         code += f"""
@@ -291,9 +291,9 @@ I_BYTES32: public(immutable(bytes32))
 
 @deploy
 def __init__():
-    I_UINT = CONST_UINT
-    I_ADDR = CONST_ADDR
-    I_BYTES32 = CONST_BYTES32
+    self.I_UINT = CONST_UINT
+    self.I_ADDR = CONST_ADDR
+    self.I_BYTES32 = CONST_BYTES32
     """
     print(code)
     c = get_contract(code)

--- a/tests/functional/codegen/features/test_immutable.py
+++ b/tests/functional/codegen/features/test_immutable.py
@@ -22,12 +22,12 @@ VALUE: immutable({typ})
 
 @deploy
 def __init__(_value: {typ}):
-    VALUE = _value
+    self.VALUE = _value
 
 @view
 @external
 def get_value() -> {typ}:
-    return VALUE
+    return self.VALUE
     """
 
     c = get_contract(code, value)
@@ -43,14 +43,14 @@ a: public(uint256)
 
 @deploy
 def __init__(_a: uint256):
-    A = _a
-    self.a = A
+    self.A = _a
+    self.a = self.A
 
 
 @external
 @view
 def a1() -> uint256:
-    return A
+    return self.A
     """
 
     c = get_contract(code, val)
@@ -65,14 +65,14 @@ c: immutable(String[64])
 
 @deploy
 def __init__(_a: uint256, _b: address, _c: String[64]):
-    a = _a
-    b = _b
-    c = _c
+    self.a = _a
+    self.b = _b
+    self.c = _c
 
 @view
 @external
 def get_values() -> (uint256, address, String[64]):
-    return a, b, c
+    return self.a, self.b, self.c
     """
     values = (3, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", "Hello world")
     c = get_contract(code, *values)
@@ -91,7 +91,7 @@ my_struct: immutable(MyStruct)
 
 @deploy
 def __init__(_a: uint256, _b: uint256, _c: address, _d: int256):
-    my_struct = MyStruct(
+    self.my_struct = MyStruct(
         a=_a,
         b=_b,
         c=_c,
@@ -101,7 +101,7 @@ def __init__(_a: uint256, _b: uint256, _c: address, _d: int256):
 @view
 @external
 def get_my_struct() -> MyStruct:
-    return my_struct
+    return self.my_struct
     """
     values = (100, 42, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", -(2**200))
     c = get_contract(code, *values)
@@ -117,15 +117,15 @@ my_struct: immutable(MyStruct)
 
 @deploy
 def __init__(a: uint256):
-    my_struct = MyStruct(a=a)
+    self.my_struct = MyStruct(a=a)
 
     # struct members are modifiable after initialization
-    my_struct.a += 1
+    self.my_struct.a += 1
 
 @view
 @external
 def get_my_struct() -> MyStruct:
-    return my_struct
+    return self.my_struct
     """
     c = get_contract(code, 1)
     assert c.get_my_struct() == (2,)
@@ -137,12 +137,12 @@ my_list: immutable(uint256[3])
 
 @deploy
 def __init__(_a: uint256, _b: uint256, _c: uint256):
-    my_list = [_a, _b, _c]
+    self.my_list = [_a, _b, _c]
 
 @view
 @external
 def get_my_list() -> uint256[3]:
-    return my_list
+    return self.my_list
     """
     values = (100, 42, 23230)
     c = get_contract(code, *values)
@@ -155,17 +155,17 @@ my_list: immutable(DynArray[uint256, 3])
 
 @deploy
 def __init__(_a: uint256, _b: uint256, _c: uint256):
-    my_list = [_a, _b, _c]
+    self.my_list = [_a, _b, _c]
 
 @view
 @external
 def get_my_list() -> DynArray[uint256, 3]:
-    return my_list
+    return self.my_list
 
 @view
 @external
 def get_idx_two() -> uint256:
-    return my_list[2]
+    return self.my_list[2]
     """
     values = (100, 42, 23230)
     c = get_contract(code, *values)
@@ -179,17 +179,17 @@ my_list: immutable(DynArray[DynArray[uint256, 3], 3])
 
 @deploy
 def __init__(_a: uint256, _b: uint256, _c: uint256):
-    my_list = [[_a, _b, _c], [_b, _a, _c], [_c, _b, _a]]
+    self.my_list = [[_a, _b, _c], [_b, _a, _c], [_c, _b, _a]]
 
 @view
 @external
 def get_my_list() -> DynArray[DynArray[uint256, 3], 3]:
-    return my_list
+    return self.my_list
 
 @view
 @external
 def get_idx_two() -> uint256:
-    return my_list[2][2]
+    return self.my_list[2][2]
     """
     values = (100, 42, 23230)
     expected_values = [[100, 42, 23230], [42, 100, 23230], [23230, 42, 100]]
@@ -204,7 +204,7 @@ my_list: immutable(DynArray[DynArray[DynArray[int128, 3], 3], 3])
 
 @deploy
 def __init__(x: int128, y: int128, z: int128):
-    my_list = [
+    self.my_list = [
         [[x, y, z], [y, z, x], [z, y, x]],
         [
             [x * 1000 + y, y * 1000 + z, z * 1000 + x],
@@ -221,12 +221,12 @@ def __init__(x: int128, y: int128, z: int128):
 @view
 @external
 def get_my_list() -> DynArray[DynArray[DynArray[int128, 3], 3], 3]:
-    return my_list
+    return self.my_list
 
 @view
 @external
 def get_idx_two() -> int128:
-    return my_list[2][2][2]
+    return self.my_list[2][2][2]
     """
     values = (37, 41, 73)
     expected_values = [
@@ -254,12 +254,12 @@ VALUE: immutable(uint256)
 def __init__(x: uint256):
     self.counter = x
     self.foo()
-    VALUE = self.foo()
+    self.VALUE = self.foo()
     self.foo()
 
 @external
 def get_immutable() -> uint256:
-    return VALUE
+    return self.VALUE
     """
 
     c = get_contract(code, n)
@@ -283,8 +283,8 @@ b: public(uint256)
 @deploy
 def __init__(to_copy: address):
     c: address = create_copy_of(to_copy)
-    self.b = a
-    a = 12
+    self.b = self.a
+    self.a = 12
     """
     c = get_contract(code, dummy_contract.address)
 
@@ -307,9 +307,9 @@ b: public(uint256)
 @deploy
 def __init__(to_copy: address):
     c: address = create_copy_of(to_copy)
-    self.b = a
-    a = 12
-    a0 = empty(uint256[10])
+    self.b = self.a
+    self.a = 12
+    self.a0 = empty(uint256[10])
     """
     c = get_contract(code, dummy_contract.address)
 
@@ -325,7 +325,7 @@ x: immutable(uint256)
 @deploy
 def __init__():
     self.d = 1
-    x = 2
+    self.x = 2
     self.a()
 
 @external
@@ -334,7 +334,7 @@ def test() -> uint256:
 
 @internal
 def a():
-    self.d = x
+    self.d = self.x
     """
     c = get_contract(code)
     assert c.test() == 2
@@ -349,7 +349,7 @@ x: public(immutable(uint256))
 @deploy
 def __init__():
     self.d = 1
-    x = 2
+    self.x = 2
     self.a()
 
 @internal
@@ -358,7 +358,7 @@ def a():
 
 @internal
 def b():
-    self.d = x
+    self.d = self.x
     """
     c = get_contract(code)
     assert c.x() == 2
@@ -374,12 +374,12 @@ x: public(immutable(uint256))
 @deploy
 def __init__():
     self.d = 1
-    x = 2
+    self.x = 2
     self.a()
 
 @internal
 def a():
-    self.d = x
+    self.d = self.x
 
 @external
 def thrash():
@@ -409,11 +409,11 @@ x: public(immutable(uint256))
 
 @deploy
 def __init__():
-    x = self.a()
+    self.x = self.a()
 
 @internal
 def a() -> uint256:
-    return x
+    return self.x
     """
 
     c = get_contract(code)
@@ -427,7 +427,7 @@ x: public(immutable(uint256))
 @deploy
 def __init__():
     for i: uint256 in range(10):
-        x = x + i
+        self.x = self.x + i
     """
 
     c = get_contract(code)
@@ -440,7 +440,7 @@ x: public(immutable(uint256))
 
 @deploy
 def __init__():
-    x = x
+    self.x = self.x
     """
 
     c = get_contract(code)
@@ -460,7 +460,7 @@ VALUE: public(immutable(uint256))
 @deploy
 def __init__(x: uint256):
     self.foo()
-    VALUE = x
+    self.VALUE = x
     self.foo()
     """
     c = get_contract(code, 4)
@@ -531,13 +531,13 @@ arr: immutable(uint256[5])
 
 @deploy
 def __init__():
-    arr = [10, 20, 30, 40, 50]
+    self.arr = [10, 20, 30, 40, 50]
 
 @external
 @view
 def sum_array() -> uint256:
     total: uint256 = 0
-    for val: uint256 in arr:
+    for val: uint256 in self.arr:
         total += val
     return total
     """
@@ -555,20 +555,20 @@ arr: immutable(DynArray[uint256, 10])
 
 @deploy
 def __init__(values: DynArray[uint256, 10]):
-    arr = values
+    self.arr = values
 
 @external
 @view
 def sum_array() -> uint256:
     total: uint256 = 0
-    for val: uint256 in arr:
+    for val: uint256 in self.arr:
         total += val
     return total
 
 @external
 @view
 def get_length() -> uint256:
-    return len(arr)
+    return len(self.arr)
     """
     c = get_contract(code, [1, 2, 3, 4, 5])
     assert c.sum_array() == 15
@@ -589,16 +589,16 @@ ctor_not_in_nine: public(bool)
 
 @deploy
 def __init__(values: DynArray[uint256, 10]):
-    arr = values
-    self.ctor_len = len(arr)
+    self.arr = values
+    self.ctor_len = len(self.arr)
 
     total: uint256 = 0
-    for value: uint256 in arr:
+    for value: uint256 in self.arr:
         total += value
     self.ctor_sum = total
 
-    self.ctor_has_two = 2 in arr
-    self.ctor_not_in_nine = 9 not in arr
+    self.ctor_has_two = 2 in self.arr
+    self.ctor_not_in_nine = 9 not in self.arr
     """
 
     c = get_contract(code, [1, 2, 3, 4])
@@ -622,15 +622,15 @@ ctor_second: public(uint256)
 
 @deploy
 def __init__(values: DynArray[uint256[1], 3]):
-    arr = values
+    self.arr = values
 
     total: uint256 = 0
-    for item: uint256[1] in arr:
+    for item: uint256[1] in self.arr:
         total += item[0]
     self.ctor_total = total
 
-    if len(arr) > 1:
-        self.ctor_second = arr[1][0]
+    if len(self.arr) > 1:
+        self.ctor_second = self.arr[1][0]
     """
 
     c = get_contract(code, [[5], [7], [11]])
@@ -650,15 +650,15 @@ ctor_second_right: public(uint256)
 
 @deploy
 def __init__(values: DynArray[uint256[2], 3]):
-    arr = values
+    self.arr = values
 
     total: uint256 = 0
-    for pair: uint256[2] in arr:
+    for pair: uint256[2] in self.arr:
         total += pair[0] + pair[1]
     self.ctor_total = total
 
-    if len(arr) > 1:
-        self.ctor_second_right = arr[1][1]
+    if len(self.arr) > 1:
+        self.ctor_second_right = self.arr[1][1]
     """
 
     c = get_contract(code, [[1, 2], [3, 4]])
@@ -682,13 +682,13 @@ arr: immutable(DynArray[uint256[2], 3])
 
 @deploy
 def __init__(values: DynArray[uint256[2], 3]):
-    arr = values
+    self.arr = values
 
 @external
 @view
 def sum_pairs() -> uint256:
     total: uint256 = 0
-    for pair: uint256[2] in arr:
+    for pair: uint256[2] in self.arr:
         total += pair[0] + pair[1]
     return total
     """
@@ -710,11 +710,11 @@ def __init__(
     left_values: DynArray[uint256, 4],
     right_values: DynArray[uint256, 4]
 ):
-    left = left_values
-    right = right_values
-    self.selected_len = len(left if use_left else right)
-    self.selected_has_seven = 7 in (left if use_left else right)
-    self.selected_has_ninetynine = 99 in (left if use_left else right)
+    self.left = left_values
+    self.right = right_values
+    self.selected_len = len(self.left if use_left else self.right)
+    self.selected_has_seven = 7 in (self.left if use_left else self.right)
+    self.selected_has_ninetynine = 99 in (self.left if use_left else self.right)
     """
 
     c = get_contract(code, True, [7, 1, 2], [5])
@@ -735,8 +735,8 @@ arr: immutable(DynArray[uint256, 1])
 
 @deploy
 def __init__(arg: uint256):
-    x: uint256 = arr[0]
-    arr = []
+    x: uint256 = self.arr[0]
+    self.arr = []
     """
 
     with tx_failed():

--- a/tests/functional/codegen/features/test_immutable_allocator_overlap.py
+++ b/tests/functional/codegen/features/test_immutable_allocator_overlap.py
@@ -17,18 +17,18 @@ EIP712_TYPEHASH: constant(bytes32) = keccak256(
 
 @deploy
 def __init__(name_eip712_: String[50], version_eip712_: String[20]):
-    VERSION_HASH = keccak256(version_eip712_)
-    NAME_HASH = keccak256(name_eip712_)
-    DOMAIN_SEPARATOR = keccak256(
+    self.VERSION_HASH = keccak256(version_eip712_)
+    self.NAME_HASH = keccak256(name_eip712_)
+    self.DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
-            VERSION_HASH,
+            self.NAME_HASH,
+            self.VERSION_HASH,
             chain.id,
             self,
         )
     )
-    PADDING = empty(uint256[12])
+    self.PADDING = empty(uint256[12])
     """
     main = """
 import eip712

--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -211,7 +211,7 @@ def test_ternary_immutable(get_contract, test):
 IMM: public(immutable(uint256))
 @deploy
 def __init__(test: bool):
-    IMM = 1 if test else 2
+    self.IMM = 1 if test else 2
     """
     c = get_contract(code, test)
 

--- a/tests/functional/codegen/modules/test_exports.py
+++ b/tests/functional/codegen/modules/test_exports.py
@@ -54,7 +54,7 @@ BAR: public(constant(uint256)) = 3
 @deploy
 def __init__():
     self.counter = 1
-    FOO = 2
+    self.FOO = 2
     """
     main = """
 import lib1

--- a/tests/functional/codegen/modules/test_module_variables.py
+++ b/tests/functional/codegen/modules/test_module_variables.py
@@ -97,7 +97,7 @@ MY_IMMUTABLE: immutable(uint256)
 @deploy
 def __init__(initial_value: uint256):
     self.counter = initial_value
-    MY_IMMUTABLE = initial_value * 2
+    self.MY_IMMUTABLE = initial_value * 2
 
 @internal
 def increment_counter():
@@ -116,7 +116,7 @@ initializes: lib
 @deploy
 def __init__():
     self.counter = 1
-    MY_IMMUTABLE = 3
+    self.MY_IMMUTABLE = 3
     lib.__init__(5)
 
 @external
@@ -147,7 +147,7 @@ MY_IMMUTABLE: immutable(uint256)
 @deploy
 def __init__(initial_value: uint256):
     self.counter = initial_value
-    MY_IMMUTABLE = initial_value * 2
+    self.MY_IMMUTABLE = initial_value * 2
 
 @internal
 def increment_counter():
@@ -211,7 +211,7 @@ MY_IMMUTABLE: immutable(uint256)
 @deploy
 def __init__(initial_value: uint256):
     self.counter = initial_value * 2
-    MY_IMMUTABLE = initial_value * 3
+    self.MY_IMMUTABLE = initial_value * 3
 
 @internal
 def increment_counter():

--- a/tests/functional/codegen/storage_variables/test_getters.py
+++ b/tests/functional/codegen/storage_variables/test_getters.py
@@ -60,8 +60,8 @@ def __init__():
     self.w[3].g = 751
     self.a[1][4] = 666
     self.b[42][self] = [5,6,7,8]
-    d = 1729
-    e = [2, 3]
+    self.d = 1729
+    self.e = [2, 3]
     """
 
     c = get_contract(getter_code)
@@ -95,7 +95,7 @@ kune: public(immutable(uint256))
 
 @deploy
 def __init__():
-    kune = 2
+    self.kune = 2
 """
 
     contract = get_contract(code)

--- a/tests/functional/codegen/types/test_bytes.py
+++ b/tests/functional/codegen/types/test_bytes.py
@@ -380,11 +380,11 @@ MY_BYTES: immutable(Bytes[100])
 
 @deploy
 def __init__():
-    MY_BYTES = b"hello"
+    self.MY_BYTES = b"hello"
 
 @external
 def compare(x: Bytes[100]) -> bool:
-    return x == MY_BYTES
+    return x == self.MY_BYTES
     """
     c = get_contract(code)
     assert c.compare(b"hello") is True

--- a/tests/functional/examples/thirdparty/curvefi/amm/stableswap/factory/factory_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/stableswap/factory/factory_v_100.vy
@@ -118,7 +118,7 @@ def __init__(_fee_receiver: address, _owner: address):
 
     self.fee_receiver = _fee_receiver
     self.admin = msg.sender
-    deployer = msg.sender
+    self.deployer = msg.sender
 
     self.asset_types[0] = "Standard"
     self.asset_types[1] = "Oracle"
@@ -129,9 +129,9 @@ def __init__(_fee_receiver: address, _owner: address):
 @external
 def set_owner(_owner: address):
     
-    assert msg.sender == deployer
-    assert self.admin == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.admin == self.deployer
+    assert _owner != self.deployer
 
     self.admin = _owner
 

--- a/tests/functional/examples/thirdparty/curvefi/amm/stableswap/implementation/implementation_v_700.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/stableswap/implementation/implementation_v_700.vy
@@ -278,16 +278,16 @@ def __init__(
     @param _oracles Array of rate oracle addresses.
     """
 
-    coins = _coins
-    asset_types = _asset_types
-    pool_contains_rebasing_tokens = 2 in asset_types
+    self.coins = _coins
+    self.asset_types = _asset_types
+    self.pool_contains_rebasing_tokens = 2 in self.asset_types
     __n_coins: uint256 = len(_coins)
-    N_COINS = __n_coins
-    N_COINS_128 = convert(__n_coins, int128)
+    self.N_COINS = __n_coins
+    self.N_COINS_128 = convert(__n_coins, int128)
 
-    rate_multipliers = _rate_multipliers
+    self.rate_multipliers = _rate_multipliers
 
-    factory = Factory(msg.sender)
+    self.factory = Factory(msg.sender)
 
     A: uint256 = unsafe_mul(_A, A_PRECISION)
     self.initial_A = A
@@ -305,9 +305,9 @@ def __init__(
     _call_amount: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     _scale_factor: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     _rate_oracles: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
-        if i < N_COINS_128 - 1:
+        if i < self.N_COINS_128 - 1:
             self.last_prices_packed.append(self.pack_2(10**18, 10**18))
 
         _rate_oracles.append(convert(_method_ids[i], uint256) * 2**224 | convert(_oracles[i], uint256))
@@ -325,27 +325,27 @@ def __init__(
             _call_amount.append(0)
             _scale_factor.append(0)
 
-    call_amount = _call_amount
-    scale_factor = _scale_factor
-    rate_oracles = _rate_oracles
+    self.call_amount = _call_amount
+    self.scale_factor = _scale_factor
+    self.rate_oracles = _rate_oracles
 
     # ----------------------------- IERC20 stuff ------------------------------
 
-    name = _name
-    symbol = _symbol
+    self.name = _name
+    self.symbol = _symbol
 
     # EIP712 related params -----------------
-    NAME_HASH = keccak256(name)
-    salt = block.prevhash
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
+    self.NAME_HASH = keccak256(self.name)
+    self.salt = block.prevhash
+    self.CACHED_CHAIN_ID = chain.id
+    self.CACHED_DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
+            self.NAME_HASH,
             VERSION_HASH,
             chain.id,
             self,
-            salt,
+            self.salt,
         )
     )
 
@@ -372,7 +372,7 @@ def _transfer_in(
     @param receiver address to transfer `_coin` to.
     @param expect_optimistic_transfer True if contract expects an optimistic coin transfer
     """
-    _dx: uint256 = staticcall IERC20(coins[coin_idx]).balanceOf(self)
+    _dx: uint256 = staticcall IERC20(self.coins[coin_idx]).balanceOf(self)
 
     # ------------------------- Handle Transfers -----------------------------
 
@@ -384,11 +384,11 @@ def _transfer_in(
     else:
 
         assert dx > 0  # dev : do not transferFrom 0 tokens into the pool
-        assert extcall IERC20(coins[coin_idx]).transferFrom(
+        assert extcall IERC20(self.coins[coin_idx]).transferFrom(
             sender, self, dx, default_return_value=True
         )
 
-        _dx = staticcall IERC20(coins[coin_idx]).balanceOf(self) - _dx
+        _dx = staticcall IERC20(self.coins[coin_idx]).balanceOf(self) - _dx
 
     # --------------------------- Store transferred in amount ---------------------------
 
@@ -410,19 +410,19 @@ def _transfer_out(_coin_idx: int128, _amount: uint256, receiver: address):
     """
     assert receiver != empty(address)  # dev: do not send tokens to zero_address
 
-    if not pool_contains_rebasing_tokens:
+    if not self.pool_contains_rebasing_tokens:
 
         # we need not cache balanceOf pool before swap out
         self.stored_balances[_coin_idx] -= _amount
-        assert extcall IERC20(coins[_coin_idx]).transfer(
+        assert extcall IERC20(self.coins[_coin_idx]).transfer(
             receiver, _amount, default_return_value=True
         )
 
     else:
 
         # cache balances pre and post to account for fee on transfers etc.
-        coin_balance: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self)
-        assert extcall IERC20(coins[_coin_idx]).transfer(
+        coin_balance: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self)
+        assert extcall IERC20(self.coins[_coin_idx]).transfer(
             receiver, _amount, default_return_value=True
         )
         self.stored_balances[_coin_idx] = coin_balance - _amount
@@ -440,16 +440,16 @@ def _stored_rates() -> DynArray[uint256, MAX_COINS]:
          this method queries that rate by static-calling an external
          contract.
     """
-    rates: DynArray[uint256, MAX_COINS] = rate_multipliers
+    rates: DynArray[uint256, MAX_COINS] = self.rate_multipliers
 
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
-        if asset_types[i] == 1 and not rate_oracles[i] == 0:
+        if self.asset_types[i] == 1 and not self.rate_oracles[i] == 0:
 
             # NOTE: fetched_rate is assumed to be 10**18 precision
             oracle_response: Bytes[32] = raw_call(
-                convert(rate_oracles[i] % 2**160, address),
-                abi_encode(rate_oracles[i] & ORACLE_BIT_MASK),
+                convert(self.rate_oracles[i] % 2**160, address),
+                abi_encode(self.rate_oracles[i] & ORACLE_BIT_MASK),
                 max_outsize=32,
                 is_static_call=True,
             )
@@ -458,13 +458,13 @@ def _stored_rates() -> DynArray[uint256, MAX_COINS]:
 
             rates[i] = unsafe_div(rates[i] * fetched_rate, PRECISION)
 
-        elif asset_types[i] == 3:  # IERC4626
+        elif self.asset_types[i] == 3:  # IERC4626
 
             # fetched_rate: uint256 = IERC4626(coins[i]).convertToAssets(call_amount[i]) * scale_factor[i]
             # here: call_amount has IERC4626 precision, but the returned value is scaled up to 18
             # using scale_factor which is (18 - n) if underlying asset has n decimals.
             rates[i] = unsafe_div(
-                rates[i] * staticcall IERC4626(coins[i]).convertToAssets(call_amount[i]) * scale_factor[i],
+                rates[i] * staticcall IERC4626(self.coins[i]).convertToAssets(self.call_amount[i]) * self.scale_factor[i],
                 PRECISION
             )  # 1e18 precision
 
@@ -485,11 +485,11 @@ def _balances() -> DynArray[uint256, MAX_COINS]:
     result: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     balances_i: uint256 = 0
 
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
-        if pool_contains_rebasing_tokens:
+        if self.pool_contains_rebasing_tokens:
             # Read balances by gulping to account for rebases
-            balances_i = staticcall IERC20(coins[i]).balanceOf(self) - self.admin_balances[i]
+            balances_i = staticcall IERC20(self.coins[i]).balanceOf(self) - self.admin_balances[i]
         else:
             # Use cached balances
             balances_i = self.stored_balances[i] - self.admin_balances[i]
@@ -556,7 +556,7 @@ def exchange_received(
     @param _receiver Address that receives `j`
     @return Actual amount of `j` received
     """
-    assert not pool_contains_rebasing_tokens  # dev: exchange_received not supported if pool contains rebasing tokens
+    assert not self.pool_contains_rebasing_tokens  # dev: exchange_received not supported if pool contains rebasing tokens
     return self._exchange(
         msg.sender,
         i,
@@ -596,7 +596,7 @@ def add_liquidity(
 
     # -------------------------- Do Transfers In -----------------------------
 
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
         if _amounts[i] > 0:
 
@@ -628,17 +628,17 @@ def add_liquidity(
         difference: uint256 = 0
         new_balance: uint256 = 0
 
-        ys: uint256 = unsafe_div(D0 + D1, N_COINS)
+        ys: uint256 = unsafe_div(D0 + D1, self.N_COINS)
         xs: uint256 = 0
         _dynamic_fee_i: uint256 = 0
 
         # Only account for fees if we are not the first to deposit
         base_fee: uint256 = unsafe_div(
-            unsafe_mul(self.fee, N_COINS),
-            unsafe_mul(4, unsafe_sub(N_COINS, 1))
+            unsafe_mul(self.fee, self.N_COINS),
+            unsafe_mul(4, unsafe_sub(self.N_COINS, 1))
         )
 
-        for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+        for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
             ideal_balance = D1 * old_balances[i] // D0
             difference = 0
@@ -746,7 +746,7 @@ def remove_liquidity_imbalance(
     D0: uint256 = self.get_D_mem(rates, old_balances, amp)
     new_balances: DynArray[uint256, MAX_COINS] = old_balances
 
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
         if _amounts[i] != 0:
             new_balances[i] -= _amounts[i]
@@ -754,10 +754,10 @@ def remove_liquidity_imbalance(
 
     D1: uint256 = self.get_D_mem(rates, new_balances, amp)
     base_fee: uint256 = unsafe_div(
-        unsafe_mul(self.fee, N_COINS),
-        unsafe_mul(4, unsafe_sub(N_COINS, 1))
+        unsafe_mul(self.fee, self.N_COINS),
+        unsafe_mul(4, unsafe_sub(self.N_COINS, 1))
     )
-    ys: uint256 = unsafe_div((D0 + D1), N_COINS)
+    ys: uint256 = unsafe_div((D0 + D1), self.N_COINS)
 
     fees: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     dynamic_fee: uint256 = 0
@@ -766,7 +766,7 @@ def remove_liquidity_imbalance(
     difference: uint256 = 0
     new_balance: uint256 = 0
 
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
         ideal_balance = D1 * old_balances[i] // D0
         difference = 0
@@ -823,13 +823,13 @@ def remove_liquidity(
     """
     total_supply: uint256 = self.total_supply
     assert _burn_amount > 0  # dev: invalid burn amount
-    assert len(_min_amounts) == N_COINS  # dev: invalid array length for _min_amounts
+    assert len(_min_amounts) == self.N_COINS  # dev: invalid array length for _min_amounts
 
     amounts: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     balances: DynArray[uint256, MAX_COINS] = self._balances()
 
     value: uint256 = 0
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
         value = unsafe_div(balances[i] * _burn_amount, total_supply)
         assert value >= _min_amounts[i], "Withdrawal resulted in fewer coins than expected"
@@ -989,12 +989,12 @@ def _exchange(
 
 @internal
 def _withdraw_admin_fees():
-    fee_receiver: address = staticcall factory.fee_receiver()
+    fee_receiver: address = staticcall self.factory.fee_receiver()
     if fee_receiver == empty(address):
         return  # Do nothing.
 
     admin_balances: DynArray[uint256, MAX_COINS] = self.admin_balances
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
 
         if admin_balances[i] > 0:
 
@@ -1030,11 +1030,11 @@ def get_y(
 
     assert i != j       # dev: same coin
     assert j >= 0       # dev: j below zero
-    assert j < N_COINS_128  # dev: j above N_COINS
+    assert j < self.N_COINS_128  # dev: j above N_COINS
 
     # should be unreachable, but good for safety
     assert i >= 0
-    assert i < N_COINS_128
+    assert i < self.N_COINS_128
 
     amp: uint256 = _amp
     D: uint256 = _D
@@ -1043,11 +1043,11 @@ def get_y(
     _x: uint256 = 0
     y_prev: uint256 = 0
     c: uint256 = D
-    Ann: uint256 = amp * N_COINS
+    Ann: uint256 = amp * self.N_COINS
 
     for _i: int128 in range(MAX_COINS_128):
 
-        if _i == N_COINS_128:
+        if _i == self.N_COINS_128:
             break
 
         if _i == i:
@@ -1058,9 +1058,9 @@ def get_y(
             continue
 
         S_ += _x
-        c = c * D // (_x * N_COINS)
+        c = c * D // (_x * self.N_COINS)
 
-    c = c * D * A_PRECISION // (Ann * N_COINS)
+    c = c * D * A_PRECISION // (Ann * self.N_COINS)
     b: uint256 = S_ + D * A_PRECISION // Ann  # - D
     y: uint256 = D
 
@@ -1096,23 +1096,23 @@ def get_D(_xp: DynArray[uint256, MAX_COINS], _amp: uint256) -> uint256:
         return 0
 
     D: uint256 = S
-    Ann: uint256 = _amp * N_COINS
+    Ann: uint256 = _amp * self.N_COINS
 
     for i: uint256 in range(255):
 
         D_P: uint256 = D
         for x: uint256 in _xp:
             D_P = D_P * D // x
-        D_P //= pow_mod256(N_COINS, N_COINS)
+        D_P //= pow_mod256(self.N_COINS, self.N_COINS)
         Dprev: uint256 = D
 
         # (Ann * S // A_PRECISION + D_P * N_COINS) * D // ((Ann - A_PRECISION) * D // A_PRECISION + (N_COINS + 1) * D_P)
         D = (
-            (unsafe_div(Ann * S, A_PRECISION) + D_P * N_COINS) * D
+            (unsafe_div(Ann * S, A_PRECISION) + D_P * self.N_COINS) * D
             //
             (
                 unsafe_div((Ann - A_PRECISION) * D, A_PRECISION) +
-                unsafe_add(N_COINS, 1) * D_P
+                unsafe_add(self.N_COINS, 1) * D_P
             )
         )
 
@@ -1148,17 +1148,17 @@ def get_y_D(
     # x in the input is converted to the same price//precision
 
     assert i >= 0  # dev: i below zero
-    assert i < N_COINS_128  # dev: i above N_COINS
+    assert i < self.N_COINS_128  # dev: i above N_COINS
 
     S_: uint256 = 0
     _x: uint256 = 0
     y_prev: uint256 = 0
     c: uint256 = D
-    Ann: uint256 = A * N_COINS
+    Ann: uint256 = A * self.N_COINS
 
     for _i: int128 in range(MAX_COINS_128):
 
-        if _i == N_COINS_128:
+        if _i == self.N_COINS_128:
             break
 
         if _i != i:
@@ -1166,9 +1166,9 @@ def get_y_D(
         else:
             continue
         S_ += _x
-        c = c * D // (_x * N_COINS)
+        c = c * D // (_x * self.N_COINS)
 
-    c = c * D * A_PRECISION // (Ann * N_COINS)
+    c = c * D * A_PRECISION // (Ann * self.N_COINS)
     b: uint256 = S_ + D * A_PRECISION // Ann
     y: uint256 = D
 
@@ -1215,7 +1215,7 @@ def _xp_mem(
 ) -> DynArray[uint256, MAX_COINS]:
 
     result: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
         result.append(unsafe_div(_rates[i] * _balances[i], PRECISION))
     return result
 
@@ -1256,11 +1256,11 @@ def _calc_withdraw_one_coin(
     new_y: uint256 = self.get_y_D(amp, i, xp, D1)
 
     base_fee: uint256 = unsafe_div(
-        unsafe_mul(self.fee, N_COINS),
-        unsafe_mul(4, unsafe_sub(N_COINS, 1))
+        unsafe_mul(self.fee, self.N_COINS),
+        unsafe_mul(4, unsafe_sub(self.N_COINS, 1))
     )
     xp_reduced: DynArray[uint256, MAX_COINS] = xp
-    ys: uint256 = unsafe_div((D0 + D1), unsafe_mul(2, N_COINS))
+    ys: uint256 = unsafe_div((D0 + D1), unsafe_mul(2, self.N_COINS))
 
     dx_expected: uint256 = 0
     xp_j: uint256 = 0
@@ -1269,7 +1269,7 @@ def _calc_withdraw_one_coin(
 
     for j: int128 in range(MAX_COINS_128):
 
-        if j == N_COINS_128:
+        if j == self.N_COINS_128:
             break
 
         dx_expected = 0
@@ -1320,10 +1320,10 @@ def _get_p(
 ) -> DynArray[uint256, MAX_COINS]:
 
     # dx_0 // dx_1 only, however can have any number of coins in pool
-    ANN: uint256 = unsafe_mul(amp, N_COINS)
-    Dr: uint256 = unsafe_div(D, pow_mod256(N_COINS, N_COINS))
+    ANN: uint256 = unsafe_mul(amp, self.N_COINS)
+    Dr: uint256 = unsafe_div(D, pow_mod256(self.N_COINS, self.N_COINS))
 
-    for i: int128 in range(N_COINS_128, bound=MAX_COINS_128):
+    for i: int128 in range(self.N_COINS_128, bound=MAX_COINS_128):
         Dr = Dr * D // xp[i]
 
     p: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
@@ -1331,7 +1331,7 @@ def _get_p(
 
     for i: uint256 in range(1, MAX_COINS):
 
-        if i == N_COINS:
+        if i == self.N_COINS:
             break
 
         p.append(10**18 * (xp0_A + unsafe_div(Dr * xp[0], xp[i])) // (xp0_A + Dr))
@@ -1354,7 +1354,7 @@ def upkeep_oracles(xp: DynArray[uint256, MAX_COINS], amp: uint256, D: uint256):
 
     for i: uint256 in range(MAX_COINS):
 
-        if i == N_COINS - 1:
+        if i == self.N_COINS - 1:
             break
 
         if spot_price[i] != 0:
@@ -1542,18 +1542,18 @@ def exp(x: int256) -> uint256:
 @view
 @internal
 def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
+    if chain.id != self.CACHED_CHAIN_ID:
         return keccak256(
             abi_encode(
                 EIP712_TYPEHASH,
-                NAME_HASH,
+                self.NAME_HASH,
                 VERSION_HASH,
                 chain.id,
                 self,
-                salt,
+                self.salt,
             )
         )
-    return CACHED_DOMAIN_SEPARATOR
+    return self.CACHED_DOMAIN_SEPARATOR
 
 
 @internal
@@ -1697,7 +1697,7 @@ def get_dx(i: int128, j: int128, dy: uint256) -> uint256:
     @param dy Amount of `j` being received after exchange
     @return Amount of `i` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dx(i, j, dy, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dx(i, j, dy, self)
 
 
 @view
@@ -1711,7 +1711,7 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
     @param dx Amount of `i` being exchanged
     @return Amount of `j` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dy(i, j, dx, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dy(i, j, dx, self)
 
 
 @view
@@ -1770,7 +1770,7 @@ def calc_token_amount(
     @param _is_deposit set True for deposits, False for withdrawals
     @return Expected amount of LP tokens received
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).calc_token_amount(_amounts, _is_deposit, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).calc_token_amount(_amounts, _is_deposit, self)
 
 
 @view
@@ -1818,7 +1818,7 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
     @param j Index value of the coin to receive
     @return Swap fee expressed as an integer with 1e10 precision
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).dynamic_fee(i, j, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).dynamic_fee(i, j, self)
 
 
 # --------------------------- AMM Admin Functions ----------------------------
@@ -1826,7 +1826,7 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1849,7 +1849,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A
@@ -1864,7 +1864,7 @@ def stop_ramp_A():
 @external
 def set_new_fee(_new_fee: uint256, _new_offpeg_fee_multiplier: uint256):
 
-    assert msg.sender == staticcall factory.admin()
+    assert msg.sender == staticcall self.factory.admin()
 
     # set new fee:
     assert _new_fee <= MAX_FEE
@@ -1884,7 +1884,7 @@ def set_ma_exp_time(_ma_exp_time: uint256, _D_ma_time: uint256):
     @param _ma_exp_time Moving average window for the price oracle. It is time_in_seconds // ln(2).
     @param _D_ma_time Moving average window for the D oracle. It is time_in_seconds // ln(2).
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert unsafe_mul(_ma_exp_time, _D_ma_time) > 0  # dev: 0 in input values
 
     self.ma_exp_time = _ma_exp_time

--- a/tests/functional/examples/thirdparty/curvefi/amm/stableswap/meta_implementation/meta_implementation_v_700.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/stableswap/meta_implementation/meta_implementation_v_700.vy
@@ -340,42 +340,42 @@ def __init__(
     @param _oracles Array of rate oracle addresses.
     """
     # The following reverts if BASE_POOL is an NG implementaion.
-    BASE_POOL_IS_NG = raw_call(_base_pool, method_id("D_ma_time()"), revert_on_failure=False)
+    self.BASE_POOL_IS_NG = raw_call(_base_pool, method_id("D_ma_time()"), revert_on_failure=False)
 
-    if not BASE_POOL_IS_NG:
+    if not self.BASE_POOL_IS_NG:
         assert len(_base_coins) <= 3  # dev: implementation does not support old gen base pool with more than 3 coins
 
-    math = Math(_math_implementation)
-    BASE_POOL = _base_pool
-    BASE_COINS = _base_coins
-    BASE_N_COINS = len(_base_coins)
-    coins = _coins  # <---------------- coins[1] is always base pool LP token.
+    self.math = Math(_math_implementation)
+    self.BASE_POOL = _base_pool
+    self.BASE_COINS = _base_coins
+    self.BASE_N_COINS = len(_base_coins)
+    self.coins = _coins  # <---------------- coins[1] is always base pool LP token.
 
-    asset_type = _asset_types[0]
-    pool_contains_rebasing_tokens = asset_type == 2
-    rate_multiplier = _rate_multipliers[0]
+    self.asset_type = _asset_types[0]
+    self.pool_contains_rebasing_tokens = self.asset_type == 2
+    self.rate_multiplier = _rate_multipliers[0]
 
     for i: uint256 in range(MAX_COINS):
-        if i < BASE_N_COINS:
+        if i < self.BASE_N_COINS:
             # Approval needed for add_liquidity operation on base pool in
             # _exchange_underlying:
             assert extcall IERC20(_base_coins[i]).approve(
-                BASE_POOL,
+                self.BASE_POOL,
                 max_value(uint256),
                 default_return_value = True
             )
 
     # For IERC4626 tokens:
-    if asset_type == 3:
+    if self.asset_type == 3:
         # In Vyper 0.3.10, if immutables are not set, because of an if-statement,
         # it is by default set to 0; this is fine in the case of these two
         # immutables, since they are only used if asset_types[0] == 3.
-        call_amount = 10**convert(staticcall IERC20Detailed(_coins[0]).decimals(), uint256)
-        scale_factor = 10**(18 - convert(staticcall IERC20Detailed(staticcall IERC4626(_coins[0]).asset()).decimals(), uint256))
+        self.call_amount = 10**convert(staticcall IERC20Detailed(_coins[0]).decimals(), uint256)
+        self.scale_factor = 10**(18 - convert(staticcall IERC20Detailed(staticcall IERC4626(_coins[0]).asset()).decimals(), uint256))
 
     # ----------------- Parameters independent of pool type ------------------
 
-    factory = Factory(msg.sender)
+    self.factory = Factory(msg.sender)
 
     A: uint256 = unsafe_mul(_A, A_PRECISION)
     self.initial_A = A
@@ -392,25 +392,25 @@ def __init__(
     self.admin_balances = [0, 0]
     self.stored_balances = [0, 0]
 
-    rate_oracle = convert(_method_ids[0], uint256) * 2**224 | convert(_oracles[0], uint256)
+    self.rate_oracle = convert(_method_ids[0], uint256) * 2**224 | convert(_oracles[0], uint256)
 
     # --------------------------- IERC20 stuff ----------------------------
 
-    name = _name
-    symbol = _symbol
+    self.name = _name
+    self.symbol = _symbol
 
     # EIP712 related params -----------------
-    NAME_HASH = keccak256(name)
-    salt = block.prevhash
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
+    self.NAME_HASH = keccak256(self.name)
+    self.salt = block.prevhash
+    self.CACHED_CHAIN_ID = chain.id
+    self.CACHED_DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
+            self.NAME_HASH,
             VERSION_HASH,
             chain.id,
             self,
-            salt,
+            self.salt,
         )
     )
 
@@ -441,13 +441,13 @@ def _transfer_in(
     @param is_base_pool_swap Default is set to False.
     @return amount of coins received
     """
-    _input_coin: IERC20 = IERC20(coins[coin_metapool_idx])
+    _input_coin: IERC20 = IERC20(self.coins[coin_metapool_idx])
     _input_coin_is_in_base_pool: bool = False
 
     # Check if _transfer_in is being called by _exchange_underlying:
     if coin_basepool_idx >= 0 and coin_metapool_idx == 1:
 
-        _input_coin = IERC20(BASE_COINS[coin_basepool_idx])
+        _input_coin = IERC20(self.BASE_COINS[coin_basepool_idx])
         _input_coin_is_in_base_pool = True
 
     _dx: uint256 = staticcall _input_coin.balanceOf(self)
@@ -505,19 +505,19 @@ def _transfer_out(
     """
     assert receiver != empty(address)  # dev: do not send tokens to zero_address
 
-    if not pool_contains_rebasing_tokens:
+    if not self.pool_contains_rebasing_tokens:
 
         # we need not cache balanceOf pool before swap out
         self.stored_balances[_coin_idx] -= _amount
-        assert extcall IERC20(coins[_coin_idx]).transfer(
+        assert extcall IERC20(self.coins[_coin_idx]).transfer(
             receiver, _amount, default_return_value=True
         )
 
     else:
 
         # cache balances pre and post to account for fee on transfers etc.
-        coin_balance: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self)
-        assert extcall IERC20(coins[_coin_idx]).transfer(
+        coin_balance: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self)
+        assert extcall IERC20(self.coins[_coin_idx]).transfer(
             receiver, _amount, default_return_value=True
         )
         self.stored_balances[_coin_idx] = coin_balance - _amount
@@ -535,14 +535,14 @@ def _stored_rates() -> uint256[N_COINS]:
          this method queries that rate by static-calling an external
          contract.
     """
-    rates: uint256[N_COINS] = [rate_multiplier, staticcall StableSwap(BASE_POOL).get_virtual_price()]
+    rates: uint256[N_COINS] = [self.rate_multiplier, staticcall StableSwap(self.BASE_POOL).get_virtual_price()]
 
-    if asset_type == 1 and not rate_oracle == 0:
+    if self.asset_type == 1 and not self.rate_oracle == 0:
 
         # NOTE: fetched_rate is assumed to be 10**18 precision
         oracle_response: Bytes[32] = raw_call(
-            convert(rate_oracle % 2**160, address),
-            abi_encode(rate_oracle & ORACLE_BIT_MASK),
+            convert(self.rate_oracle % 2**160, address),
+            abi_encode(self.rate_oracle & ORACLE_BIT_MASK),
             max_outsize=32,
             is_static_call=True,
         )
@@ -552,11 +552,11 @@ def _stored_rates() -> uint256[N_COINS]:
         # rates[0] * fetched_rate // PRECISION
         rates[0] = unsafe_div(rates[0] * fetched_rate, PRECISION)
 
-    elif asset_type == 3:  # IERC4626
+    elif self.asset_type == 3:  # IERC4626
 
         # rates[0] * fetched_rate // PRECISION
         rates[0] = unsafe_div(
-            rates[0] * staticcall IERC4626(coins[0]).convertToAssets(call_amount) * scale_factor,
+            rates[0] * staticcall IERC4626(self.coins[0]).convertToAssets(self.call_amount) * self.scale_factor,
             PRECISION
         )  # 1e18 precision
 
@@ -578,9 +578,9 @@ def _balances() -> uint256[N_COINS]:
     admin_balances: DynArray[uint256, MAX_COINS] = self.admin_balances
     for i: uint256 in range(N_COINS_128):
 
-        if pool_contains_rebasing_tokens:
+        if self.pool_contains_rebasing_tokens:
             # Read balances by gulping to account for rebases
-            result[i] = staticcall IERC20(coins[i]).balanceOf(self) - admin_balances[i]
+            result[i] = staticcall IERC20(self.coins[i]).balanceOf(self) - admin_balances[i]
         else:
             # Use cached balances
             result[i] = self.stored_balances[i] - admin_balances[i]
@@ -645,7 +645,7 @@ def exchange_received(
     @param _receiver Address that receives `j`
     @return Actual amount of `j` received
     """
-    assert not pool_contains_rebasing_tokens  # dev: exchange_received not supported if pool contains rebasing tokens
+    assert not self.pool_contains_rebasing_tokens  # dev: exchange_received not supported if pool contains rebasing tokens
     return self._exchange(
         msg.sender,
         i,
@@ -698,11 +698,11 @@ def exchange_underlying(
 
     # Get output coin and indices:
     if j == 0:
-        output_coin = coins[0]
+        output_coin = self.coins[0]
     else:
         base_j = j - MAX_METAPOOL_COIN_INDEX
         meta_j = 1
-        output_coin = BASE_COINS[base_j]
+        output_coin = self.BASE_COINS[base_j]
 
     # --------------------------- Do Transfer in -----------------------------
 
@@ -730,7 +730,7 @@ def exchange_underlying(
         # Withdraw from the base pool if needed
         if j > 0:
             out_amount: uint256 = staticcall IERC20(output_coin).balanceOf(self)
-            extcall StableSwap(BASE_POOL).remove_liquidity_one_coin(dy, base_j, 0)
+            extcall StableSwap(self.BASE_POOL).remove_liquidity_one_coin(dy, base_j, 0)
             dy = staticcall IERC20(output_coin).balanceOf(self) - out_amount
 
         assert dy >= _min_dy
@@ -738,7 +738,7 @@ def exchange_underlying(
     else:  # base pool swap (user should swap at base pool for better gas)
 
         dy = staticcall IERC20(output_coin).balanceOf(self)
-        extcall StableSwap(BASE_POOL).exchange(base_i, base_j, dx_w_fee, _min_dy)
+        extcall StableSwap(self.BASE_POOL).exchange(base_i, base_j, dx_w_fee, _min_dy)
         dy = staticcall IERC20(output_coin).balanceOf(self) - dy
 
     # --------------------------- Do Transfer out ----------------------------
@@ -843,7 +843,7 @@ def add_liquidity(
             new_balances[i] -= fees[i]
 
         xp: uint256[N_COINS] = self._xp_mem(rates, new_balances)
-        D1 = staticcall math.get_D([xp[0], xp[1]], amp, N_COINS)  # <------ Reuse D1 for new D value.
+        D1 = staticcall self.math.get_D([xp[0], xp[1]], amp, N_COINS)  # <------ Reuse D1 for new D value.
         # we do unsafe div here because we already did several safedivs with D0
         mint_amount = unsafe_div(total_supply * (D1 - D0), D0)
         self.upkeep_oracles(xp, amp, D1)
@@ -1118,8 +1118,8 @@ def __exchange(
 ) -> uint256:
 
     amp: uint256 = self._A()
-    D: uint256 = staticcall math.get_D([_xp[0], _xp[1]], amp, N_COINS)
-    y: uint256 = staticcall math.get_y(i, j, x, [_xp[0], _xp[1]], amp, D, N_COINS)
+    D: uint256 = staticcall self.math.get_D([_xp[0], _xp[1]], amp, N_COINS)
+    y: uint256 = staticcall self.math.get_y(i, j, x, [_xp[0], _xp[1]], amp, D, N_COINS)
 
     dy: uint256 = _xp[j] - y - 1  # -1 just in case there were some rounding errors
     dy_fee: uint256 = unsafe_div(
@@ -1198,30 +1198,30 @@ def _exchange(
 @internal
 def _meta_add_liquidity(dx: uint256, base_i: int128) -> uint256:
 
-    if BASE_POOL_IS_NG:
+    if self.BASE_POOL_IS_NG:
 
         base_inputs: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
-        for i: uint256 in range(BASE_N_COINS, bound=MAX_COINS):
+        for i: uint256 in range(self.BASE_N_COINS, bound=MAX_COINS):
             if i == convert(base_i, uint256):
                 base_inputs.append(dx)
             else:
                 base_inputs.append(0)
-        return extcall StableSwapNG(BASE_POOL).add_liquidity(base_inputs, 0)
+        return extcall StableSwapNG(self.BASE_POOL).add_liquidity(base_inputs, 0)
 
-    coin_i: address = coins[MAX_METAPOOL_COIN_INDEX]
+    coin_i: address = self.coins[MAX_METAPOOL_COIN_INDEX]
     x: uint256 = staticcall IERC20(coin_i).balanceOf(self)
 
-    if BASE_N_COINS == 2:
+    if self.BASE_N_COINS == 2:
 
         base_inputs: uint256[2] = empty(uint256[2])
         base_inputs[base_i] = dx
-        extcall StableSwap2(BASE_POOL).add_liquidity(base_inputs, 0)
+        extcall StableSwap2(self.BASE_POOL).add_liquidity(base_inputs, 0)
 
-    if BASE_N_COINS == 3:
+    if self.BASE_N_COINS == 3:
 
         base_inputs: uint256[3] = empty(uint256[3])
         base_inputs[base_i] = dx
-        extcall StableSwap3(BASE_POOL).add_liquidity(base_inputs, 0)
+        extcall StableSwap3(self.BASE_POOL).add_liquidity(base_inputs, 0)
 
     return staticcall IERC20(coin_i).balanceOf(self) - x
 
@@ -1229,7 +1229,7 @@ def _meta_add_liquidity(dx: uint256, base_i: int128) -> uint256:
 @internal
 def _withdraw_admin_fees():
 
-    fee_receiver: address = staticcall factory.fee_receiver()
+    fee_receiver: address = staticcall self.factory.fee_receiver()
     if fee_receiver == empty(address):
         return  # Do nothing.
 
@@ -1287,7 +1287,7 @@ def get_D_mem(
     _amp: uint256
 ) -> uint256:
     xp: uint256[N_COINS] = self._xp_mem(_rates, _balances)
-    return staticcall math.get_D([xp[0], xp[1]], _amp, N_COINS)
+    return staticcall self.math.get_D([xp[0], xp[1]], _amp, N_COINS)
 
 
 @view
@@ -1311,11 +1311,11 @@ def _calc_withdraw_one_coin(
     amp: uint256 = self._A()
     rates: uint256[N_COINS] = self._stored_rates()
     xp: uint256[N_COINS] = self._xp_mem(rates, self._balances())
-    D0: uint256 = staticcall math.get_D([xp[0], xp[1]], amp, N_COINS)
+    D0: uint256 = staticcall self.math.get_D([xp[0], xp[1]], amp, N_COINS)
 
     total_supply: uint256 = self.total_supply
     D1: uint256 = D0 - _burn_amount * D0 // total_supply
-    new_y: uint256 = staticcall math.get_y_D(amp, i, [xp[0], xp[1]], D1, N_COINS)
+    new_y: uint256 = staticcall self.math.get_y_D(amp, i, [xp[0], xp[1]], D1, N_COINS)
 
     base_fee: uint256 = unsafe_div(unsafe_mul(self.fee, N_COINS), 4)
     xp_reduced: uint256[N_COINS] = xp
@@ -1343,7 +1343,7 @@ def _calc_withdraw_one_coin(
         dynamic_fee = self._dynamic_fee(xavg, ys, base_fee)
         xp_reduced[j] = xp_j - unsafe_div(dynamic_fee * dx_expected, FEE_DENOMINATOR)
 
-    dy: uint256 = xp_reduced[convert(i, uint256)] - staticcall math.get_y_D(amp, i, [xp_reduced[0], xp_reduced[1]], D1, N_COINS)
+    dy: uint256 = xp_reduced[convert(i, uint256)] - staticcall self.math.get_y_D(amp, i, [xp_reduced[0], xp_reduced[1]], D1, N_COINS)
     dy_0: uint256 = (xp[convert(i, uint256)] - new_y) * PRECISION // rates[convert(i, uint256)]  # w//o fees
     dy = unsafe_div((dy - 1) * PRECISION, rates[convert(i, uint256)])  # Withdraw less to account for rounding errors
 
@@ -1448,7 +1448,7 @@ def _calc_moving_average(
     last_ema_value: uint256 = (packed_value >> 128)
 
     if ma_last_time < block.timestamp:  # calculate new_ema_value and return that.
-        alpha: uint256 = staticcall math.exp(
+        alpha: uint256 = staticcall self.math.exp(
             -convert(
                 unsafe_div(unsafe_mul(unsafe_sub(block.timestamp, ma_last_time), 10**18), averaging_window), int256
             )
@@ -1487,7 +1487,7 @@ def get_p(i: uint256) -> uint256:
     xp: uint256[N_COINS] = self._xp_mem(
         self._stored_rates(), self._balances()
     )
-    D: uint256 = staticcall math.get_D([xp[0], xp[1]], amp, N_COINS)
+    D: uint256 = staticcall self.math.get_D([xp[0], xp[1]], amp, N_COINS)
     return self._get_p(xp, amp, D)
 
 
@@ -1520,18 +1520,18 @@ def D_oracle() -> uint256:
 @view
 @internal
 def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
+    if chain.id != self.CACHED_CHAIN_ID:
         return keccak256(
             abi_encode(
                 EIP712_TYPEHASH,
-                NAME_HASH,
+                self.NAME_HASH,
                 VERSION_HASH,
                 chain.id,
                 self,
-                salt,
+                self.salt,
             )
         )
-    return CACHED_DOMAIN_SEPARATOR
+    return self.CACHED_DOMAIN_SEPARATOR
 
 
 @internal
@@ -1675,7 +1675,7 @@ def get_dx(i: int128, j: int128, dy: uint256) -> uint256:
     @param dy Amount of `j` being received after exchange
     @return Amount of `i` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dx(i, j, dy, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dx(i, j, dy, self)
 
 
 @view
@@ -1690,7 +1690,7 @@ def get_dx_underlying(i: int128, j: int128, dy: uint256) -> uint256:
     @param dy Amount of `j` being received after exchange
     @return Amount of `i` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dx_underlying(i, j, dy, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dx_underlying(i, j, dy, self)
 
 
 @view
@@ -1704,7 +1704,7 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
     @param dx Amount of `i` being exchanged
     @return Amount of `j` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dy(i, j, dx, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dy(i, j, dx, self)
 
 
 @view
@@ -1719,7 +1719,7 @@ def get_dy_underlying(i: int128, j: int128, dx: uint256) -> uint256:
     @param dx Amount of `i` being exchanged
     @return Amount of `j` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dy_underlying(i, j, dx, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dy_underlying(i, j, dx, self)
 
 
 @view
@@ -1757,7 +1757,7 @@ def get_virtual_price() -> uint256:
     @return LP token virtual price normalized to 1e18
     """
     xp: uint256[N_COINS] = self._xp_mem(self._stored_rates(), self._balances())
-    D: uint256 = staticcall math.get_D([xp[0], xp[1]], self._A(), N_COINS)
+    D: uint256 = staticcall self.math.get_D([xp[0], xp[1]], self._A(), N_COINS)
     # D is in the units similar to DAI (e.g. converted to precision 1e18)
     # When balanced, D = n * x_u - total virtual value of the portfolio
     return D * PRECISION // self.total_supply
@@ -1775,7 +1775,7 @@ def calc_token_amount(
     @param _is_deposit set True for deposits, False for withdrawals
     @return Expected amount of LP tokens received
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).calc_token_amount(
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).calc_token_amount(
         [_amounts[0], _amounts[1]],
         _is_deposit,
         self
@@ -1829,7 +1829,7 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
     @param j Index value of the coin to receive
     @return Swap fee expressed as an integer with 1e10 precision
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).dynamic_fee(i, j, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).dynamic_fee(i, j, self)
 
 
 # --------------------------- AMM Admin Functions ----------------------------
@@ -1837,7 +1837,7 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1860,7 +1860,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A
@@ -1875,7 +1875,7 @@ def stop_ramp_A():
 @external
 def set_new_fee(_new_fee: uint256, _new_offpeg_fee_multiplier: uint256):
 
-    assert msg.sender == staticcall factory.admin()
+    assert msg.sender == staticcall self.factory.admin()
 
     # set new fee:
     assert _new_fee <= MAX_FEE
@@ -1895,7 +1895,7 @@ def set_ma_exp_time(_ma_exp_time: uint256, _D_ma_time: uint256):
     @param _ma_exp_time Moving average window for the price oracle. It is time_in_seconds // ln(2).
     @param _D_ma_time Moving average window for the D oracle. It is time_in_seconds // ln(2).
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert unsafe_mul(_ma_exp_time, _D_ma_time) > 0  # dev: 0 in input values
 
     self.ma_exp_time = _ma_exp_time

--- a/tests/functional/examples/thirdparty/curvefi/amm/tricryptoswap/factory/factory_v_200.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/tricryptoswap/factory/factory_v_200.vy
@@ -107,7 +107,7 @@ def __init__(_fee_receiver: address):
 
     self.fee_receiver = _fee_receiver
     self.admin = msg.sender
-    deployer = msg.sender
+    self.deployer = msg.sender
 
     log UpdateFeeReceiver(_old_fee_receiver=empty(address), _new_fee_receiver=_fee_receiver)
     log TransferOwnership(_old_owner=empty(address), _new_owner=msg.sender)
@@ -116,12 +116,12 @@ def __init__(_fee_receiver: address):
 @external
 def set_owner(_owner: address):
     
-    assert msg.sender == deployer
-    assert self.admin == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.admin == self.deployer
+    assert _owner != self.deployer
 
     self.admin = _owner
-    log TransferOwnership(_old_owner=deployer, _new_owner=_owner)
+    log TransferOwnership(_old_owner=self.deployer, _new_owner=_owner)
 
 
 @internal

--- a/tests/functional/examples/thirdparty/curvefi/amm/tricryptoswap/implementation/implementation_v_200.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/tricryptoswap/implementation/implementation_v_200.vy
@@ -236,13 +236,13 @@ def __init__(
     packed_rebalancing_params: uint256,
     packed_prices: uint256,
 ):
-    MATH = Math(_math)
-    factory = Factory(msg.sender)
-    name = _name
-    symbol = _symbol
-    coins = _coins
+    self.MATH = Math(_math)
+    self.factory = Factory(msg.sender)
+    self.name = _name
+    self.symbol = _symbol
+    self.coins = _coins
 
-    PRECISIONS = self._unpack_3(__packed_precisions)  # <------- Precisions of
+    self.PRECISIONS = self._unpack_3(__packed_precisions)  # <------- Precisions of
     #                      coins are calculated as 10**(18 - coin.decimals()).
 
     self.initial_A_gamma = packed_A_gamma  # <------------------- A and gamma.
@@ -266,17 +266,17 @@ def __init__(
     #     DOMAIN_SEPARATOR will be re-calculated each time `permit` is called.
     #                   Otherwise, it will always use CACHED_DOMAIN_SEPARATOR.
     #                       see: `_domain_separator()` for its implementation.
-    NAME_HASH = keccak256(name)
-    salt = _salt
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
+    self.NAME_HASH = keccak256(self.name)
+    self.salt = _salt
+    self.CACHED_CHAIN_ID = chain.id
+    self.CACHED_DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
+            self.NAME_HASH,
             VERSION_HASH,
             chain.id,
             self,
-            salt,
+            self.salt,
         )
     )
 
@@ -304,7 +304,7 @@ def _transfer_in(
             This is only enabled for exchange_received.
     @return The amount of tokens received.
     """
-    coin_balance: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self)
+    coin_balance: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self)
 
     if expect_optimistic_transfer:  # Only enabled in exchange_received:
         # it expects the caller of exchange_received to have sent tokens to
@@ -327,14 +327,14 @@ def _transfer_in(
     # ----------------------------------------------- ERC20 transferFrom flow.
 
     # EXTERNAL CALL
-    assert extcall IERC20(coins[_coin_idx]).transferFrom(
+    assert extcall IERC20(self.coins[_coin_idx]).transferFrom(
         sender,
         self,
         _dx,
         default_return_value=True
     )
 
-    dx: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self) - coin_balance
+    dx: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self) - coin_balance
     self.balances[_coin_idx] += dx
     return dx
 
@@ -354,7 +354,7 @@ def _transfer_out(_coin_idx: uint256, _amount: uint256, receiver: address):
     self.balances[_coin_idx] -= _amount
 
     # EXTERNAL CALL
-    assert extcall IERC20(coins[_coin_idx]).transfer(
+    assert extcall IERC20(self.coins[_coin_idx]).transfer(
         receiver,
         _amount,
         default_return_value=True
@@ -503,14 +503,14 @@ def add_liquidity(
             )
             xp[i] = xp[i] + amounts_received[i]
 
-    xp[0] *= PRECISIONS[0]
-    xp_old[0] *= PRECISIONS[0]
+    xp[0] *= self.PRECISIONS[0]
+    xp_old[0] *= self.PRECISIONS[0]
     for i: uint256 in range(N_COINS):
 
         if i >= 1:
-            xp[i] = unsafe_div(xp[i] * price_scale[i-1] * PRECISIONS[i], PRECISION)
+            xp[i] = unsafe_div(xp[i] * price_scale[i-1] * self.PRECISIONS[i], PRECISION)
             xp_old[i] = unsafe_div(
-                xp_old[i] * unsafe_mul(price_scale[i-1], PRECISIONS[i]),
+                xp_old[i] * unsafe_mul(price_scale[i-1], self.PRECISIONS[i]),
                 PRECISION
             )
 
@@ -522,13 +522,13 @@ def add_liquidity(
     if self.future_A_gamma_time > block.timestamp:  # <--- A_gamma is ramping.
 
         # ----- Recalculate the invariant if A or gamma are undergoing a ramp.
-        old_D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp_old, 0)
+        old_D = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp_old, 0)
 
     else:
 
         old_D = self.D
 
-    D: uint256 = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+    D: uint256 = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
     token_supply: uint256 = self.totalSupply
     if old_D > 0:
@@ -644,7 +644,7 @@ def remove_liquidity(
 
     # Update xcp since liquidity was removed:
     xp: uint256[N_COINS] = self.xp(self.balances, self.price_scale_packed)
-    last_xcp: uint256 = staticcall MATH.geometric_mean(xp)  # <----------- Cache it for now.
+    last_xcp: uint256 = staticcall self.MATH.geometric_mean(xp)  # <----------- Cache it for now.
 
     last_timestamp: uint256[2] = self._unpack_2(self.last_timestamp)
     if last_timestamp[1] < block.timestamp:
@@ -831,14 +831,14 @@ def _exchange(
         packed_price_scale
     )
 
-    xp[0] *= PRECISIONS[0]
+    xp[0] *= self.PRECISIONS[0]
     for k: uint256 in range(1, N_COINS):
         xp[k] = unsafe_div(
-            xp[k] * price_scale[k - 1] * PRECISIONS[k],
+            xp[k] * price_scale[k - 1] * self.PRECISIONS[k],
             PRECISION
         )  # <-------- Safu to do unsafe_div here since PRECISION is not zero.
 
-    prec_i: uint256 = PRECISIONS[i]
+    prec_i: uint256 = self.PRECISIONS[i]
 
     # ----------- Update invariant if A, gamma are undergoing ramps ---------
 
@@ -852,20 +852,20 @@ def _exchange(
 
         x1: uint256 = xp[i]  # <------------------ Back up old value in xp ...
         xp[i] = x0                                                         # |
-        self.D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)              # |
+        self.D = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)              # |
         xp[i] = x1  # <-------------------------------------- ... and restore.
 
     # ----------------------- Calculate dy and fees --------------------------
 
     D: uint256 = self.D
-    y_out: uint256[2] = staticcall MATH.get_y(A_gamma[0], A_gamma[1], xp, D, j)
+    y_out: uint256[2] = staticcall self.MATH.get_y(A_gamma[0], A_gamma[1], xp, D, j)
     dy = xp[j] - y_out[0]
     xp[j] -= dy
     dy -= 1
 
     if j > 0:
         dy = dy * PRECISION // price_scale[j - 1]
-    dy //= PRECISIONS[j]
+    dy //= self.PRECISIONS[j]
 
     fee: uint256 = unsafe_div(self._fee(xp) * dy, 10**10)
     dy -= fee  # <--------------------- Subtract fee from the outgoing amount.
@@ -873,7 +873,7 @@ def _exchange(
 
     y -= dy
 
-    y *= PRECISIONS[j]
+    y *= self.PRECISIONS[j]
     if j > 0:
         y = unsafe_div(y * price_scale[j - 1], PRECISION)
     xp[j] = y  # <------------------------------------------------- Update xp.
@@ -968,11 +968,11 @@ def tweak_price(
 
     D_unadjusted: uint256 = new_D
     if new_D == 0:  #  <--------------------------- _exchange sets new_D to 0.
-        D_unadjusted = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], _xp, K0_prev)
+        D_unadjusted = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], _xp, K0_prev)
 
     # ----------------------- Calculate last_prices --------------------------
 
-    last_prices = staticcall MATH.get_p(_xp, D_unadjusted, A_gamma)
+    last_prices = staticcall self.MATH.get_p(_xp, D_unadjusted, A_gamma)
     for k: uint256 in range(N_COINS - 1):
         last_prices[k] = unsafe_div(last_prices[k] * price_scale[k], 10**18)
     self.last_prices_packed = self._pack_prices(last_prices)
@@ -991,7 +991,7 @@ def tweak_price(
 
     if old_virtual_price > 0:
 
-        xcp: uint256 = staticcall MATH.geometric_mean(xp)
+        xcp: uint256 = staticcall self.MATH.geometric_mean(xp)
         virtual_price = 10**18 * xcp // total_supply
 
         xcp_profit = unsafe_div(
@@ -1060,7 +1060,7 @@ def tweak_price(
                 # unsafe_div because we did safediv before ----^
 
             # ------------------------------------------ Update D with new xp.
-            D: uint256 = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+            D: uint256 = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
             assert D > 0  # dev: unsafe D
             # Check if calculated p_new is safu:
             for k: uint256 in range(N_COINS):
@@ -1075,7 +1075,7 @@ def tweak_price(
             # ---------- Calculate new virtual_price using new xp and D. Reuse
             #              `old_virtual_price` (but it has new virtual_price).
             old_virtual_price = unsafe_div(
-                10**18 * staticcall MATH.geometric_mean(xp), total_supply
+                10**18 * staticcall self.MATH.geometric_mean(xp), total_supply
             )  # <----- unsafe_div because we did safediv before (if vp>1e18)
 
             # ---------------------------- Proceed if we've got enough profit.
@@ -1141,7 +1141,7 @@ def _claim_admin_fees():
     D: uint256 = self.D
     vprice: uint256 = self.virtual_price
     packed_price_scale: uint256 = self.price_scale_packed
-    fee_receiver: address = staticcall factory.fee_receiver()
+    fee_receiver: address = staticcall self.factory.fee_receiver()
     balances: uint256[N_COINS] = self.balances
 
     #  Admin fees are calculated as follows.
@@ -1230,10 +1230,10 @@ def xp(
 ) -> uint256[N_COINS]:
 
     result: uint256[N_COINS] = balances
-    result[0] *= PRECISIONS[0]
+    result[0] *= self.PRECISIONS[0]
     packed_prices: uint256 = price_scale_packed
     for i: uint256 in range(1, N_COINS):
-        p: uint256 = (packed_prices & PRICE_MASK) * PRECISIONS[i]
+        p: uint256 = (packed_prices & PRICE_MASK) * self.PRECISIONS[i]
         result[i] = result[i] * p // PRECISION
         packed_prices = packed_prices >> PRICE_SIZE
 
@@ -1244,7 +1244,7 @@ def xp(
 @view
 def _alpha(last_timestamp: uint256, ma_exp_time: uint256) -> uint256:
 
-    return staticcall MATH.wad_exp(
+    return staticcall self.MATH.wad_exp(
         -convert(
             unsafe_div(
                 (block.timestamp - last_timestamp) * 10**18,
@@ -1286,7 +1286,7 @@ def _A_gamma() -> uint256[2]:
 def _fee(xp: uint256[N_COINS]) -> uint256:
 
     fee_params: uint256[3] = self._unpack_3(self.packed_fee_params)
-    f: uint256 = staticcall MATH.reduction_coefficient(xp, fee_params[2])
+    f: uint256 = staticcall self.MATH.reduction_coefficient(xp, fee_params[2])
 
     return unsafe_div(
         fee_params[0] * f + fee_params[1] * (10**18 - f),
@@ -1307,7 +1307,7 @@ def get_xcp(D: uint256, price_scale_packed: uint256) -> uint256:
         x[i] = D * 10**18 // (N_COINS * (packed_prices & PRICE_MASK))
         packed_prices = packed_prices >> PRICE_SIZE
 
-    return staticcall MATH.geometric_mean(x)
+    return staticcall self.MATH.geometric_mean(x)
 
 
 @view
@@ -1349,12 +1349,12 @@ def _calc_withdraw_one_coin(
     assert i < N_COINS  # dev: coin out of range
 
     xx: uint256[N_COINS] = self.balances
-    xp: uint256[N_COINS] = PRECISIONS
+    xp: uint256[N_COINS] = self.PRECISIONS
     D0: uint256 = 0
 
     # -------------------------- Calculate D0 and xp -------------------------
 
-    price_scale_i: uint256 = PRECISION * PRECISIONS[0]
+    price_scale_i: uint256 = PRECISION * self.PRECISIONS[0]
     packed_prices: uint256 = self.price_scale_packed
     xp[0] *= xx[0]
     for k: uint256 in range(1, N_COINS):
@@ -1365,7 +1365,7 @@ def _calc_withdraw_one_coin(
         packed_prices = packed_prices >> PRICE_SIZE
 
     if update_D:  # <-------------- D is updated if pool is undergoing a ramp.
-        D0 = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+        D0 = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
     else:
         D0 = self.D
 
@@ -1401,7 +1401,7 @@ def _calc_withdraw_one_coin(
     # ------------------------------------------------------------------------
     D -= (dD - D_fee)  # <----------------------------------- Charge fee on D.
     # --------------------------------- Calculate `y_out`` with `(D - D_fee)`.
-    y: uint256 = (staticcall MATH.get_y(A_gamma[0], A_gamma[1], xp, D, i))[0]
+    y: uint256 = (staticcall self.MATH.get_y(A_gamma[0], A_gamma[1], xp, D, i))[0]
     dy: uint256 = (xp[i] - y) * PRECISION // price_scale_i
     xp[i] = y
 
@@ -1431,18 +1431,18 @@ def _transfer(_from: address, _to: address, _value: uint256):
 @view
 @internal
 def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
+    if chain.id != self.CACHED_CHAIN_ID:
         return keccak256(
             abi_encode(
                 EIP712_TYPEHASH,
-                NAME_HASH,
+                self.NAME_HASH,
                 VERSION_HASH,
                 chain.id,
                 self,
-                salt,
+                self.salt,
             )
         )
-    return CACHED_DOMAIN_SEPARATOR
+    return self.CACHED_DOMAIN_SEPARATOR
 
 
 @external
@@ -1578,7 +1578,7 @@ def fee_receiver() -> address:
     @notice Returns the address of the admin fee receiver.
     @return address Fee receiver.
     """
-    return staticcall factory.fee_receiver()
+    return staticcall self.factory.fee_receiver()
 
 
 @external
@@ -1588,7 +1588,7 @@ def admin() -> address:
     @notice Returns the address of the pool's admin.
     @return address Admin.
     """
-    return staticcall factory.admin()
+    return staticcall self.factory.admin()
 
 
 @external
@@ -1602,7 +1602,7 @@ def calc_token_amount(amounts: uint256[N_COINS], deposit: bool) -> uint256:
     @param deposit True if it is a deposit action, False if withdrawn.
     @return uint256 Amount of LP tokens deposited or withdrawn.
     """
-    view_contract: address = staticcall factory.views_implementation()
+    view_contract: address = staticcall self.factory.views_implementation()
     return staticcall Views(view_contract).calc_token_amount(amounts, deposit, self)
 
 
@@ -1617,7 +1617,7 @@ def get_dy(i: uint256, j: uint256, dx: uint256) -> uint256:
     @param dx amount of input coin[i] tokens
     @return uint256 Exact amount of output j tokens for dx amount of i input tokens.
     """
-    view_contract: address = staticcall factory.views_implementation()
+    view_contract: address = staticcall self.factory.views_implementation()
     return staticcall Views(view_contract).get_dy(i, j, dx, self)
 
 
@@ -1635,7 +1635,7 @@ def get_dx(i: uint256, j: uint256, dy: uint256) -> uint256:
     @param dy amount of input coin[j] tokens received
     @return uint256 Approximate amount of input i tokens to get dy amount of j tokens.
     """
-    view_contract: address = staticcall factory.views_implementation()
+    view_contract: address = staticcall self.factory.views_implementation()
     return staticcall Views(view_contract).get_dx(i, j, dy, self)
 
 
@@ -1651,7 +1651,7 @@ def lp_price() -> uint256:
 
     price_oracle: uint256[N_COINS-1] = self._unpack_prices(self.price_oracle_packed)
     return (
-        3 * self.virtual_price * staticcall MATH.cbrt(price_oracle[0] * price_oracle[1])
+        3 * self.virtual_price * staticcall self.MATH.cbrt(price_oracle[0] * price_oracle[1])
     ) // 10**24
 
 
@@ -1895,7 +1895,7 @@ def precisions() -> uint256[N_COINS]:  # <-------------- For by view contract.
     @notice Returns the precisions of each coin in the pool.
     @return uint256[3] precisions of coins.
     """
-    return PRECISIONS
+    return self.PRECISIONS
 
 
 @external
@@ -1933,7 +1933,7 @@ def ramp_A_gamma(
     @param future_gamma The future gamma value.
     @param future_time The timestamp at which the ramping will end.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert block.timestamp > self.initial_A_gamma_time + (MIN_RAMP_TIME - 1)  # dev: ramp undergoing
     assert future_time > block.timestamp + MIN_RAMP_TIME - 1  # dev: insufficient time
 
@@ -1978,7 +1978,7 @@ def stop_ramp_A_gamma():
     @notice Stop Ramping A and gamma parameters immediately.
     @dev Only accessible by factory admin.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     A_gamma: uint256[2] = self._A_gamma()
     current_A_gamma: uint256 = A_gamma[0] << 128
@@ -2015,7 +2015,7 @@ def apply_new_parameters(
     @param _new_ma_time The new ma time. ma_time is time_in_seconds/ln(2).
     @param _new_xcp_ma_time The new ma time for xcp oracle.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     # ----------------------------- Set fee params ---------------------------
 

--- a/tests/functional/examples/thirdparty/curvefi/amm/twocryptoswap/factory/factory_v_200.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/twocryptoswap/factory/factory_v_200.vy
@@ -102,7 +102,7 @@ deployer: immutable(address)
 
 @deploy
 def __init__(_fee_receiver: address):
-    deployer = msg.sender
+    self.deployer = msg.sender
     self.admin = msg.sender
     self.fee_receiver = _fee_receiver
 
@@ -110,9 +110,9 @@ def __init__(_fee_receiver: address):
 @external
 def set_owner(_owner: address):
     
-    assert msg.sender == deployer
-    assert self.admin == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.admin == self.deployer
+    assert _owner != self.deployer
 
     self.admin = _owner
 

--- a/tests/functional/examples/thirdparty/curvefi/amm/twocryptoswap/implementation/implementation_v_210.vy
+++ b/tests/functional/examples/thirdparty/curvefi/amm/twocryptoswap/implementation/implementation_v_210.vy
@@ -226,14 +226,14 @@ def __init__(
     initial_price: uint256,
 ):
 
-    MATH = Math(_math)
+    self.MATH = Math(_math)
 
-    factory = Factory(msg.sender)
-    name = _name
-    symbol = _symbol
-    coins = _coins
+    self.factory = Factory(msg.sender)
+    self.name = _name
+    self.symbol = _symbol
+    self.coins = _coins
 
-    PRECISIONS = self._unpack_2(packed_precisions)  # <-- Precisions of coins.
+    self.PRECISIONS = self._unpack_2(packed_precisions)  # <-- Precisions of coins.
 
     # --------------- Validate A and gamma parameters here and not in staticcall factory.
     gamma_A: uint256[2] = self._unpack_2(packed_gamma_A)  # gamma is at idx 0.
@@ -265,17 +265,17 @@ def __init__(
     #     DOMAIN_SEPARATOR will be re-calculated each time `permit` is called.
     #                   Otherwise, it will always use CACHED_DOMAIN_SEPARATOR.
     #                       see: `_domain_separator()` for its implementation.
-    NAME_HASH = keccak256(name)
-    salt = _salt
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
+    self.NAME_HASH = keccak256(self.name)
+    self.salt = _salt
+    self.CACHED_CHAIN_ID = chain.id
+    self.CACHED_DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
+            self.NAME_HASH,
             VERSION_HASH,
             chain.id,
             self,
-            salt,
+            self.salt,
         )
     )
 
@@ -303,7 +303,7 @@ def _transfer_in(
             This is only enabled for exchange_received.
     @return The amount of tokens received.
     """
-    coin_balance: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self)
+    coin_balance: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self)
 
     if expect_optimistic_transfer:  # Only enabled in exchange_received:
         # it expects the caller of exchange_received to have sent tokens to
@@ -326,14 +326,14 @@ def _transfer_in(
     # ----------------------------------------------- IERC20 transferFrom flow.
 
     # EXTERNAL CALL
-    assert extcall IERC20(coins[_coin_idx]).transferFrom(
+    assert extcall IERC20(self.coins[_coin_idx]).transferFrom(
         sender,
         self,
         _dx,
         default_return_value=True
     )
 
-    dx: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self) - coin_balance
+    dx: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self) - coin_balance
     self.balances[_coin_idx] += dx
     return dx
 
@@ -353,7 +353,7 @@ def _transfer_out(_coin_idx: uint256, _amount: uint256, receiver: address):
     self.balances[_coin_idx] -= _amount
 
     # EXTERNAL CALL
-    assert extcall IERC20(coins[_coin_idx]).transfer(
+    assert extcall IERC20(self.coins[_coin_idx]).transfer(
         receiver,
         _amount,
         default_return_value=True
@@ -502,12 +502,12 @@ def add_liquidity(
             xp[i] = xp[i] + amounts_received[i]
 
     xp = [
-        xp[0] * PRECISIONS[0],
-        unsafe_div(xp[1] * price_scale * PRECISIONS[1], PRECISION)
+        xp[0] * self.PRECISIONS[0],
+        unsafe_div(xp[1] * price_scale * self.PRECISIONS[1], PRECISION)
     ]
     xp_old = [
-        xp_old[0] * PRECISIONS[0],
-        unsafe_div(xp_old[1] * price_scale * PRECISIONS[1], PRECISION)
+        xp_old[0] * self.PRECISIONS[0],
+        unsafe_div(xp_old[1] * price_scale * self.PRECISIONS[1], PRECISION)
     ]
 
     for i: uint256 in range(N_COINS):
@@ -519,13 +519,13 @@ def add_liquidity(
     if self.future_A_gamma_time > block.timestamp:  # <--- A_gamma is ramping.
 
         # ----- Recalculate the invariant if A or gamma are undergoing a ramp.
-        old_D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp_old, 0)
+        old_D = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp_old, 0)
 
     else:
 
         old_D = self.D
 
-    D: uint256 = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+    D: uint256 = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
     token_supply: uint256 = self.totalSupply
     if old_D > 0:
@@ -767,8 +767,8 @@ def _exchange(
 
     price_scale: uint256 = self.cached_price_scale
     xp = [
-        xp[0] * PRECISIONS[0],
-        unsafe_div(xp[1] * price_scale * PRECISIONS[1], PRECISION)
+        xp[0] * self.PRECISIONS[0],
+        unsafe_div(xp[1] * price_scale * self.PRECISIONS[1], PRECISION)
     ]
 
     # ----------- Update invariant if A, gamma are undergoing ramps ---------
@@ -776,34 +776,34 @@ def _exchange(
     t: uint256 = self.future_A_gamma_time
     if t > block.timestamp:
 
-        x0 *= PRECISIONS[i]
+        x0 *= self.PRECISIONS[i]
 
         if i > 0:
             x0 = unsafe_div(x0 * price_scale, PRECISION)
 
         x1: uint256 = xp[i]  # <------------------ Back up old value in xp ...
         xp[i] = x0                                                         # |
-        self.D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)              # |
+        self.D = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)              # |
         xp[i] = x1  # <-------------------------------------- ... and restore.
 
     # ----------------------- Calculate dy and fees --------------------------
 
     D: uint256 = self.D
-    y_out: uint256[2] = staticcall MATH.get_y(A_gamma[0], A_gamma[1], xp, D, j)
+    y_out: uint256[2] = staticcall self.MATH.get_y(A_gamma[0], A_gamma[1], xp, D, j)
     dy = xp[j] - y_out[0]
     xp[j] -= dy
     dy -= 1
 
     if j > 0:
         dy = dy * PRECISION // price_scale
-    dy //= PRECISIONS[j]
+    dy //= self.PRECISIONS[j]
 
     fee: uint256 = unsafe_div(self._fee(xp) * dy, 10**10)
     dy -= fee  # <--------------------- Subtract fee from the outgoing amount.
     assert dy >= min_dy, "Slippage"
     y -= dy
 
-    y *= PRECISIONS[j]
+    y *= self.PRECISIONS[j]
     if j > 0:
         y = unsafe_div(y * price_scale, PRECISION)
     xp[j] = y  # <------------------------------------------------- Update xp.
@@ -858,7 +858,7 @@ def tweak_price(
 
         # ------------------ Calculate moving average params -----------------
 
-        alpha = staticcall MATH.wad_exp(
+        alpha = staticcall self.MATH.wad_exp(
             -convert(
                 unsafe_div(
                     unsafe_sub(block.timestamp, last_timestamp) * 10**18,
@@ -890,12 +890,12 @@ def tweak_price(
 
     D_unadjusted: uint256 = new_D
     if new_D == 0:  #  <--------------------------- _exchange sets new_D to 0.
-        D_unadjusted = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], _xp, K0_prev)
+        D_unadjusted = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], _xp, K0_prev)
 
     # ----------------------- Calculate last_prices --------------------------
 
     self.last_prices = unsafe_div(
-        staticcall MATH.get_p(_xp, D_unadjusted, A_gamma) * price_scale,
+        staticcall self.MATH.get_p(_xp, D_unadjusted, A_gamma) * price_scale,
         10**18
     )
 
@@ -969,7 +969,7 @@ def tweak_price(
             ]
 
             # ------------------------------------------ Update D with new xp.
-            D: uint256 = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+            D: uint256 = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
             # ------------------------------------- Convert xp to real prices.
             xp = [
@@ -1044,7 +1044,7 @@ def _claim_admin_fees():
     D: uint256 = self.D
     vprice: uint256 = self.virtual_price
     price_scale: uint256 = self.cached_price_scale
-    fee_receiver: address = staticcall factory.fee_receiver()
+    fee_receiver: address = staticcall self.factory.fee_receiver()
     balances: uint256[N_COINS] = self.balances
 
     #  Admin fees are calculated as follows.
@@ -1133,8 +1133,8 @@ def xp(
 ) -> uint256[N_COINS]:
 
     return [
-        balances[0] * PRECISIONS[0],
-        unsafe_div(balances[1] * PRECISIONS[1] * price_scale, PRECISION)
+        balances[0] * self.PRECISIONS[0],
+        unsafe_div(balances[1] * self.PRECISIONS[1] * price_scale, PRECISION)
     ]
 
 
@@ -1236,16 +1236,16 @@ def _calc_withdraw_one_coin(
 
     # -------------------------- Calculate D0 and xp -------------------------
 
-    price_scale_i: uint256 = self.cached_price_scale * PRECISIONS[1]
+    price_scale_i: uint256 = self.cached_price_scale * self.PRECISIONS[1]
     xp: uint256[N_COINS] = [
-        xx[0] * PRECISIONS[0],
+        xx[0] * self.PRECISIONS[0],
         unsafe_div(xx[1] * price_scale_i, PRECISION)
     ]
     if i == 0:
-        price_scale_i = PRECISION * PRECISIONS[0]
+        price_scale_i = PRECISION * self.PRECISIONS[0]
 
     if update_D:  # <-------------- D is updated if pool is undergoing a ramp.
-        D0 = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+        D0 = staticcall self.MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
     else:
         D0 = self.D
 
@@ -1281,7 +1281,7 @@ def _calc_withdraw_one_coin(
     # ------------------------------------------------------------------------
     D -= (dD - D_fee)  # <----------------------------------- Charge fee on D.
     # --------------------------------- Calculate `y_out`` with `(D - D_fee)`.
-    y: uint256 = (staticcall MATH.get_y(A_gamma[0], A_gamma[1], xp, D, i))[0]
+    y: uint256 = (staticcall self.MATH.get_y(A_gamma[0], A_gamma[1], xp, D, i))[0]
     dy: uint256 = (xp[i] - y) * PRECISION // price_scale_i
     xp[i] = y
 
@@ -1311,18 +1311,18 @@ def _transfer(_from: address, _to: address, _value: uint256):
 @view
 @internal
 def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
+    if chain.id != self.CACHED_CHAIN_ID:
         return keccak256(
             abi_encode(
                 EIP712_TYPEHASH,
-                NAME_HASH,
+                self.NAME_HASH,
                 VERSION_HASH,
                 chain.id,
                 self,
-                salt,
+                self.salt,
             )
         )
-    return CACHED_DOMAIN_SEPARATOR
+    return self.CACHED_DOMAIN_SEPARATOR
 
 
 @external
@@ -1476,7 +1476,7 @@ def internal_price_oracle() -> uint256:
 
         last_prices: uint256 = self.last_prices
         ma_time: uint256 = self._unpack_3(self.packed_rebalancing_params)[2]
-        alpha: uint256 = staticcall MATH.wad_exp(
+        alpha: uint256 = staticcall self.MATH.wad_exp(
             -convert(
                 unsafe_sub(block.timestamp, last_prices_timestamp) * 10**18 // ma_time,
                 int256,
@@ -1499,7 +1499,7 @@ def fee_receiver() -> address:
     @notice Returns the address of the admin fee receiver.
     @return address Fee receiver.
     """
-    return staticcall factory.fee_receiver()
+    return staticcall self.factory.fee_receiver()
 
 
 @external
@@ -1509,7 +1509,7 @@ def admin() -> address:
     @notice Returns the address of the pool's admin.
     @return address Admin.
     """
-    return staticcall factory.admin()
+    return staticcall self.factory.admin()
 
 
 @external
@@ -1523,7 +1523,7 @@ def calc_token_amount(amounts: uint256[N_COINS], deposit: bool) -> uint256:
     @param deposit True if it is a deposit action, False if withdrawn.
     @return uint256 Amount of LP tokens deposited or withdrawn.
     """
-    view_contract: address = staticcall factory.views_implementation()
+    view_contract: address = staticcall self.factory.views_implementation()
     return staticcall Views(view_contract).calc_token_amount(amounts, deposit, self)
 
 
@@ -1538,7 +1538,7 @@ def get_dy(i: uint256, j: uint256, dx: uint256) -> uint256:
     @param dx amount of input coin[i] tokens
     @return uint256 Exact amount of output j tokens for dx amount of i input tokens.
     """
-    view_contract: address = staticcall factory.views_implementation()
+    view_contract: address = staticcall self.factory.views_implementation()
     return staticcall Views(view_contract).get_dy(i, j, dx, self)
 
 
@@ -1556,7 +1556,7 @@ def get_dx(i: uint256, j: uint256, dy: uint256) -> uint256:
     @param dy amount of input coin[j] tokens received
     @return uint256 Approximate amount of input i tokens to get dy amount of j tokens.
     """
-    view_contract: address = staticcall factory.views_implementation()
+    view_contract: address = staticcall self.factory.views_implementation()
     return staticcall Views(view_contract).get_dx(i, j, dy, self)
 
 
@@ -1748,7 +1748,7 @@ def precisions() -> uint256[N_COINS]:  # <-------------- For by view contract.
     @notice Returns the precisions of each coin in the pool.
     @return uint256[3] precisions of coins.
     """
-    return PRECISIONS
+    return self.PRECISIONS
 
 
 @external
@@ -1786,7 +1786,7 @@ def ramp_A_gamma(
     @param future_gamma The future gamma value.
     @param future_time The timestamp at which the ramping will end.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert block.timestamp > self.future_A_gamma_time # dev: ramp undergoing
     assert future_time > block.timestamp + MIN_RAMP_TIME - 1  # dev: insufficient time
 
@@ -1831,7 +1831,7 @@ def stop_ramp_A_gamma():
     @notice Stop Ramping A and gamma parameters immediately.
     @dev Only accessible by factory admin.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     A_gamma: uint256[2] = self._A_gamma()
     current_A_gamma: uint256 = A_gamma[0] << 128
@@ -1866,7 +1866,7 @@ def apply_new_parameters(
     @param _new_adjustment_step The new adjustment step.
     @param _new_ma_time The new ma time. ma_time is time_in_seconds//ln(2).
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     # ----------------------------- Set fee params ---------------------------
 

--- a/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/factory/factory_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/factory/factory_v_100.vy
@@ -80,16 +80,16 @@ deployer: immutable(address)
 
 @deploy
 def __init__():
-    deployer = msg.sender
-    self.owner = deployer
+    self.deployer = msg.sender
+    self.owner = self.deployer
 
 
 @external
 def set_owner(_owner: address):
 
-    assert msg.sender == deployer
-    assert self.owner == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.owner == self.deployer
+    assert _owner != self.deployer
 
     self.owner = _owner
     log TransferOwnership(_old_owner=empty(address), _new_owner=_owner)

--- a/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/factory/factory_v_201.vy
+++ b/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/factory/factory_v_201.vy
@@ -112,15 +112,15 @@ def __init__(_root_factory: address, _root_impl: address, _crv: address):
     self.manager = msg.sender
     log UpdateManager(_manager=msg.sender)
 
-    deployer = msg.sender
+    self.deployer = msg.sender
 
 
 @external
 def set_owner(_owner: address):
 
-    assert msg.sender == deployer
-    assert self.owner == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.owner == self.deployer
+    assert _owner != self.deployer
 
     log TransferOwnership(_old_owner=self.owner, _new_owner=_owner)
     self.owner = _owner

--- a/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/implementation/implementation_v_020.vy
+++ b/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/implementation/implementation_v_020.vy
@@ -119,13 +119,13 @@ root_gauge: public(address)
 @deploy
 def __init__(_factory: Factory):
     self.lp_token = empty(address)
-    FACTORY = _factory
+    self.FACTORY = _factory
 
 
 @internal
 @view
 def _crv() -> address:
-    return staticcall FACTORY.CRV()
+    return staticcall self.FACTORY.CRV()
 
 
 @internal
@@ -166,7 +166,7 @@ def _checkpoint(_user: address):
     if crv_balance != 0:
         current_week: uint256 = block.timestamp // WEEK
         self.inflation_rate[current_week] += crv_balance // ((current_week + 1) * WEEK - block.timestamp)
-        success: bool = extcall IERC20(self._crv()).transfer(FACTORY.address, crv_balance)
+        success: bool = extcall IERC20(self._crv()).transfer(self.FACTORY.address, crv_balance)
         assert success
 
     period += 1
@@ -487,7 +487,7 @@ def user_checkpoint(addr: address) -> bool:
     @param addr User address
     @return bool success
     """
-    assert msg.sender in [addr, FACTORY.address]  # dev: unauthorized
+    assert msg.sender in [addr, self.FACTORY.address]  # dev: unauthorized
     self._checkpoint(addr)
     self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
     return True
@@ -501,7 +501,7 @@ def claimable_tokens(addr: address) -> uint256:
     @return uint256 number of claimable tokens per user
     """
     self._checkpoint(addr)
-    return self.integrate_fraction[addr] - staticcall FACTORY.minted(addr, self)
+    return self.integrate_fraction[addr] - staticcall self.FACTORY.minted(addr, self)
 
 
 @view
@@ -568,7 +568,7 @@ def add_reward(_reward_token: address, _distributor: address):
     """
     @notice Set the active reward contract
     """
-    assert msg.sender == self.manager or msg.sender == staticcall FACTORY.owner()
+    assert msg.sender == self.manager or msg.sender == staticcall self.FACTORY.owner()
 
     reward_count: uint256 = self.reward_count
     assert reward_count < MAX_REWARDS
@@ -583,7 +583,7 @@ def add_reward(_reward_token: address, _distributor: address):
 def set_reward_distributor(_reward_token: address, _distributor: address):
     current_distributor: address = self.reward_data[_reward_token].distributor
 
-    assert msg.sender == current_distributor or msg.sender == self.manager or msg.sender == staticcall FACTORY.owner()
+    assert msg.sender == current_distributor or msg.sender == self.manager or msg.sender == staticcall self.FACTORY.owner()
     assert current_distributor != empty(address)
     assert _distributor != empty(address)
 
@@ -614,7 +614,7 @@ def deposit_reward_token(_reward_token: address, _amount: uint256):
 
 @external
 def set_manager(_manager: address):
-    assert msg.sender == staticcall FACTORY.owner()
+    assert msg.sender == staticcall self.FACTORY.owner()
 
     self.manager = _manager
 
@@ -625,7 +625,7 @@ def set_root_gauge(_root: address):
     @notice Set Root contract in case something went wrong (e.g. between implementation updates)
     @param _root Root gauge to set
     """
-    assert msg.sender == staticcall FACTORY.owner()
+    assert msg.sender == staticcall self.FACTORY.owner()
     assert _root != empty(address)
 
     self.root_gauge = _root
@@ -636,7 +636,7 @@ def update_voting_escrow():
     """
     @notice Update the voting escrow contract in storage
     """
-    self.voting_escrow = staticcall FACTORY.voting_escrow()
+    self.voting_escrow = staticcall self.FACTORY.voting_escrow()
 
 
 @external
@@ -645,7 +645,7 @@ def set_killed(_is_killed: bool):
     @notice Set the kill status of the gauge
     @param _is_killed Kill status to put the gauge into
     """
-    assert msg.sender == staticcall FACTORY.owner()
+    assert msg.sender == staticcall self.FACTORY.owner()
 
     self.is_killed = _is_killed
 
@@ -668,7 +668,7 @@ def integrate_checkpoint() -> uint256:
 @view
 @external
 def factory() -> Factory:
-    return FACTORY
+    return self.FACTORY
 
 
 @view

--- a/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/implementation/implementation_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/implementation/implementation_v_100.vy
@@ -143,7 +143,7 @@ root_gauge: public(address)
 def __init__(_factory: Factory):
     self.lp_token = 0x000000000000000000000000000000000000dEaD
 
-    FACTORY = _factory
+    self.FACTORY = _factory
 
 
 @external
@@ -208,13 +208,13 @@ def _checkpoint(_user: address):
             week_time = min(week_time + WEEK, block.timestamp)
 
     # check CRV balance and increase weekly inflation rate by delta for the rest of the week
-    crv: IERC20 = staticcall FACTORY.crv()
+    crv: IERC20 = staticcall self.FACTORY.crv()
     if crv != empty(IERC20):
         crv_balance: uint256 = staticcall crv.balanceOf(self)
         if crv_balance != 0:
             current_week: uint256 = block.timestamp // WEEK
             self.inflation_rate[current_week] += crv_balance // ((current_week + 1) * WEEK - block.timestamp)
-            success: bool = extcall crv.transfer(FACTORY.address, crv_balance)
+            success: bool = extcall crv.transfer(self.FACTORY.address, crv_balance)
             assert success
 
     period += 1
@@ -572,7 +572,7 @@ def user_checkpoint(addr: address) -> bool:
     @param addr User address
     @return bool success
     """
-    assert msg.sender in [addr, FACTORY.address]  # dev: unauthorized
+    assert msg.sender in [addr, self.FACTORY.address]  # dev: unauthorized
     self._checkpoint(addr)
     self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
     return True
@@ -600,7 +600,7 @@ def set_gauge_manager(_gauge_manager: address):
         method, but only for the gauge which they are the manager of.
     @param _gauge_manager The account to set as the new manager of the gauge.
     """
-    assert msg.sender in [self.manager, staticcall FACTORY.owner()]  # dev: only manager or factory admin
+    assert msg.sender in [self.manager, staticcall self.FACTORY.owner()]  # dev: only manager or factory admin
 
     self.manager = _gauge_manager
     log SetGaugeManager(_gauge_manager=_gauge_manager)
@@ -616,7 +616,7 @@ def set_manager(_gauge_manager: address):
         method, but only for the gauge which they are the manager of.
     @param _gauge_manager The account to set as the new manager of the gauge.
     """
-    assert msg.sender in [self.manager, staticcall FACTORY.owner()]  # dev: only manager or factory admin
+    assert msg.sender in [self.manager, staticcall self.FACTORY.owner()]  # dev: only manager or factory admin
 
     self.manager = _gauge_manager
     log SetGaugeManager(_gauge_manager=_gauge_manager)
@@ -681,8 +681,8 @@ def add_reward(_reward_token: address, _distributor: address):
     @param _reward_token The token to add as an additional reward
     @param _distributor Address permitted to fund this contract with the reward token
     """
-    assert msg.sender in [self.manager, staticcall FACTORY.owner()]  # dev: only manager or factory admin
-    crv_token: IERC20 = staticcall FACTORY.crv()
+    assert msg.sender in [self.manager, staticcall self.FACTORY.owner()]  # dev: only manager or factory admin
+    crv_token: IERC20 = staticcall self.FACTORY.crv()
     assert _reward_token != crv_token.address  # dev: can not distinguish CRV reward from CRV emission
     assert _distributor != empty(address)  # dev: distributor cannot be zero address
 
@@ -704,7 +704,7 @@ def set_reward_distributor(_reward_token: address, _distributor: address):
     """
     current_distributor: address = self.reward_data[_reward_token].distributor
 
-    assert msg.sender in [current_distributor, staticcall FACTORY.owner(), self.manager]
+    assert msg.sender in [current_distributor, staticcall self.FACTORY.owner(), self.manager]
     assert current_distributor != empty(address)
     assert _distributor != empty(address)
 
@@ -718,7 +718,7 @@ def set_killed(_is_killed: bool):
     @dev Nothing happens, just stop emissions and that's it
     @param _is_killed Killed status to set
     """
-    assert msg.sender == staticcall FACTORY.owner()  # dev: only owner
+    assert msg.sender == staticcall self.FACTORY.owner()  # dev: only owner
 
     self.is_killed = _is_killed
 
@@ -729,7 +729,7 @@ def set_root_gauge(_root: address):
     @notice Set Root contract in case something went wrong (e.g. between implementation updates)
     @param _root Root gauge to set
     """
-    assert msg.sender in [staticcall FACTORY.owner(), staticcall FACTORY.manager()]
+    assert msg.sender in [staticcall self.FACTORY.owner(), staticcall self.FACTORY.manager()]
     assert _root != empty(address)
 
     self.root_gauge = _root
@@ -740,7 +740,7 @@ def update_voting_escrow():
     """
     @notice Update the voting escrow contract in storage
     """
-    self.voting_escrow = staticcall FACTORY.voting_escrow()
+    self.voting_escrow = staticcall self.FACTORY.voting_escrow()
 
 
 # View Methods
@@ -788,7 +788,7 @@ def claimable_tokens(addr: address) -> uint256:
     @return uint256 number of claimable tokens per user
     """
     self._checkpoint(addr)
-    return self.integrate_fraction[addr] - staticcall FACTORY.minted(addr, self)
+    return self.integrate_fraction[addr] - staticcall self.FACTORY.minted(addr, self)
 
 
 @view
@@ -826,4 +826,4 @@ def factory() -> Factory:
     """
     @notice Get factory of this gauge
     """
-    return FACTORY
+    return self.FACTORY

--- a/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/implementation/implementation_v_110.vy
+++ b/tests/functional/examples/thirdparty/curvefi/gauge/child_gauge/implementation/implementation_v_110.vy
@@ -158,7 +158,7 @@ def __init__(_factory: Factory):
     """
     self.lp_token = 0x000000000000000000000000000000000000dEaD
 
-    FACTORY = _factory
+    self.FACTORY = _factory
 
 
 @external
@@ -232,13 +232,13 @@ def _checkpoint(_user: address):
             week_time = min(week_time + WEEK, block.timestamp)
 
     # check CRV balance and increase weekly inflation rate by delta for the rest of the week
-    crv: IERC20 = staticcall FACTORY.crv()
+    crv: IERC20 = staticcall self.FACTORY.crv()
     if crv != empty(IERC20):
         crv_balance: uint256 = staticcall crv.balanceOf(self)
         if crv_balance != 0:
             current_week: uint256 = block.timestamp // WEEK
             self.inflation_rate[current_week] += crv_balance // ((current_week + 1) * WEEK - block.timestamp)
-            success: bool = extcall crv.transfer(FACTORY.address, crv_balance)
+            success: bool = extcall crv.transfer(self.FACTORY.address, crv_balance)
             assert success
 
     period += 1
@@ -599,7 +599,7 @@ def user_checkpoint(addr: address) -> bool:
     @param addr User address
     @return bool success
     """
-    assert msg.sender in [addr, FACTORY.address]  # dev: unauthorized
+    assert msg.sender in [addr, self.FACTORY.address]  # dev: unauthorized
     self._checkpoint(addr)
     self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
     return True
@@ -627,7 +627,7 @@ def set_gauge_manager(_gauge_manager: address):
         method, but only for the gauge which they are the manager of.
     @param _gauge_manager The account to set as the new manager of the gauge.
     """
-    assert msg.sender in [self.manager, staticcall FACTORY.owner()]  # dev: only manager or factory admin
+    assert msg.sender in [self.manager, staticcall self.FACTORY.owner()]  # dev: only manager or factory admin
 
     self.manager = _gauge_manager
     log SetGaugeManager(_gauge_manager=_gauge_manager)
@@ -643,7 +643,7 @@ def set_manager(_gauge_manager: address):
         method, but only for the gauge which they are the manager of.
     @param _gauge_manager The account to set as the new manager of the gauge.
     """
-    assert msg.sender in [self.manager, staticcall FACTORY.owner()]  # dev: only manager or factory admin
+    assert msg.sender in [self.manager, staticcall self.FACTORY.owner()]  # dev: only manager or factory admin
 
     self.manager = _gauge_manager
     log SetGaugeManager(_gauge_manager=_gauge_manager)
@@ -709,8 +709,8 @@ def add_reward(_reward_token: address, _distributor: address):
     @param _reward_token The token to add as an additional reward
     @param _distributor Address permitted to fund this contract with the reward token
     """
-    assert msg.sender in [self.manager, staticcall FACTORY.owner()]  # dev: only manager or factory admin
-    crv_token: IERC20 = staticcall FACTORY.crv()
+    assert msg.sender in [self.manager, staticcall self.FACTORY.owner()]  # dev: only manager or factory admin
+    crv_token: IERC20 = staticcall self.FACTORY.crv()
     assert _reward_token != crv_token.address  # dev: can not distinguish CRV reward from CRV emission
     assert _distributor != empty(address)  # dev: distributor cannot be zero address
 
@@ -734,7 +734,7 @@ def set_reward_distributor(_reward_token: address, _distributor: address):
     """
     current_distributor: address = self.reward_data[_reward_token].distributor
 
-    assert msg.sender in [current_distributor, staticcall FACTORY.owner(), self.manager]
+    assert msg.sender in [current_distributor, staticcall self.FACTORY.owner(), self.manager]
     assert current_distributor != empty(address)
     assert _distributor != empty(address)
 
@@ -749,7 +749,7 @@ def set_killed(_is_killed: bool):
     @dev Nothing happens, just stop emissions and that's it
     @param _is_killed Killed status to set
     """
-    assert msg.sender == staticcall FACTORY.owner()  # dev: only owner
+    assert msg.sender == staticcall self.FACTORY.owner()  # dev: only owner
 
     self.is_killed = _is_killed
     log SetKilled(is_killed=_is_killed)
@@ -761,7 +761,7 @@ def set_root_gauge(_root: address):
     @notice Set Root contract in case something went wrong (e.g. between implementation updates)
     @param _root Root gauge to set
     """
-    assert msg.sender in [staticcall FACTORY.owner(), staticcall FACTORY.manager()]
+    assert msg.sender in [staticcall self.FACTORY.owner(), staticcall self.FACTORY.manager()]
     assert _root != empty(address)
 
     self.root_gauge = _root
@@ -772,7 +772,7 @@ def update_voting_escrow():
     """
     @notice Update the voting escrow contract in storage
     """
-    self.voting_escrow = staticcall FACTORY.voting_escrow()
+    self.voting_escrow = staticcall self.FACTORY.voting_escrow()
 
 
 # View Methods
@@ -821,7 +821,7 @@ def claimable_tokens(addr: address) -> uint256:
     @return uint256 number of claimable tokens per user
     """
     self._checkpoint(addr)
-    return self.integrate_fraction[addr] - staticcall FACTORY.minted(addr, self)
+    return self.integrate_fraction[addr] - staticcall self.FACTORY.minted(addr, self)
 
 
 @view
@@ -852,4 +852,4 @@ def factory() -> Factory:
     @notice Get factory of this gauge
     @return address of factory
     """
-    return FACTORY
+    return self.FACTORY

--- a/tests/functional/examples/thirdparty/curvefi/governance/agent/agent_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/agent/agent_v_100.vy
@@ -23,7 +23,7 @@ RELAYER: public(immutable(address))
 
 @deploy
 def __init__():
-    RELAYER = msg.sender
+    self.RELAYER = msg.sender
 
 
 @external
@@ -32,7 +32,7 @@ def execute(_messages: DynArray[Message, MAX_MESSAGES]):
     @notice Execute a sequence of messages.
     @param _messages An array of messages to be executed.
     """
-    assert msg.sender == RELAYER
+    assert msg.sender == self.RELAYER
 
     for message: Message in _messages:
         raw_call(message.target, message.data)

--- a/tests/functional/examples/thirdparty/curvefi/governance/agent/agent_v_101.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/agent/agent_v_101.vy
@@ -33,7 +33,7 @@ RELAYER: public(immutable(address))
 
 @deploy
 def __init__():
-    RELAYER = msg.sender
+    self.RELAYER = msg.sender
 
 
 @external
@@ -42,7 +42,7 @@ def execute(_messages: DynArray[Message, MAX_MESSAGES]):
     @notice Execute a sequence of messages.
     @param _messages An array of messages to be executed.
     """
-    assert msg.sender == RELAYER
+    assert msg.sender == self.RELAYER
 
     for message: Message in _messages:
         raw_call(message.target, message.data)

--- a/tests/functional/examples/thirdparty/curvefi/governance/relayer/arb_orbit/relayer_v_101.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/relayer/arb_orbit/relayer_v_101.vy
@@ -47,16 +47,16 @@ agent: HashMap[Agent, address]
 
 @deploy
 def __init__(broadcaster: address, _agent_blueprint: address, _arbsys: address):
-    BROADCASTER = broadcaster
-    ARBSYS = _arbsys
+    self.BROADCASTER = broadcaster
+    self.ARBSYS = _arbsys
 
-    OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
 
-    self.agent[Agent.OWNERSHIP] = OWNERSHIP_AGENT
-    self.agent[Agent.PARAMETER] = PARAMETER_AGENT
-    self.agent[Agent.EMERGENCY] = EMERGENCY_AGENT
+    self.agent[Agent.OWNERSHIP] = self.OWNERSHIP_AGENT
+    self.agent[Agent.PARAMETER] = self.PARAMETER_AGENT
+    self.agent[Agent.EMERGENCY] = self.EMERGENCY_AGENT
 
 
 @external
@@ -66,7 +66,7 @@ def relay(_agent: Agent, _messages: DynArray[Message, MAX_MESSAGES]):
     @param _agent The agent to relay messages to.
     @param _messages The sequence of messages to relay.
     """
-    assert staticcall IArbSys(ARBSYS).wasMyCallersAddressAliased()
-    assert staticcall IArbSys(ARBSYS).myCallersAddressWithoutAliasing() == BROADCASTER
+    assert staticcall IArbSys(self.ARBSYS).wasMyCallersAddressAliased()
+    assert staticcall IArbSys(self.ARBSYS).myCallersAddressWithoutAliasing() == self.BROADCASTER
 
     extcall IAgent(self.agent[_agent]).execute(_messages)

--- a/tests/functional/examples/thirdparty/curvefi/governance/relayer/not_rollup/relayer_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/relayer/not_rollup/relayer_v_100.vy
@@ -46,13 +46,13 @@ def __init__(_agent_blueprint: address, _messenger: address):
     self.messenger = _messenger
     log SetMessenger(messenger=_messenger)
 
-    OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
 
-    self.agent[Agent.OWNERSHIP] = OWNERSHIP_AGENT
-    self.agent[Agent.PARAMETER] = PARAMETER_AGENT
-    self.agent[Agent.EMERGENCY] = EMERGENCY_AGENT
+    self.agent[Agent.OWNERSHIP] = self.OWNERSHIP_AGENT
+    self.agent[Agent.PARAMETER] = self.PARAMETER_AGENT
+    self.agent[Agent.EMERGENCY] = self.EMERGENCY_AGENT
 
 
 @external
@@ -73,7 +73,7 @@ def set_messenger(_messenger: address):
     @notice Set the messenger which verifies messages and is permitted to call `relay`.
     @dev Only callable by the OWNERSHIP_AGENT.
     """
-    assert msg.sender == OWNERSHIP_AGENT
+    assert msg.sender == self.OWNERSHIP_AGENT
 
     self.messenger = _messenger
     log SetMessenger(messenger=_messenger)

--- a/tests/functional/examples/thirdparty/curvefi/governance/relayer/op_stack/relayer_v_101.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/relayer/op_stack/relayer_v_101.vy
@@ -46,16 +46,16 @@ agent: HashMap[Agent, address]
 
 @deploy
 def __init__(_broadcaster: address, _agent_blueprint: address, _messenger: address):
-    BROADCASTER = _broadcaster
-    MESSENGER = _messenger
+    self.BROADCASTER = _broadcaster
+    self.MESSENGER = _messenger
 
-    OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
 
-    self.agent[Agent.OWNERSHIP] = OWNERSHIP_AGENT
-    self.agent[Agent.PARAMETER] = PARAMETER_AGENT
-    self.agent[Agent.EMERGENCY] = EMERGENCY_AGENT
+    self.agent[Agent.OWNERSHIP] = self.OWNERSHIP_AGENT
+    self.agent[Agent.PARAMETER] = self.PARAMETER_AGENT
+    self.agent[Agent.EMERGENCY] = self.EMERGENCY_AGENT
 
 
 @external
@@ -65,7 +65,7 @@ def relay(_agent: Agent, _messages: DynArray[Message, MAX_MESSAGES]):
     @param _agent The agent to relay messages to.
     @param _messages The sequence of messages to relay.
     """
-    assert msg.sender == MESSENGER
-    assert staticcall IMessenger(MESSENGER).xDomainMessageSender() == BROADCASTER
+    assert msg.sender == self.MESSENGER
+    assert staticcall IMessenger(self.MESSENGER).xDomainMessageSender() == self.BROADCASTER
 
     extcall IAgent(self.agent[_agent]).execute(_messages)

--- a/tests/functional/examples/thirdparty/curvefi/governance/relayer/polygon_cdk/relayer_v_101.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/relayer/polygon_cdk/relayer_v_101.vy
@@ -55,18 +55,18 @@ ORIGIN_NETWORK: public(immutable(uint32))
 
 @deploy
 def __init__(_broadcaster: address, _agent_blueprint: address, _messenger: address, _origin_network: uint32):
-    BROADCASTER = _broadcaster
-    MESSENGER = _messenger
+    self.BROADCASTER = _broadcaster
+    self.MESSENGER = _messenger
     log SetMessenger(messenger=_messenger)
-    ORIGIN_NETWORK = _origin_network
+    self.ORIGIN_NETWORK = _origin_network
 
-    OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
 
-    self.agent[Agent.OWNERSHIP] = OWNERSHIP_AGENT
-    self.agent[Agent.PARAMETER] = PARAMETER_AGENT
-    self.agent[Agent.EMERGENCY] = EMERGENCY_AGENT
+    self.agent[Agent.OWNERSHIP] = self.OWNERSHIP_AGENT
+    self.agent[Agent.PARAMETER] = self.PARAMETER_AGENT
+    self.agent[Agent.EMERGENCY] = self.EMERGENCY_AGENT
 
 
 @external
@@ -85,8 +85,8 @@ def relay(_agent: Agent, _messages: DynArray[Message, MAX_MESSAGES]):
 
 @external
 def onMessageReceived(_origin_address: address, _origin_network: uint32, _data: Bytes[MAX_MESSAGE_RECEIVED]):
-    assert msg.sender == MESSENGER
-    assert _origin_address == BROADCASTER
-    assert _origin_network == ORIGIN_NETWORK
+    assert msg.sender == self.MESSENGER
+    assert _origin_address == self.BROADCASTER
+    assert _origin_network == self.ORIGIN_NETWORK
 
     raw_call(self, _data)  # .relay()

--- a/tests/functional/examples/thirdparty/curvefi/governance/relayer/relayer_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/relayer/relayer_v_100.vy
@@ -32,15 +32,15 @@ BROADCASTER: public(immutable(address))
 
 @deploy
 def __init__(_broadcaster: address, _agent_blueprint: address):
-    BROADCASTER = _broadcaster
+    self.BROADCASTER = _broadcaster
 
-    OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
-    EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.OWNERSHIP_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.PARAMETER_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
+    self.EMERGENCY_AGENT = create_from_blueprint(_agent_blueprint, code_offset=CODE_OFFSET)
 
-    self.agent[agent_lib.Agent.OWNERSHIP] = agent_lib.IAgent(OWNERSHIP_AGENT)
-    self.agent[agent_lib.Agent.PARAMETER] = agent_lib.IAgent(PARAMETER_AGENT)
-    self.agent[agent_lib.Agent.EMERGENCY] = agent_lib.IAgent(EMERGENCY_AGENT)
+    self.agent[agent_lib.Agent.OWNERSHIP] = agent_lib.IAgent(self.OWNERSHIP_AGENT)
+    self.agent[agent_lib.Agent.PARAMETER] = agent_lib.IAgent(self.PARAMETER_AGENT)
+    self.agent[agent_lib.Agent.EMERGENCY] = agent_lib.IAgent(self.EMERGENCY_AGENT)
 
 
 @internal

--- a/tests/functional/examples/thirdparty/curvefi/governance/relayer/taiko/relayer_v_001.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/relayer/taiko/relayer_v_001.vy
@@ -42,7 +42,7 @@ def __init__(_broadcaster: address, _agent_blueprint: address):
         if mul10 == 0:
             break
         addr += mul16 * ((chain.id // mul10) % 10)
-    BRIDGE = IBridge(convert(addr, address))
+    self.BRIDGE = IBridge(convert(addr, address))
 
     Relayer.__init__(_broadcaster, _agent_blueprint)
 
@@ -56,8 +56,8 @@ def onMessageInvocation(_data: Bytes[10000]):
     @notice Call handler from Taiko bridge
     @param _data ABI encoded data of governance messages
     """
-    assert msg.sender == BRIDGE.address
-    context: Context = staticcall BRIDGE.context()
+    assert msg.sender == self.BRIDGE.address
+    context: Context = staticcall self.BRIDGE.context()
     assert context.msgFrom == Relayer.BROADCASTER
     assert context.srcChainId == 1
 

--- a/tests/functional/examples/thirdparty/curvefi/governance/vault/vault_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/governance/vault/vault_v_100.vy
@@ -35,15 +35,15 @@ def __init__(_owner: address):
 
     log ApplyOwnership(owner=_owner)
 
-    deployer = msg.sender
+    self.deployer = msg.sender
 
 
 @external
 def set_owner(_owner: address):
 
-    assert msg.sender == deployer
-    assert self.owner == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.owner == self.deployer
+    assert _owner != self.deployer
 
     self.owner = _owner
     log CommitOwnership(future_owner=_owner)

--- a/tests/functional/examples/thirdparty/curvefi/helpers/rate_provider/rate_provider_v_100.vy
+++ b/tests/functional/examples/thirdparty/curvefi/helpers/rate_provider/rate_provider_v_100.vy
@@ -43,7 +43,7 @@ CRYPTOSWAP_ABI: constant(String[64]) = "get_dy(uint256,uint256,uint256)"
 
 @deploy
 def __init__(address_provider: address):
-    ADDRESS_PROVIDER = AddressProvider(address_provider)
+    self.ADDRESS_PROVIDER = AddressProvider(address_provider)
 
 # Quote View method
 
@@ -52,7 +52,7 @@ def __init__(address_provider: address):
 def get_quotes(source_token: address, destination_token: address, amount_in: uint256) -> DynArray[Quote, MAX_QUOTES]:
 
     quotes: DynArray[Quote, MAX_QUOTES] = []
-    metaregistry: Metaregistry = Metaregistry(staticcall ADDRESS_PROVIDER.get_address(METAREGISTRY_ID))
+    metaregistry: Metaregistry = Metaregistry(staticcall self.ADDRESS_PROVIDER.get_address(METAREGISTRY_ID))
     pools: DynArray[address, 1000] = staticcall metaregistry.find_pools_for_coins(source_token, destination_token)
 
     if len(pools) == 0:

--- a/tests/functional/examples/thirdparty/curvefi/helpers/rate_provider/rate_provider_v_101.vy
+++ b/tests/functional/examples/thirdparty/curvefi/helpers/rate_provider/rate_provider_v_101.vy
@@ -44,7 +44,7 @@ CRYPTOSWAP_ABI: constant(String[64]) = "get_dy(uint256,uint256,uint256)"
 
 @deploy
 def __init__(address_provider: address):
-    ADDRESS_PROVIDER = AddressProvider(address_provider)
+    self.ADDRESS_PROVIDER = AddressProvider(address_provider)
 
 
 @external
@@ -102,7 +102,7 @@ def weighted_average_quote(
 def _get_quotes(source_token: address, destination_token: address, amount_in: uint256) -> DynArray[Quote, MAX_QUOTES]:
 
     quotes: DynArray[Quote, MAX_QUOTES] = []
-    metaregistry: Metaregistry = Metaregistry(staticcall ADDRESS_PROVIDER.get_address(METAREGISTRY_ID))
+    metaregistry: Metaregistry = Metaregistry(staticcall self.ADDRESS_PROVIDER.get_address(METAREGISTRY_ID))
     pools: DynArray[address, 1000] = staticcall metaregistry.find_pools_for_coins(source_token, destination_token)
 
     if len(pools) == 0:

--- a/tests/functional/examples/thirdparty/curvefi/helpers/router/router_v_110.vy
+++ b/tests/functional/examples/thirdparty/curvefi/helpers/router/router_v_110.vy
@@ -71,7 +71,7 @@ def __default__():
 
 @deploy
 def __init__( _weth: address):
-    WETH_ADDRESS = _weth
+    self.WETH_ADDRESS = _weth
 
 
 @external
@@ -165,9 +165,9 @@ def exchange(
             else:  # twocrypto-ng, tricrypto-ng
                 extcall CryptoNgPool(swap).remove_liquidity_one_coin(amount, params[1], 0)
         elif params[2] == 8:
-            if input_token == ETH_ADDRESS and output_token == WETH_ADDRESS:
+            if input_token == ETH_ADDRESS and output_token == self.WETH_ADDRESS:
                 extcall WETH(swap).deposit(value=amount)
-            elif input_token == WETH_ADDRESS and output_token == ETH_ADDRESS:
+            elif input_token == self.WETH_ADDRESS and output_token == ETH_ADDRESS:
                 extcall WETH(swap).withdraw(amount)
             else:
                 raise "Swap type 8 is only for ETH <-> WETH"

--- a/tests/functional/examples/thirdparty/curvefi/legacy/CurveStableSwapMetaNG.vy
+++ b/tests/functional/examples/thirdparty/curvefi/legacy/CurveStableSwapMetaNG.vy
@@ -220,7 +220,7 @@ nonces: public(HashMap[address, uint256])
 
 # keccak256("isValidSignature(bytes32,bytes)")[:4] << 224
 ERC1271_MAGIC_VAL: constant(bytes32) = 0x1626ba7e00000000000000000000000000000000000000000000000000000000
-EIP712_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)")
+EIP712_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string self.name,string version,uint256 chainId,address verifyingContract,bytes32 self.salt)")
 EIP2612_TYPEHASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
 
 VERSION_HASH: constant(bytes32) = keccak256(version)
@@ -272,24 +272,24 @@ def __init__(
     @param _oracles Array of rate oracle addresses.
     """
 
-    WETH20 = _weth
-    BASE_POOL = _base_pool
-    BASE_COINS = _base_coins
-    BASE_N_COINS = len(_base_coins)
-    coins = _coins
-    rate_multipliers = _rate_multipliers
-    asset_types = _asset_types  # contains asset types for all pool tokens including base pool tokens
+    self.WETH20 = _weth
+    self.BASE_POOL = _base_pool
+    self.BASE_COINS = _base_coins
+    self.BASE_N_COINS = len(_base_coins)
+    self.coins = _coins
+    self.rate_multipliers = _rate_multipliers
+    self.asset_types = _asset_types  # contains asset types for all pool tokens including base pool tokens
 
     for i: uint256 in range(MAX_COINS):
-        if i < BASE_N_COINS:
+        if i < self.BASE_N_COINS:
             # Approval needed for add_liquidity operation on base pool in _exchange_underlying
-            extcall IERC20(_base_coins[i]).approve(BASE_POOL, max_value(uint256))
+            extcall IERC20(_base_coins[i]).approve(self.BASE_POOL, max_value(uint256))
 
     self.last_prices_packed.append(self.pack_prices(10**18, 10**18))
 
     # ----------------- Parameters independent of pool type ------------------
 
-    factory = Factory(msg.sender)
+    self.factory = Factory(msg.sender)
 
     A: uint256 = _A * A_PRECISION
     self.initial_A = A
@@ -303,7 +303,7 @@ def __init__(
     for i: int128 in range(N_COINS_128):
 
         # Enforce native token as coin[0]
-        if _coins[i] == WETH20:
+        if _coins[i] == self.WETH20:
             assert i == 0 # dev: "ETH must be at index 0"
 
         self.oracles.append(convert(_method_ids[i], uint256) * 2**224 | convert(_oracles[i], uint256))
@@ -311,21 +311,21 @@ def __init__(
 
     # --------------------------- ERC20 stuff ----------------------------
 
-    name = _name
-    symbol = _symbol
+    self.name = _name
+    self.symbol = _symbol
 
     # EIP712 related params -----------------
-    NAME_HASH = keccak256(name)
-    salt = block.prevhash
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
+    self.NAME_HASH = keccak256(self.name)
+    self.salt = block.prevhash
+    self.CACHED_CHAIN_ID = chain.id
+    self.CACHED_DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
+            self.NAME_HASH,
             VERSION_HASH,
             chain.id,
             self,
-            salt,
+            self.salt,
         )
     )
 
@@ -341,7 +341,7 @@ def __init__(
 @external
 def __default__():
     if msg.value > 0:
-        assert WETH20 in coins
+        assert self.WETH20 in self.coins
 
 
 @internal
@@ -380,20 +380,20 @@ def _transfer_in(
     @params use_eth True if the transfer is ETH, False otherwise.
     @params expect_optimistic_transfer True if contract expects an optimistic coin transfer
     """
-    _dx: uint256 = staticcall IERC20(coins[coin_idx]).balanceOf(self)
-    _incoming_coin_asset_type: uint8 = asset_types[coin_idx]
+    _dx: uint256 = staticcall IERC20(self.coins[coin_idx]).balanceOf(self)
+    _incoming_coin_asset_type: uint8 = self.asset_types[coin_idx]
 
     # ------------------------- Handle Transfers -----------------------------
 
-    if use_eth and coins[coin_idx] == WETH20:
+    if use_eth and self.coins[coin_idx] == self.WETH20:
 
         _dx = mvalue
-        extcall WETH(WETH20).deposit(value=dx)
+        extcall WETH(self.WETH20).deposit(value=dx)
 
     elif expect_optimistic_transfer:
 
         assert _incoming_coin_asset_type != 3 # dev: "exchange_received not allowed if incoming token is rebasing"
-        _dx = staticcall IERC20(coins[coin_idx]).balanceOf(self) - self.stored_balances[coin_idx]
+        _dx = staticcall IERC20(self.coins[coin_idx]).balanceOf(self) - self.stored_balances[coin_idx]
 
     elif callback_sig != empty(bytes32):
 
@@ -401,19 +401,19 @@ def _transfer_in(
                 callbacker,
                 concat(
                     slice(callback_sig, 0, 4),
-                    abi_encode(sender, receiver, coins[coin_idx], dx, dy)
+                    abi_encode(sender, receiver, self.coins[coin_idx], dx, dy)
                 )
             )
 
-        _dx = staticcall IERC20(coins[coin_idx]).balanceOf(self) - _dx
+        _dx = staticcall IERC20(self.coins[coin_idx]).balanceOf(self) - _dx
 
     else:
 
-        assert extcall IERC20(coins[coin_idx]).transferFrom(
+        assert extcall IERC20(self.coins[coin_idx]).transferFrom(
             sender, self, dx, default_return_value=True
         )
 
-        _dx = staticcall IERC20(coins[coin_idx]).balanceOf(self) - _dx
+        _dx = staticcall IERC20(self.coins[coin_idx]).balanceOf(self) - _dx
 
     # --------------------------- Check Transfer -----------------------------
 
@@ -445,14 +445,14 @@ def _transfer_out(
 
     # ------------------------- Handle Transfers -----------------------------
 
-    if use_eth and coins[_coin_idx] == WETH20:
+    if use_eth and self.coins[_coin_idx] == self.WETH20:
 
-        extcall WETH(WETH20).withdraw(_amount)
+        extcall WETH(self.WETH20).withdraw(_amount)
         raw_call(receiver, b"", value=_amount)
 
     else:
 
-        assert extcall IERC20(coins[_coin_idx]).transfer(
+        assert extcall IERC20(self.coins[_coin_idx]).transfer(
             receiver, _amount, default_return_value=True
         )
 
@@ -474,10 +474,10 @@ def _stored_rates() -> DynArray[uint256, MAX_COINS]:
          contract.
     """
     rates: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
-    if BASE_POOL != empty(address):
-        rates = [rate_multipliers[0], staticcall StableSwap(BASE_POOL).get_virtual_price()]
+    if self.BASE_POOL != empty(address):
+        rates = [self.rate_multipliers[0], staticcall StableSwap(self.BASE_POOL).get_virtual_price()]
     else:
-        rates = rate_multipliers
+        rates = self.rate_multipliers
 
     oracles: DynArray[uint256, MAX_COINS] = self.oracles
 
@@ -510,7 +510,7 @@ def _balances() -> DynArray[uint256, MAX_COINS]:
     result: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
 
     for i: int128 in range(N_COINS_128):
-        result.append(staticcall IERC20(coins[i]).balanceOf(self) - self.admin_balances[i])
+        result.append(staticcall IERC20(self.coins[i]).balanceOf(self) - self.admin_balances[i])
 
     return result
 
@@ -1072,7 +1072,7 @@ def _exchange_underlying(
     expect_optimistic_transfer: bool = False
 ) -> uint256:
 
-    assert BASE_POOL != empty(address)  # dev: pool is not a metapool
+    assert self.BASE_POOL != empty(address)  # dev: pool is not a metapool
 
     rates: DynArray[uint256, MAX_COINS] = self._stored_rates()
     old_balances: DynArray[uint256, MAX_COINS] = self._balances()
@@ -1088,17 +1088,17 @@ def _exchange_underlying(
     output_coin: address = empty(address)
 
     if i == 0:
-        input_coin = coins[0]
+        input_coin = self.coins[0]
     else:
         base_i = i - MAX_METAPOOL_COIN_INDEX  # if i == 1, this reverts
         meta_i = 1
-        input_coin = BASE_COINS[base_i]
+        input_coin = self.BASE_COINS[base_i]
     if j == 0:
-        output_coin = coins[0]
+        output_coin = self.coins[0]
     else:
         base_j = j - MAX_METAPOOL_COIN_INDEX  # if j == 1, this reverts
         meta_j = 1
-        output_coin = BASE_COINS[base_j]
+        output_coin = self.BASE_COINS[base_j]
 
     # --------------------------- Do Transfer in -----------------------------
 
@@ -1107,10 +1107,10 @@ def _exchange_underlying(
     # for exchange_underlying, optimistic transfers need to be handled differently
     if expect_optimistic_transfer:
 
-        assert asset_types[i] != 3  # dev: rebasing coins not supported
+        assert self.asset_types[i] != 3  # dev: rebasing coins not supported
 
         # This branch is never reached for rebasing tokens
-        if input_coin == BASE_COINS[base_i]:
+        if input_coin == self.BASE_COINS[base_i]:
             # we expect base_coin's balance to be 0. So swap whatever base_coin's
             # balance the pool has:
             dx_w_fee = staticcall IERC20(input_coin).balanceOf(self)
@@ -1155,7 +1155,7 @@ def _exchange_underlying(
         # Withdraw from the base pool if needed
         if j > 0:
             out_amount: uint256 = staticcall IERC20(output_coin).balanceOf(self)
-            extcall StableSwap(BASE_POOL).remove_liquidity_one_coin(dy, base_j, 0)
+            extcall StableSwap(self.BASE_POOL).remove_liquidity_one_coin(dy, base_j, 0)
             dy = staticcall IERC20(output_coin).balanceOf(self) - out_amount
 
         assert dy >= _min_dy
@@ -1166,7 +1166,7 @@ def _exchange_underlying(
     else:  # base pool swap (user should swap at base pool for better gas)
 
         dy = staticcall IERC20(output_coin).balanceOf(self)
-        extcall StableSwap(BASE_POOL).exchange(base_i, base_j, dx_w_fee, _min_dy)
+        extcall StableSwap(self.BASE_POOL).exchange(base_i, base_j, dx_w_fee, _min_dy)
         dy = staticcall IERC20(output_coin).balanceOf(self) - dy
 
     # --------------------------- Do Transfer out ----------------------------
@@ -1183,26 +1183,26 @@ def _exchange_underlying(
 @internal
 def _meta_add_liquidity(dx: uint256, base_i: int128) -> uint256:
 
-    coin_i: address = coins[MAX_METAPOOL_COIN_INDEX]
+    coin_i: address = self.coins[MAX_METAPOOL_COIN_INDEX]
     x: uint256 = staticcall IERC20(coin_i).balanceOf(self)
 
-    if BASE_N_COINS == 2:
+    if self.BASE_N_COINS == 2:
 
         base_inputs: uint256[2] = empty(uint256[2])
         base_inputs[base_i] = dx
-        extcall StableSwap2(BASE_POOL).add_liquidity(base_inputs, 0)
+        extcall StableSwap2(self.BASE_POOL).add_liquidity(base_inputs, 0)
 
-    if BASE_N_COINS == 3:
+    if self.BASE_N_COINS == 3:
 
         base_inputs: uint256[3] = empty(uint256[3])
         base_inputs[base_i] = dx
-        extcall StableSwap3(BASE_POOL).add_liquidity(base_inputs, 0)
+        extcall StableSwap3(self.BASE_POOL).add_liquidity(base_inputs, 0)
 
     else:
 
         base_inputs: uint256[4] = empty(uint256[4])
         base_inputs[base_i] = dx
-        extcall StableSwap4(BASE_POOL).add_liquidity(base_inputs, 0)
+        extcall StableSwap4(self.BASE_POOL).add_liquidity(base_inputs, 0)
 
     return staticcall IERC20(coin_i).balanceOf(self) - x
 
@@ -1210,7 +1210,7 @@ def _meta_add_liquidity(dx: uint256, base_i: int128) -> uint256:
 @internal
 def _withdraw_admin_fees():
 
-    fee_receiver: address = staticcall factory.get_fee_receiver()
+    fee_receiver: address = staticcall self.factory.get_fee_receiver()
     assert fee_receiver != empty(address)  # dev: fee receiver not set
 
     for i: int128 in range(N_COINS_128):
@@ -1668,18 +1668,18 @@ def exp(x: int256) -> uint256:
 @view
 @internal
 def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
+    if chain.id != self.CACHED_CHAIN_ID:
         return keccak256(
             abi_encode(
                 EIP712_TYPEHASH,
-                NAME_HASH,
+                self.NAME_HASH,
                 VERSION_HASH,
                 chain.id,
                 self,
-                salt,
+                self.salt,
             )
         )
-    return CACHED_DOMAIN_SEPARATOR
+    return self.CACHED_DOMAIN_SEPARATOR
 
 
 @internal
@@ -1822,7 +1822,7 @@ def get_dx(i: int128, j: int128, dy: uint256) -> uint256:
     @param dy Amount of `j` being received after exchange
     @return Amount of `i` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dx(i, j, dy, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dx(i, j, dy, self)
 
 
 @view
@@ -1836,7 +1836,7 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
     @param dx Amount of `i` being exchanged
     @return Amount of `j` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dy(i, j, dx, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dy(i, j, dx, self)
 
 
 @view
@@ -1879,7 +1879,7 @@ def calc_token_amount(
     @param _is_deposit set True for deposits, False for withdrawals
     @return Expected amount of LP tokens received
     """
-    views: address = staticcall factory.views_implementation()
+    views: address = staticcall self.factory.views_implementation()
     return staticcall StableSwapViews(views).calc_token_amount(_amounts, _is_deposit, self)
 
 
@@ -1936,7 +1936,7 @@ def stored_rates(i: uint256) -> uint256:
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1959,7 +1959,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A
@@ -1974,7 +1974,7 @@ def stop_ramp_A():
 @external
 def apply_new_fee(_new_fee: uint256):
 
-    assert msg.sender == staticcall factory.admin()
+    assert msg.sender == staticcall self.factory.admin()
     assert _new_fee <= MAX_FEE
     self.fee = _new_fee
 
@@ -1987,7 +1987,7 @@ def set_ma_exp_time(_ma_exp_time: uint256):
     @notice Set the moving average window of the price oracle.
     @param _ma_exp_time Moving average window. It is time_in_seconds // ln(2)
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert _ma_exp_time != 0
 
     self.ma_exp_time = _ma_exp_time

--- a/tests/functional/examples/thirdparty/curvefi/legacy/CurveStableSwapNG.vy
+++ b/tests/functional/examples/thirdparty/curvefi/legacy/CurveStableSwapNG.vy
@@ -269,15 +269,15 @@ def __init__(
     @param _oracles Array of rate oracle addresses.
     """
 
-    coins = _coins
-    asset_types = _asset_types
+    self.coins = _coins
+    self.asset_types = _asset_types
     __n_coins: uint256 = len(_coins)
-    N_COINS = __n_coins
-    N_COINS_128 = convert(__n_coins, uint128)
+    self.N_COINS = __n_coins
+    self.N_COINS_128 = convert(__n_coins, uint128)
 
-    rate_multipliers = _rate_multipliers
+    self.rate_multipliers = _rate_multipliers
 
-    factory = Factory(msg.sender)
+    self.factory = Factory(msg.sender)
 
     A: uint256 = _A * A_PRECISION
     self.initial_A = A
@@ -296,10 +296,10 @@ def __init__(
     _scale_factor: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
-        if i < N_COINS_128 - 1:
+        if i < self.N_COINS_128 - 1:
             self.last_prices_packed.append(self.pack_2(10**18, 10**18))
 
         self.oracles.append(convert(_method_ids[i], uint256) * 2**224 | convert(_oracles[i], uint256))
@@ -317,26 +317,26 @@ def __init__(
             _call_amount.append(0)
             _scale_factor.append(0)
 
-    call_amount = _call_amount
-    scale_factor = _scale_factor
+    self.call_amount = _call_amount
+    self.scale_factor = _scale_factor
 
     # ----------------------------- ERC20 stuff ------------------------------
 
-    name = _name
-    symbol = _symbol
+    self.name = _name
+    self.symbol = _symbol
 
     # EIP712 related params -----------------
-    NAME_HASH = keccak256(name)
-    salt = block.prevhash
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
+    self.NAME_HASH = keccak256(self.name)
+    self.salt = block.prevhash
+    self.CACHED_CHAIN_ID = chain.id
+    self.CACHED_DOMAIN_SEPARATOR = keccak256(
         abi_encode(
             EIP712_TYPEHASH,
-            NAME_HASH,
+            self.NAME_HASH,
             VERSION_HASH,
             chain.id,
             self,
-            salt,
+            self.salt,
         )
     )
 
@@ -364,7 +364,7 @@ def _transfer_in(
     @param receiver address to transfer `_coin` to.
     @param expect_optimistic_transfer True if contract expects an optimistic coin transfer
     """
-    _dx: uint256 = staticcall IERC20(coins[coin_idx]).balanceOf(self)
+    _dx: uint256 = staticcall IERC20(self.coins[coin_idx]).balanceOf(self)
 
     # ------------------------- Handle Transfers -----------------------------
 
@@ -376,11 +376,11 @@ def _transfer_in(
     else:
 
         assert dx > 0  # dev : do not transferFrom 0 tokens into the pool
-        assert extcall IERC20(coins[coin_idx]).transferFrom(
+        assert extcall IERC20(self.coins[coin_idx]).transferFrom(
             sender, self, dx, default_return_value=True
         )
 
-        _dx = staticcall IERC20(coins[coin_idx]).balanceOf(self) - _dx
+        _dx = staticcall IERC20(self.coins[coin_idx]).balanceOf(self) - _dx
 
     # --------------------------- Store transferred in amount ---------------------------
 
@@ -400,11 +400,11 @@ def _transfer_out(_coin_idx: uint128, _amount: uint256, receiver: address):
     @param receiver Address to send the tokens to
     """
 
-    coin_balance: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self)
+    coin_balance: uint256 = staticcall IERC20(self.coins[_coin_idx]).balanceOf(self)
 
     # ------------------------- Handle Transfers -----------------------------
 
-    assert extcall IERC20(coins[_coin_idx]).transfer(
+    assert extcall IERC20(self.coins[_coin_idx]).transfer(
         receiver, _amount, default_return_value=True
     )
 
@@ -425,15 +425,15 @@ def _stored_rates() -> DynArray[uint256, MAX_COINS]:
          this method queries that rate by static-calling an external
          contract.
     """
-    rates: DynArray[uint256, MAX_COINS] = rate_multipliers
+    rates: DynArray[uint256, MAX_COINS] = self.rate_multipliers
     oracles: DynArray[uint256, MAX_COINS] = self.oracles
 
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
-        if asset_types[i] == 1 and not oracles[i] == 0:
+        if self.asset_types[i] == 1 and not oracles[i] == 0:
 
             # NOTE: fetched_rate is assumed to be 10**18 precision
             fetched_rate: uint256 = convert(
@@ -448,13 +448,13 @@ def _stored_rates() -> DynArray[uint256, MAX_COINS]:
 
             rates[i] = unsafe_div(rates[i] * fetched_rate, PRECISION)
 
-        elif asset_types[i] == 3:  # ERC4626
+        elif self.asset_types[i] == 3:  # ERC4626
 
             # fetched_rate: uint256 = ERC4626(coins[i]).convertToAssets(call_amount[i]) * scale_factor[i]
             # here: call_amount has ERC4626 precision, but the returned value is scaled up to 18
             # using scale_factor which is (18 - n) if underlying asset has n decimals.
             rates[i] = unsafe_div(
-                rates[i] * (staticcall IERC4626(coins[i]).convertToAssets(call_amount[i])) * scale_factor[i],
+                rates[i] * (staticcall IERC4626(self.coins[i]).convertToAssets(self.call_amount[i])) * self.scale_factor[i],
                 PRECISION
             )  # 1e18 precision
 
@@ -477,11 +477,11 @@ def _balances() -> DynArray[uint256, MAX_COINS]:
 
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
-        if 2 in asset_types:
-            balances_i = staticcall IERC20(coins[i]).balanceOf(self) - self.admin_balances[i]
+        if 2 in self.asset_types:
+            balances_i = staticcall IERC20(self.coins[i]).balanceOf(self) - self.admin_balances[i]
         else:
             balances_i = self.stored_balances[i] - self.admin_balances[i]
 
@@ -545,7 +545,7 @@ def exchange_received(
     @param _min_dy Minimum amount of `j` to receive
     @return Actual amount of `j` received
     """
-    assert not 2 in asset_types  # dev: exchange_received not supported if pool contains rebasing tokens
+    assert not 2 in self.asset_types  # dev: exchange_received not supported if pool contains rebasing tokens
     return self._exchange(
         msg.sender,
         i,
@@ -585,7 +585,7 @@ def add_liquidity(
 
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
         if _amounts[i] > 0:
@@ -618,16 +618,16 @@ def add_liquidity(
         difference: uint256 = 0
         new_balance: uint256 = 0
 
-        ys: uint256 = (D0 + D1) // N_COINS
+        ys: uint256 = (D0 + D1) // self.N_COINS
         xs: uint256 = 0
         _dynamic_fee_i: uint256 = 0
 
         # Only account for fees if we are not the first to deposit
-        base_fee: uint256 = self.fee * N_COINS // (4 * (N_COINS - 1))
+        base_fee: uint256 = self.fee * self.N_COINS // (4 * (self.N_COINS - 1))
 
         for i: uint128 in range(MAX_COINS_128):
 
-            if i == N_COINS_128:
+            if i == self.N_COINS_128:
                 break
 
             ideal_balance = D1 * old_balances[i] // D0
@@ -732,7 +732,7 @@ def remove_liquidity_imbalance(
 
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
         if _amounts[i] != 0:
@@ -740,8 +740,8 @@ def remove_liquidity_imbalance(
             self._transfer_out(i, _amounts[i], _receiver)
 
     D1: uint256 = self.get_D_mem(rates, new_balances, amp)
-    base_fee: uint256 = self.fee * N_COINS // (4 * (N_COINS - 1))
-    ys: uint256 = (D0 + D1) // N_COINS
+    base_fee: uint256 = self.fee * self.N_COINS // (4 * (self.N_COINS - 1))
+    ys: uint256 = (D0 + D1) // self.N_COINS
 
     fees: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     dynamic_fee: uint256 = 0
@@ -752,7 +752,7 @@ def remove_liquidity_imbalance(
 
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
         ideal_balance = D1 * old_balances[i] // D0
@@ -814,7 +814,7 @@ def remove_liquidity(
     value: uint256 = 0
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
         value = balances[i] * _burn_amount // total_supply
@@ -966,13 +966,13 @@ def _exchange(
 
 @internal
 def _withdraw_admin_fees():
-    fee_receiver: address = staticcall factory.fee_receiver()
+    fee_receiver: address = staticcall self.factory.fee_receiver()
     assert fee_receiver != empty(address)  # dev: fee receiver not set
 
     admin_balances: DynArray[uint256, MAX_COINS] = self.admin_balances
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
         if admin_balances[i] > 0:
@@ -1009,11 +1009,11 @@ def get_y(
 
     assert i != j       # dev: same coin
     assert j >= 0       # dev: j below zero
-    assert j < N_COINS_128  # dev: j above N_COINS
+    assert j < self.N_COINS_128  # dev: j above N_COINS
 
     # should be unreachable, but good for safety
     assert i >= 0
-    assert i < N_COINS_128
+    assert i < self.N_COINS_128
 
     amp: uint256 = _amp
     D: uint256 = _D
@@ -1022,11 +1022,11 @@ def get_y(
     _x: uint256 = 0
     y_prev: uint256 = 0
     c: uint256 = D
-    Ann: uint256 = amp * N_COINS
+    Ann: uint256 = amp * self.N_COINS
 
     for _i: uint128 in range(MAX_COINS_128):
 
-        if _i == N_COINS_128:
+        if _i == self.N_COINS_128:
             break
 
         if _i == i:
@@ -1037,9 +1037,9 @@ def get_y(
             continue
 
         S_ += _x
-        c = c * D // (_x * N_COINS)
+        c = c * D // (_x * self.N_COINS)
 
-    c = c * D * A_PRECISION // (Ann * N_COINS)
+    c = c * D * A_PRECISION // (Ann * self.N_COINS)
     b: uint256 = S_ + D * A_PRECISION // Ann  # - D
     y: uint256 = D
 
@@ -1075,7 +1075,7 @@ def get_D(_xp: DynArray[uint256, MAX_COINS], _amp: uint256) -> uint256:
         return 0
 
     D: uint256 = S
-    Ann: uint256 = _amp * N_COINS
+    Ann: uint256 = _amp * self.N_COINS
     D_P: uint256 = 0
     Dprev: uint256 = 0
 
@@ -1083,15 +1083,15 @@ def get_D(_xp: DynArray[uint256, MAX_COINS], _amp: uint256) -> uint256:
 
         D_P = D
         for x: uint256 in _xp:
-            D_P = D_P * D // (x * N_COINS)
+            D_P = D_P * D // (x * self.N_COINS)
         Dprev = D
 
         # (Ann * S // A_PRECISION + D_P * N_COINS) * D // ((Ann - A_PRECISION) * D // A_PRECISION + (N_COINS + 1) * D_P)
         D = (
-            (unsafe_div(Ann * S, A_PRECISION) + D_P * N_COINS) *
+            (unsafe_div(Ann * S, A_PRECISION) + D_P * self.N_COINS) *
             D // (
                 unsafe_div((Ann - A_PRECISION) * D, A_PRECISION) +
-                unsafe_add(N_COINS, 1) * D_P
+                unsafe_add(self.N_COINS, 1) * D_P
             )
         )
 
@@ -1127,17 +1127,17 @@ def get_y_D(
     # x in the input is converted to the same price/precision
 
     assert i >= 0  # dev: i below zero
-    assert i < N_COINS_128  # dev: i above N_COINS
+    assert i < self.N_COINS_128  # dev: i above N_COINS
 
     S_: uint256 = 0
     _x: uint256 = 0
     y_prev: uint256 = 0
     c: uint256 = D
-    Ann: uint256 = A * N_COINS
+    Ann: uint256 = A * self.N_COINS
 
     for _i: uint128 in range(MAX_COINS_128):
 
-        if _i == N_COINS_128:
+        if _i == self.N_COINS_128:
             break
 
         if _i != i:
@@ -1145,9 +1145,9 @@ def get_y_D(
         else:
             continue
         S_ += _x
-        c = c * D // (_x * N_COINS)
+        c = c * D // (_x * self.N_COINS)
 
-    c = c * D * A_PRECISION // (Ann * N_COINS)
+    c = c * D * A_PRECISION // (Ann * self.N_COINS)
     b: uint256 = S_ + D * A_PRECISION // Ann
     y: uint256 = D
 
@@ -1195,7 +1195,7 @@ def _xp_mem(
 
     result: DynArray[uint256, MAX_COINS] = empty(DynArray[uint256, MAX_COINS])
     for i: uint128 in range(MAX_COINS_128):
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
         result.append(_rates[i] * _balances[i] // PRECISION)
     return result
@@ -1236,8 +1236,8 @@ def _calc_withdraw_one_coin(
     D1: uint256 = D0 - _burn_amount * D0 // total_supply
     new_y: uint256 = self.get_y_D(amp, i, xp, D1)
 
-    base_fee: uint256 = self.fee * N_COINS // (4 * (N_COINS - 1))
-    ys: uint256 = (D0 + D1) // (2 * N_COINS)
+    base_fee: uint256 = self.fee * self.N_COINS // (4 * (self.N_COINS - 1))
+    ys: uint256 = (D0 + D1) // (2 * self.N_COINS)
     xp_reduced: DynArray[uint256, MAX_COINS] = xp
 
     dx_expected: uint256 = 0
@@ -1247,7 +1247,7 @@ def _calc_withdraw_one_coin(
 
     for j: uint128 in range(MAX_COINS_128):
 
-        if j == N_COINS_128:
+        if j == self.N_COINS_128:
             break
 
         dx_expected = 0
@@ -1298,12 +1298,12 @@ def _get_p(
 ) -> DynArray[uint256, MAX_COINS]:
 
     # dx_0 // dx_1 only, however can have any number of coins in pool
-    ANN: uint256 = unsafe_mul(amp, N_COINS)
-    Dr: uint256 = unsafe_div(D, pow_mod256(N_COINS, N_COINS))
+    ANN: uint256 = unsafe_mul(amp, self.N_COINS)
+    Dr: uint256 = unsafe_div(D, pow_mod256(self.N_COINS, self.N_COINS))
 
     for i: uint128 in range(MAX_COINS_128):
 
-        if i == N_COINS_128:
+        if i == self.N_COINS_128:
             break
 
         Dr = Dr * D // xp[i]
@@ -1313,7 +1313,7 @@ def _get_p(
 
     for i: uint256 in range(1, MAX_COINS):
 
-        if i == N_COINS:
+        if i == self.N_COINS:
             break
 
         p.append(10**18 * (xp0_A + Dr * xp[0] // xp[i]) // (xp0_A + Dr))
@@ -1336,7 +1336,7 @@ def upkeep_oracles(xp: DynArray[uint256, MAX_COINS], amp: uint256, D: uint256):
 
     for i: uint256 in range(MAX_COINS):
 
-        if i == N_COINS - 1:
+        if i == self.N_COINS - 1:
             break
 
         if spot_price[i] != 0:
@@ -1524,18 +1524,18 @@ def exp(x: int256) -> uint256:
 @view
 @internal
 def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
+    if chain.id != self.CACHED_CHAIN_ID:
         return keccak256(
             abi_encode(
                 EIP712_TYPEHASH,
-                NAME_HASH,
+                self.NAME_HASH,
                 VERSION_HASH,
                 chain.id,
                 self,
-                salt,
+                self.salt,
             )
         )
-    return CACHED_DOMAIN_SEPARATOR
+    return self.CACHED_DOMAIN_SEPARATOR
 
 
 @internal
@@ -1678,7 +1678,7 @@ def get_dx(i: int128, j: int128, dy: uint256) -> uint256:
     @param dy Amount of `j` being received after exchange
     @return Amount of `i` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dx(i, j, dy, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dx(i, j, dy, self)
 
 
 @view
@@ -1692,7 +1692,7 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
     @param dx Amount of `i` being exchanged
     @return Amount of `j` predicted
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).get_dy(i, j, dx, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).get_dy(i, j, dx, self)
 
 
 @view
@@ -1751,7 +1751,7 @@ def calc_token_amount(
     @param _is_deposit set True for deposits, False for withdrawals
     @return Expected amount of LP tokens received
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).calc_token_amount(_amounts, _is_deposit, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).calc_token_amount(_amounts, _is_deposit, self)
 
 
 @view
@@ -1799,7 +1799,7 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
     @param j Index value of the coin to recieve
     @return Swap fee expressed as an integer with 1e10 precision
     """
-    return staticcall StableSwapViews(staticcall factory.views_implementation()).dynamic_fee(i, j, self)
+    return staticcall StableSwapViews(staticcall self.factory.views_implementation()).dynamic_fee(i, j, self)
 
 
 # --------------------------- AMM Admin Functions ----------------------------
@@ -1807,7 +1807,7 @@ def dynamic_fee(i: int128, j: int128) -> uint256:
 
 @external
 def ramp_A(_future_A: uint256, _future_time: uint256):
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
     assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
 
@@ -1830,7 +1830,7 @@ def ramp_A(_future_A: uint256, _future_time: uint256):
 
 @external
 def stop_ramp_A():
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
 
     current_A: uint256 = self._A()
     self.initial_A = current_A
@@ -1845,7 +1845,7 @@ def stop_ramp_A():
 @external
 def set_new_fee(_new_fee: uint256, _new_offpeg_fee_multiplier: uint256):
 
-    assert msg.sender == staticcall factory.admin()
+    assert msg.sender == staticcall self.factory.admin()
 
     # set new fee:
     assert _new_fee <= MAX_FEE
@@ -1864,7 +1864,7 @@ def set_ma_exp_time(_ma_exp_time: uint256, _D_ma_time: uint256):
     @notice Set the moving average window of the price oracles.
     @param _ma_exp_time Moving average window. It is time_in_seconds // ln(2)
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall self.factory.admin()  # dev: only owner
     assert 0 not in [_ma_exp_time, _D_ma_time]
 
     self.ma_exp_time = _ma_exp_time

--- a/tests/functional/examples/thirdparty/curvefi/registries/address_provider/address_provider_v_201.vy
+++ b/tests/functional/examples/thirdparty/curvefi/registries/address_provider/address_provider_v_201.vy
@@ -81,15 +81,15 @@ deployer: immutable(address)
 @deploy
 def __init__():
     self.admin  = msg.sender
-    deployer = msg.sender
+    self.deployer = msg.sender
 
 
 @external
 def set_owner(_owner: address):
     
-    assert msg.sender == deployer
-    assert self.admin == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.admin == self.deployer
+    assert _owner != self.deployer
 
     self.admin = _owner
     log NewAdmin(admin=_owner)

--- a/tests/functional/examples/thirdparty/curvefi/registries/metaregistry/metaregistry_v_110.vy
+++ b/tests/functional/examples/thirdparty/curvefi/registries/metaregistry/metaregistry_v_110.vy
@@ -82,15 +82,15 @@ def __init__(_gauge_factory: address, _gauge_type: int128):
     self.gauge_factory = GaugeFactory(_gauge_factory)
     self.gauge_type = _gauge_type
 
-    deployer = msg.sender
+    self.deployer = msg.sender
 
 
 @external
 def set_owner(_owner: address):
     
-    assert msg.sender == deployer
-    assert self.admin == deployer
-    assert _owner != deployer
+    assert msg.sender == self.deployer
+    assert self.admin == self.deployer
+    assert _owner != self.deployer
 
     self.admin = _owner
     log NewAdmin(admin=_owner)

--- a/tests/functional/examples/thirdparty/yearnfi/VaultFactory.vy
+++ b/tests/functional/examples/thirdparty/yearnfi/VaultFactory.vy
@@ -95,7 +95,7 @@ use_custom_protocol_fee: public(HashMap[address, bool])
 @deploy
 def __init__(name: String[64], vault_blueprint: address, governance: address):
     self.name = name
-    VAULT_BLUEPRINT = vault_blueprint
+    self.VAULT_BLUEPRINT = vault_blueprint
     self.governance = governance
 
 @external
@@ -120,7 +120,7 @@ def deploy_new_vault(
 
     # Deploy the new vault using the blueprint.
     vault_address: address = create_from_blueprint(
-            VAULT_BLUEPRINT, 
+            self.VAULT_BLUEPRINT, 
             asset, 
             name, 
             symbol, 
@@ -140,7 +140,7 @@ def vault_blueprint()-> address:
     @notice Get the address of the vault blueprint
     @return The address of the vault blueprint
     """
-    return VAULT_BLUEPRINT
+    return self.VAULT_BLUEPRINT
 
 @view
 @external

--- a/tests/functional/examples/thirdparty/yearnfi/VaultV3.vy
+++ b/tests/functional/examples/thirdparty/yearnfi/VaultV3.vy
@@ -234,11 +234,11 @@ def __init__(asset: IERC20, name: String[64], symbol: String[32], role_manager: 
     @param profit_max_unlock_time
         The maximum amount of time that the profit can be locked for
     """
-    ASSET = asset
-    DECIMALS = convert(staticcall IERC20Detailed(asset.address).decimals(), uint256)
-    assert DECIMALS < 256 # dev: see VVE-2020-0001
+    self.ASSET = asset
+    self.DECIMALS = convert(staticcall IERC20Detailed(asset.address).decimals(), uint256)
+    assert self.DECIMALS < 256 # dev: see VVE-2020-0001
     
-    FACTORY = msg.sender
+    self.FACTORY = msg.sender
 
     # Must be > 0 so we can unlock shares
     assert profit_max_unlock_time > 0 # dev: profit unlock time too low
@@ -542,7 +542,7 @@ def _deposit(sender: address, recipient: address, assets: uint256) -> uint256:
 
     assert self._total_assets() + assets <= self.deposit_limit, "exceed deposit limit"
  
-    self.erc20_safe_transfer_from(ASSET.address, msg.sender, self, assets)
+    self.erc20_safe_transfer_from(self.ASSET.address, msg.sender, self, assets)
     self.total_idle += assets
    
     shares: uint256 = self._issue_shares_for_amount(assets, recipient)
@@ -608,7 +608,7 @@ def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: 
         assets_to_withdraw: uint256 = 0
 
         # NOTE: to compare against real withdrawals from strategies
-        previous_balance: uint256 = staticcall ASSET.balanceOf(self)
+        previous_balance: uint256 = staticcall self.ASSET.balanceOf(self)
         for strategy: address in _strategies:
             assert self.strategies[strategy].activation != 0, "inactive strategy"
 
@@ -667,7 +667,7 @@ def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: 
             
             # WITHDRAW FROM STRATEGY
             extcall IStrategy(strategy).withdraw(assets_to_withdraw, self, self)
-            post_balance: uint256 = staticcall ASSET.balanceOf(self)
+            post_balance: uint256 = staticcall self.ASSET.balanceOf(self)
             
             # If we have not received what we expected, we consider the difference a loss
             loss: uint256 = 0
@@ -711,7 +711,7 @@ def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: 
     self._burn_shares(shares, owner)
     # commit memory to storage
     self.total_idle = curr_total_idle - requested_assets
-    self.erc20_safe_transfer(ASSET.address, receiver, requested_assets)
+    self.erc20_safe_transfer(self.ASSET.address, receiver, requested_assets)
 
     log Withdraw(
         sender=sender,
@@ -726,7 +726,7 @@ def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: 
 @internal
 def _add_strategy(new_strategy: address):
     assert new_strategy not in [self, empty(address)], "strategy cannot be zero address"
-    assert staticcall IStrategy(new_strategy).asset() == ASSET.address, "invalid asset"
+    assert staticcall IStrategy(new_strategy).asset() == self.ASSET.address, "invalid asset"
     assert self.strategies[new_strategy].activation == 0, "strategy already active"
 
     self.strategies[new_strategy] = StrategyParams(
@@ -832,9 +832,9 @@ def _update_debt(strategy: address, target_debt: uint256) -> uint256:
         unrealised_losses_share: uint256 = self._assess_share_of_unrealised_losses(strategy, assets_to_withdraw)
         assert unrealised_losses_share == 0, "strategy has unrealised losses"
         
-        pre_balance: uint256 = staticcall ASSET.balanceOf(self)
+        pre_balance: uint256 = staticcall self.ASSET.balanceOf(self)
         extcall IStrategy(strategy).withdraw(assets_to_withdraw, self, self)
-        post_balance: uint256 = staticcall ASSET.balanceOf(self)
+        post_balance: uint256 = staticcall self.ASSET.balanceOf(self)
         
         # making sure we are changing according to the real result no matter what. This will spend more gas but makes it more robust
         # also prevents issues from faulty strategy that either under or over delievers 'assets_to_withdraw'
@@ -868,11 +868,11 @@ def _update_debt(strategy: address, target_debt: uint256) -> uint256:
             assets_to_deposit = available_idle
 
         if assets_to_deposit > 0:
-            self.erc20_safe_approve(ASSET.address, strategy, assets_to_deposit)
-            pre_balance: uint256 = staticcall ASSET.balanceOf(self)
+            self.erc20_safe_approve(self.ASSET.address, strategy, assets_to_deposit)
+            pre_balance: uint256 = staticcall self.ASSET.balanceOf(self)
             extcall IStrategy(strategy).deposit(assets_to_deposit, self)
-            post_balance: uint256 = staticcall ASSET.balanceOf(self)
-            self.erc20_safe_approve(ASSET.address, strategy, 0)
+            post_balance: uint256 = staticcall self.ASSET.balanceOf(self)
+            self.erc20_safe_approve(self.ASSET.address, strategy, 0)
 
             # making sure we are changing according to the real result no matter what. 
             # This will spend more gas but makes it more robust
@@ -903,7 +903,7 @@ def _assess_protocol_fees() -> (uint256, address):
         protocol_fee_bps: uint16 = 0
         protocol_fee_last_change: uint32 = 0
 
-        protocol_fee_bps, protocol_fee_last_change, protocol_fee_recipient = staticcall IFactory(FACTORY).protocol_fee_config()
+        protocol_fee_bps, protocol_fee_last_change, protocol_fee_recipient = staticcall IFactory(self.FACTORY).protocol_fee_config()
 
         if(protocol_fee_bps > 0):
             # NOTE: charge fees since last report OR last fee change (this will mean less fees are charged after a change in protocol_fees, but fees should not change frequently)
@@ -1192,7 +1192,7 @@ def pricePerShare() -> uint256:
     exact precision should use convertToAssets or convertToShares instead.
     @return The price per share.
     """
-    return self._convert_to_assets(10 ** DECIMALS, Rounding.ROUND_DOWN)
+    return self._convert_to_assets(10 ** self.DECIMALS, Rounding.ROUND_DOWN)
 
 
 @view
@@ -1229,8 +1229,8 @@ def sweep(token: address) -> (uint256):
     assert token != self, "can't sweep self"
     assert self.strategies[token].activation == 0, "can't sweep strategy"
     amount: uint256 = 0
-    if token == ASSET.address:
-        amount = staticcall ASSET.balanceOf(self) - self.total_idle
+    if token == self.ASSET.address:
+        amount = staticcall self.ASSET.balanceOf(self) - self.total_idle
     else:
         amount = staticcall IERC20(token).balanceOf(self)
     assert amount != 0, "no dust"
@@ -1472,7 +1472,7 @@ def asset() -> address:
     @notice Get the address of the asset.
     @return The address of the asset.
     """
-    return ASSET.address
+    return self.ASSET.address
 
 @view
 @external
@@ -1481,7 +1481,7 @@ def decimals() -> uint8:
     @notice Get the number of decimals of the asset/share.
     @return The number of decimals of the asset/share.
     """
-    return convert(DECIMALS, uint8)
+    return convert(self.DECIMALS, uint8)
 
 @view
 @external

--- a/tests/functional/syntax/abstract/test_abstract.py
+++ b/tests/functional/syntax/abstract/test_abstract.py
@@ -1216,10 +1216,10 @@ FOO: immutable(uint256)
 
 @deploy
 def __init__():
-    FOO = 42
+    self.FOO = 42
 
 @abstract
-def bar(x: uint256 = FOO) -> uint256: ...
+def bar(x: uint256 = self.FOO) -> uint256: ...
     """
 
     # Override module has its own FOO immutable - should NOT match
@@ -1232,11 +1232,11 @@ FOO: immutable(uint256)
 
 @deploy
 def __init__():
-    FOO = 100
+    self.FOO = 100
     abstract_module.__init__()
 
 @override(abstract_module)
-def bar(x: uint256 = FOO) -> uint256:
+def bar(x: uint256 = self.FOO) -> uint256:
     return x
     """
 

--- a/tests/functional/syntax/exceptions/test_function_declaration_exception.py
+++ b/tests/functional/syntax/exceptions/test_function_declaration_exception.py
@@ -43,7 +43,7 @@ a: immutable(uint256)
 
 @internal
 def __init__():
-    a = 1
+    self.a = 1
     """,
     """
 a: immutable(uint256)
@@ -51,7 +51,7 @@ a: immutable(uint256)
 @deploy
 @pure
 def __init__():
-    a = 1
+    self.a = 1
     """,
     """
 a: immutable(uint256)
@@ -59,7 +59,7 @@ a: immutable(uint256)
 @deploy
 @view
 def __init__():
-    a = 1
+    self.a = 1
     """,
 ]
 

--- a/tests/functional/syntax/exceptions/test_instantiation_exception.py
+++ b/tests/functional/syntax/exceptions/test_instantiation_exception.py
@@ -72,7 +72,7 @@ b: immutable(HashMap[uint256, uint256])
 
 @deploy
 def __init__():
-    b = empty(HashMap[uint256, uint256])
+    self.b = empty(HashMap[uint256, uint256])
     """,
 ]
 

--- a/tests/functional/syntax/exceptions/test_invalid_reference.py
+++ b/tests/functional/syntax/exceptions/test_invalid_reference.py
@@ -44,17 +44,6 @@ a: public(constant(uint256)) = 1
 def foo():
     b: uint256 = self.a
     """,
-    """
-a: public(immutable(uint256))
-
-@deploy
-def __init__():
-    self.a = 123
-
-@external
-def foo():
-    b: uint256 = a
-    """,
 ]
 
 

--- a/tests/functional/syntax/exceptions/test_invalid_reference.py
+++ b/tests/functional/syntax/exceptions/test_invalid_reference.py
@@ -49,11 +49,11 @@ a: public(immutable(uint256))
 
 @deploy
 def __init__():
-    a = 123
+    self.a = 123
 
 @external
 def foo():
-    b: uint256 = self.a
+    b: uint256 = a
     """,
 ]
 

--- a/tests/functional/syntax/exceptions/test_structure_exception.py
+++ b/tests/functional/syntax/exceptions/test_structure_exception.py
@@ -65,7 +65,7 @@ n: public(HashMap[uint256, bool][a])
 
 @deploy
 def __init__():
-    a = 3
+    self.a = 3
     """,
     """
 n: HashMap[uint256, bool][3][3]

--- a/tests/functional/syntax/modules/test_initializers.py
+++ b/tests/functional/syntax/modules/test_initializers.py
@@ -533,7 +533,7 @@ MY_IMMUTABLE: immutable(uint256)
 
 @deploy
 def __init__():
-    MY_IMMUTABLE = 7
+    self.MY_IMMUTABLE = 7
     """
     lib2 = """
 import lib1
@@ -574,11 +574,11 @@ MY_IMMUTABLE: immutable(uint256)
 
 @deploy
 def __init__():
-    MY_IMMUTABLE = 9
+    self.MY_IMMUTABLE = 9
 
 @internal
 def get_counter() -> uint256:
-    return MY_IMMUTABLE
+    return self.MY_IMMUTABLE
     """
     lib2 = """
 import lib1

--- a/tests/functional/syntax/test_constants.py
+++ b/tests/functional/syntax/test_constants.py
@@ -96,7 +96,7 @@ VAL: uint256
 
 @deploy
 def __init__():
-    VAL = 1
+    self.VAL = 1
     """,
         NamespaceCollision,
     ),
@@ -108,7 +108,7 @@ VAL: immutable(uint256)
 
 @deploy
 def __init__():
-    VAL = 1
+    self.VAL = 1
     """,
         NamespaceCollision,
     ),

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -185,6 +185,20 @@ def hello() :
     """,
         "Immutable value cannot be written to",
     ),
+    (
+        """
+VALUE: immutable(uint256)
+
+@deploy
+def __init__():
+    self.VALUE = 1
+
+@external
+def bump():
+    self.VALUE += 1
+    """,
+        "Immutable value cannot be written to",
+    ),
 ]
 
 

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -146,32 +146,6 @@ def test_compilation_success(good_code):
 fail_list_with_messages = [
     (
         """
-imm: immutable(uint256)
-
-@deploy
-def __init__(x: uint256):
-    self.imm = x
-
-@external
-def report() -> uint256:
-    return imm
-    """,
-        "'imm'",
-        "did you mean self.imm?",
-    ),
-    (
-        """
-imm: immutable(uint256)
-
-@deploy
-def __init__(x: uint256):
-    imm = x
-    """,
-        "'imm'",
-        "did you mean self.imm?",
-    ),
-    (
-        """
 struct Foo:
     a : uint256
 
@@ -212,23 +186,3 @@ def test_compilation_fails_with_exception_message(bad_code: str, message: str, h
         compile_code(bad_code)
     assert excinfo.value.message == message
     assert excinfo.value.hint == hint
-
-
-def test_immutable_multiple_wrong_assignments_all_reported():
-    bad_code = """
-imm: immutable(uint256)
-
-@deploy
-def __init__(x: uint256, y: uint256):
-    imm = x
-    imm = y
-    """
-    with pytest.raises(VyperException) as excinfo:
-        compile_code(bad_code)
-
-    err = str(excinfo.value)
-    assert "Compilation failed with the following errors:" in err
-    assert err.count("InvalidReference") == 2
-    assert err.count("did you mean self.imm?") == 2
-    assert "imm = x" in err
-    assert "imm = y" in err

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -19,7 +19,7 @@ VALUE: immutable(uint256)
 @view
 @external
 def get_value() -> uint256:
-    return VALUE
+    return self.VALUE
     """,
     # VALUE given an initial value
     """
@@ -35,11 +35,11 @@ VALUE: immutable(uint256)
 
 @deploy
 def __init__():
-    VALUE = 0
+    self.VALUE = 0
 
 @external
 def set_value(_value: uint256):
-    VALUE = _value
+    self.VALUE = _value
     """,
     # modifying immutable multiple times in constructor
     """
@@ -47,8 +47,8 @@ VALUE: immutable(uint256)
 
 @deploy
 def __init__(_value: uint256):
-    VALUE = _value * 3
-    VALUE = VALUE + 1
+    self.VALUE = _value * 3
+    self.VALUE = self.VALUE + 1
     """,
     # immutable(public()) banned
     """
@@ -56,7 +56,7 @@ VALUE: immutable(public(uint256))
 
 @deploy
 def __init__(_value: uint256):
-    VALUE = _value * 3
+    self.VALUE = _value * 3
     """,
 ]
 
@@ -87,12 +87,12 @@ VALUE: immutable({typ})
 
 @deploy
 def __init__(_value: {typ}):
-    VALUE = _value
+    self.VALUE = _value
 
 @view
 @external
 def get_value() -> {typ}:
-    return VALUE
+    return self.VALUE
     """
 
     assert compile_code(code)
@@ -105,8 +105,8 @@ VALUE: immutable(uint256)
 
 @deploy
 def __init__(_value: uint256):
-    VALUE = _value * 3
-    x: uint256 = VALUE + 1
+    self.VALUE = _value * 3
+    x: uint256 = self.VALUE + 1
     """
 ]
 
@@ -124,22 +124,12 @@ imm: immutable(uint256)
 @deploy
 def __init__(x: uint256):
     self.imm = x
-    """,
-        "Immutable variables must be accessed without 'self'",
-    ),
-    (
-        """
-imm: immutable(uint256)
-
-@deploy
-def __init__(x: uint256):
-    x = imm
 
 @external
-def report():
-    y: uint256 = imm + imm
+def report() -> uint256:
+    return imm
     """,
-        "Immutable definition requires an assignment in the constructor",
+        "'imm' is an assignable variable, access it as self.imm",
     ),
     (
         """
@@ -148,13 +138,8 @@ imm: immutable(uint256)
 @deploy
 def __init__(x: uint256):
     imm = x
-
-@external
-def report():
-    y: uint256 = imm
-    z: uint256 = self.imm
     """,
-        "'imm' is not a storage variable, it should not be prepended with self",
+        "'imm' is an assignable variable, access it as self.imm",
     ),
     (
         """
@@ -165,11 +150,11 @@ x: immutable(Foo)
 
 @deploy
 def __init__():
-    x = Foo(a=1)
+    self.x = Foo(a=1)
 
 @external
 def hello() :
-    x.a =  2
+    self.x.a =  2
     """,
         "Immutable value cannot be written to",
     ),

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -167,9 +167,8 @@ imm: immutable(uint256)
 def __init__(x: uint256):
     imm = x
     """,
-        # TODO: not great UX, the user did try to assign, we should point them to how to fix it
-        "Immutable definition requires an assignment in the constructor",
-        None,
+        "'imm'",
+        "did you mean self.imm?",
     ),
     (
         """

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -212,3 +212,23 @@ def test_compilation_fails_with_exception_message(bad_code: str, message: str, h
         compile_code(bad_code)
     assert excinfo.value.message == message
     assert excinfo.value.hint == hint
+
+
+def test_immutable_multiple_wrong_assignments_all_reported():
+    bad_code = """
+imm: immutable(uint256)
+
+@deploy
+def __init__(x: uint256, y: uint256):
+    imm = x
+    imm = y
+    """
+    with pytest.raises(VyperException) as excinfo:
+        compile_code(bad_code)
+
+    err = str(excinfo.value)
+    assert "Compilation failed with the following errors:" in err
+    assert err.count("InvalidReference") == 2
+    assert err.count("did you mean self.imm?") == 2
+    assert "imm = x" in err
+    assert "imm = y" in err

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import VyperException
+from vyper.exceptions import ImmutableViolation, VyperException
 
 fail_list = [
     # VALUE is not set in the constructor
@@ -65,6 +65,33 @@ def __init__(_value: uint256):
 def test_compilation_fails_with_exception(bad_code):
     with pytest.raises(VyperException):
         compile_code(bad_code)
+
+
+def test_augassign_modification():
+    code = """
+VALUE: immutable(uint256)
+
+@deploy
+def __init__():
+    self.VALUE = 1
+    self.VALUE += 1
+    """
+    with pytest.raises(ImmutableViolation) as e:
+        compile_code(code)
+    assert e.value.message == "Immutable value cannot be modified"
+
+
+def test_augassign_setting():
+    code = """
+VALUE: immutable(uint256)
+
+@deploy
+def __init__():
+    self.VALUE += 1
+    """
+    with pytest.raises(ImmutableViolation) as e:
+        compile_code(code)
+    assert e.value.message == "Immutable value cannot be modified"
 
 
 types_list = (

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -78,7 +78,7 @@ def __init__():
     """
     with pytest.raises(ImmutableViolation) as e:
         compile_code(code)
-    assert e.value.message == "Immutable value cannot be modified"
+    assert e.value.message == "Immutable value cannot be modified after assignment"
 
 
 def test_augassign_setting():
@@ -91,7 +91,7 @@ def __init__():
     """
     with pytest.raises(ImmutableViolation) as e:
         compile_code(code)
-    assert e.value.message == "Immutable value cannot be modified"
+    assert e.value.message == "Immutable definition requires an assignment in the constructor"
 
 
 types_list = (
@@ -166,7 +166,8 @@ imm: immutable(uint256)
 def __init__(x: uint256):
     imm = x
     """,
-        "'imm' is an assignable variable, access it as self.imm",
+        # TODO: not great UX, the user did try to assign, we should point them to how to fix it
+        "Immutable definition requires an assignment in the constructor",
     ),
     (
         """

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -208,9 +208,7 @@ def bump():
 
 
 @pytest.mark.parametrize(["bad_code", "message", "hint"], fail_list_with_messages)
-def test_compilation_fails_with_exception_message(
-    bad_code: str, message: str, hint: str | None
-):
+def test_compilation_fails_with_exception_message(bad_code: str, message: str, hint: str | None):
     with pytest.raises(VyperException) as excinfo:
         compile_code(bad_code)
     assert excinfo.value.message == message

--- a/tests/functional/syntax/test_immutables.py
+++ b/tests/functional/syntax/test_immutables.py
@@ -156,7 +156,8 @@ def __init__(x: uint256):
 def report() -> uint256:
     return imm
     """,
-        "'imm' is an assignable variable, access it as self.imm",
+        "'imm'",
+        "did you mean self.imm?",
     ),
     (
         """
@@ -168,6 +169,7 @@ def __init__(x: uint256):
     """,
         # TODO: not great UX, the user did try to assign, we should point them to how to fix it
         "Immutable definition requires an assignment in the constructor",
+        None,
     ),
     (
         """
@@ -185,6 +187,7 @@ def hello() :
     self.x.a =  2
     """,
         "Immutable value cannot be written to",
+        None,
     ),
     (
         """
@@ -199,12 +202,16 @@ def bump():
     self.VALUE += 1
     """,
         "Immutable value cannot be written to",
+        None,
     ),
 ]
 
 
-@pytest.mark.parametrize(["bad_code", "message"], fail_list_with_messages)
-def test_compilation_fails_with_exception_message(bad_code: str, message: str):
+@pytest.mark.parametrize(["bad_code", "message", "hint"], fail_list_with_messages)
+def test_compilation_fails_with_exception_message(
+    bad_code: str, message: str, hint: str | None
+):
     with pytest.raises(VyperException) as excinfo:
         compile_code(bad_code)
     assert excinfo.value.message == message
+    assert excinfo.value.hint == hint

--- a/tests/functional/syntax/test_init.py
+++ b/tests/functional/syntax/test_init.py
@@ -21,7 +21,7 @@ SOME_IMMUTABLE: immutable(uint256)
 
 @deploy
 def __init__():
-    SOME_IMMUTABLE = 5
+    self.SOME_IMMUTABLE = 5
     self.counter = 1
     """,
 ]

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -380,7 +380,7 @@ foo: public(immutable(uint256))
 
 @deploy
 def __init__(x: uint256):
-    foo = x
+    self.foo = x
     """,
     """
 interface Foo:

--- a/tests/functional/syntax/test_public.py
+++ b/tests/functional/syntax/test_public.py
@@ -12,7 +12,7 @@ y: public(immutable(int128))
 
 @deploy
 def __init__():
-    y = 0
+    self.y = 0
     """,
     """
 x: public(int128)

--- a/tests/functional/syntax/test_tuple_assign.py
+++ b/tests/functional/syntax/test_tuple_assign.py
@@ -94,7 +94,7 @@ B: immutable(uint256)
 
 @deploy
 def __init__(b: uint256):
-    B = b
+    self.B = b
 
 @internal
 def foo() -> (uint256, uint256):
@@ -103,7 +103,7 @@ def foo() -> (uint256, uint256):
 @external
 def bar():
     a: uint256 = 1
-    a, B = self.foo()
+    a, self.B = self.foo()
     """,
         ImmutableViolation,
     ),

--- a/tests/functional/syntax/warnings/test_deprecation_warning.py
+++ b/tests/functional/syntax/warnings/test_deprecation_warning.py
@@ -5,6 +5,7 @@ import pytest
 
 import vyper
 from vyper.cli.vyper_json import compile_json
+from vyper.exceptions import ImmutableViolation
 
 deprecated = [
     """
@@ -24,6 +25,24 @@ event Foo:
 @external
 def foo():
     log Foo({a: 128, b: 256})
+    """,
+    """
+imm: immutable(uint256)
+
+@deploy
+def __init__(x: uint256):
+    self.imm = x
+
+@external
+def report() -> uint256:
+    return imm
+    """,
+    """
+imm: immutable(uint256)
+
+@deploy
+def __init__(x: uint256):
+    imm = x
     """,
 ]
 
@@ -51,6 +70,26 @@ def bar():
     for w in ws:
         msg = w.message.message
         assert "selfdestruct" in msg and "deprecated" in msg
+
+
+def test_multiple_immutable_bare_access_warnings():
+    code = """
+imm: immutable(uint256)
+
+@deploy
+def __init__(x: uint256, y: uint256):
+    imm = x
+    imm = y
+    """
+    with warnings.catch_warnings(record=True) as ws:
+        with pytest.raises(ImmutableViolation):
+            vyper.compile_code(code)
+
+    assert len(ws) == 2
+    for w in ws:
+        assert isinstance(w.message, vyper.warnings.Deprecation)
+        assert w.message.message == "immutables should now be accessed through `self`"
+        assert w.message.hint == "use `self.imm` instead"
 
 
 def test_deprecated_optimize_boolean_flag():

--- a/tests/unit/cli/storage_layout/test_storage_layout.py
+++ b/tests/unit/cli/storage_layout/test_storage_layout.py
@@ -64,8 +64,8 @@ DECIMALS: immutable(uint8)
 
 @deploy
 def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
+    self.SYMBOL = "VYPR"
+    self.DECIMALS = 18
     """
 
     expected_layout = {
@@ -89,8 +89,8 @@ DECIMALS: immutable(uint8)
 
 @deploy
 def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
+    self.SYMBOL = "VYPR"
+    self.DECIMALS = 18
     """
     code = """
 import lib1 as a_library
@@ -104,7 +104,7 @@ initializes: a_library
 
 @deploy
 def __init__():
-    some_immutable = [1, 2, 3]
+    self.some_immutable = [1, 2, 3]
     a_library.__init__()
     """
 
@@ -139,8 +139,8 @@ DECIMALS: immutable(uint8)
 
 @deploy
 def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
+    self.SYMBOL = "VYPR"
+    self.DECIMALS = 18
     """
     code = """
 import lib1 as a_library
@@ -155,7 +155,7 @@ counter2: uint256
 @deploy
 def __init__():
     a_library.__init__()
-    some_immutable = [1, 2, 3]
+    self.some_immutable = [1, 2, 3]
     """
     input_bundle = make_input_bundle({"lib1.vy": lib1})
 
@@ -189,8 +189,8 @@ DECIMALS: immutable(uint8)
 
 @deploy
 def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
+    self.SYMBOL = "VYPR"
+    self.DECIMALS = 18
     """
     lib2 = """
 import lib1
@@ -202,7 +202,7 @@ immutable_variable: immutable(uint256)
 
 @deploy
 def __init__(s: uint256):
-    immutable_variable = s
+    self.immutable_variable = s
 
 @internal
 def decimals() -> uint8:
@@ -230,7 +230,7 @@ initializes: a_library
 @deploy
 def __init__():
     a_library.__init__()
-    some_immutable = [1, 2, 3]
+    self.some_immutable = [1, 2, 3]
 
     lib2.__init__(17)
 
@@ -273,8 +273,8 @@ DECIMALS: immutable(uint8)
 
 @deploy
 def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
+    self.SYMBOL = "VYPR"
+    self.DECIMALS = 18
     """
     lib2 = """
 import lib1
@@ -286,7 +286,7 @@ immutable_variable: immutable(uint256)
 
 @deploy
 def __init__(s: uint256):
-    immutable_variable = s
+    self.immutable_variable = s
     lib1.__init__()
 
 @internal
@@ -309,7 +309,7 @@ uses: a_library
 
 @deploy
 def __init__():
-    some_immutable = [1, 2, 3]
+    self.some_immutable = [1, 2, 3]
 
     lib2.__init__(17)
 

--- a/tests/unit/cli/storage_layout/test_storage_layout_overrides.py
+++ b/tests/unit/cli/storage_layout/test_storage_layout_overrides.py
@@ -251,7 +251,7 @@ name: public(String[64])
 
 @deploy
 def __init__():
-    some_immutable = 5
+    self.some_immutable = 5
     """
 
     storage_layout_override = {"name": {"slot": 10, "type": "String[64]", "n_slots": 3}}
@@ -280,8 +280,8 @@ DECIMALS: immutable(uint8)
 
 @deploy
 def __init__():
-    SYMBOL = "VYPR"
-    DECIMALS = 18
+    self.SYMBOL = "VYPR"
+    self.DECIMALS = 18
     """
     lib2 = """
 import lib1
@@ -294,7 +294,7 @@ immutable_variable: immutable(uint256)
 
 @deploy
 def __init__(s: uint256):
-    immutable_variable = s
+    self.immutable_variable = s
     lib1.__init__()
 
 @internal
@@ -317,7 +317,7 @@ uses: a_library
 
 @deploy
 def __init__():
-    some_immutable = [1, 2, 3]
+    self.some_immutable = [1, 2, 3]
 
     lib2.__init__(17)
 

--- a/tests/unit/compiler/test_abi.py
+++ b/tests/unit/compiler/test_abi.py
@@ -270,8 +270,8 @@ public_constant_variable: public(constant(uint256)) = 10
 
 @deploy
 def __init__(a: uint256, b: uint256):
-    public_immutable_variable = a
-    private_immutable_variable = b
+    self.public_immutable_variable = a
+    self.private_immutable_variable = b
     """
 
     main = """

--- a/tests/unit/compiler/test_bytecode_runtime.py
+++ b/tests/unit/compiler/test_bytecode_runtime.py
@@ -37,7 +37,7 @@ A_GOOD_PRIME: public(immutable(uint256))
 
 @deploy
 def __init__():
-    A_GOOD_PRIME = 967
+    self.A_GOOD_PRIME = 967
 """
 
 

--- a/vyper/semantics/analysis/getters.py
+++ b/vyper/semantics/analysis/getters.py
@@ -31,8 +31,6 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
         # constants just return a value
         if node.is_constant:
             return_expr = node.value
-        elif node.is_immutable:
-            return_expr = vy_ast.Name(id=funcname)  # type: ignore
         else:
             # the base return statement is an `Attribute` node, e.g.
             # `self.<var_name>`. for each input type we wrap it in a

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -540,10 +540,21 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             raise ImmutableViolation("Cannot write to calldata")
 
         if info.modifiability == Modifiability.RUNTIME_CONSTANT:
-            if info.location != DataLocation.CODE:
+            if info.location == DataLocation.CODE:
+                if not func_t.is_constructor:
+                    raise ImmutableViolation("Immutable value cannot be written to")
+
+                # handle immutables
+                if info.var_info is not None:  # don't handle complex (struct,array) immutables
+                    # special handling for immutable variables in the ctor
+                    # TODO: maybe we want to remove this restriction.
+                    if info.var_info._modification_count != 0:
+                        raise ImmutableViolation(
+                            "Immutable value cannot be modified after assignment"
+                        )
+                    info.var_info._modification_count += 1
+            else:
                 raise ImmutableViolation("Environment variable cannot be written to")
-            if not func_t.is_constructor:
-                raise ImmutableViolation("Immutable value cannot be written to")
 
         if info.modifiability == Modifiability.CONSTANT:
             raise ImmutableViolation("Constant value cannot be written to.")

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -540,21 +540,10 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
             raise ImmutableViolation("Cannot write to calldata")
 
         if info.modifiability == Modifiability.RUNTIME_CONSTANT:
-            if info.location == DataLocation.CODE:
-                if not func_t.is_constructor:
-                    raise ImmutableViolation("Immutable value cannot be written to")
-
-                # handle immutables
-                if info.var_info is not None:  # don't handle complex (struct,array) immutables
-                    # special handling for immutable variables in the ctor
-                    # TODO: maybe we want to remove this restriction.
-                    if info.var_info._modification_count != 0:
-                        raise ImmutableViolation(
-                            "Immutable value cannot be modified after assignment"
-                        )
-                    info.var_info._modification_count += 1
-            else:
+            if info.location != DataLocation.CODE:
                 raise ImmutableViolation("Environment variable cannot be written to")
+            if not func_t.is_constructor:
+                raise ImmutableViolation("Immutable value cannot be written to")
 
         if info.modifiability == Modifiability.CONSTANT:
             raise ImmutableViolation("Constant value cannot be written to.")

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -137,7 +137,7 @@ def _analyze_module_bodies(module_ast: vy_ast.Module) -> None:
     with override_global_namespace(namespace):
         analyze_functions(module_ast)
         _validate_exports_uses(module_ast, module_t)
-        _validate_initialized_modules(module_ast, module_t)
+        _validate_constructor(module_ast, module_t)
         _validate_used_modules(module_ast, module_t)
 
 
@@ -181,7 +181,7 @@ def _validate_used_modules(module_ast: vy_ast.Module, module_t: ModuleT) -> None
         err_list.raise_if_not_empty()
 
 
-def _validate_initialized_modules(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
+def _validate_init_calls(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
     """Check all `initializes:` modules have `__init__()` called exactly once."""
     # only call `__init__()` for modules which have an
     # `__init__()` function
@@ -248,6 +248,63 @@ def _validate_initialized_modules(module_ast: vy_ast.Module, module_t: ModuleT) 
             err_list.append(InitializerException(msg, init_func_node, s.node, hint=hint))
 
         err_list.raise_if_not_empty()
+
+
+def _validate_immutable_assignments(module_ast: vy_ast.Module, module_t: ModuleT):
+
+    constructor = module_t.init_function
+
+    set_immutables: dict[str, vy_ast.Assign] = {}
+
+    if constructor is not None:
+        assert isinstance(constructor.ast_def, vy_ast.FunctionDef)
+        self_assigns = constructor.ast_def.get_descendants(
+            vy_ast.Assign, {"target.value.id": "self"}
+        )
+
+        for self_assign in self_assigns:
+            # self.<attr> =
+            attr = self_assign.target.attr
+
+            member = module_t.members.get(attr)
+
+            if member is None:
+                # Will be handled somewhere else
+                continue
+
+            if not isinstance(member, VarInfo):
+                # Will be handled somewhere else
+                continue
+
+            if not member.is_immutable:
+                # We only check immutable assignments
+                continue
+
+            previous_assign = set_immutables.get(attr)
+
+            if previous_assign is not None:
+                raise ImmutableViolation(
+                    "Immutable value cannot be modified after assignment",
+                    self_assign,
+                    previous_assign,
+                )
+
+            set_immutables[attr] = self_assign
+
+    for name, var_info in module_t.variables.items():
+
+        if not var_info.is_immutable:
+            continue
+
+        if name not in set_immutables:
+            raise ImmutableViolation(
+                "Immutable definition requires an assignment in the constructor", var_info.decl_node
+            )
+
+
+def _validate_constructor(module_ast: vy_ast.Module, module_t: ModuleT):
+    _validate_init_calls(module_ast, module_t)
+    _validate_immutable_assignments(module_ast, module_t)
 
 
 def _validate_exports_uses(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
@@ -751,26 +808,6 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 "reentrant() is not allowed without `pragma nonreentrancy on`", node
             )
 
-        # TODO: move this check to local analysis
-        if node.is_immutable:
-            # mutability is checked automatically preventing assignment
-            # outside of the constructor, here we just check a value is assigned,
-            # not necessarily where
-            assignments = self.ast.get_descendants(
-                vy_ast.Assign, filters={"target.id": node.target.id}
-            )
-            if not assignments:
-                # Special error message for common wrong usages via `self.<immutable name>`
-                wrong_self_attribute = self.ast.get_descendants(
-                    vy_ast.Attribute, {"value.id": "self", "attr": node.target.id}
-                )
-                message = (
-                    "Immutable variables must be accessed without 'self'"
-                    if len(wrong_self_attribute) > 0
-                    else "Immutable definition requires an assignment in the constructor"
-                )
-                raise ImmutableViolation(message, node)
-
         location = (
             DataLocation.CODE
             if node.is_immutable
@@ -814,7 +851,7 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             # add the variable name to `self` namespace if the variable is either
             # 1. a public constant or immutable; or
             # 2. a storage variable, whether private or public
-            if (node.is_constant or node.is_immutable) and not node.is_public:
+            if node.is_constant and not node.is_public:
                 return
 
             self._self_t.typ.add_member(name, var_info)
@@ -837,9 +874,6 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             return _finalize()
 
         assert node.value is None  # checked in VariableDecl.validate()
-        if node.is_immutable:
-            _validate_self_namespace()
-            return _finalize()
 
         self.namespace.validate_assignment(name)
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -258,12 +258,13 @@ def _validate_immutable_assignments(module_ast: vy_ast.Module, module_t: ModuleT
 
     if constructor is not None:
         assert isinstance(constructor.ast_def, vy_ast.FunctionDef)
+
         self_assigns = constructor.ast_def.get_descendants(
-            vy_ast.Assign, {"target.value.id": "self"}
+            (vy_ast.Assign, vy_ast.AugAssign), {"target.value.id": "self"}
         )
 
         for self_assign in self_assigns:
-            # self.<attr> =
+            # self.<attr> = or +=, *=, ...
             attr = self_assign.target.attr
 
             member = module_t.members.get(attr)
@@ -279,6 +280,10 @@ def _validate_immutable_assignments(module_ast: vy_ast.Module, module_t: ModuleT
             if not member.is_immutable:
                 # We only check immutable assignments
                 continue
+
+            # self.<attr> += or *=, /=, etc
+            if isinstance(self_assign, vy_ast.AugAssign):
+                raise ImmutableViolation("Immutable value cannot be modified", self_assign)
 
             previous_assign = set_immutables.get(attr)
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -766,10 +766,16 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 wrong_assignments = self.ast.get_descendants(
                     vy_ast.Assign, filters={"target.id": name}
                 )
-                if wrong_assignments:
+
+                err_list = ExceptionList()
+
+                for wrong_assignment in wrong_assignments:
                     # same error that would be raised later
-                    node = wrong_assignments[0].target
-                    raise InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?")
+                    node = wrong_assignment.target
+
+                    err_list.append(InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?"))
+                
+                err_list.raise_if_not_empty()
 
                 message = "Immutable definition requires an assignment in the constructor"
                 raise ImmutableViolation(message, node)

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -16,7 +16,6 @@ from vyper.exceptions import (
     InitializerException,
     InterfaceViolation,
     InvalidLiteral,
-    InvalidReference,
     InvalidType,
     StateAccessViolation,
     StructureException,
@@ -761,23 +760,12 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             assignments = self.ast.get_descendants(
                 vy_ast.Assign, filters={"target.value.id": "self", "target.attr": name}
             )
-            if not assignments:
-                # `<name> = ...`: Assign(target=<name>)
-                wrong_assignments = self.ast.get_descendants(
-                    vy_ast.Assign, filters={"target.id": name}
-                )
+            # `<name> = ...`: Assign(target=<name>)
+            deprecated_assignments = self.ast.get_descendants(
+                vy_ast.Assign, filters={"target.id": name}
+            )
 
-                err_list = ExceptionList()
-
-                for wrong_assignment in wrong_assignments:
-                    # same error that would be raised later
-                    node = wrong_assignment.target
-
-                    err_list.append(
-                        InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?")
-                    )
-
-                err_list.raise_if_not_empty()
+            if not assignments and not deprecated_assignments:
 
                 message = "Immutable definition requires an assignment in the constructor"
                 raise ImmutableViolation(message, node)
@@ -850,6 +838,10 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
         assert node.value is None  # checked in VariableDecl.validate()
 
         self.namespace.validate_assignment(name)
+
+        if node.is_immutable:
+            # TODO: Remove once referring to immutables without going through self is forbidden
+            self.namespace[name] = var_info
 
         return _finalize()
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -773,8 +773,10 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                     # same error that would be raised later
                     node = wrong_assignment.target
 
-                    err_list.append(InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?"))
-                
+                    err_list.append(
+                        InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?")
+                    )
+
                 err_list.raise_if_not_empty()
 
                 message = "Immutable definition requires an assignment in the constructor"

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -16,6 +16,7 @@ from vyper.exceptions import (
     InitializerException,
     InterfaceViolation,
     InvalidLiteral,
+    InvalidReference,
     InvalidType,
     StateAccessViolation,
     StructureException,
@@ -756,11 +757,20 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
             # mutability is checked automatically preventing assignment
             # outside of the constructor, here we just check a value is assigned,
             # not necessarily where
-            # Assign(target=Attribute(value=Name("self"), attr=<node.target.id>))
+            # `self.<name> = ...`: Assign(target=Attribute(value=Name("self"), attr=<name>))
             assignments = self.ast.get_descendants(
-                vy_ast.Assign, filters={"target.value.id": "self", "target.attr": node.target.id}
+                vy_ast.Assign, filters={"target.value.id": "self", "target.attr": name}
             )
             if not assignments:
+                # `<name> = ...`: Assign(target=<name>)
+                wrong_assignments = self.ast.get_descendants(
+                    vy_ast.Assign, filters={"target.id": name}
+                )
+                if wrong_assignments:
+                    # same error that would be raised later
+                    node = wrong_assignments[0].target
+                    raise InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?")
+
                 message = "Immutable definition requires an assignment in the constructor"
                 raise ImmutableViolation(message, node)
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -137,7 +137,7 @@ def _analyze_module_bodies(module_ast: vy_ast.Module) -> None:
     with override_global_namespace(namespace):
         analyze_functions(module_ast)
         _validate_exports_uses(module_ast, module_t)
-        _validate_constructor(module_ast, module_t)
+        _validate_initialized_modules(module_ast, module_t)
         _validate_used_modules(module_ast, module_t)
 
 
@@ -181,7 +181,7 @@ def _validate_used_modules(module_ast: vy_ast.Module, module_t: ModuleT) -> None
         err_list.raise_if_not_empty()
 
 
-def _validate_init_calls(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
+def _validate_initialized_modules(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
     """Check all `initializes:` modules have `__init__()` called exactly once."""
     # only call `__init__()` for modules which have an
     # `__init__()` function
@@ -248,68 +248,6 @@ def _validate_init_calls(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
             err_list.append(InitializerException(msg, init_func_node, s.node, hint=hint))
 
         err_list.raise_if_not_empty()
-
-
-def _validate_immutable_assignments(module_ast: vy_ast.Module, module_t: ModuleT):
-
-    constructor = module_t.init_function
-
-    set_immutables: dict[str, vy_ast.Assign] = {}
-
-    if constructor is not None:
-        assert isinstance(constructor.ast_def, vy_ast.FunctionDef)
-
-        self_assigns = constructor.ast_def.get_descendants(
-            (vy_ast.Assign, vy_ast.AugAssign), {"target.value.id": "self"}
-        )
-
-        for self_assign in self_assigns:
-            # self.<attr> = or +=, *=, ...
-            attr = self_assign.target.attr
-
-            member = module_t.members.get(attr)
-
-            if member is None:
-                # Will be handled somewhere else
-                continue
-
-            if not isinstance(member, VarInfo):
-                # Will be handled somewhere else
-                continue
-
-            if not member.is_immutable:
-                # We only check immutable assignments
-                continue
-
-            # self.<attr> += or *=, /=, etc
-            if isinstance(self_assign, vy_ast.AugAssign):
-                raise ImmutableViolation("Immutable value cannot be modified", self_assign)
-
-            previous_assign = set_immutables.get(attr)
-
-            if previous_assign is not None:
-                raise ImmutableViolation(
-                    "Immutable value cannot be modified after assignment",
-                    self_assign,
-                    previous_assign,
-                )
-
-            set_immutables[attr] = self_assign
-
-    for name, var_info in module_t.variables.items():
-
-        if not var_info.is_immutable:
-            continue
-
-        if name not in set_immutables:
-            raise ImmutableViolation(
-                "Immutable definition requires an assignment in the constructor", var_info.decl_node
-            )
-
-
-def _validate_constructor(module_ast: vy_ast.Module, module_t: ModuleT):
-    _validate_init_calls(module_ast, module_t)
-    _validate_immutable_assignments(module_ast, module_t)
 
 
 def _validate_exports_uses(module_ast: vy_ast.Module, module_t: ModuleT) -> None:
@@ -813,6 +751,19 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
                 "reentrant() is not allowed without `pragma nonreentrancy on`", node
             )
 
+        # TODO: move this check to local analysis
+        if node.is_immutable:
+            # mutability is checked automatically preventing assignment
+            # outside of the constructor, here we just check a value is assigned,
+            # not necessarily where
+            # Assign(target=Attribute(value=Name("self"), attr=<node.target.id>))
+            assignments = self.ast.get_descendants(
+                vy_ast.Assign, filters={"target.value.id": "self", "target.attr": node.target.id}
+            )
+            if not assignments:
+                message = "Immutable definition requires an assignment in the constructor"
+                raise ImmutableViolation(message, node)
+
         location = (
             DataLocation.CODE
             if node.is_immutable
@@ -854,8 +805,8 @@ class ModuleAnalyzer(VyperNodeVisitorBase):
 
         def _finalize():
             # add the variable name to `self` namespace if the variable is either
-            # 1. a public constant or immutable; or
-            # 2. a storage variable, whether private or public
+            # 1. a public constant; or
+            # 2. a storage/transient/immutable variable, whether private or public
             if node.is_constant and not node.is_public:
                 return
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 from vyper.semantics.types.primitives import AddressT, BoolT, BytesM_T, IntegerT
 from vyper.semantics.types.subscriptable import DArrayT, SArrayT, TupleT
 from vyper.utils import OrderedSet, checksum_encode, int_to_fourbytes
+from vyper.warnings import Deprecation, vyper_warn
 
 
 def _validate_op(node, types_list, validation_fn_name):
@@ -385,12 +386,21 @@ class _ExprAnalyser:
     def types_from_Name(self, node):
         # variable name, e.g. `foo`
         name = node.id
+
+        if "self" in self.namespace and getattr(
+            self.namespace["self"].typ.members.get(name), "is_immutable", False
+        ):
+            msg = "immutables should now be accessed through `self`"
+            hint = f"use `self.{name}` instead"
+            vyper_warn(Deprecation(msg, node, hint=hint))
+
         if (
             name not in self.namespace
             and "self" in self.namespace
             and name in self.namespace["self"].typ.members
         ):
             raise InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?")
+
         try:
             t = self.namespace[node.id]
             # when this is a type, we want to lower it

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -212,7 +212,7 @@ class _ExprAnalyser:
                 return [s]
 
             # general case. s is a VarInfo, e.g. self.foo
-            if is_self_reference and (s.is_constant or s.is_immutable):
+            if is_self_reference and s.is_constant:
                 _raise_invalid_reference(name, node)
             return [s.typ]
 
@@ -391,7 +391,7 @@ class _ExprAnalyser:
             and name in self.namespace["self"].typ.members
         ):
             raise InvalidReference(
-                f"'{name}' is a storage variable, access it as self.{name}", node
+                f"'{name}' is an assignable variable, access it as self.{name}", node
             )
         try:
             t = self.namespace[node.id]

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -390,9 +390,7 @@ class _ExprAnalyser:
             and "self" in self.namespace
             and name in self.namespace["self"].typ.members
         ):
-            raise InvalidReference(
-                f"'{name}' is an assignable variable, access it as self.{name}", node
-            )
+            raise InvalidReference(f"'{name}'", node, hint=f"did you mean self.{name}?")
         try:
             t = self.namespace[node.id]
             # when this is a type, we want to lower it


### PR DESCRIPTION
### What I did

Make immutables accessible through `self`, consistent with storage and transient variables. Bare-name access (`foo` instead of `self.foo`) still works but now emits a `Deprecation` warning; it will be removed in a future release.

### How I did it

Mostly by removing special cases:

- Register immutables as members of the `self` type, like storage variables (they are also still added to the module namespace so the deprecated bare-name form keeps working for now).
- Emit a `Deprecation` warning (with a `use self.<name>` hint) whenever an immutable is referenced by bare name — every occurrence is reported so a contract can be migrated in one pass.
- Accept both `self.<name> = ...` and the deprecated `<name> = ...` in the constructor-assignment check, and drop the old special-cased "Immutable variables must be accessed without 'self'" error.
- Generate public getters with a standard `self.<name>` return expression instead of the immutable-specific `Name` node.
- While at it, reword the bare-name storage variable error to hint style: `did you mean self.<name>?`.

### How to verify it

This now compiles cleanly:

```vyper
foo: public(immutable(uint256))

@deploy
def __init__(x: uint256):
    self.foo = x

@external
def bar() -> uint256:
    return self.foo
```

while the old bare-name form still compiles but warns on every occurrence:

```
Deprecation: immutables should now be accessed through `self`

  contract "imm.vy:5", function "__init__", line 5:4
       4 def __init__(x: uint256):
  ---> 5     foo = x
  -----------^

  (hint: use `self.foo` instead)
```

Test coverage: `tests/functional/syntax/test_immutables.py`, `tests/functional/syntax/warnings/test_deprecation_warning.py`, `tests/functional/codegen/features/test_immutable.py`; the rest of the test suite was migrated to the `self.` form.

### Commit message

```
immutables were registered in the module namespace and accessed as bare
names, unlike storage and transient variables which are accessed through
`self`.

register immutables as members of the self type so `self.<name>` becomes
the canonical way to read and assign them. bare-name access keeps
working for now but emits a `Deprecation` warning with a `use
self.<name>` hint; every occurrence is reported so a contract can be
migrated in one pass. the constructor assignment check accepts both
forms. desugaring of public getters is also updated to use
`self.<name>`, matching storage getters.

bare-name access will be removed in a future release.
```

### Description for the changelog

Immutables are now accessed through `self` (e.g. `self.foo`); bare-name access is deprecated and will be removed in a future release.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()