### PR TITLE
fix[venom]: correct signed division range bounds

### DIFF
--- a/tests/unit/venom/test_variable_range_analysis.py
+++ b/tests/unit/venom/test_variable_range_analysis.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from vyper.venom.analysis import IRAnalysesCache
 from vyper.venom.analysis.variable_range import VariableRangeAnalysis
-from vyper.venom.analysis.variable_range.value_range import SIGNED_MAX, SIGNED_MIN
+from vyper.venom.analysis.variable_range.evaluators import eval_sdiv
+from vyper.venom.analysis.variable_range.value_range import SIGNED_MAX, SIGNED_MIN, ValueRange
 from vyper.venom.parser import parse_venom
 
 
@@ -2116,6 +2117,16 @@ def test_sdiv_negative_range():
     rng = analysis.get_range(sdiv_inst.output, entry.instructions[-1])
     # x in [-99, 0], y = x / 10, so y in [-9, 0] (truncation toward zero)
     assert rng.lo == -9 and rng.hi == 0
+
+
+def test_eval_sdiv_all_negative_range_positive_divisor():
+    rng = eval_sdiv(ValueRange.iv(-10, -3), ValueRange.constant(3))
+    assert rng == ValueRange.iv(-3, -1)
+
+
+def test_eval_sdiv_all_negative_range_exact_positive_divisor():
+    rng = eval_sdiv(ValueRange.iv(-9, -6), ValueRange.constant(3))
+    assert rng == ValueRange.iv(-3, -2)
 
 
 def test_sdiv_spanning_zero():

--- a/vyper/venom/analysis/variable_range/evaluators.py
+++ b/vyper/venom/analysis/variable_range/evaluators.py
@@ -370,8 +370,8 @@ def eval_sdiv(dividend: ValueRange, divisor: ValueRange) -> ValueRange:
         elif dividend.hi < 0:
             # Both negative: division truncates toward zero
             # -7 // 3 in EVM = -2 (truncate), in Python = -3 (floor)
-            result_hi = -(abs(dividend.lo) // d)
-            result_lo = -(abs(dividend.hi) // d)
+            result_lo = -(abs(dividend.lo) // d)
+            result_hi = -(abs(dividend.hi) // d)
         else:
             # Range spans zero - result spans from negative to positive
             result_lo = -(abs(dividend.lo) // d)


### PR DESCRIPTION
Fixes #4943.

## Summary
- Correct signed-division range bounds for all-negative dividend intervals.
- Add regression coverage for the signed division range evaluator.

## Verification
- Direct evaluator smoke test for the changed range case.

Full pytest was not run locally because installing the required test dependencies attempted to build `pyrevm`, which requires Cargo in this environment.
