### PR TITLE
fix[docs]: fix JSON field annotations in `compiling-a-contract`

### DIFF
--- a/docs/compiling-a-contract.rst
+++ b/docs/compiling-a-contract.rst
@@ -415,13 +415,13 @@ The following example describes the output format of ``vyper-json``. Comments ar
                 // The contract name will always be the file name without a suffix
                 "source_file": {
                     // The Ethereum Contract ABI.
-                    // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+                    // See https://docs.soliditylang.org/en/latest/abi-spec.html
                     "abi": [],
                     // Natspec developer documentation
                     "devdoc": {},
-                    // Intermediate representation (string)
-                    "ir": "",
-                    // Natspec developer documentation
+                    // Intermediate representation (the IR node tree as a JSON object)
+                    "ir": {},
+                    // Natspec user documentation
                     "userdoc": {},
                     // Storage layout of the contract
                     "layout": {
@@ -440,7 +440,7 @@ The following example describes the output format of ``vyper-json``. Comments ar
                             "object": "00fe",
                             // Opcodes list (string)
                             "opcodes": "",
-                            // The deployed source mapping.
+                            // The creation source mapping.
                             "sourceMap": {
                                 "breakpoints": [],
                                 "error_map": {},
@@ -449,7 +449,7 @@ The following example describes the output format of ``vyper-json``. Comments ar
                                 "pc_breakpoints": [],
                                 "pc_jump_map": {},
                                 "pc_pos_map": {},
-                                // The deployed source mapping as a string.
+                                // The creation source mapping as a string.
                                 "pc_pos_map_compressed": ""
                             }
                         },


### PR DESCRIPTION
### What I did

Correct four mislabeled fields in the "Output JSON Description" example in `docs/compiling-a-contract.rst`.

### How I did it

1. **`ir` type** — annotated `(string)` / `"ir": ""`, but `vyper-json` emits the IR node tree as a JSON object (e.g. `{"seq": [...]}`). In `vyper/compiler/output.py`, the `ir`/`ir_dict` outputs go through `_ir_to_dict()`, which returns a dict. The `(string)` annotation reflects the pre-0.3.2 text (LLL) IR.
2. **`userdoc`** — comment said "Natspec developer documentation" (copy-paste from `devdoc`); it is user documentation.
3. **`evm.bytecode.sourceMap`** — comments said "deployed source mapping", copied from the `deployedBytecode` block; this is the creation block.
4. **ABI link** — replaced the archived `ethereum/wiki` link with the current ABI spec URL.

Found while typing Vyper's standard-JSON output in Sourcify, where `ir` is parsed from compiler output. Verified empirically that requesting `ir` from `vyper-json` returns a JSON object on the versions tested (0.3.7, 0.3.10, 0.4.0); the string form only applies to ≤0.3.1. Ref: argotorg/sourcify#2817.

### How to verify it

- Inspect the diff in `docs/compiling-a-contract.rst` — four annotation/link fixes, no behavioral change.
- Run `vyper-json --format ir` on any contract and confirm the output is a JSON object, not a string.

### Commit message

```
the "Output JSON Description" example in compiling-a-contract.rst
mislabeled several contract-level fields:

- `ir` was annotated `(string)` with `"ir": ""`, but vyper-json emits
  the IR node tree as a JSON object (e.g. {"seq": [...]}) for v0.3.2+.
  the string form corresponds to the older text (LLL) IR.
- `userdoc` was labeled "Natspec developer documentation" (copy-pasted
  from devdoc); it is user documentation.
- the evm.bytecode (creation) sourceMap comments said "deployed
  source mapping", copied from the deployedBytecode block.
- the ABI link pointed at the archived ethereum/wiki; updated to the
  current ABI spec URL.
```

### Description for the changelog

Fix mislabeled field annotations in "Output JSON Description" docs example.

### Cute Animal Picture

![](https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/Yellow_fancy_mouse.jpg/220px-Yellow_fancy_mouse.jpg)
