### PR TITLE
fix[lang]: fix incorrect supertype computation

### DIFF
--- a/tests/functional/syntax/test_nested_list.py
+++ b/tests/functional/syntax/test_nested_list.py
@@ -58,6 +58,22 @@ def test_nested_list_fail(bad_code, exc):
         compiler.compile_code(bad_code)
 
 
+def test_nested_dynarray_mismatched_inner_bytes():
+    code = """
+@external
+def foo():
+    tmp1: DynArray[Bytes[3], 5] = []
+    tmp2: DynArray[Bytes[5], 5] = []
+    tmp: DynArray[DynArray[Bytes[3], 5], 5] = [tmp1, tmp2]
+    """
+    with pytest.raises(TypeMismatch) as excinfo:
+        compiler.compile_code(code)
+    assert excinfo.value.message == (
+        "Expected DynArray[DynArray[Bytes[3], 5], 5] but literal can only be cast as"
+        " DynArray[Bytes[5], 5][2] or DynArray[DynArray[Bytes[5], 5], 2]."
+    )
+
+
 valid_list = [
     """
 bar: int128[3][3]

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -60,7 +60,6 @@ from vyper.semantics.types import (
     StructT,
     TupleT,
     VyperType,
-    _BytestringT,
     is_type_t,
     map_void,
 )

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -1087,18 +1087,9 @@ class ExprVisitor(VyperNodeVisitorBase):
         else:
             # ex. a < b
             cmp_typ = get_common_types(node.left, node.right).pop()
-            if isinstance(cmp_typ, _BytestringT):
-                # for bytestrings, get_common_types automatically downcasts
-                # to the smaller common type - that will annotate with the
-                # wrong type, instead use get_exact_type_from_node (which
-                # resolves to the right type for bytestrings anyways).
-                ltyp = get_exact_type_from_node(node.left)
-                rtyp = get_exact_type_from_node(node.right)
-            else:
-                ltyp = rtyp = cmp_typ
 
-            self.visit(node.left, ltyp)
-            self.visit(node.right, rtyp)
+            self.visit(node.left, cmp_typ)
+            self.visit(node.right, cmp_typ)
 
     def visit_Constant(self, node: vy_ast.Constant, typ: VyperType) -> None:
         pass

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -528,10 +528,14 @@ def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> Li
         tmp = []
         for c in common_types:
             for t in new_types:
-                # TODO: This can add either the supertype or the subtype to tmp depending on
-                # the order
-                if t.compare_type(c) or c.compare_type(t):
+                # The common type is the one such that both are subtypes
+
+                if t.is_subtype_of(c):
                     tmp.append(c)
+                    break
+
+                if c.is_subtype_of(t):
+                    tmp.append(t)
                     break
 
         common_types = tmp


### PR DESCRIPTION
### What I did

Fix: https://github.com/vyperlang/vyper/issues/5176

More broadly, fixes `get_common_types` always selecting the first type, as opposed to the supremum of the two:
```
type A <: B

a: A
b: B

# before:
[a, b] # inferred to have element type `A` # incorrect, b does not have type A
[b, a] # inferred to have element type `B`

# after:
[a, b] # inferred to have element type `B`
[b, a] # inferred to have element type `B`
``` 

This never lead to issues because a second check is done in `validate_expected_type`.
(By itself, this PR is not enough to remove it, see OTHER_PR)

To go around the above limitation, some similar logic was added when type checking `a < b`, which is no longer required, and thus removed.

### How I did it

```diff
- if t.compare_type(c) or c.compare_type(t):
-     tmp.append(c)
-     break
+ if t.is_subtype_of(c):
+     tmp.append(c)
+     break
+ 
+ if c.is_subtype_of(t):
+     tmp.append(t) # old is equivalent to tmp.append(c) here
+     break
```

### How to verify it

`pytest`

### Commit message

```
'get_common_types' is used to compute a set of types such that all given
nodes conform to them. this is notably used to determine the type of
list literals. in the presence of covariant types like `Bytes`, the
previous logic always favored the first occurrence of the type, instead
of the supremum. this lead to issues where the inferred type was
incorrect, see added test for an example. additional logic was added in
'visit_Compare' for the case 'a < b' where 'a' and 'b' are bytestrings.
this commit fixes 'get_common_types', and remove the now-obsolete logic
in 'visit_Compare'.
```

### Description for the changelog

Fix some issues related to computing types of list literals

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
