### PR TITLE
chore[test]: add convert() pipeline parity and boundary tests

### DIFF
--- a/tests/functional/builtins/codegen/test_convert.py
+++ b/tests/functional/builtins/codegen/test_convert.py
@@ -818,3 +818,69 @@ def test_convert() -> uint256:
     """  # noqa: E501
     c = get_contract(code)
     assert c.test_convert() == 42
+
+
+FLAG_PREAMBLE = """
+flag Roles:
+    ADMIN
+    USER
+"""
+
+# conversions which the venom pipeline accepted due to missing input
+# validation (GH 5111, GH 5019). the conversion matrix is shared between
+# pipelines, so both must reject these at compile time.
+ILLEGAL_CONVERSIONS = [
+    ("String[20]", "uint256"),
+    ("String[20]", "address"),
+    ("Roles", "uint8"),
+    ("Roles", "bool"),
+    ("Roles", "decimal"),
+    ("uint8", "Roles"),
+    ("bytes32", "Roles"),
+    ("bool", "Roles"),
+    ("bool", "address"),
+    ("address", "decimal"),
+    ("address", "int256"),
+    ("decimal", "address"),
+    ("decimal", "Roles"),
+]
+
+
+@pytest.mark.parametrize("i_typ,o_typ", ILLEGAL_CONVERSIONS)
+@pytest.mark.parametrize("use_venom", [False, True])
+def test_illegal_conversions_blocked(i_typ, o_typ, use_venom):
+    preamble = FLAG_PREAMBLE if "Roles" in (i_typ, o_typ) else ""
+    code = f"""{preamble}
+@external
+def foo(x: {i_typ}) -> {o_typ}:
+    return convert(x, {o_typ})
+    """
+    settings = Settings(experimental_codegen=use_venom, enable_decimals=True)
+    # compile bytecode only: other output formats run the legacy pipeline
+    # even when experimental_codegen is set, masking venom-only bugs
+    with pytest.raises(TypeMismatch):
+        compile_code(code, output_formats=("bytecode",), settings=settings)
+
+
+def test_int_to_decimal_clamp_bounds(get_contract, tx_failed):
+    code = """
+@external
+def foo(x: int256) -> decimal:
+    return convert(x, decimal)
+    """
+    c = get_contract(code)
+
+    # the largest-magnitude integers whose promotion stays within the
+    # decimal range: MIN/MAX raw decimal divided by the divisor, rounded
+    # towards zero. flooring instead admits one extra negative value
+    # whose scaled result lands below the decimal lower bound (GH 5110).
+    bound = 18707220957835557353007165858768422651595
+    assert -(2**167) // DECIMAL_DIVISOR == -bound - 1  # floor differs from truncation
+
+    assert c.foo(bound) == bound * DECIMAL_DIVISOR
+    assert c.foo(-bound) == -bound * DECIMAL_DIVISOR
+
+    with tx_failed():
+        c.foo(bound + 1)
+    with tx_failed():
+        c.foo(-bound - 1)

--- a/tests/functional/builtins/codegen/test_convert_pipeline_parity.py
+++ b/tests/functional/builtins/codegen/test_convert_pipeline_parity.py
@@ -1,0 +1,154 @@
+"""
+Differential tests: the legacy and venom pipelines must agree on which
+`convert()` programs are valid, and on the runtime clamp behavior at the
+boundaries of every numeric conversion.
+
+Note these tests compile bytecode-only, on purpose: several output
+formats (ir_dict, metadata, abi) run the *legacy* codegen even under
+`--experimental-codegen`, so multi-format compilation (as used by most
+fixtures) lets legacy validation mask venom accepts-invalid bugs.
+"""
+
+import itertools
+
+import pytest
+
+from vyper.compiler import compile_code
+from vyper.compiler.settings import Settings
+from vyper.exceptions import VyperException
+from vyper.semantics.types import DecimalT, IntegerT
+from vyper.utils import evm_div
+
+INT_TYPES = ["uint8", "int8", "uint128", "int128", "uint160", "uint256", "int256"]
+BYTES_M_TYPES = ["bytes1", "bytes4", "bytes20", "bytes21", "bytes32"]
+SCALAR_TYPES = ["decimal", "bool", "address"]
+BYTESTRING_TYPES = ["Bytes[20]", "Bytes[32]", "Bytes[33]", "String[20]", "String[32]", "String[33]"]
+FLAG_TYPES = ["Roles"]
+
+ALL_TYPES = INT_TYPES + BYTES_M_TYPES + SCALAR_TYPES + BYTESTRING_TYPES + FLAG_TYPES
+
+FLAG_PREAMBLE = """
+flag Roles:
+    ADMIN
+    USER
+    GUEST
+"""
+
+
+def _make_code(i_typ, o_typ):
+    preamble = FLAG_PREAMBLE if "Roles" in (i_typ, o_typ) else ""
+    return f"""{preamble}
+@external
+def foo(x: {i_typ}) -> {o_typ}:
+    return convert(x, {o_typ})
+    """
+
+
+def _compile_verdict(code, use_venom):
+    settings = Settings(experimental_codegen=use_venom, enable_decimals=True)
+    try:
+        compile_code(code, output_formats=("bytecode",), settings=settings)
+        return "accept"
+    except VyperException as e:
+        return type(e).__name__
+
+
+@pytest.mark.parametrize(
+    "i_typ,o_typ", [(i, o) for i, o in itertools.product(ALL_TYPES, ALL_TYPES) if i != o]
+)
+def test_convert_acceptance_parity(i_typ, o_typ):
+    """
+    Both pipelines accept the same convert() programs and reject with the
+    same exception type.
+    """
+    code = _make_code(i_typ, o_typ)
+    legacy = _compile_verdict(code, use_venom=False)
+    venom = _compile_verdict(code, use_venom=True)
+    assert legacy == venom, f"{i_typ} -> {o_typ}: legacy={legacy} venom={venom}"
+
+
+def _parse_int(name):
+    return IntegerT(name.startswith("i"), int(name.replace("uint", "").replace("int", "")))
+
+
+def _conversion_window(i_typ, o_typ):
+    """
+    The legal input window for convert(x, o_typ), in x's raw representation,
+    plus a function mapping an in-window raw input to the expected raw output.
+    """
+    if isinstance(i_typ, IntegerT) and isinstance(o_typ, DecimalT):
+        in_lo, in_hi = i_typ.int_bounds
+        out_lo, out_hi = o_typ.int_bounds
+        divisor = o_typ.divisor
+        lo = max(in_lo, evm_div(out_lo, divisor))
+        hi = min(in_hi, evm_div(out_hi, divisor))
+        return lo, hi, lambda x: x * divisor
+
+    if isinstance(i_typ, DecimalT) and isinstance(o_typ, IntegerT):
+        in_lo, in_hi = i_typ.int_bounds
+        out_lo, out_hi = o_typ.int_bounds
+        divisor = i_typ.divisor
+        lo = max(in_lo, out_lo * divisor)
+        hi = min(in_hi, out_hi * divisor)
+        return lo, hi, lambda x: evm_div(x, divisor)
+
+    assert isinstance(i_typ, IntegerT) and isinstance(o_typ, IntegerT)
+    in_lo, in_hi = i_typ.int_bounds
+    out_lo, out_hi = o_typ.int_bounds
+    return max(in_lo, out_lo), min(in_hi, out_hi), lambda x: x
+
+
+NUMERIC_PAIRS = [
+    ("int256", "decimal"),
+    ("uint256", "decimal"),
+    ("int128", "decimal"),
+    ("decimal", "int256"),
+    ("decimal", "uint256"),
+    ("decimal", "int8"),
+    ("decimal", "uint8"),
+    ("int256", "uint8"),
+    ("int256", "int8"),
+    ("int256", "uint256"),
+    ("uint256", "int256"),
+    ("uint256", "uint8"),
+    ("int8", "int256"),
+    ("int8", "uint256"),
+]
+
+
+@pytest.mark.parametrize("i_name,o_name", NUMERIC_PAIRS)
+def test_numeric_convert_boundaries(get_contract, tx_failed, i_name, o_name):
+    """
+    Exact behavior at the edges of the legal input window: the boundary
+    values convert to the expected result, one past them reverts.
+
+    Runs under whichever pipeline the session selects, so CI exercises
+    both. Regression test for GH 5110 (int->decimal lower bound off by
+    one under venom).
+    """
+
+    def parse(name):
+        return DecimalT() if name == "decimal" else _parse_int(name)
+
+    i_typ, o_typ = parse(i_name), parse(o_name)
+
+    code = f"""
+@external
+def foo(x: {i_name}) -> {o_name}:
+    return convert(x, {o_name})
+    """
+    c = get_contract(code)
+
+    lo, hi, expected = _conversion_window(i_typ, o_typ)
+    in_lo, in_hi = i_typ.int_bounds
+
+    assert c.foo(lo) == expected(lo)
+    assert c.foo(hi) == expected(hi)
+
+    # one past each boundary must revert, when representable in the input type
+    if lo - 1 >= in_lo:
+        with tx_failed():
+            c.foo(lo - 1)
+    if hi + 1 <= in_hi:
+        with tx_failed():
+            c.foo(hi + 1)

--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -3,6 +3,11 @@ import functools
 import math
 
 from vyper import ast as vy_ast
+from vyper.builtins._convert_rules import (
+    fixed_to_int_clamp_bounds,
+    int_to_fixed_clamp_bounds,
+    validate_convertibility,
+)
 from vyper.codegen.core import (
     LOAD,
     IRnode,
@@ -31,20 +36,11 @@ from vyper.exceptions import (
     StructureException,
     TypeMismatch,
 )
-from vyper.semantics.types import (
-    AddressT,
-    BoolT,
-    BytesM_T,
-    BytesT,
-    DecimalT,
-    FlagT,
-    IntegerT,
-    StringT,
-)
+from vyper.semantics.types import AddressT, BoolT, BytesT, StringT
 from vyper.semantics.types.bytestrings import _BytestringT
 from vyper.semantics.types.infinity import is_bounded_length
 from vyper.semantics.types.shortcuts import INT256_T, UINT160_T, UINT256_T
-from vyper.utils import DECIMAL_DIVISOR, round_towards_zero, unsigned_to_signed
+from vyper.utils import DECIMAL_DIVISOR, unsigned_to_signed
 
 
 def _FAIL(ityp, otyp, source_expr=None):
@@ -53,27 +49,24 @@ def _FAIL(ityp, otyp, source_expr=None):
     raise TypeMismatch(f"Can't convert {ityp} to {otyp}", source_expr)
 
 
-def _input_types(*allowed_types):
-    def decorator(f):
-        @functools.wraps(f)
-        def check_input_type(expr, arg, out_typ):
-            # convert arg to out_typ.
-            # (expr is the AST corresponding to `arg`)
-            ok = isinstance(arg.typ, allowed_types)
-            if not ok:
-                _FAIL(arg.typ, out_typ, expr)
+def _validate_inputs(f):
+    # validate convert(arg, out_typ) against the shared conversion matrix.
+    # (expr is the AST corresponding to `arg`)
+    @functools.wraps(f)
+    def check_input_type(expr, arg, out_typ):
+        # user safety: disallow convert from type to itself
+        # note allowance of [u]int256; this is due to type inference
+        # on literals not quite working yet.
+        # (checked before the conversion matrix so that same-type errors
+        # keep raising InvalidType rather than TypeMismatch.)
+        if arg.typ == out_typ and arg.typ not in (UINT256_T, INT256_T):
+            raise InvalidType(f"value and target are both {out_typ}", expr)
 
-            # user safety: disallow convert from type to itself
-            # note allowance of [u]int256; this is due to type inference
-            # on literals not quite working yet.
-            if arg.typ == out_typ and arg.typ not in (UINT256_T, INT256_T):
-                raise InvalidType(f"value and target are both {out_typ}", expr)
+        validate_convertibility(arg.typ, out_typ, expr)
 
-            return f(expr, arg, out_typ)
+        return f(expr, arg, out_typ)
 
-        return check_input_type
-
-    return decorator
+    return check_input_type
 
 
 def _bytes_to_num(arg, out_typ, signed):
@@ -126,9 +119,7 @@ def _fixed_to_int(arg, out_typ):
 
     # block inputs which are out of bounds before truncation.
     # e.g., convert(255.1, uint8) should revert or fail to compile.
-    out_lo, out_hi = out_typ.int_bounds
-    out_lo *= DIVISOR
-    out_hi *= DIVISOR
+    out_lo, out_hi = fixed_to_int_clamp_bounds(arg.typ, out_typ)
 
     arg_bounds = arg.typ.int_bounds
 
@@ -143,9 +134,7 @@ def _int_to_fixed(arg, out_typ):
     DIVISOR = out_typ.divisor
 
     # block inputs which are out of bounds before promotion
-    out_lo, out_hi = out_typ.int_bounds
-    out_lo = round_towards_zero(out_lo / decimal.Decimal(DIVISOR))
-    out_hi = round_towards_zero(out_hi / decimal.Decimal(DIVISOR))
+    out_lo, out_hi = int_to_fixed_clamp_bounds(out_typ)
 
     arg_bounds = arg.typ.int_bounds
 
@@ -268,7 +257,7 @@ def _literal_decimal(expr, arg_typ, out_typ):
 
 
 # any base type or bytes/string
-@_input_types(IntegerT, DecimalT, BytesM_T, AddressT, BoolT, BytesT, StringT)
+@_validate_inputs
 def to_bool(expr, arg, out_typ):
     _check_bytes(expr, arg, out_typ, 32)  # should we restrict to Bytes[1]?
 
@@ -282,7 +271,7 @@ def to_bool(expr, arg, out_typ):
     return IRnode.from_list(["iszero", ["iszero", arg]], typ=out_typ)
 
 
-@_input_types(IntegerT, DecimalT, BytesM_T, AddressT, BoolT, FlagT, BytesT)
+@_validate_inputs
 def to_int(expr, arg, out_typ):
     return _to_int(expr, arg, out_typ)
 
@@ -331,7 +320,7 @@ def _to_int(expr, arg, out_typ):
     return IRnode.from_list(arg, typ=out_typ)
 
 
-@_input_types(IntegerT, BoolT, BytesM_T, BytesT)
+@_validate_inputs
 def to_decimal(expr, arg, out_typ):
     _check_bytes(expr, arg, out_typ, 32)
 
@@ -368,7 +357,7 @@ def to_decimal(expr, arg, out_typ):
         raise CompilerPanic("unreachable")
 
 
-@_input_types(IntegerT, DecimalT, BytesM_T, AddressT, BytesT, BoolT)
+@_validate_inputs
 def to_bytes_m(expr, arg, out_typ):
     _check_bytes(expr, arg, out_typ, max_bytes_allowed=out_typ.m)
 
@@ -416,7 +405,7 @@ def to_bytes_m(expr, arg, out_typ):
     return IRnode.from_list(arg, typ=out_typ)
 
 
-@_input_types(BytesM_T, IntegerT, BytesT)
+@_validate_inputs
 def to_address(expr, arg, out_typ):
     # question: should this be allowed?
     if is_integer_type(arg.typ):
@@ -444,17 +433,17 @@ def _cast_bytestring(expr, arg, out_typ):
 
 
 # question: should we allow bytesM -> String?
-@_input_types(BytesT, StringT)
+@_validate_inputs
 def to_string(expr, arg, out_typ):
     return _cast_bytestring(expr, arg, out_typ)
 
 
-@_input_types(StringT, BytesT)
+@_validate_inputs
 def to_bytes(expr, arg, out_typ):
     return _cast_bytestring(expr, arg, out_typ)
 
 
-@_input_types(IntegerT)
+@_validate_inputs
 def to_flag(expr, arg, out_typ):
     if arg.typ != UINT256_T:
         _FAIL(arg.typ, out_typ, expr)

--- a/vyper/builtins/_convert_rules.py
+++ b/vyper/builtins/_convert_rules.py
@@ -1,0 +1,115 @@
+"""
+Shared `convert()` rules: which conversions are legal, and the numeric
+bounds used to clamp conversion inputs.
+
+This is the single source of truth for both codegen backends (legacy
+`vyper/builtins/_convert.py` and venom-direct
+`vyper/codegen_venom/builtins/convert.py`). Keeping the conversion
+matrix in one backend-neutral module prevents the two pipelines from
+diverging on which programs are valid (GH 4987, GH 5019, GH 5111).
+
+This module must not import from either codegen package.
+"""
+
+from vyper.exceptions import StructureException, TypeMismatch
+from vyper.semantics.types import (
+    AddressT,
+    BoolT,
+    BytesM_T,
+    BytesT,
+    DecimalT,
+    FlagT,
+    IntegerT,
+    StringT,
+)
+from vyper.semantics.types.bytestrings import _BytestringT
+from vyper.semantics.types.shortcuts import UINT256_T
+from vyper.utils import evm_div
+
+# allowed input type classes, keyed by output type class
+_ALLOWED_CONVERSIONS: dict[type, tuple[type, ...]] = {
+    BoolT: (IntegerT, DecimalT, BytesM_T, AddressT, BoolT, BytesT, StringT),
+    AddressT: (BytesM_T, IntegerT, BytesT),
+    IntegerT: (IntegerT, DecimalT, BytesM_T, AddressT, BoolT, FlagT, BytesT),
+    DecimalT: (IntegerT, BoolT, BytesM_T, BytesT),
+    BytesM_T: (IntegerT, DecimalT, BytesM_T, AddressT, BytesT, BoolT),
+    BytesT: (StringT, BytesT),
+    StringT: (BytesT, StringT),
+    FlagT: (IntegerT,),
+}
+
+
+def _fail(in_typ, out_typ, node=None):
+    raise TypeMismatch(f"Can't convert {in_typ} to {out_typ}", node)
+
+
+def validate_convertibility(in_typ, out_typ, node=None):
+    """
+    Validate that `convert(<in_typ>, <out_typ>)` is a legal conversion,
+    raising TypeMismatch (or StructureException for unsupported target
+    types) otherwise.
+
+    Only rules which are pure functions of the type pair live here;
+    value-dependent rules (e.g. literal range checks) stay in codegen.
+    """
+    allowed = _ALLOWED_CONVERSIONS.get(type(out_typ))
+    if allowed is None:
+        raise StructureException(f"Conversion to {out_typ} is invalid.", node)
+
+    if not isinstance(in_typ, allowed):
+        _fail(in_typ, out_typ, node)
+
+    if isinstance(in_typ, _BytestringT) and not isinstance(out_typ, _BytestringT):
+        # bytestring inputs must fit in the output word
+        max_bytes = out_typ.m if isinstance(out_typ, BytesM_T) else 32
+        if in_typ.maxlen > max_bytes:
+            _fail(in_typ, out_typ, node)
+
+    if isinstance(out_typ, _BytestringT):
+        # widening a bytestring within the same class is not a real
+        # conversion -- the assignment is already legal without convert()
+        if isinstance(in_typ, type(out_typ)) and in_typ.maxlen <= out_typ.maxlen:
+            _fail(in_typ, out_typ, node)
+
+    # flags only convert to and from uint256
+    if isinstance(in_typ, FlagT) and out_typ != UINT256_T:
+        _fail(in_typ, out_typ, node)
+    if isinstance(out_typ, FlagT) and in_typ != UINT256_T:
+        _fail(in_typ, out_typ, node)
+
+    # addresses are unsigned
+    if isinstance(in_typ, AddressT) and isinstance(out_typ, IntegerT) and out_typ.is_signed:
+        _fail(in_typ, out_typ, node)
+    if isinstance(in_typ, IntegerT) and in_typ.is_signed and isinstance(out_typ, AddressT):
+        _fail(in_typ, out_typ, node)
+
+    # narrowing conversions to bytesM are blocked (no runtime clamp)
+    if isinstance(out_typ, BytesM_T):
+        if isinstance(in_typ, (IntegerT, DecimalT)) and out_typ.m_bits < in_typ.bits:
+            _fail(in_typ, out_typ, node)
+        if isinstance(in_typ, AddressT) and out_typ.m_bits < 160:
+            _fail(in_typ, out_typ, node)
+
+
+def int_to_fixed_clamp_bounds(out_typ: DecimalT) -> tuple[int, int]:
+    """
+    Inclusive bounds on an integer input such that `input * out_typ.divisor`
+    stays within `out_typ`'s representable range.
+
+    Note truncating (not floor) division: flooring the negative bound
+    admits one extra value whose scaled result lands below the output
+    type's lower bound (GH 5110).
+    """
+    out_lo, out_hi = out_typ.int_bounds
+    divisor = out_typ.divisor
+    return evm_div(out_lo, divisor), evm_div(out_hi, divisor)
+
+
+def fixed_to_int_clamp_bounds(in_typ: DecimalT, out_typ: IntegerT) -> tuple[int, int]:
+    """
+    Inclusive bounds (in `in_typ`'s fixed-point representation) on a
+    decimal input such that truncation to integer lands within `out_typ`.
+    """
+    out_lo, out_hi = out_typ.int_bounds
+    divisor = in_typ.divisor
+    return out_lo * divisor, out_hi * divisor

--- a/vyper/codegen_venom/builtins/convert.py
+++ b/vyper/codegen_venom/builtins/convert.py
@@ -16,10 +16,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from vyper import ast as vy_ast
+from vyper.builtins._convert_rules import (
+    fixed_to_int_clamp_bounds,
+    int_to_fixed_clamp_bounds,
+    validate_convertibility,
+)
 from vyper.exceptions import CompilerPanic, InvalidLiteral, TypeMismatch
 from vyper.semantics.types import AddressT, BoolT, BytesM_T, BytesT, DecimalT, IntegerT, StringT
 from vyper.semantics.types.bytestrings import _BytestringT
-from vyper.semantics.types.shortcuts import UINT160_T, UINT256_T
+from vyper.semantics.types.shortcuts import UINT160_T
 from vyper.semantics.types.user import FlagT
 from vyper.venom.basicblock import IRLiteral, IROperand, IRVariable
 
@@ -38,6 +43,11 @@ def lower_convert(node: vy_ast.Call, ctx: VenomCodegenContext) -> IROperand:
     arg_node = node.args[0]
     in_t = arg_node._metadata["type"]
     out_t = node.args[1]._metadata["type"].typedef
+
+    # validate against the conversion matrix shared with the legacy
+    # pipeline. downstream lowering helpers rely on this and only handle
+    # legal input types.
+    validate_convertibility(in_t, out_t, arg_node)
 
     # For bytestrings we need pointer, for primitives we need value
     if isinstance(in_t, _BytestringT):
@@ -111,8 +121,6 @@ def _to_bool(
 
     Any nonzero value is True. For bytestrings, loads the data and checks.
     """
-    _check_bytes(in_t, out_t, 32, arg_node)
-
     b = ctx.builder
 
     if isinstance(in_t, _BytestringT):
@@ -144,12 +152,9 @@ def _to_address(
     """
     Convert to address (160-bit unsigned).
 
-    From signed integers: disallowed (type checker handles this)
+    From signed integers: disallowed (rejected by the conversion matrix)
     From bytes: right-shift if needed, clamp to 160 bits
     """
-    if isinstance(in_t, IntegerT) and in_t.is_signed:
-        raise TypeMismatch(f"Can't convert {in_t} to address", arg_node)
-
     # Use _to_int to get uint160, which handles clamping
     result = _to_int(val, in_t, UINT160_T, arg_node, ctx)
     return result
@@ -169,7 +174,6 @@ def _to_int(
     - flag: treated as uint256
     - other integer: clamp to bounds
     """
-    _check_bytes(in_t, out_t, 32, arg_node)
     # Check literal bounds at compile time
     _check_literal_int_bounds(arg_node, out_t)
 
@@ -208,30 +212,24 @@ def _to_int(
 
     # From decimal: divide by divisor
     if isinstance(in_t, DecimalT):
-        divisor = in_t.divisor
         # Clamp first to avoid overflow in intermediate
-        out_lo, out_hi = out_t.int_bounds
+        scaled_lo, scaled_hi = fixed_to_int_clamp_bounds(in_t, out_t)
         in_lo, in_hi = in_t.int_bounds
-        # Scale output bounds by divisor for clamping the decimal value
-        scaled_lo = out_lo * divisor
-        scaled_hi = out_hi * divisor
         val = _clamp_numeric_convert(
             val, (in_lo, in_hi), (scaled_lo, scaled_hi), in_t.is_signed, ctx
         )
         # Now divide
-        val = b.sdiv(val, IRLiteral(divisor))
+        val = b.sdiv(val, IRLiteral(in_t.divisor))
         return val
 
-    # From flag: treat as uint256, use int-to-int rules
+    # From flag: the conversion matrix guarantees out_t is uint256,
+    # so this is a no-op
     if isinstance(in_t, FlagT):
-        # Flags can only convert to uint256
-        return _int_to_int(val, UINT256_T, out_t, ctx)
+        return val
 
-    # From address: treat as uint160
+    # From address: treat as uint160 (the conversion matrix guarantees
+    # out_t is unsigned)
     if in_t == AddressT():
-        if out_t.is_signed:
-            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-        # Can only go to unsigned types >= 160 bits
         if out_t.bits < 160:
             val = _int_clamp(val, out_t, ctx)
         return val
@@ -253,8 +251,6 @@ def _to_decimal(
     From integer: multiply by DECIMAL_DIVISOR with overflow check.
     From bytes: shift and interpret as decimal.
     """
-    _check_bytes(in_t, out_t, 32, arg_node)
-
     b = ctx.builder
     divisor = out_t.divisor
 
@@ -281,11 +277,9 @@ def _to_decimal(
 
     # From integer: multiply by divisor
     if isinstance(in_t, IntegerT):
-        # Clamp input to valid range before scaling
-        out_lo, out_hi = out_t.int_bounds
-        # Scale bounds for pre-multiplication check
-        pre_lo = out_lo // divisor
-        pre_hi = out_hi // divisor
+        # Clamp input to valid range before scaling. Note the bounds are
+        # computed with truncating division (GH 5110).
+        pre_lo, pre_hi = int_to_fixed_clamp_bounds(out_t)
         in_lo, in_hi = in_t.int_bounds
         val = _clamp_numeric_convert(val, (in_lo, in_hi), (pre_lo, pre_hi), in_t.is_signed, ctx)
         # Multiply by divisor
@@ -296,7 +290,7 @@ def _to_decimal(
     if isinstance(in_t, BoolT):
         return b.mul(val, IRLiteral(divisor))
 
-    return val
+    raise CompilerPanic(f"Unsupported conversion: {in_t} to {out_t}")  # pragma: nocover
 
 
 def _to_bytes_m(
@@ -307,8 +301,6 @@ def _to_bytes_m(
 
     Values are left-aligned in 32-byte word.
     """
-    _check_bytes(in_t, out_t, out_t.m, arg_node)
-
     b = ctx.builder
 
     # From bytes/string: load data, mask/shift as needed
@@ -335,17 +327,8 @@ def _to_bytes_m(
         # Widening is no-op (already left-aligned)
         return val
 
-    if isinstance(in_t, IntegerT):
-        if out_t.m_bits < in_t.bits:
-            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-    elif in_t == AddressT():
-        if out_t.m_bits < 160:
-            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-    elif isinstance(in_t, DecimalT):
-        if out_t.m_bits < in_t.bits:
-            raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-
-    # From integer/address/decimal: left-shift to align
+    # From integer/address/decimal/bool: left-shift to align. Narrowing
+    # conversions are rejected by the conversion matrix.
     shift_bits = (32 - out_t.m) * 8
     return b.shl(IRLiteral(shift_bits), val)
 
@@ -358,14 +341,6 @@ def _to_bytes(
 
     From string: just reinterpret (check length)
     """
-    # Only bytestring types can be converted to Bytes
-    if not isinstance(in_t, _BytestringT):  # pragma: nocover
-        raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-
-    # Ban converting same type (e.g. Bytes[20] to Bytes[21] upcast is not a real conversion)
-    if isinstance(in_t, BytesT) and in_t.maxlen <= out_t.maxlen:  # pragma: nocover
-        raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-
     # Can't downcast literals with known length (e.g. b"abc" to Bytes[2])
     # Use reduced() to handle constant variables like `BAR: constant(Bytes[5])`
     reduced = arg_node.reduced() if arg_node.has_folded_value else arg_node
@@ -395,14 +370,6 @@ def _to_string(
 
     From bytes: just reinterpret (check length)
     """
-    # Only bytestring types can be converted to String
-    if not isinstance(in_t, _BytestringT):  # pragma: nocover
-        raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-
-    # Ban converting same type (e.g. String[20] to String[21] upcast is not a real conversion)
-    if isinstance(in_t, StringT) and in_t.maxlen <= out_t.maxlen:  # pragma: nocover
-        raise TypeMismatch(f"Can't convert {in_t} to {out_t}", arg_node)
-
     # Can't downcast literals with known length (e.g. "abc" to String[2])
     # Use reduced() to handle constant variables like `BAR: constant(String[5])`
     reduced = arg_node.reduced() if arg_node.has_folded_value else arg_node
@@ -441,16 +408,6 @@ def _to_flag(val: IROperand, in_t, out_t: FlagT, ctx: VenomCodegenContext) -> IR
 
 
 # === Helper functions ===
-
-
-def _check_bytes(in_t, out_t, max_bytes_allowed: int, source_expr: vy_ast.VyperNode):
-    """
-    Validate bytestring input doesn't exceed maximum allowed size.
-
-    Raises TypeMismatch if in_t is a bytestring with maxlen > max_bytes_allowed.
-    """
-    if isinstance(in_t, _BytestringT) and in_t.maxlen > max_bytes_allowed:  # pragma: nocover
-        raise TypeMismatch(f"Can't convert {in_t} to {out_t}", source_expr)
 
 
 def _int_clamp(val: IROperand, out_t: IntegerT, ctx: VenomCodegenContext) -> IROperand:


### PR DESCRIPTION
### What I did

Adds the enforcement layer for #5110/#5111/#5019 (fixed in #5114): a differential test that the legacy and venom pipelines agree on which `convert()` programs are valid, plus exact boundary-value tests for every numeric conversion window.

**Depends on #5114** (branched on top of it; without it, the parity test correctly fails on the venom side).

### How I did it

Two test layers in `tests/functional/builtins/codegen/test_convert_pipeline_parity.py`:

* `test_convert_acceptance_parity` — compiles the full type-pair matrix (representative integers, bytesM widths straddling the boundaries, decimal, bool, address, bytestrings straddling 32 bytes, flags; 462 pairs) under **both** pipelines, bytecode-only, and asserts identical accept/reject verdicts including exception type. Bytecode-only matters: several output formats (`ir_dict`, `metadata`, `abi`) run the legacy codegen even under `--experimental-codegen`, which is precisely how the existing matrix tests (`test_type_conversion_blocked`) missed the #5111 cluster — legacy validation masked venom's. Pointed at master, this test immediately catches the divergences.
* `test_numeric_convert_boundaries` — for each numeric conversion pair, computes the legal input window and asserts the exact edge behavior: the boundary value converts to the expected result, one-past-boundary reverts. Runs under the session pipeline, so both CI lanes exercise it. This is the structural regression test for #5110 (which survived because boundary coverage lives in fuzzing-marked tests, and the fuzzing CI lane never runs `--experimental-codegen`).

The infra gaps themselves (format masking, fuzzing lane) are tracked in #5116.

### How to verify it

```
$ pytest tests/functional/builtins/codegen/test_convert_pipeline_parity.py
$ pytest tests/functional/builtins/codegen/test_convert_pipeline_parity.py --experimental-codegen
```

476 tests, ~7s. To see it catch real bugs: check out master's `vyper/` directory and rerun — the parity test fails on the first venom-accepted illegal pair.

### Commit message

```
the legacy and venom pipelines maintain separate codegen for convert();
nothing previously enforced that they agree on which programs are
valid. the existing conversion matrix tests (test_type_conversion_blocked,
test_flag_conversion) did not catch venom accepts-invalid bugs (GH 5019,
GH 5111) because the test fixtures compile with many output formats, and
several of those (ir_dict, metadata, abi) run the legacy codegen even
under --experimental-codegen -- legacy validation masked the venom holes.
boundary-value coverage had the same gap from a different angle: it
lives in fuzzing-marked tests, and the fuzzing CI lane never runs with
--experimental-codegen (which is how GH 5110 survived).

add two test layers:

- an acceptance parity test which compiles the full type-pair matrix
  (integers, bytesM, decimal, bool, address, bytestrings, flags)
  bytecode-only under both pipelines and asserts identical verdicts,
  immune to the output-format masking. pointed at master, it
  immediately catches the GH 5111 cluster.

- numeric boundary tests asserting exact clamp behavior at the edges
  of every conversion window (boundary converts, one-past-boundary
  reverts), running under the session pipeline so both CI lanes
  exercise them. regression test for GH 5110.
```

### Description for the changelog

Add differential tests enforcing that the legacy and venom pipelines agree on `convert()` validity, plus boundary-value tests for numeric conversion clamps.

### Cute Animal Picture

\![dog](https://images.dog.ceo/breeds/greyhound-indian/rampur-greyhound.jpg)

