### PR TITLE
fix[venom]: fix call argument evaluation order

### DIFF
--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -2705,3 +2705,31 @@ def boo() -> uint256:
 
     assert c.foo() == [1, 2, 3, 4]
     assert c.bar() == [1, 2, 3, 4]
+
+
+def test_external_call_arg_evaluation_order(get_contract):
+    # the first argument must be read before the second argument's
+    # side effects execute
+    code = """
+interface Bar:
+    def get_a_b(a: uint256, b: uint256) -> uint256: nonpayable
+
+x: public(uint256)
+
+@internal
+def mutate() -> uint256:
+    self.x = 999
+    return 0
+
+@external
+def get_a_b(a: uint256, b: uint256) -> uint256:
+    return a * 10 + b
+
+@external
+def bar() -> uint256:
+    self.x = 1
+    return extcall Bar(self).get_a_b(self.x, self.mutate())
+    """
+    c = get_contract(code)
+    assert c.bar() == 10
+    assert c.x() == 999

--- a/tests/functional/codegen/calling_convention/test_internal_call.py
+++ b/tests/functional/codegen/calling_convention/test_internal_call.py
@@ -795,3 +795,44 @@ def test_swap() -> uint256:
     c = get_contract(code)
     assert c.test_increment() == 6
     assert c.test_swap() == 30
+
+
+def test_internal_call_arg_evaluation_order(get_contract):
+    # the first argument must be read before the second argument's
+    # side effects execute
+    code = """
+x: uint256
+
+@internal
+def mutate() -> uint256:
+    self.x = 999
+    return 0
+
+@internal
+def foo(a: uint256, b: uint256) -> uint256:
+    return a
+
+@external
+def bar() -> uint256:
+    self.x = 1
+    return self.foo(self.x, self.mutate())
+    """
+    c = get_contract(code)
+    assert c.bar() == 1
+
+
+def test_internal_call_arg_evaluation_order_complex(get_contract):
+    # complex (memory) arguments must be snapshotted before later
+    # arguments mutate them
+    code = """
+@internal
+def take(a: DynArray[uint256, 4], b: uint256) -> uint256:
+    return len(a) * 100 + b
+
+@external
+def bar() -> uint256:
+    arr: DynArray[uint256, 4] = [1, 2, 3]
+    return self.take(arr, arr.pop())
+    """
+    c = get_contract(code)
+    assert c.bar() == 303

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -173,6 +173,16 @@ class VenomCodegenContext:
         self.store_vyper_value(vv, ret.operand, typ)
         return ret
 
+    def freeze_value(self, vv: VyperValue, annotation: Optional[str] = None) -> VyperValue:
+        """Snapshot a value so later side effects cannot change it.
+
+        Primitive words are loaded onto the stack; composite values are
+        copied into a fresh memory temporary.
+        """
+        if vv.typ._is_prim_word:
+            return VyperValue.from_stack_op(self.unwrap(vv), vv.typ)
+        return self.materialize_value(vv, annotation=annotation)
+
     def bytes_data_ptr(self, vv: VyperValue) -> IROperand:
         """Get pointer to bytestring data (skipping length word).
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -70,6 +70,15 @@ class _CallKwargs:
 ENVIRONMENT_VARIABLES = {"block", "msg", "tx", "chain"}
 
 
+def _may_have_side_effects(node: vy_ast.VyperNode) -> bool:
+    """Whether evaluating the expression can mutate observable state.
+
+    Conservative: any call (internal call, extcall, builtin, mutating
+    method call like `arr.append(...)`) counts as a side effect.
+    """
+    return len(node.get_descendants(vy_ast.Call, include_self=True)) > 0
+
+
 class Expr:
     """Lower Vyper expressions to Venom IR.
 
@@ -1355,9 +1364,18 @@ class Expr:
         # By evaluating all args first, we ensure nested calls complete before we
         # allocate staging buffers, avoiding corruption.
         # See legacy codegen: vyper/codegen/self_call.py (contains_self_call handling)
+        #
+        # Each argument is frozen (loaded to stack / copied to a fresh
+        # temporary) as soon as it is evaluated if any later argument can
+        # have side effects; otherwise the lazily-read location could be
+        # mutated before the staging copy, observably changing evaluation
+        # order vs the legacy pipeline.
         arg_vals: list[VyperValue] = []
-        for arg_node in all_arg_nodes:
-            arg_vals.append(Expr(arg_node, self.ctx).lower())
+        for i, arg_node in enumerate(all_arg_nodes):
+            arg_val = Expr(arg_node, self.ctx).lower()
+            if any(_may_have_side_effects(n) for n in all_arg_nodes[i + 1 :]):
+                arg_val = self.ctx.freeze_value(arg_val, annotation="internal call arg")
+            arg_vals.append(arg_val)
 
         # Now allocate staging buffers and copy evaluated values
         for i, arg_val in enumerate(arg_vals):
@@ -1728,10 +1746,20 @@ class Expr:
         # Evaluate contract address (the interface value)
         contract_address = Expr(call_node.func.value, self.ctx).lower_value()
 
-        # Evaluate arguments.
+        # Evaluate arguments left-to-right. Each argument is frozen (loaded
+        # to stack / copied to a fresh temporary) as soon as it is evaluated
+        # if any later argument or kwarg expression can have side effects;
+        # otherwise the lazily-read location could be mutated before the
+        # staging copy below, observably changing evaluation order vs the
+        # legacy pipeline. Kwargs count because they are evaluated next.
+        kwarg_nodes = [kw.value for kw in call_node.keywords]
         arg_vals: list[VyperValue] = []
-        for arg in call_node.args:
-            arg_vals.append(Expr(arg, self.ctx).lower())
+        for i, arg in enumerate(call_node.args):
+            arg_val = Expr(arg, self.ctx).lower()
+            later_nodes = list(call_node.args[i + 1 :]) + kwarg_nodes
+            if any(_may_have_side_effects(n) for n in later_nodes):
+                arg_val = self.ctx.freeze_value(arg_val, annotation="external call arg")
+            arg_vals.append(arg_val)
 
         # Parse kwargs
         call_kwargs = self._parse_external_call_kwargs(call_node)


### PR DESCRIPTION
### What I did

fixes #5050
Fixed an argument evaluation-order bug in the experimental codegen pipeline (`codegen_venom`): internal and external call arguments were read *after* later arguments' (or kwargs') side effects executed, passing the mutated values.

### How I did it

Both call paths lower all argument expressions before unwrapping/staging them. But lowering a storage/memory variable yields a *pointer*, not a value — no read is emitted. If a later argument (or an extcall kwarg like `value=`) mutates the location, the staging copy reads the mutated value:

```vyper
self.x = 1
return self.foo(self.x, self.mutate())   # mutate() sets self.x = 999
```

passes `999` for the first argument under venom; legacy copies each argument into the args buffer before evaluating the next one and passes `1`. The same divergence affects complex arguments, e.g. `self.take(arr, arr.pop())` sees the shrunk array.

The fix freezes each argument as soon as it is evaluated — loading primitive words onto the stack, copying composites into a fresh temporary — whenever any later argument or kwarg expression can have side effects (conservatively: contains a call). Arguments without risky successors keep the lazy pointer, so the common case emits no extra copies. Staging buffers are still allocated only after all arguments are evaluated, preserving the existing protection against nested internal calls clobbering them.

### How to verify it

The added tests cover the internal-call scalar case, the internal-call complex (dynarray + `pop()`) case, and the extcall case, under both pipelines. All three fail on master with `--experimental-codegen` (e.g. `9990 != 10`, `203 != 303`) and pass with this fix.

### Commit message

```
in the codegen_venom pipeline, internal and external calls lower all
argument expressions before unwrapping and staging them. but lowering a
storage/memory variable yields a pointer, not a value -- no read is
emitted. if a later argument (or an extcall kwarg such as `value=`)
has side effects that mutate the location, the mutated value is read
during staging and passed to the callee:

    self.x = 1
    self.foo(self.x, self.mutate())  # mutate() sets self.x = 999

passes 999 for the first argument, whereas the legacy pipeline copies
each argument into the args buffer before evaluating the next one and
passes 1. the same divergence affects complex arguments, e.g.
`self.take(arr, arr.pop())` sees the shrunk array.

fix by freezing each argument as soon as it is evaluated -- loading
primitive words onto the stack and copying composites into a fresh
temporary -- whenever any later argument or kwarg expression can have
side effects (conservatively, contains a call). arguments without
risky successors keep the lazy pointer, avoiding gratuitous copies in
the common case. the staging buffers are still allocated only after all
arguments are evaluated, since nested internal calls may clobber them
(see the existing comment referencing legacy contains_self_call
handling).
```

### Description for the changelog

fix[venom]: fix call argument evaluation order

### Cute Animal Picture

![]()

