### PR TITLE
fix[venom]: only kill mem liveness on must-write stores

### DIFF
--- a/tests/unit/compiler/venom/test_mem_liveness.py
+++ b/tests/unit/compiler/venom/test_mem_liveness.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for MemLivenessAnalysis.
+"""
+
+from tests.venom_utils import parse_from_basic_block
+from vyper.venom.analysis import IRAnalysesCache, MemLivenessAnalysis
+from vyper.venom.memory_location import Allocation
+
+
+def _analyze(pre: str):
+    ctx = parse_from_basic_block(pre)
+    fn = next(iter(ctx.functions.values()))
+    ac = IRAnalysesCache(fn)
+    mem_liveness = ac.request_analysis(MemLivenessAnalysis)
+    return fn, mem_liveness
+
+
+def _find_inst(fn, predicate):
+    for bb in fn.get_basic_blocks():
+        for inst in bb.instructions:
+            if predicate(inst):
+                return inst
+    raise AssertionError("instruction not found")
+
+
+def _alloca_by_var(fn, name):
+    inst = _find_inst(fn, lambda i: i.opcode == "alloca" and i.output.value == name)
+    return Allocation(inst)
+
+
+def test_may_write_through_phi_does_not_kill_liveness():
+    """
+    BasePtrAnalysis is a may-analysis: a phi-derived pointer resolves to
+    multiple candidate allocas. A full-size store through such a pointer
+    may write either alloca, so it must NOT kill liveness for any of them.
+
+    Here, killing %a's liveness at `mstore %p, 2` would make %a look dead
+    between `mstore %a, 1` and `mload %a`, allowing the allocator to
+    overlap %a with another buffer in that gap.
+    """
+    pre = """
+    main:
+        %a = alloca 32
+        %b = alloca 32
+        %cond = source
+        mstore %a, 1
+        jnz %cond, @left, @right
+    left:
+        jmp @join
+    right:
+        jmp @join
+    join:
+        %p = phi @left, %a, @right, %b
+        mstore %p, 2
+        %v = mload %a
+        sink %v
+    """
+    fn, mem_liveness = _analyze(pre)
+
+    alloc_a = _alloca_by_var(fn, "%a")
+    store_a = _find_inst(fn, lambda i: i.opcode == "mstore" and i.operands[1].value == "%a")
+
+    # %a must stay live across the ambiguous (may-write) store through %p,
+    # i.e. it is live at the earlier definite store to %a.
+    assert alloc_a in mem_liveness.liveat[store_a], (
+        "may-write through a phi-derived pointer must not kill liveness "
+        f"of candidate alloca %a: {mem_liveness.liveat[store_a]}"
+    )
+
+
+def test_must_write_kills_liveness():
+    """
+    Sanity check for the kill path: a full-size store through a pointer
+    that resolves to exactly one alloca is a must-write and DOES kill
+    liveness above it.
+    """
+    pre = """
+    main:
+        %a = alloca 32
+        %cond = source
+        mstore %a, 1
+        mstore %a, 2
+        %v = mload %a
+        sink %v
+    """
+    fn, mem_liveness = _analyze(pre)
+
+    alloc_a = _alloca_by_var(fn, "%a")
+    first_store = _find_inst(
+        fn, lambda i: i.opcode == "mstore" and getattr(i.operands[0], "value", None) == 1
+    )
+
+    # the second (full-size, must-write) store kills %a's liveness, so %a
+    # is not live at the first store.
+    assert alloc_a not in mem_liveness.liveat[first_store], mem_liveness.liveat[first_store]

--- a/vyper/venom/analysis/mem_liveness.py
+++ b/vyper/venom/analysis/mem_liveness.py
@@ -92,14 +92,24 @@ class MemLivenessAnalysis(IRAnalysis):
 
             self.liveat[inst] = live.copy()
 
-            for write_ptr in write_ptrs:
-                size = get_write_size(inst)
-                if not isinstance(size, IRLiteral):
-                    continue
+            # BasePtrAnalysis is a may-analysis: a pointer (e.g. derived
+            # through a phi) can resolve to multiple candidate allocas, and
+            # an unrecognized derivation resolves to the empty set. killing
+            # liveness is only sound for a must-write, i.e. when the pointer
+            # resolves to exactly one base alloca and the store overwrites
+            # the whole allocation. for multi-candidate or empty/unknown
+            # resolutions, skip the kill.
+            size = get_write_size(inst)
+            if len(write_ptrs) == 1 and isinstance(size, IRLiteral):
+                (write_ptr,) = write_ptrs
                 alloca = write_ptr.base_alloca
                 if alloca in live and size.value == alloca.alloca_size:
                     live.remove(alloca)
-                if alloca in (ptr.base_alloca for ptr in read_ptrs):
+
+            read_allocas = set(ptr.base_alloca for ptr in read_ptrs)
+            for write_ptr in write_ptrs:
+                alloca = write_ptr.base_alloca
+                if alloca in read_allocas:
                     live.add(alloca)
 
         return before != self.liveat[bb.instructions[0]]


### PR DESCRIPTION
### What I did

Fixes #5044.

`MemLivenessAnalysis` killed liveness for *every* candidate alloca returned by `BasePtrAnalysis` when it saw a full-size store. `BasePtrAnalysis` is a may-analysis: a phi-derived pointer can resolve to multiple candidate allocas, so the store is not a must-write to any single one of them. Killing all candidates can make an alloca look dead between a definite earlier write and a later read, feeding bad liveness facts into `ConcretizeMemLocPass` and potentially allowing buffer overlap.

### How I did it

The kill now fires only when the write pointer resolves to **exactly one** base alloca (a singleton may-result from a sound may-analysis is a must-write within that allocation) and the store size is a literal equal to the full allocation size (the pre-existing condition). Multi-candidate resolutions never kill; empty/unknown resolutions (unrecognized pointer derivations) are excluded by the same singleton check. The "mark live if also read by the same instruction" behavior now applies to all write candidates unconditionally — previously it was skipped for non-literal sizes — which is strictly more conservative.

### How to verify it

New `tests/unit/compiler/venom/test_mem_liveness.py`: `test_may_write_through_phi_does_not_kill_liveness` asserts directly on `liveat` that an alloca stays live across a full-size store through a phi over two allocas (fails on master), and `test_must_write_kills_liveness` pins that the kill path still fires for singleton resolutions. Full `tests/unit/compiler/` passes.

### Commit message

```
MemLivenessAnalysis killed liveness for every candidate alloca
returned by BasePtrAnalysis when a full-size store was seen. but
BasePtrAnalysis is a may-analysis: a phi-derived pointer can resolve
to multiple candidate allocas, and the store is not a must-write to
any single one of them. killing all candidates can make an alloca
look dead between an earlier definite write and a later read, feeding
unsound facts into memory allocation and allowing buffer overlap.

only kill liveness when the write pointer resolves to exactly one
base alloca (a singleton may-result is a must-write within that
allocation) and the store fully overwrites it. multi-candidate and
empty/unknown resolutions skip the kill; stores still mark their
candidate locations live.
```

### Description for the changelog

Fix: Venom memory liveness no longer treats ambiguous (may-write) stores as definite overwrites of all candidate allocations.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Red_Panda_%2824986761703%29.jpg/960px-Red_Panda_%2824986761703%29.jpg)
