### PR TITLE
fix[ux]: panic explicitly in `safe_pow()` for two-variable case

### DIFF
--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -10,7 +10,7 @@ from vyper.codegen.core import (
     is_numeric_type,
 )
 from vyper.codegen.ir_node import IRnode
-from vyper.exceptions import CompilerPanic, TypeCheckFailure, UnimplementedException
+from vyper.exceptions import CodegenPanic, CompilerPanic, TypeCheckFailure, UnimplementedException
 
 
 def calculate_largest_power(a: int, num_bits: int, is_signed: bool) -> int:
@@ -370,9 +370,10 @@ def safe_pow(x, y):
                 ok = ["le", x, upper_bound]
     else:
         # `a ** b` where neither `a` or `b` are known.
-        # this branch is currently unreachable; raise instead of silently
-        # returning None so a clear compiler error surfaces if it is ever hit.
-        raise TypeCheckFailure("pow requires at least one literal operand")  # pragma: nocover
+        # this is already caught by the type checker, so this branch is
+        # unreachable; panic instead of silently returning None so we fail
+        # loudly if it is ever hit.
+        raise CodegenPanic("pow requires at least one literal operand")  # pragma: nocover
 
     assertion = IRnode.from_list(["assert", ok], error_msg="safepow")
     return IRnode.from_list(["seq", assertion, ["exp", x, y]])

--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -368,12 +368,9 @@ def safe_pow(x, y):
                 ok = ["and", ["sge", x, lower_bound], ["sle", x, upper_bound]]
             else:
                 ok = ["le", x, upper_bound]
-    else:
-        # `a ** b` where neither `a` or `b` are known.
-        # this is already caught by the type checker, so this branch is
-        # unreachable; panic instead of silently returning None so we fail
-        # loudly if it is ever hit.
-        raise CodegenPanic("pow requires at least one literal operand")  # pragma: nocover
+    else:  # pragma: nocover
+        # type checker guarantees pow has at least one literal operand
+        raise CodegenPanic("unreachable")
 
     assertion = IRnode.from_list(["assert", ok], error_msg="safepow")
     return IRnode.from_list(["seq", assertion, ["exp", x, y]])

--- a/vyper/codegen/arithmetic.py
+++ b/vyper/codegen/arithmetic.py
@@ -369,10 +369,10 @@ def safe_pow(x, y):
             else:
                 ok = ["le", x, upper_bound]
     else:
-        # `a ** b` where neither `a` or `b` are known
-        # TODO this is currently unreachable, once we implement a way to do it safely
-        # remove the check in `vyper/context/types/value/numeric.py`
-        return
+        # `a ** b` where neither `a` or `b` are known.
+        # this branch is currently unreachable; raise instead of silently
+        # returning None so a clear compiler error surfaces if it is ever hit.
+        raise TypeCheckFailure("pow requires at least one literal operand")  # pragma: nocover
 
     assertion = IRnode.from_list(["assert", ok], error_msg="safepow")
     return IRnode.from_list(["seq", assertion, ["exp", x, y]])


### PR DESCRIPTION
### What I did
Fixes #5026. `safe_pow()` in `vyper/codegen/arithmetic.py` had an `else` branch
(neither operand a compile-time constant) that silently `return`ed `None`. The
caller in `expr.py` feeds that into IR construction, so if the front-end guard
were ever bypassed you'd get a cryptic downstream crash instead of a clear error.
### How I did it
Replaced the bare `return` with `raise CodegenPanic("unreachable")`, matching the
defensive `raise` style used a few lines above in the same function. The branch is
unreachable in practice (the type checker rejects two-variable exponentiation
with `InvalidOperation`), so it's marked `# pragma: nocover`. Also added
`CodegenPanic` to the `vyper.exceptions` import list.
### How to verify it
- `a ** 2` (literal exponent) still compiles unchanged.
- `a ** b` (both variables) is still rejected at the front-end (`InvalidOperation`).
- `pytest tests/functional/codegen/types/numbers/test_exponents.py` passes (23).
- pre-commit (isort / black / flake8 / mypy) clean.

### Commit message
```text
the else branch of `safe_pow()` (neither base nor exponent is a compile-
time constant) silently `return`ed `None`, which propagates into IR
construction in `expr.py` and would surface as a cryptic downstream
crash if the front-end guard were ever bypassed.

raise `CodegenPanic("unreachable")` instead of returning `None`,
matching the defensive `raise` style used a few lines above. the branch
is unreachable today because the type checker rejects two-variable
exponentiation with `InvalidOperation`, so mark it `# pragma: nocover`.

fixes GH 5026
```
### Description for the changelog
Make `safe_pow()` raise a clear compiler error instead of silently returning
`None` when both exponentiation operands are runtime values.
### Cute Animal Picture
<img width="300" alt="image" src="https://github.com/user-attachments/assets/cf5bcc62-41a4-4a71-b259-59f60fbeb1b2" />

