### PR TITLE
fix[lang]: fix off-by-one in storage allocator bounds check

### DIFF
--- a/tests/unit/semantics/test_storage_slots.py
+++ b/tests/unit/semantics/test_storage_slots.py
@@ -1,5 +1,6 @@
 import pytest
 
+from vyper.compiler import compile_code
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import StorageLayoutException
 
@@ -97,7 +98,7 @@ def test_reentrancy_lock(get_contract):
     assert c.h(0) == 123456789
 
 
-def test_allocator_overflow(get_contract):
+def test_allocator_exact_fit():
     # cancun allocates reeentrancy slot in transient storage,
     # so allocate an actual storage variable
     if version_check(begin="cancun"):
@@ -109,8 +110,50 @@ def test_allocator_overflow(get_contract):
 y: uint256[max_value(uint256)]
     """
 
+    # y exactly fills the remaining slots (1 through 2**256 - 1)
+    assert compile_code(code) is not None
+
+
+def test_allocator_overflow():
+    # like test_allocator_exact_fit, but y overflows storage by one slot
+    if version_check(begin="cancun"):
+        slots = "x: uint256\nz: uint256"
+    else:
+        slots = "z: uint256  # nonreentrancy slot at 0, z at 1"
+    code = f"""
+{slots}
+y: uint256[max_value(uint256)]
+    """
+
     with pytest.raises(
         StorageLayoutException,
-        match=f"Invalid storage slot, tried to allocate slots 1 through {2**256}",
+        match=f"Invalid storage slot, tried to allocate slots 2 through {2**256}",
     ):
-        get_contract(code)
+        compile_code(code)
+
+
+def test_immutables_exact_fit():
+    # immutables exactly fill the 0x6000 byte allocation limit (768 words)
+    code = """
+X: immutable(uint256[768])
+
+@deploy
+def __init__():
+    X = empty(uint256[768])
+    """
+    assert compile_code(code) is not None
+
+
+def test_immutables_overflow():
+    code = """
+X: immutable(uint256[769])
+
+@deploy
+def __init__():
+    X = empty(uint256[769])
+    """
+    with pytest.raises(
+        StorageLayoutException,
+        match=f"Invalid storage slot, tried to allocate slots 0 through {769 * 32 - 1}",
+    ):
+        compile_code(code)

--- a/vyper/semantics/analysis/data_positions.py
+++ b/vyper/semantics/analysis/data_positions.py
@@ -64,10 +64,12 @@ class SimpleAllocator:
 
     def allocate_slot(self, n, node=None):
         ret = self._slot
-        if self._slot + n >= self._max_slot:
+        # valid slots are [_starting_slot, _max_slot); this allocation
+        # uses slots [_slot, _slot + n)
+        if self._slot + n > self._max_slot:
             raise StorageLayoutException(
                 f"Invalid storage slot, tried to allocate"
-                f" slots {self._slot} through {self._slot + n}",
+                f" slots {self._slot} through {self._slot + n - 1}",
                 node,
             )
         self._slot += n


### PR DESCRIPTION
### What I did

Fixed an off-by-one in `SimpleAllocator.allocate_slot`: an allocation that exactly fills the available space was rejected, and the error message overstated the attempted range by one slot.

### How I did it

The allocator hands out slots `[_slot, _slot + n)`, so the last slot used is `_slot + n - 1` and the bound should be `_slot + n > _max_slot`, not `>=`. Concretely, on master:

- `X: immutable(uint256[768])` (exactly the `0x6000`-byte immutables limit) is rejected, while 767 words compiles;
- a storage array exactly filling slots `1 .. 2**256 - 1` is rejected with *"tried to allocate slots 1 through 115792…936"* — slot 2**256 was never part of the allocation.

With the fix, exact-fit allocations compile and the error message reports the true range (`_slot + n - 1`). One-slot-over allocations still fail, now with an accurate message.

### How to verify it

`test_allocator_exact_fit`, `test_allocator_overflow`, `test_immutables_exact_fit`, and `test_immutables_overflow` in `tests/unit/semantics/test_storage_slots.py`. The pre-existing `test_allocator_overflow` pinned the buggy boundary (its array exactly filled storage and was expected to fail); it is split into an exact-fit success case and a genuine overflow case.

### Commit message

```
the storage allocator hands out slots [_slot, _slot + n), so the last
slot used by an allocation is _slot + n - 1 -- but the bounds check
rejected _slot + n >= _max_slot, refusing allocations that exactly
fill the available space. concretely, immutables of exactly 0x6000
bytes (`uint256[768]`) and storage arrays exactly filling slots
1 through 2**256 - 1 were rejected. the error message also overstated
the attempted range by one slot.

relax the check to `>` and report the correct last slot in the error
message.
```

### Description for the changelog

Fix: storage and immutable allocations that exactly fill the available space are no longer rejected with an off-by-one bounds error.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Two_Red_Panda_Cubs_in_the_Tree_01.jpg/960px-Two_Red_Panda_Cubs_in_the_Tree_01.jpg)
