### PR TITLE
fix[venom]: reject `abi_encode` with no arguments

### DIFF
--- a/tests/functional/builtins/codegen/test_abi_encode.py
+++ b/tests/functional/builtins/codegen/test_abi_encode.py
@@ -3,7 +3,6 @@ from eth.codecs import abi
 
 from tests.utils import decimal_to_int
 from vyper.compiler import compile_code
-from vyper.compiler.settings import Settings
 from vyper.exceptions import StructureException
 
 
@@ -397,13 +396,11 @@ def foo(ensure_tuple: bool) -> Bytes[96]:
     assert c.foo(True) == expected_output
 
 
-@pytest.mark.parametrize("use_venom", [False, True])
-def test_abi_encode_no_args(use_venom):
+def test_abi_encode_no_args():
     code = """
 @external
 def foo() -> Bytes[32]:
     return abi_encode()
     """
-    settings = Settings(experimental_codegen=use_venom)
     with pytest.raises(StructureException, match="abi_encode expects at least one argument"):
-        compile_code(code, settings=settings)
+        compile_code(code)

--- a/tests/functional/builtins/codegen/test_abi_encode.py
+++ b/tests/functional/builtins/codegen/test_abi_encode.py
@@ -2,6 +2,9 @@ import pytest
 from eth.codecs import abi
 
 from tests.utils import decimal_to_int
+from vyper.compiler import compile_code
+from vyper.compiler.settings import Settings
+from vyper.exceptions import StructureException
 
 
 # @pytest.mark.parametrize("string", ["a", "abc", "abcde", "potato"])
@@ -392,3 +395,15 @@ def foo(ensure_tuple: bool) -> Bytes[96]:
     assert c.foo(False) == expected_output
     expected_output = b"\x00" * 31 + b"\x20" + b"\x00" * 32
     assert c.foo(True) == expected_output
+
+
+@pytest.mark.parametrize("use_venom", [False, True])
+def test_abi_encode_no_args(use_venom):
+    code = """
+@external
+def foo() -> Bytes[32]:
+    return abi_encode()
+    """
+    settings = Settings(experimental_codegen=use_venom)
+    with pytest.raises(StructureException, match="abi_encode expects at least one argument"):
+        compile_code(code, settings=settings)

--- a/vyper/codegen_venom/builtins/abi.py
+++ b/vyper/codegen_venom/builtins/abi.py
@@ -15,7 +15,7 @@ from vyper.codegen.core import calculate_type_for_external_return
 from vyper.codegen_venom.abi import abi_decode_to_buf, abi_encode_to_buf
 from vyper.codegen_venom.buffer import Buffer, Ptr
 from vyper.codegen_venom.value import VyperValue
-from vyper.exceptions import CompilerPanic
+from vyper.exceptions import CompilerPanic, StructureException
 from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.types import BytesT, TupleT
 from vyper.utils import fourbytes_to_int
@@ -116,6 +116,9 @@ def lower_abi_encode(node: vy_ast.Call, ctx: VenomCodegenContext) -> VyperValue:
     - method_id: Optional 4-byte prefix (function selector)
     """
     from vyper.codegen_venom.expr import Expr
+
+    if len(node.args) < 1:
+        raise StructureException("abi_encode expects at least one argument", node)
 
     b = ctx.builder
 


### PR DESCRIPTION
### What I did

Fixes #5059.

The experimental Venom codegen accepted `abi_encode()` / `_abi_encode()` with zero positional arguments, building an empty tuple payload (or a bare selector with `method_id`), while legacy codegen rejects the shape with `StructureException("abi_encode expects at least one argument")`. Experimental codegen should not silently accept a larger source set.

### How I did it

Added the same `len(node.args) < 1` guard at the top of `lower_abi_encode` in `vyper/codegen_venom/builtins/abi.py`, raising the identical exception type and message as legacy (`vyper/builtins/functions.py`).

### How to verify it

`test_abi_encode_no_args` in `tests/functional/builtins/codegen/test_abi_encode.py`, parametrized over both pipelines via `Settings(experimental_codegen=...)`. The venom case fails on master ("DID NOT RAISE"); the legacy case pins existing behavior. Full `test_abi_encode.py` passes under both pipelines.

### Commit message

```
the venom codegen accepted `abi_encode()` with zero positional
arguments, building an empty tuple payload (or a bare selector with
method_id), while legacy codegen rejects the shape with a
StructureException. the rejection lives in codegen (semantic analysis
allows the shape through), so the venom path silently accepted a
larger source set.

add the same validation to `lower_abi_encode`, with the identical
exception type and message.
```

### Description for the changelog

Fix: experimental codegen rejects `abi_encode()` with no arguments, matching legacy.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Red_Panda.JPG/960px-Red_Panda.JPG)
