### PR TITLE
fix[tool]: make integrity sum invariant to layout file formatting

### DIFF
--- a/tests/unit/cli/vyper_compile/test_compile_files.py
+++ b/tests/unit/cli/vyper_compile/test_compile_files.py
@@ -337,7 +337,9 @@ def bar(x: uint256) -> uint256:
         "a": {"type": "uint256", "n_slots": 1, "slot": 5},
         "b": {"type": "uint256", "n_slots": 1, "slot": 0},
     }
-    storage_layout_source = json.dumps(storage_layout_overrides)
+    # pretty-print to test that the integrity sum is invariant to the
+    # formatting of the storage layout file
+    storage_layout_source = json.dumps(storage_layout_overrides, indent=4)
 
     tmpdir = tmp_path_factory.mktemp("fake-package")
     with open(tmpdir / "lib.vy", "w") as f:
@@ -353,7 +355,7 @@ def bar(x: uint256) -> uint256:
     library_hash = sha256sum(library_source)
     jsonabi_hash = sha256sum(json_source)
     resolved_imports_hash = sha256sum(contract_hash + sha256sum(library_hash) + jsonabi_hash)
-    storage_layout_hash = sha256sum(storage_layout_source)
+    storage_layout_hash = sha256sum(json.dumps(storage_layout_overrides, sort_keys=True))
     expected_integrity = sha256sum(storage_layout_hash + resolved_imports_hash)
 
     return (
@@ -561,6 +563,27 @@ def test_solc_json_output(input_files):
     w = warn_data[Path("contract.vy")]
     assert len(w) == 1, [s.message for s in w]
     assert w[0].message.message.startswith(INTEGRITY_WARNING.format(integrity=integrity))
+
+
+# the integrity sum must not depend on the formatting of the storage
+# layout file, since formatting is not preserved by the solc_json output
+# format (GH 5074)
+def test_solc_json_storage_layout_integrity(input_files):
+    tmpdir, _, _, storage_layout_path, contract_file, integrity = input_files
+    search_paths = [".", tmpdir]
+
+    out = compile_files(
+        [contract_file],
+        ["solc_json"],
+        paths=search_paths,
+        storage_layout_paths=[storage_layout_path],
+    )
+    json_input = out[contract_file]["solc_json"]
+    assert json_input["integrity"] == integrity
+
+    # round-tripping thru standard json must not warn about the integrity sum
+    _, warn_data = compile_from_input_dict(json_input)
+    assert len(warn_data) == 0, [str(w.message) for ws in warn_data.values() for w in ws]
 
 
 # test that we can construct output bundles even when there is a semantic error

--- a/vyper/compiler/input_bundle.py
+++ b/vyper/compiler/input_bundle.py
@@ -68,6 +68,15 @@ class JSONInput(CompilerInput):
         s = json.loads(file_input.source_code)
         return cls(**asdict(file_input), data=s)
 
+    @cached_property
+    def canonical_sha256sum(self):
+        # like `sha256sum`, but hash a canonical serialization of the data
+        # rather than the raw file contents, so that the hash is invariant
+        # to the formatting of the input file. (formatting is not preserved
+        # by all input/output bundle types, e.g. solc-style json output
+        # round-trips json inputs through parse/serialize.)
+        return sha256sum(json.dumps(self.data, sort_keys=True))
+
     def __hash__(self):
         # don't use dataclass provided implementation
         return super().__hash__()

--- a/vyper/compiler/phases.py
+++ b/vyper/compiler/phases.py
@@ -151,7 +151,10 @@ class CompilerData:
 
     def _compute_integrity_sum(self, imports_integrity_sum: str) -> str:
         if self.storage_layout_override is not None:
-            layout_sum = self.storage_layout_override.sha256sum
+            # use canonical_sha256sum so that the integrity sum does not
+            # depend on the formatting of the storage layout file, which
+            # is not preserved by the solc_json output format
+            layout_sum = self.storage_layout_override.canonical_sha256sum
             return sha256sum(layout_sum + imports_integrity_sum)
         return imports_integrity_sum
 


### PR DESCRIPTION
### What I did

Fixes #5074.

A clean round trip through `-f solc_json` with a storage layout override produced a spurious `Mismatched integrity sum! ... (This likely indicates a corrupted archive)` warning (an outright failure with `-W error`).

### How I did it

The integrity sum hashed the layout override's raw file text, but `SolcJSONWriter` exports the *parsed* layout object and `vyper_json` reconstructs the contents with compact `json.dumps` — so any layout file whose formatting differs from compact `json.dumps` output (e.g. pretty-printed) broke the round trip. The `.vyz` archive format was unaffected since it stores raw bytes.

Fix: add `JSONInput.canonical_sha256sum`, which hashes a canonical serialization (`json.dumps(data, sort_keys=True)`) of the parsed data instead of the raw text, and use it for the layout component of the integrity sum. This makes the integrity sum invariant to layout file formatting across all input bundle types (filesystem, standard json, archive).

Note: this changes integrity sums for compilations that use a storage layout override, so archives produced by older compiler versions will produce a one-time integrity warning when recompiled.

### How to verify it

The `input_files` fixture now pretty-prints the layout file, and the new `test_solc_json_storage_layout_integrity` asserts a solc_json round trip produces no warnings. Both this test and the pre-existing `test_integrity_sum` fail on master with the pretty-printed fixture.

### Commit message

```
the integrity sum hashed the storage layout override's raw file text,
but the solc_json output format exports the parsed layout object and
`vyper_json` reconstructs the contents with compact `json.dumps`. any
layout file whose formatting differs from compact `json.dumps` output
(e.g. pretty-printed) therefore produced a spurious "Mismatched
integrity sum! (This likely indicates a corrupted archive)" warning on
a clean solc_json round trip -- or an outright failure with `-W error`.
(the .vyz archive format was unaffected, since it stores the raw file
bytes.)

fix by hashing a canonical serialization of the parsed layout data
instead of the raw text, making the integrity sum invariant to layout
file formatting across all input bundle types. note this changes
integrity sums for compilations which use a storage layout override,
so archives produced by older compiler versions will produce a
(one-time) integrity warning when recompiled with fixed versions.
```

### Description for the changelog

Fix: spurious integrity sum mismatch warning when round-tripping a compilation with storage layout overrides through the `solc_json` format.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Red_Panda_%2824986761703%29.jpg/960px-Red_Panda_%2824986761703%29.jpg)
