### PR TITLE
fix[lang]: method_id panic on non-constant

### DIFF
--- a/tests/functional/syntax/test_method_id.py
+++ b/tests/functional/syntax/test_method_id.py
@@ -24,6 +24,15 @@ FOO: constant(Bytes[4]) = method_id("bar ()")
     """,
         InvalidLiteral,
     ),
+    (
+        """
+@external
+@view
+def f(s: String[20]) -> Bytes[4]:
+    return method_id(s)
+    """,
+        InvalidType,
+    ),
 ]
 
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -718,7 +718,7 @@ class MethodID(FoldedFunctionT):
     def _try_fold(self, node):
         validate_call_args(node, 1, ["output_type"])
 
-        value = node.args[0].get_folded_value()
+        value = node.args[0].reduced()
         if not isinstance(value, vy_ast.Str):
             raise InvalidType("method id must be given as a literal string", node.args[0])
         if " " in value.value:


### PR DESCRIPTION
### What I did

Fix #5152. `method_id(s)` where `s` is a runtime `String[N]` variable crashed the compiler with a `CodegenPanic: 'MethodID' object has no attribute 'build_IR'` instead of raising the intended `InvalidType: method id must be given as a literal string`.

### How I did it

`MethodID._try_fold` called `node.args[0].get_folded_value()`, which raises when the argument can't be constant-folded. The folding pass swallows that exception and skips `_try_fold` entirely, so codegen receives the un-folded `method_id(...)` call and falls through to `MethodID.build_IR`, which does not exist.

Switch to `node.args[0].reduced()`, which returns the original node unchanged when folding fails. The existing `isinstance(value, vy_ast.Str)` guard then raises the clean `InvalidType` as intended, before codegen is reached.

### How to verify it

- New syntax test in `tests/functional/syntax/test_method_id.py` asserts that `method_id(s)` with a runtime `String[20]` argument raises `InvalidType`.
- `uv run pytest tests/functional/syntax/test_method_id.py` passes.

### Commit message

```
method_id's arg is assumed to be a constant during codegen: `_try_fold` is
meant to constant-fold the call into a Bytes literal so codegen never
sees it. but `_try_fold` used `get_folded_value()`, which raises on non-
constant args; the folding pass swallows that exception, leaving codegen
to dispatch `MethodID.build_IR`, which doesn't exist — hence the
`CodegenPanic`.

use `reduced()` instead, which returns the original node when folding
fails. the existing `isinstance(value, vy_ast.Str)` guard then raises
`InvalidType` as intended, before codegen is reached.
```

### Description for the changelog

`method_id` with a non-literal (runtime) string argument now raises a clean `InvalidType` error instead of crashing the compiler with `CodegenPanic`.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
