### PR TITLE
feat[lang]: allow conversions from flag to bytes32

### DIFF
--- a/tests/functional/builtins/codegen/test_convert.py
+++ b/tests/functional/builtins/codegen/test_convert.py
@@ -540,6 +540,36 @@ def foo(a: {typ}) -> Status:
         assert_compile_failed(lambda: get_contract(contract), TypeMismatch)
 
 
+def test_first_flag_member_to_bytes32(get_contract):
+    contract = """
+flag MyFlag:
+    MEMBER1
+    MEMBER2
+
+@external
+@pure
+def foo() -> bytes32:
+    return convert(MyFlag.MEMBER1, bytes32)
+    """
+    c = get_contract(contract)
+    assert c.foo() == (1).to_bytes(32, "big")
+
+
+def test_second_flag_member_to_bytes32(get_contract):
+    contract = """
+flag MyFlag:
+    MEMBER1
+    MEMBER2
+
+@external
+@pure
+def foo() -> bytes32:
+    return convert(MyFlag.MEMBER2, bytes32)
+    """
+    c = get_contract(contract)
+    assert c.foo() == (2).to_bytes(32, "big")
+
+
 # uint256 conversion is currently valid due to type inference on literals
 # not quite working yet
 same_type_conversion_blocked = sorted(TEST_TYPES - {UINT256_T})

--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -368,7 +368,7 @@ def to_decimal(expr, arg, out_typ):
         raise CompilerPanic("unreachable")
 
 
-@_input_types(IntegerT, DecimalT, BytesM_T, AddressT, BytesT, BoolT)
+@_input_types(IntegerT, DecimalT, BytesM_T, AddressT, BytesT, BoolT, FlagT)
 def to_bytes_m(expr, arg, out_typ):
     _check_bytes(expr, arg, out_typ, max_bytes_allowed=out_typ.m)
 
@@ -408,6 +408,16 @@ def to_bytes_m(expr, arg, out_typ):
 
         # note: neg numbers not OOB. keep sign bit
         arg = shl(256 - out_typ.m_bits, arg)
+
+    elif is_flag_type(arg.typ):
+        if out_typ.m_bits != 256:
+            _FAIL(arg.typ, out_typ, expr)
+
+        # leave `arg` as-is, equivalent to the way we treat uin256:
+        # arg = shl(256 - out_typ.m_bits, arg)
+        # => arg = shl(256 - 256, arg)
+        # => arg = shl(0, arg)
+        # => arg = arg
 
     else:
         # bool


### PR DESCRIPTION
### What I did

Fix https://github.com/vyperlang/vyper/issues/5131

### How I did it

### How to verify it

### Commit message

```
this commit adds the ability for flag values to be converted to bytes32.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
