### PR TITLE
fix[lang]!: reserve `unreachable` keyword

### DIFF
--- a/tests/functional/codegen/abstract/test_abstract.py
+++ b/tests/functional/codegen/abstract/test_abstract.py
@@ -84,7 +84,7 @@ SUCCESSFUL_OVERRIDES = [
     # Basic successful override
     ("x: uint256", "uint256", "x", "x: uint256", "uint256", "42", 42),
     # Boolean parameter and return type matching
-    ("_flag: bool", "bool", "_flag", "_flag: bool", "bool", "True", True),
+    ("flag_: bool", "bool", "flag_", "flag_: bool", "bool", "True", True),
     # Bytes32 parameter matching
     (
         "data: bytes32",
@@ -224,10 +224,10 @@ SUCCESSFUL_OVERRIDES = [
     # === ADDITIONAL DEFAULT EXPRESSION TYPES ===
     # Boolean literal default
     (
-        "x: uint256, _flag: bool = True",
+        "x: uint256, flag_: bool = True",
         "bool",
-        "_flag",
-        "x: uint256, _flag: bool = True",
+        "flag_",
+        "x: uint256, flag_: bool = True",
         "bool",
         "1",
         True,
@@ -863,7 +863,7 @@ FLAG_B: constant(bool) = False
 import constants_lib
 
 @abstract
-def check(_flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool: ...
+def check(flag_: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool: ...
     """
 
     override_contract = """
@@ -877,8 +877,8 @@ def call_check() -> bool:
     return self.check()
 
 @override(abstract_module)
-def check(_flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool:
-    return _flag
+def check(flag_: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool:
+    return flag_
     """
 
     input_bundle = make_input_bundle(

--- a/tests/functional/codegen/abstract/test_abstract.py
+++ b/tests/functional/codegen/abstract/test_abstract.py
@@ -84,7 +84,7 @@ SUCCESSFUL_OVERRIDES = [
     # Basic successful override
     ("x: uint256", "uint256", "x", "x: uint256", "uint256", "42", 42),
     # Boolean parameter and return type matching
-    ("flag: bool", "bool", "flag", "flag: bool", "bool", "True", True),
+    ("_flag: bool", "bool", "_flag", "_flag: bool", "bool", "True", True),
     # Bytes32 parameter matching
     (
         "data: bytes32",
@@ -224,10 +224,10 @@ SUCCESSFUL_OVERRIDES = [
     # === ADDITIONAL DEFAULT EXPRESSION TYPES ===
     # Boolean literal default
     (
-        "x: uint256, flag: bool = True",
+        "x: uint256, _flag: bool = True",
         "bool",
-        "flag",
-        "x: uint256, flag: bool = True",
+        "_flag",
+        "x: uint256, _flag: bool = True",
         "bool",
         "1",
         True,
@@ -863,7 +863,7 @@ FLAG_B: constant(bool) = False
 import constants_lib
 
 @abstract
-def check(flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool: ...
+def check(_flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool: ...
     """
 
     override_contract = """
@@ -877,8 +877,8 @@ def call_check() -> bool:
     return self.check()
 
 @override(abstract_module)
-def check(flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool:
-    return flag
+def check(_flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool:
+    return _flag
     """
 
     input_bundle = make_input_bundle(

--- a/tests/functional/codegen/abstract/test_abstract.py
+++ b/tests/functional/codegen/abstract/test_abstract.py
@@ -84,7 +84,7 @@ SUCCESSFUL_OVERRIDES = [
     # Basic successful override
     ("x: uint256", "uint256", "x", "x: uint256", "uint256", "42", 42),
     # Boolean parameter and return type matching
-    ("flag_: bool", "bool", "flag_", "flag_: bool", "bool", "True", True),
+    ("flag: bool", "bool", "flag", "flag: bool", "bool", "True", True),
     # Bytes32 parameter matching
     (
         "data: bytes32",
@@ -224,10 +224,10 @@ SUCCESSFUL_OVERRIDES = [
     # === ADDITIONAL DEFAULT EXPRESSION TYPES ===
     # Boolean literal default
     (
-        "x: uint256, flag_: bool = True",
+        "x: uint256, flag: bool = True",
         "bool",
-        "flag_",
-        "x: uint256, flag_: bool = True",
+        "flag",
+        "x: uint256, flag: bool = True",
         "bool",
         "1",
         True,
@@ -863,7 +863,7 @@ FLAG_B: constant(bool) = False
 import constants_lib
 
 @abstract
-def check(flag_: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool: ...
+def check(flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool: ...
     """
 
     override_contract = """
@@ -877,8 +877,8 @@ def call_check() -> bool:
     return self.check()
 
 @override(abstract_module)
-def check(flag_: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool:
-    return flag_
+def check(flag: bool = constants_lib.FLAG_A and not constants_lib.FLAG_B) -> bool:
+    return flag
     """
 
     input_bundle = make_input_bundle(

--- a/vyper/ast/identifiers.py
+++ b/vyper/ast/identifiers.py
@@ -71,7 +71,7 @@ RESERVED_KEYWORDS = _PYTHON_RESERVED_KEYWORDS | {
     "struct",
     "event",
     "enum",
-    "flag",
+    "flag"
     # EVM operations
     "unreachable",
     # special functions (no name mangling)

--- a/vyper/ast/identifiers.py
+++ b/vyper/ast/identifiers.py
@@ -71,7 +71,7 @@ RESERVED_KEYWORDS = _PYTHON_RESERVED_KEYWORDS | {
     "struct",
     "event",
     "enum",
-    "flag"
+    # "flag", # Made into a soft keyword to preserve backwards compat
     # EVM operations
     "unreachable",
     # special functions (no name mangling)

--- a/vyper/ast/identifiers.py
+++ b/vyper/ast/identifiers.py
@@ -71,7 +71,7 @@ RESERVED_KEYWORDS = _PYTHON_RESERVED_KEYWORDS | {
     "struct",
     "event",
     "enum",
-    # "flag", # Made into a soft keyword, since it's useful as an identifier
+    # "flag", # allowed since it's useful as an identifier per user feedback
     # EVM operations
     "unreachable",
     # special functions (no name mangling)

--- a/vyper/ast/identifiers.py
+++ b/vyper/ast/identifiers.py
@@ -71,7 +71,7 @@ RESERVED_KEYWORDS = _PYTHON_RESERVED_KEYWORDS | {
     "struct",
     "event",
     "enum",
-    # "flag", # Made into a soft keyword to preserve backwards compat
+    # "flag", # Made into a soft keyword, since it's useful as an identifier
     # EVM operations
     "unreachable",
     # special functions (no name mangling)

--- a/vyper/ast/identifiers.py
+++ b/vyper/ast/identifiers.py
@@ -71,7 +71,7 @@ RESERVED_KEYWORDS = _PYTHON_RESERVED_KEYWORDS | {
     "struct",
     "event",
     "enum",
-    "flag"
+    "flag",
     # EVM operations
     "unreachable",
     # special functions (no name mangling)


### PR DESCRIPTION
### What I did

Fix https://github.com/vyperlang/vyper/issues/5140

### How I did it

The missing comma between `"flag"` and `"unreachable"` in the `RESERVED_KEYWORDS` set literal in `vyper/ast/identifiers.py` caused Python's implicit string-literal concatenation to merge them into the single string `"flagunreachable"`, so neither keyword was actually reserved. Per @charles-cooper's feedback in the PR thread, `flag` is useful as an identifier and should remain allowed; only `unreachable` needs to be reserved. So instead of adding the missing comma, I commented out the `flag` entry — this both resolves the concatenation (so `unreachable` is reserved as intended) and keeps `flag` usable as an identifier.

### How to verify it

```vyper
# `unreachable` is now rejected as a reserved keyword
@external
def f() -> uint256:
    unreachable: uint256 = 5
    return unreachable
```

```vyper
# `flag` remains usable as an identifier
@external
def f() -> uint256:
    flag: uint256 = 5
    return flag
```

Run `uv run vyper` on each snippet; the first should fail with `StructureException: 'unreachable' is a reserved keyword`, the second should compile.

### Commit message

```
a missing comma in the RESERVED_KEYWORDS set literal between "flag" and
"unreachable" let Python's implicit string-literal concatenation merge
them into the single string "flagunreachable". as a result, neither
`flag` nor `unreachable` was actually reserved — both could be used as
identifiers — while the impossible-to-write "flagunreachable" was
reserved instead.

per user feedback, `flag` is useful as an identifier and should remain
allowed; only `unreachable` needs to be reserved (it maps to the
IR-level `assert_unreachable`). comment out the `flag` entry rather than
adding the missing comma — this both fixes the concatenation (so
`unreachable` is reserved as intended) and keeps `flag` usable as an
identifier.

this is a breaking change for `unreachable`: programs that previously
used `unreachable` as an identifier will no longer compile. that is the
intended behavior.
```

### Description for the changelog

breaking change: `unreachable` is now a reserved keyword and can no longer be used as an identifier. (`flag` remains usable as an identifier.)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
