### PR TITLE
fix[lang]: forbid creation of unusable interfaces

### DIFF
--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -266,6 +266,13 @@ def f():
         """,
         InterfaceViolation,
     ),
+    (
+        """
+interface Foo:
+    def bar(self: uint256): nonpayable
+        """,
+        ArgumentException,
+    ),
 ]
 
 
@@ -525,6 +532,25 @@ from ethereum.ercs import {erc}
     assert e.value._message == f"ethereum.ercs.{erc}"
     assert e.value._hint == f"try renaming `{erc}` to `I{erc}`"
     assert "code.vy:" in str(e.value)
+
+
+def test_interface_self_param_vyi(make_input_bundle):
+    interface_code = """
+def bar(self: uint256): ...
+"""
+    input_bundle = make_input_bundle({"foo.vyi": interface_code})
+
+    code = """
+import foo as Foo
+
+@external
+def baz():
+    pass
+"""
+    with pytest.raises(ArgumentException) as e:
+        compiler.compile_code(code, input_bundle=input_bundle)
+
+    assert e.value.message == "Cannot use 'self' as a variable name in a function input"
 
 
 def test_interface_body_check(make_input_bundle):

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -1083,7 +1083,8 @@ def _parse_args(
 
     for i, arg in enumerate(funcdef.args.args):
         argname = arg.arg
-        if argname in ("gas", "value", "skip_contract_check", "default_return_value"):
+        # TODO: Forbid `self`/`Self`/... everywhere, would be a breaking change
+        if argname in ("gas", "value", "skip_contract_check", "default_return_value", "self"):
             raise ArgumentException(
                 f"Cannot use '{argname}' as a variable name in a function input", arg
             )

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -48,8 +48,6 @@ from vyper.warnings import Deprecation, vyper_warn
 RESERVED_PARAM_NAMES = ["self"]
 KWARG_PARAM_NAMES = ["gas", "value", "skip_contract_check", "default_return_value"]
 
-FORBIDDEN_PARAM_NAMES = KWARG_PARAM_NAMES + RESERVED_PARAM_NAMES
-
 
 @dataclass
 class _FunctionArg:
@@ -1089,7 +1087,7 @@ def _parse_args(
 
     for i, arg in enumerate(funcdef.args.args):
         argname = arg.arg
-        if argname in FORBIDDEN_PARAM_NAMES:
+        if argname in RESERVED_PARAM_NAMES or argname in KWARG_PARAM_NAMES:
             raise ArgumentException(
                 f"Cannot use '{argname}' as a variable name in a function input", arg
             )

--- a/vyper/semantics/types/function.py
+++ b/vyper/semantics/types/function.py
@@ -44,6 +44,12 @@ from vyper.semantics.types.utils import type_from_abi, type_from_annotation
 from vyper.utils import OrderedSet, keccak256
 from vyper.warnings import Deprecation, vyper_warn
 
+# TODO: Forbid `self`/`Self`/... everywhere, would be a breaking change
+RESERVED_PARAM_NAMES = ["self"]
+KWARG_PARAM_NAMES = ["gas", "value", "skip_contract_check", "default_return_value"]
+
+FORBIDDEN_PARAM_NAMES = KWARG_PARAM_NAMES + RESERVED_PARAM_NAMES
+
 
 @dataclass
 class _FunctionArg:
@@ -1083,8 +1089,7 @@ def _parse_args(
 
     for i, arg in enumerate(funcdef.args.args):
         argname = arg.arg
-        # TODO: Forbid `self`/`Self`/... everywhere, would be a breaking change
-        if argname in ("gas", "value", "skip_contract_check", "default_return_value", "self"):
+        if argname in FORBIDDEN_PARAM_NAMES:
             raise ArgumentException(
                 f"Cannot use '{argname}' as a variable name in a function input", arg
             )


### PR DESCRIPTION
### What I did

Fix #5143

### How I did it

checking for 'self' parameters in '_parse_args' which is called when constructing 'ContractFunctionT's.
This ensures all functions are validated, even ones which come from interfaces.

### How to verify it

`pytest`

### Commit message

```
interfaces were allowed to define methods whose parameters contained
`self`, which lead to making them impossible to implement. the reason is
that interface methods are not analyzed, and so the namespace collision
check never fired. this commit fixes it by checking for `self`
parameters in `_parse_args` which is called when constructing
`ContractFunctionT`s. This ensures all functions are validated, even
ones which come from interfaces.
```
### Description for the changelog

Add check that interface functions do not have `self` as parameter, as that would make them un-implementable

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
