### PR TITLE
fix[tool]: make decimal precision thread-independent

### DIFF
--- a/tests/unit/utils/test_decimal_context.py
+++ b/tests/unit/utils/test_decimal_context.py
@@ -1,0 +1,25 @@
+import decimal
+import threading
+
+from tests.utils import parse_and_fold
+
+
+def test_decimal_precision_in_worker_thread():
+    # decimal contexts are thread-local; threads other than the one which
+    # imported vyper must also evaluate decimals at full precision, not
+    # the stdlib default of 28 significant digits
+    results = {}
+
+    def fold():
+        try:
+            vyper_ast = parse_and_fold("12345678901234567890.1234567890 + 0.0000000001")
+            results["value"] = vyper_ast.body[0].value.get_folded_value().value
+        except Exception as e:  # pragma: nocover
+            results["error"] = e
+
+    t = threading.Thread(target=fold)
+    t.start()
+    t.join()
+
+    assert "error" not in results, results.get("error")
+    assert results["value"] == decimal.Decimal("12345678901234567890.1234567891")

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -223,11 +223,10 @@ class DecimalContextOverride(decimal.Context):
 decimal.setcontext(DecimalContextOverride(prec=78))
 
 # contexts are thread-local; a thread which has not called setcontext()
-# gets a context copied from the `DefaultContext` template on first use.
-# mutate the template so that threads spawned later (e.g. compiling in a
-# thread pool) also get 78 digits of precision instead of the stdlib
-# default of 28, which silently rounds decimal constants wider than 28
-# significant digits.
+# gets a context copied from the original `DefaultContext` template on
+# first use. Mutate that template in place instead of rebinding
+# `decimal.DefaultContext`, which the C decimal module does not use for
+# seeding new thread contexts.
 decimal.DefaultContext.prec = 78
 
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -219,7 +219,16 @@ class DecimalContextOverride(decimal.Context):
         super().__setattr__(name, value)
 
 
+# set the context for the thread which imports vyper
 decimal.setcontext(DecimalContextOverride(prec=78))
+
+# contexts are thread-local; a thread which has not called setcontext()
+# gets a context copied from the `DefaultContext` template on first use.
+# mutate the template so that threads spawned later (e.g. compiling in a
+# thread pool) also get 78 digits of precision instead of the stdlib
+# default of 28, which silently rounds decimal constants wider than 28
+# significant digits.
+decimal.DefaultContext.prec = 78
 
 
 def keccak256(x):


### PR DESCRIPTION
### What I did

Fix #5105: decimal contexts are thread-local, so `decimal.setcontext(DecimalContextOverride(prec=78))` in `vyper/utils.py` only configures the thread which imports vyper. Compiling on any other thread (e.g. in a thread pool) silently used the stdlib default of 28 significant digits, rounding decimal constants wider than 28 digits -- the same source compiled to different bytecode depending on the calling thread.

### How I did it

Also mutate the `decimal.DefaultContext` template. Threads which haven't called `setcontext()` copy their context from this template on first use, so threads spawned after vyper is imported get prec=78 as well. (A thread whose decimal context was already initialized before the vyper import still keeps the default precision -- fully closing that would require running all decimal arithmetic under an explicit context, which seems not worth the invasiveness.)

### How to verify it

`tests/unit/utils/test_decimal_context.py` folds `12345678901234567890.1234567890 + 0.0000000001` on a fresh worker thread and checks the exact result. Without the fix it folds to `...67900` (rounded half-even at 28 significant digits) instead of `...67891`, and the repro in #5105 produces different bytecode on main vs. worker threads.

### Commit message

```text
decimal.setcontext() only applies to the thread which imports
vyper.utils. compiling on any other thread (e.g. in a thread pool)
silently used the stdlib default context of 28 significant digits,
rounding decimal constants wider than 28 digits and producing
different bytecode for the same source depending on the calling
thread.

also mutate the decimal.DefaultContext template, which threads
created later copy their context from on first use.
```

### Description for the changelog

Decimal constants are now evaluated at full precision regardless of which thread runs the compiler.

### Cute Animal Picture

![dog](https://upload.wikimedia.org/wikipedia/commons/3/34/Labrador_on_Quantock_%282175262184%29.jpg)

