### PR TITLE
fix[tool]: validate storage layout overrides in standard json input

### DIFF
--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -326,16 +326,16 @@ def test_unknown_storage_layout_overrides(input_json):
 @pytest.mark.parametrize(
     "bad_override",
     [
-        # more than one override file for a single target
-        {
-            "foo_overrides.json": FOO_STORAGE_LAYOUT_OVERRIDES,
-            "bar_overrides.json": BAR_STORAGE_LAYOUT_OVERRIDES,
-        },
-        # not a dict
-        [FOO_STORAGE_LAYOUT_OVERRIDES],
-        "foo_overrides.json",
-        # empty dict
-        {},
+        pytest.param(
+            {
+                "foo_overrides.json": FOO_STORAGE_LAYOUT_OVERRIDES,
+                "bar_overrides.json": BAR_STORAGE_LAYOUT_OVERRIDES,
+            },
+            id="multiple-override-paths",
+        ),
+        pytest.param([FOO_STORAGE_LAYOUT_OVERRIDES], id="not-a-dict-list"),
+        pytest.param("foo_overrides.json", id="not-a-dict-string"),
+        pytest.param({}, id="empty-dict"),
     ],
 )
 def test_invalid_storage_layout_overrides(input_json, bad_override):

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -323,6 +323,28 @@ def test_unknown_storage_layout_overrides(input_json):
     assert e.value.args[0] == f"unknown target for storage layout override: {unknown_contract_path}"
 
 
+@pytest.mark.parametrize(
+    "bad_override",
+    [
+        # more than one override file for a single target
+        {
+            "foo_overrides.json": FOO_STORAGE_LAYOUT_OVERRIDES,
+            "bar_overrides.json": BAR_STORAGE_LAYOUT_OVERRIDES,
+        },
+        # not a dict
+        [FOO_STORAGE_LAYOUT_OVERRIDES],
+        "foo_overrides.json",
+        # empty dict
+        {},
+    ],
+)
+def test_invalid_storage_layout_overrides(input_json, bad_override):
+    input_json["storage_layout_overrides"] = {"contracts/foo.vy": bad_override}
+    with pytest.raises(JSONError) as e:
+        compile_json(input_json)
+    assert e.value.args[0] == f"invalid storage layout override: {bad_override}"
+
+
 def test_source_ids_increment(input_json):
     input_json["settings"]["outputSelection"] = {"*": ["ast", "evm.deployedBytecode.sourceMap"]}
     result = compile_json(input_json)

--- a/vyper/cli/vyper_json.py
+++ b/vyper/cli/vyper_json.py
@@ -218,7 +218,7 @@ def get_storage_layout_overrides(input_dict: dict) -> dict[PurePath, JSONInput]:
         if path not in input_dict["sources"]:
             raise JSONError(f"unknown target for storage layout override: {path}")
 
-        if not isinstance(value, dict) and len(value.items()) != 1:
+        if not isinstance(value, dict) or len(value) != 1:
             raise JSONError(f"invalid storage layout override: {value}")
         override_path, override_data = next(iter(value.items()))
         override_path = _normpath(override_path)


### PR DESCRIPTION
### What I did

Fixes #5076.

Fixed an operator precedence bug in `get_storage_layout_overrides` which made the storage layout override validation in standard json input ineffective.

### How I did it

```python
if not isinstance(value, dict) and len(value.items()) != 1:
```

short-circuits to `False` for any dict, so a multi-entry override dict passed validation and `next(iter(value.items()))` silently used the first entry, dropping the rest. A non-dict value (e.g. a list) crashed with `AttributeError` instead of raising a `JSONError`. Changed `and` to `or` (and `len(value.items())` to `len(value)`, which also rejects empty dicts before `next()` would raise `StopIteration`).

### How to verify it

New parametrized test `test_invalid_storage_layout_overrides` covers multi-entry dicts, non-dict values, and the empty dict — all four cases fail on master.

### Commit message

```
the validation in `get_storage_layout_overrides` used `and` where it
meant `or`, so the check never fired for dict values: an override with
multiple files for one target passed validation and all entries except
the first were silently dropped. non-dict values crashed with
`AttributeError` instead of raising `JSONError`.
```

### Description for the changelog

Fix: storage layout overrides in standard json input with multiple override files per target are now rejected instead of silently dropping all but the first.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Two_Red_Panda_Cubs_in_the_Tree_01.jpg/960px-Two_Red_Panda_Cubs_in_the_Tree_01.jpg)
