### PR TITLE
fix[venom]: order memtop after memory-expanding reads

### DIFF
--- a/tests/unit/compiler/venom/test_dft.py
+++ b/tests/unit/compiler/venom/test_dft.py
@@ -4,8 +4,8 @@ from vyper.venom.passes import DFTPass
 _check_pre_post = PrePostChecker([DFTPass])
 
 
-def _check_no_change(pre):
-    _check_pre_post(pre, pre)
+def _check_no_change(pre, hevm=None):
+    _check_pre_post(pre, pre, hevm=hevm)
 
 
 def test_dft():
@@ -25,3 +25,35 @@ def test_dft():
         return %x, %y
     """
     _check_pre_post(pre, post)
+
+
+def test_dft_memtop_stays_after_memory_read():
+    """
+    `memtop` lowers to MSIZE, and memory reads (like mload) can expand
+    memory, advancing MSIZE. DFT must not schedule `memtop` before a
+    prior memory read.
+    """
+    pre = """
+    main:
+        %ptr = source
+        %v = mload %ptr
+        %m = memtop
+        sink %v, %m
+    """
+    # hevm does not model msize-dependent equivalence
+    _check_no_change(pre, hevm=False)
+
+
+def test_dft_memory_read_stays_after_memtop():
+    """
+    The converse direction: a memory read scheduled before a prior
+    `memtop` could expand memory and change the observed MSIZE.
+    """
+    pre = """
+    main:
+        %ptr = source
+        %m = memtop
+        %v = mload %ptr
+        sink %m, %v
+    """
+    _check_no_change(pre, hevm=False)

--- a/vyper/venom/effects.py
+++ b/vyper/venom/effects.py
@@ -8,6 +8,7 @@ class Effects(Flag):
     STORAGE = auto()
     TRANSIENT = auto()
     MEMORY = auto()
+    MSIZE = auto()
     IMMUTABLES = auto()
     RETURNDATA = auto()
     LOG = auto()
@@ -30,6 +31,7 @@ ALL = ~EMPTY
 STORAGE = Effects.STORAGE
 TRANSIENT = Effects.TRANSIENT
 MEMORY = Effects.MEMORY
+MSIZE = Effects.MSIZE
 IMMUTABLES = Effects.IMMUTABLES
 RETURNDATA = Effects.RETURNDATA
 LOG = Effects.LOG
@@ -39,7 +41,19 @@ NON_MEMORY_EFFECTS = ~Effects.MEMORY
 NON_STORAGE_EFFECTS = ~Effects.STORAGE
 NON_TRANSIENT_EFFECTS = ~Effects.TRANSIENT
 
+# MSIZE models the EVM memory high-water mark, which is observed by
+# `memtop` (lowered to the MSIZE opcode). any memory access -- read or
+# write -- can expand memory and therefore bump msize. memory expansion
+# commutes (msize is monotonically non-decreasing), so memory-touching
+# instructions can be freely reordered with each other as far as msize is
+# concerned, but `memtop` must not cross any of them. we model this by
+# making `memtop` *write* MSIZE and making instructions which read memory
+# (without writing it) *read* MSIZE: this serializes `memtop` against
+# memory reads in both directions while leaving the reads free to commute
+# with each other. instructions which write MEMORY are already serialized
+# against `memtop` through its MEMORY read effect.
 _writes = {
+    "memtop": MSIZE,
     "sstore": STORAGE,
     "tstore": TRANSIENT,
     "mstore": MEMORY,
@@ -63,8 +77,8 @@ _writes = {
 _reads = {
     "sload": STORAGE,
     "tload": TRANSIENT,
-    "iload": IMMUTABLES | MEMORY,
-    "mload": MEMORY,
+    "iload": IMMUTABLES | MEMORY | MSIZE,
+    "mload": MEMORY | MSIZE,
     "mcopy": MEMORY,
     "call": ALL,
     "delegatecall": ALL,
@@ -80,11 +94,11 @@ _reads = {
     "extcodesize": EXTCODE,
     "extcodehash": EXTCODE,
     "selfdestruct": BALANCE,  # may modify code, but after the transaction
-    "log": MEMORY,
-    "revert": MEMORY,
-    "sha3": MEMORY,
-    "return": MEMORY,
-    "memtop": MEMORY,  # lowers to MSIZE; depends on all prior memory writes
+    "log": MEMORY | MSIZE,
+    "revert": MEMORY | MSIZE,
+    "sha3": MEMORY | MSIZE,
+    "return": MEMORY | MSIZE,
+    "memtop": MEMORY,  # lowers to MSIZE; depends on all prior memory accesses
 }
 
 reads = _reads.copy()


### PR DESCRIPTION
### What I did

Fixes #5071.

`memtop` lowers to `MSIZE`, but DFT only serialized it against memory *writes*, so it could be scheduled before a memory-expanding *read* — `[source, mload, memtop, sink]` reordered to `[source, memtop, mload, sink]` (and reads could equally be hoisted above a memtop). EVM memory reads expand memory when they touch beyond the high-water mark, so the reorder changes the observed value.

### How I did it

Added an `MSIZE` effect with an intentionally "inverted" orientation: `memtop` *writes* MSIZE, and instructions that read memory without writing it (`mload`, `iload`, `sha3`, `log`, `return`, `revert`; the call/create/invoke families inherit via `ALL`) *read* MSIZE. Memory expansion commutes — msize is a monotonic high-water mark — so reads stay freely reorderable with each other, while `memtop` is serialized against them in both directions (reads-before-write and read-after-write edges). Memory writers were already ordered against `memtop` through its existing MEMORY read effect, which also covers `mcopy` and the copy opcodes.

The "honest" model (readers write MSIZE, memtop reads it) was rejected: DFT's write-after-write rule would chain every pair of memory-touching instructions — a real scheduling regression — and it would pessimize CSE and DSE. Audited all `get_read_effects`/`get_write_effects` consumers (DSE, CSE/available-expression, load elimination, mem-SSA, memmerging, copy elision, assert combiner): no store opcode gains effects and `mload` keeps empty overlap effects, so eligibility and CSE-ability are untouched; existing memtop CSE tests still pass.

### How to verify it

`test_dft_memtop_stays_after_memory_read` and `test_dft_memory_read_stays_after_memtop` in `tests/unit/compiler/venom/test_dft.py`; both fail on master. Full `tests/unit/compiler/` passes.

### Commit message

```
`memtop` lowers to MSIZE, which observes the memory high-water mark.
DFT serialized memtop only against memory writes, so it could be
scheduled across a memory-expanding *read* (e.g. mload past the
high-water mark), changing the observed value.

add an MSIZE effect: memtop writes it, and memory-reading
instructions read it. memory expansion commutes (msize is monotonic),
so reads remain freely reorderable with each other, while memtop is
ordered against them in both directions. memory writers were already
ordered against memtop via its MEMORY read effect.

the inverse orientation (readers write MSIZE) would serialize every
pair of memory-touching instructions via the write-after-write rule
and pessimize CSE/DSE; this orientation adds no new constraints
between ordinary instructions.
```

### Description for the changelog

Fix: Venom instruction scheduling no longer moves `msize` observations across memory-expanding reads.

### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Red_Panda.JPG/960px-Red_Panda.JPG)
