### PR TITLE
fix[tool]: include transitive interface imports in integrity sum

### DIFF
--- a/tests/unit/cli/vyper_compile/test_compile_files.py
+++ b/tests/unit/cli/vyper_compile/test_compile_files.py
@@ -3,7 +3,7 @@ import json
 import sys
 import warnings
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import pytest
 
@@ -11,7 +11,7 @@ from vyper.cli.compile_archive import compiler_data_from_zip
 from vyper.cli.vyper_compile import compile_files
 from vyper.cli.vyper_json import compile_from_input_dict, compile_json
 from vyper.compiler import INTERFACE_OUTPUT_FORMATS, OUTPUT_FORMATS
-from vyper.compiler.input_bundle import FilesystemInputBundle
+from vyper.compiler.input_bundle import FilesystemInputBundle, JSONInputBundle
 from vyper.compiler.output_bundle import OutputBundle
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import Settings
@@ -621,6 +621,57 @@ def test_integrity_sum(input_files):
     )
 
     assert out[contract_file]["integrity"] == integrity
+
+
+def _make_compiler_data(sources):
+    sources = {PurePath(path): {"content": content} for path, content in sources.items()}
+    input_bundle = JSONInputBundle(sources, search_paths=[PurePath(".")])
+    file_input = input_bundle.load_file(PurePath("main.vy"))
+    return CompilerData(file_input, input_bundle)
+
+
+# integrity sum must cover transitive imports of `.vyi` files (GH 5073)
+def test_integrity_sum_vyi_imports():
+    main_source = "import foo as Foo\n"
+    foo_source = """
+import bar
+
+@external
+def foobar():
+    ...
+"""
+    bar_source = """
+@external
+def bar_func():
+    ...
+"""
+    sources = {"main.vy": main_source, "foo.vyi": foo_source, "bar.vyi": bar_source}
+    compiler_data = _make_compiler_data(sources)
+
+    bar_hash = sha256sum(sha256sum(bar_source))
+    foo_hash = sha256sum(sha256sum(foo_source) + bar_hash)
+    expected = sha256sum(sha256sum(main_source) + foo_hash)
+    assert compiler_data.integrity_sum == expected
+
+    # changing a transitively imported interface changes the integrity sum
+    sources["bar.vyi"] = bar_source + "\n# comment\n"
+    compiler_data2 = _make_compiler_data(sources)
+    assert compiler_data.integrity_sum != compiler_data2.integrity_sum
+
+
+# integrity sum calculation should be linear in the size of the import
+# graph; diamond-shaped imports used to blow up exponentially (GH 5075)
+def test_integrity_sum_diamond_imports():
+    depth = 64
+    sources = {"main.vy": "import m0 as M\n", f"m{depth}.vy": ""}
+    for i in range(depth):
+        # m_i imports a_i and b_i, which both import m_{i+1}
+        sources[f"m{i}.vy"] = f"import a{i} as A\nimport b{i} as B\n"
+        sources[f"a{i}.vy"] = f"import m{i + 1} as M\n"
+        sources[f"b{i}.vy"] = f"import m{i + 1} as M\n"
+
+    compiler_data = _make_compiler_data(sources)
+    assert compiler_data.integrity_sum is not None
 
 
 # does this belong in tests/unit/compiler?

--- a/vyper/semantics/analysis/imports.py
+++ b/vyper/semantics/analysis/imports.py
@@ -103,6 +103,11 @@ class ImportAnalyzer:
 
         self._integrity_sum = None
 
+        # memoization for _calculate_integrity_sum_r. the import graph is
+        # a DAG, so without memoization the traversal is exponential in
+        # the presence of diamond-shaped imports.
+        self._integrity_cache: dict[int, str] = {}
+
         # should be all system paths + topmost module path
         self.absolute_search_paths = input_bundle.search_paths.copy()
 
@@ -115,16 +120,22 @@ class ImportAnalyzer:
         return self._compiler_inputs
 
     def _calculate_integrity_sum_r(self, module_ast: vy_ast.Module):
+        if id(module_ast) in self._integrity_cache:
+            return self._integrity_cache[id(module_ast)]
+
         acc = [sha256sum(module_ast.full_source_code)]
         for s in module_ast.get_children((vy_ast.Import, vy_ast.ImportFrom)):
             for info in s._metadata["import_infos"]:
-                if info.compiler_input.path.suffix in (".vyi", ".json"):
-                    # NOTE: this needs to be redone if interfaces can import other interfaces
+                if isinstance(info.compiler_input, JSONInput):
+                    # json (ABI) inputs cannot have imports; hash the input
                     acc.append(info.compiler_input.sha256sum)
                 else:
+                    # .vy and .vyi modules can have their own imports; recurse
                     acc.append(self._calculate_integrity_sum_r(info.parsed))
 
-        return sha256sum("".join(acc))
+        ret = sha256sum("".join(acc))
+        self._integrity_cache[id(module_ast)] = ret
+        return ret
 
     def _resolve_imports_r(self, module_ast: vy_ast.Module):
         if module_ast in self.seen:


### PR DESCRIPTION
### What I did

Fixes #5073, fixes #5075.

The integrity sum did not cover transitive imports of `.vyi` interfaces, so two compilations with different bytecode could have the same integrity hash (and a tampered archive would pass the integrity check silently). Additionally, the integrity traversal had no memoization, making it exponential on diamond-shaped import graphs.

### How I did it

`_calculate_integrity_sum_r` treated `.vyi` imports as leaves (hashing only the file's own contents). The `NOTE` in that branch — "this needs to be redone if interfaces can import other interfaces" — went stale with #4303, which made interface imports resolve recursively. Now the function recurses into everything that has an AST (`.vy` and `.vyi`); only json (ABI) inputs are leaves. The suffix check is replaced by an `isinstance(..., JSONInput)` check, which is the actual property that matters (json inputs have no module AST to recurse into).

Memoization is keyed on `id(module_ast)`, which is safe because ASTs are deduplicated per source file by `_ast_from_file` (and builtins by `_builtins_cache`) and kept alive by the analyzer.

Note: this changes integrity sums for projects that import `.vyi` files, so archives produced by older compiler versions will produce a one-time integrity warning when recompiled.

### How to verify it

- `test_integrity_sum_vyi_imports` asserts the new recursive structure and that editing a transitively imported `.vyi` changes the sum — it fails on master.
- `test_integrity_sum_diamond_imports` builds a depth-64 diamond chain; on master it effectively hangs (2^64 traversals), with the fix it completes instantly.

### Commit message

```
the integrity sum treated `.vyi` imports as leaves, hashing only the
interface file's own contents. this dates from when interfaces could not
import anything; since GH 4303, imports inside `.vyi` files are resolved
recursively, so anything reachable only through an interface was
invisible to the hash. two compilations with different bytecode could
report the same integrity sum, and tampered transitive sources in an
archive would pass the integrity check silently.

fix by recursing into `.vyi` modules the same way as `.vy` modules; only
json (ABI) inputs are true leaves. note this changes integrity sums for
projects which import `.vyi` files, so archives produced by older
compiler versions will produce a (one-time) integrity warning when
recompiled with fixed versions.

also memoize the traversal. the import graph is a DAG, and without
memoization the walk is exponential in the presence of diamond-shaped
imports, since shared modules are re-walked once per path through the
graph -- a ~50 module project could take seconds, a ~90 module project
hours.
```

### Description for the changelog

Fix: integrity sums now cover transitive imports of `.vyi` interface files, and integrity calculation is no longer exponential on diamond-shaped import graphs.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Red_Panda.JPG/960px-Red_Panda.JPG)
