### PR TITLE
fix[lang]: fix regression on method_id

### DIFF
--- a/tests/functional/syntax/test_method_id.py
+++ b/tests/functional/syntax/test_method_id.py
@@ -42,14 +42,24 @@ def test_method_id_fail(bad_code, exc):
         compile_code(bad_code)
 
 
-valid_list = ["""
+valid_list = [
+    """
 FOO: constant(String[5]) = "foo()"
 BAR: constant(Bytes[4]) = method_id(FOO)
 
 @external
 def foo(a: Bytes[4] = BAR):
     pass
-    """]
+    """,
+    """
+@external
+def foo(a: Bytes[4] = BAR):
+    pass
+
+BAR: constant(Bytes[4]) = method_id(FOO) # forward reference
+FOO: constant(String[5]) = "foo()"
+    """,
+]
 
 
 @pytest.mark.parametrize("code", valid_list)

--- a/tests/functional/syntax/test_method_id.py
+++ b/tests/functional/syntax/test_method_id.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compile_code
-from vyper.exceptions import InvalidLiteral, InvalidType
+from vyper.exceptions import InvalidLiteral, InvalidType, StructureException
 
 fail_list = [
     (
@@ -31,7 +31,7 @@ FOO: constant(Bytes[4]) = method_id("bar ()")
 def f(s: String[20]) -> Bytes[4]:
     return method_id(s)
     """,
-        InvalidType,
+        StructureException,
     ),
 ]
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -58,6 +58,7 @@ from vyper.exceptions import (
 )
 from vyper.semantics.analysis.base import Modifiability, StateMutability
 from vyper.semantics.analysis.utils import (
+    check_modifiability,
     get_common_types,
     get_exact_type_from_node,
     get_possible_types_from_node,
@@ -718,8 +719,9 @@ class MethodID(FoldedFunctionT):
     def _try_fold(self, node):
         validate_call_args(node, 1, ["output_type"])
 
-        value = node.args[0].reduced()
+        value = node.args[0].get_folded_value()
         if not isinstance(value, vy_ast.Str):
+            # Constant Folder runs before the type-checker, so incorrect types can show up
             raise InvalidType("method id must be given as a literal string", node.args[0])
         if " " in value.value:
             raise InvalidLiteral("Invalid function signature - no spaces allowed.", node.args[0])
@@ -739,6 +741,9 @@ class MethodID(FoldedFunctionT):
         return type_
 
     def infer_arg_types(self, node, expected_return_typ=None):
+        is_constant = check_modifiability(node.args[0], Modifiability.CONSTANT)
+        if not is_constant:
+            raise StructureException("Value must be a literal", node.args[0])
         return [self._inputs[0][1]]
 
     def infer_kwarg_types(self, node):


### PR DESCRIPTION
### What I did

Fix regression introduced in #5156:
It changed how method_id was computed, and made it not raise UnfoldableNode anymore, this clashed with how the constant folder deals with forward-references.
See the added test for an example of the regression.

### How I did it

Revert the changes to logic from #5156 (keep the tests), and re-implement it by checking the modifiability of the argument instead.

### How to verify it

Passes all tests

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

```
this commit fixes the regression introduced by
6f4ad4bb8dc541fbb544d6eeab340963996566e0. the constant folder deals with
forward-references by catching and continuing on forward-references, and
that commit raised an error directly when dealing with 'method_id'. this
commit reverts the logic changes from that commit, and implements it by
instead checking the modifiability of the argument.
```

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
