### PR TITLE
fix[venom]: release nonreentrant lock on internal function return

### DIFF
--- a/tests/functional/codegen/features/decorators/test_nonreentrant.py
+++ b/tests/functional/codegen/features/decorators/test_nonreentrant.py
@@ -1038,3 +1038,22 @@ def foo() -> uint256:
     c = get_contract(code)
 
     assert c.foo() == 42
+
+
+def test_nonreentrant_internal_explicit_return(get_contract):
+    # the lock must be released on explicit-return exits,
+    # not just on fall-through
+    code = """
+@internal
+@nonreentrant
+def _double(u: uint256) -> uint256:
+    return u * 2
+
+@external
+def foo(u: uint256) -> uint256:
+    a: uint256 = self._double(u)
+    b: uint256 = self._double(a)
+    return b
+    """
+    c = get_contract(code)
+    assert c.foo(3) == 12

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -871,11 +871,16 @@ class Stmt:
         """Lower internal function return.
 
         For internal functions:
+        - Nonreentrant unlock (if applicable)
         - Load return values and pass on stack
         - ret to return_pc
         """
         return_pc = self.ctx.return_pc
         assert return_pc is not None  # Caller ensures this
+
+        # Nonreentrant unlock. The return expression has already been
+        # evaluated by the caller, so this runs at function exit.
+        self.ctx.emit_nonreentrant_unlock(func_t)
 
         if ret_val is None:
             self.builder.ret(return_pc)


### PR DESCRIPTION
### What I did

fixes #5049
Fixed a bug in the experimental codegen pipeline (`codegen_venom`) where a `@nonreentrant` internal function exiting via an explicit `return` statement never releases the nonreentrant lock.

### How I did it

`_lower_internal_return` emitted `ret` directly; the unlock was only emitted on the fall-through path in `_generate_internal_function`. Since every value-returning nonreentrant internal function necessarily exits via explicit `return`, it acquired the lock at entry and never released it — any subsequent nonreentrant call in the same transaction then reverts (single shared global lock key).

The fix mirrors `_lower_external_return` (which already unlocks correctly) by emitting the unlock at the top of `_lower_internal_return`. The return expression is evaluated by `lower_Return` before dispatching there, so the unlock runs at function exit, after all side effects of the return value — matching the legacy pipeline, which routes all internal returns through a shared cleanup label (`nonreentrant_post` before `exit_to`).

### How to verify it

```vyper
@internal
@nonreentrant
def _double(u: uint256) -> uint256:
    return u * 2

@external
def foo(u: uint256) -> uint256:
    a: uint256 = self._double(u)
    b: uint256 = self._double(a)
    return b
```

Before this fix, `foo()` reverts under `--experimental-codegen` (the second `_double` call sees the lock still held). The added test exercises this under both pipelines.

### Commit message

```
in the codegen_venom pipeline, `_lower_internal_return` emits `ret`
directly without releasing the nonreentrant lock. the unlock for
internal functions is only emitted on the fall-through path in
`_generate_internal_function`, so any `@nonreentrant` internal
function exiting via an explicit `return` statement -- which includes
every value-returning nonreentrant internal function -- acquires the
lock at entry and never releases it. since the lock is a single shared
global key, any subsequent nonreentrant call in the same transaction
reverts.

the external return path already unlocks correctly in
`_lower_external_return`; mirror it by emitting the unlock at the top
of `_lower_internal_return`. the return expression is evaluated by
`lower_Return` before dispatching here, so the unlock runs at function
exit, after all side effects of the return value -- matching the legacy
pipeline, which routes all internal returns through a shared cleanup
label that performs `nonreentrant_post` before `exit_to`.
```

### Description for the changelog

fix[venom]: release nonreentrant lock on internal function return

### Cute Animal Picture

![]()

