### PR TITLE
fix[docs]: add `html_static_path` config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ author = "Vyper Team (originally created by Vitalik Buterin)"
 language = "vyper"
 
 # -- Options for HTML output ----------------------------------------------
+html_static_path = ["_static"]
 html_theme = "shibuya"
 html_theme_options = {
     "light_logo": "_static/logo-light.svg",


### PR DESCRIPTION
### What I did

Add the missing config `html_static_path` in bc5d00a.

If `html_static_path = ['_static']` is not specified, any logos placed in the `_static` subdirectory of the source directory will not be copied to the `_static` subdirectory under the build directory when building the HTML documentation. This will cause the following two theme option configurations to fail to find the `_static/logo-dark|light.svg` files:

```python
html_theme_options = {
    "light_logo": "_static/logo-light.svg",
    "dark_logo": "_static/logo-dark.svg",
}
```

which will result in:

<img width="2399" height="1088" alt="Screenshot_20260606_143701" src="https://github.com/user-attachments/assets/ba1399b4-7ca4-405a-895c-7ad3f161b66a" />

### How I did it

Add the following configuration in `conf.py` file:

```python
html_static_path = ["_static"]
```

### How to verify it

```
uv run --group docs make -C docs html
```

### Commit message

```
if `html_static_path = ["_static"]` is not specified, any logos placed
in the `_static` subdirectory of the source directory will not be copied
to the `_static` subdirectory under the build directory when building
the html documentation. this causes the `light_logo` and `dark_logo`
theme option configurations to fail to find the `_static/logo-dark.svg`
and `_static/logo-light.svg` files, resulting in missing logos in the
rendered docs.

add the missing `html_static_path` config that was dropped in bc5d00a.
```
