### PR TITLE
fix[venom]: fix bad uses in dload/mstore merge

### DIFF
--- a/tests/unit/compiler/venom/test_memmerging.py
+++ b/tests/unit/compiler/venom/test_memmerging.py
@@ -1687,3 +1687,54 @@ def test_merge_mstore_dload_disallowed():
     """
 
     _check_no_change(pre)
+
+
+def test_merge_mstore_dload_dst_disallowed():
+    """
+    Test that the dload/mstore merge does not fire when the only use of
+    the dload output is as the *destination* pointer of the mstore
+    (rather than the stored value).
+    """
+    pre = """
+    _global:
+        %par = source
+        %d = dload %par
+        mstore %d, 42
+        stop
+    """
+
+    _check_no_change(pre)
+
+
+def test_merge_mstore_dload_self_dst_disallowed():
+    """
+    Test that the dload/mstore merge does not fire when the dload output
+    is used both as the stored value and as the destination pointer of
+    the mstore (single-use path).
+    """
+    pre = """
+    _global:
+        %par = source
+        %d = dload %par
+        mstore %d, %d
+        stop
+    """
+
+    _check_no_change(pre)
+
+
+def test_merge_mstore_dload_self_dst_more_uses_disallowed():
+    """
+    Test that the dload/mstore merge does not fire when the dload output
+    is used both as the stored value and as the destination pointer of
+    the mstore (multi-use path).
+    """
+    pre = """
+    _global:
+        %par = source
+        %d = dload %par
+        mstore %d, %d
+        sink %d
+    """
+
+    _check_no_change(pre)

--- a/vyper/venom/passes/memmerging.py
+++ b/vyper/venom/passes/memmerging.py
@@ -559,7 +559,11 @@ class MemMergePass(IRPass):
                 mstore: IRInstruction = uses.first()
                 if mstore.opcode != "mstore":
                     continue
-                _, dst = mstore.operands
+                var, dst = mstore.operands
+                # the dload output must be the stored value, and must not
+                # be used as the destination pointer
+                if var != dload_out or dst == dload_out:
+                    continue
                 # merge simple
                 self.updater.update(mstore, "dloadbytes", [IRLiteral(32), src, dst])
                 self.updater.nop(dload)
@@ -582,7 +586,9 @@ class MemMergePass(IRPass):
 
             var, dst = mstore.operands
 
-            if var != dload_out:
+            # the dload output must be the stored value, and must not
+            # be used as the destination pointer
+            if var != dload_out or dst == dload_out:
                 continue
             new_var = bb.parent.get_next_variable()
 


### PR DESCRIPTION
### What I did

Fixes #5042.

`MemMergePass._merge_mstore_dload` assumed that when a `dload` result is consumed by an `mstore`, it is always the *value* being stored. When the dload output was actually the destination pointer (`mstore %d, 42`) — or both operands (`mstore %d, %d`) — the pass either rewrote the store to `dloadbytes`, dropping the stored value, and then crashed in `updater.nop` (the dload was still used), or silently emitted self-referential IR via `move_uses` (`%1 = mload %1`).

### How I did it

Both paths now validate operand roles (venom `mstore` operands are `[value, ptr]`): the single-use path unpacks the operands and skips unless the dload output is the stored value and is not the destination; the multi-use path's existing value-operand check is extended to also reject a destination that depends on the dload output.

### How to verify it

Three new tests next to `test_merge_mstore_dload_disallowed` cover destination-only, self-referential single-use, and self-referential multi-use shapes, all asserting no change. On master they fail with the assertion crash / malformed-IR mismatch described above. Full venom suite passes.

### Commit message

```
`MemMergePass._merge_mstore_dload` assumed the dload output is always
the value operand of the consuming mstore. when it was actually the
destination pointer (or both operands), the single-use path rewrote
the mstore to dloadbytes -- dropping the stored value -- and then
crashed in `updater.nop` because the dload still had uses; the
multi-use path could emit self-referential IR via `move_uses`.

validate operand roles in both paths: the dload output must be the
stored value and must not appear as the destination pointer.
```

### Description for the changelog

Fix: Venom memory merging validates operand roles before rewriting `dload`/`mstore` pairs to `dloadbytes`, fixing crashes and malformed IR when the loaded word is used as a store destination.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Two_Red_Panda_Cubs_in_the_Tree_01.jpg/960px-Two_Red_Panda_Cubs_in_the_Tree_01.jpg)
