### PR TITLE
fix[tool]: update gas delta table format

### DIFF
--- a/.github/scripts/compare_gas.py
+++ b/.github/scripts/compare_gas.py
@@ -5,6 +5,12 @@ import json
 import sys
 
 
+def fmt_percent(delta, base_gas):
+    if base_gas == 0:
+        return "-"
+    return f"{delta / base_gas:+.2%}"
+
+
 def fmt_row(test, base_entry, head_entry):
     # returns (display_row, delta_for_sorting, kind) where kind in
     # {"new", "deleted", "broke", "fixed", "regression", "improvement", "unchanged"}
@@ -17,15 +23,15 @@ def fmt_row(test, base_entry, head_entry):
     # otherwise the "Newly failing" summary count under-reports regressions
     if base_entry is None and head_entry is not None:
         if head_status != "Success":
-            return f"| {test} | - | 💥 | new failing ({head_status}) |", 0, "broke"
-        return f"| {test} | - | ➕ **{head_gas}** | new |", 0, "new"
+            return f"| new failing ({head_status}) | - | - | 💥 | {test} |", 0, "broke"
+        return f"| new | - | - | ➕ **{head_gas}** | {test} |", 0, "new"
     if base_entry is not None and head_entry is None:
-        return f"| {test} | **{base_gas}** | - | 🗑️ |", 0, "deleted"
+        return f"| deleted | - | **{base_gas}** | - | {test} |", 0, "deleted"
     # status flips: forge marks suite-level breakage at the test level too
     if base_status == "Success" and head_status != "Success":
-        return f"| {test} | **{base_gas}** | 💥 | failing ({head_status}) |", 0, "broke"
+        return f"| failing ({head_status}) | - | **{base_gas}** | 💥 | {test} |", 0, "broke"
     if base_status != "Success" and head_status == "Success":
-        return f"| {test} | ❌ | 🔧 **{head_gas}** | fixed |", 0, "fixed"
+        return f"| fixed | - | ❌ | 🔧 **{head_gas}** | {test} |", 0, "fixed"
     if base_gas is None or head_gas is None:
         return None
     if base_gas == head_gas:
@@ -34,7 +40,8 @@ def fmt_row(test, base_entry, head_entry):
     sign = "+" if delta > 0 else ""
     icon = "🔴" if delta > 0 else "🟢"
     return (
-        f"| {test} | **{base_gas}** | **{head_gas}** | {icon}{sign}{delta} |",
+        f"| {icon}{sign}{delta} | {fmt_percent(delta, base_gas)} | "
+        f"**{base_gas}** | **{head_gas}** | {test} |",
         delta,
         ("regression" if delta > 0 else "improvement"),
     )
@@ -76,8 +83,8 @@ def generate_report(base_path, head_path):
 
     rows.sort(key=lambda r: abs(r[1]), reverse=True)
 
-    header = "| Test | Base Gas | Head Gas | Delta |"
-    sep = "|---|---|---|---|"
+    header = "| Delta | Delta % | Base Gas | Head Gas | Test |"
+    sep = "|---|---|---|---|---|"
 
     if rows:
         body = "## Gas Changes\n\n" + header + "\n" + sep + "\n" + "\n".join(r[0] for r in rows)

--- a/tests/unit/utils/test_compare_gas.py
+++ b/tests/unit/utils/test_compare_gas.py
@@ -1,0 +1,77 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def load_compare_gas():
+    script_path = Path(__file__).parents[3] / ".github" / "scripts" / "compare_gas.py"
+    spec = importlib.util.spec_from_file_location("compare_gas", script_path)
+    compare_gas = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(compare_gas)
+    return compare_gas
+
+
+def write_gas_report(tmp_path, name, tests):
+    path = tmp_path / name
+    path.write_text(json.dumps({"tests": tests}))
+    return path
+
+
+def test_generate_report_puts_gas_deltas_before_test_names(tmp_path):
+    compare_gas = load_compare_gas()
+    long_test = "test_very_long_name_" * 8
+    base_path = write_gas_report(
+        tmp_path,
+        "base.json",
+        {
+            long_test: {"gas": 100, "status": "Success"},
+            "test_saves_gas": {"gas": 200, "status": "Success"},
+            "test_unchanged": {"gas": 10, "status": "Success"},
+        },
+    )
+    head_path = write_gas_report(
+        tmp_path,
+        "head.json",
+        {
+            long_test: {"gas": 125, "status": "Success"},
+            "test_saves_gas": {"gas": 150, "status": "Success"},
+            "test_unchanged": {"gas": 10, "status": "Success"},
+        },
+    )
+
+    report = compare_gas.generate_report(base_path, head_path)
+
+    assert "| Delta | Delta % | Base Gas | Head Gas | Test |" in report
+    assert f"| 🔴+25 | +25.00% | **100** | **125** | {long_test} |" in report
+    assert "| 🟢-50 | -25.00% | **200** | **150** | test_saves_gas |" in report
+
+
+def test_generate_report_keeps_status_rows_in_compact_column_order(tmp_path):
+    compare_gas = load_compare_gas()
+    base_path = write_gas_report(
+        tmp_path,
+        "base.json",
+        {
+            "test_deleted": {"gas": 100, "status": "Success"},
+            "test_broke": {"gas": 50, "status": "Success"},
+            "test_fixed": {"gas": None, "status": "Failure"},
+        },
+    )
+    head_path = write_gas_report(
+        tmp_path,
+        "head.json",
+        {
+            "test_new": {"gas": 10, "status": "Success"},
+            "test_new_failing": {"gas": None, "status": "Failure"},
+            "test_broke": {"gas": None, "status": "Failure"},
+            "test_fixed": {"gas": 40, "status": "Success"},
+        },
+    )
+
+    report = compare_gas.generate_report(base_path, head_path)
+
+    assert "| deleted | - | **100** | - | test_deleted |" in report
+    assert "| failing (Failure) | - | **50** | 💥 | test_broke |" in report
+    assert "| fixed | - | ❌ | 🔧 **40** | test_fixed |" in report
+    assert "| new | - | - | ➕ **10** | test_new |" in report
+    assert "| new failing (Failure) | - | - | 💥 | test_new_failing |" in report


### PR DESCRIPTION
### What I did

Brought the delta data to the front and test names left to the right for better visibility of the data.

Example output:

| Delta | Delta % | Base Gas | Head Gas | Test |
|---|---|---|---|---|
| 🔴+1250 | +5.49% | **22760** | **24010** | test_erc4626_preview_withdraw_when_total_assets_and_total_supply_are_nonzero_and_rounding_changes |
| 🟢-840 | -3.29% | **25500** | **24660** | test_erc20_permit_reuses_nonce_after_failed_signature_validation_with_long_fixture_name |
| new | - | - | ➕ **18240** | test_new_vault_deposit_flow_with_permit_and_callback |
| deleted | - | **30110** | - | test_removed_legacy_allowance_path_with_many_named_parameters |
| failing (Failure) | - | **31900** | 💥 | test_regression_case_that_now_fails_before_reporting_gas |
| fixed | - | ❌ | 🔧 **19420** | test_previously_failing_case_that_now_reports_gas |

### How I did it

### How to verify it

### Commit message

```
rearrange the gas delta data for better visibility of the deltas 
without having to scroll the table horizontally 
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
