### PR TITLE
chore[ci]: pin snekmate to `main`

### DIFF
--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: pcaversaccio/snekmate
-          ref: 400f6b4f2288635aff5861aa95f5e99c5f451d54
+          ref: main
           submodules: recursive
           path: snekmate
           persist-credentials: false


### PR DESCRIPTION
### What I did

Closes #5169.

### How I did it

N/A.

### How to verify it

N/A.

### Commit message

```
the gas-bench workflow checks out snekmate to compile and run its
foundry test suite, so gas comparisons reflect the latest snekmate
contracts. pinning snekmate to a fixed commit SHA lets that snapshot go
stale as snekmate evolves.

track snekmate's `main` branch instead so the bench always uses the
current contracts. the per-PR comparison stays valid because base and
head share the same snekmate revision within a single run; only the
absolute baseline shifts as snekmate moves.
```

### Description for the changelog

Pin snekmate in `gas-bench.yml` workflow to `main` branch.

### Cute Animal Picture

<img src=https://github.com/user-attachments/assets/7b6cd089-d6ac-474e-92b3-2aadf35d7d43 width="1050"/>


