### PR TITLE
fix[lang]: missing no-return implements check

### DIFF
--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -240,6 +240,32 @@ foo: public(constant(uint256)) = 1
         """,
         InterfaceViolation,
     ),
+    (
+        """
+interface IA:
+    def f(): nonpayable
+
+implements: IA
+
+@external
+def f() -> uint256:
+    return 1
+        """,
+        InterfaceViolation,
+    ),
+    (
+        """
+interface IA:
+    def f() -> uint256: nonpayable
+
+implements: IA
+
+@external
+def f():
+    pass
+        """,
+        InterfaceViolation,
+    ),
 ]
 
 

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -660,15 +660,24 @@ class ContractFunctionT(VyperType):
         arguments, return_type = self._iface_sig
         other_arguments, other_return_type = other._iface_sig
 
-        # Contravariant
         if len(arguments) != len(other_arguments):
             return False
         for atyp, btyp in zip(arguments, other_arguments):
+            # Contravariant
             if not btyp.is_subtype_of(atyp):
                 return False
 
-        # Covariant
-        if return_type and not return_type.is_subtype_of(other_return_type):  # type: ignore
+        neither_returns = return_type is None and other_return_type is None
+
+        both_return_and_match = (
+            return_type is not None
+            and other_return_type is not None
+            and return_type.is_subtype_of(other_return_type)  # Covariant
+        )
+
+        return_types_match = both_return_and_match or neither_returns
+
+        if not return_types_match:  # type: ignore
             return False
 
         return self.mutability == other.mutability

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -657,28 +657,24 @@ class ContractFunctionT(VyperType):
 
         assert self.visibility == other.visibility
 
-        arguments, return_type = self._iface_sig
-        other_arguments, other_return_type = other._iface_sig
+        arguments, return_t = self._iface_sig
+        other_arguments, other_return_t = other._iface_sig
 
         if len(arguments) != len(other_arguments):
             return False
         for atyp, btyp in zip(arguments, other_arguments):
-            # Contravariant
+            # argument checking is contravariant
             if not btyp.is_subtype_of(atyp):
                 return False
 
-        neither_returns = return_type is None and other_return_type is None
-
-        both_return_and_match = (
-            return_type is not None
-            and other_return_type is not None
-            and return_type.is_subtype_of(other_return_type)  # Covariant
-        )
-
-        return_types_match = both_return_and_match or neither_returns
-
-        if not return_types_match:  # type: ignore
+        if (return_t is None) != (other_return_t is None):
             return False
+
+        # return type checking is covariant
+        if return_t is not None:
+            assert other_return_t is not None  # help mypy
+            if not return_t.is_subtype_of(other_return_t):
+                return False
 
         return self.mutability == other.mutability
 


### PR DESCRIPTION
### What I did

Fix: #5145 

### How I did it

Fast-path on None-ness mismatch of return types in `compare_signature`,
then apply the covariance check only when both sides return. See commit
message below for the rationale.

### How to verify it

Two tests added under `tests/functional/syntax/test_interfaces.py`; both
fail on the prior code (one with a compiler panic, one by accepting an
invalid `implements`).

### Commit message

```
`compare_signature` only enforced return-type covariance when the
implementing function had a non-None return type: the `if return_type
and ...` guard was truthy, so a function declaring no return value would
silently satisfy an interface that does return. this led to a compiler
panic (NoneType has no is_subtype_of) when the mismatch was detected
downstream, and in other cases accepted an incorrect implements
declaration without raising.

require the None-ness of both return types to match as a fast-path, then
apply the covariance check only when both sides actually return. the
assert on `other_return_t` is there to narrow the type for mypy after
the symmetry check, which a plain `!=` comparison will not do.
```
### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()

