### PR TITLE
fix[lang]: fix empty lists having incorrect type

### DIFF
--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -235,6 +235,18 @@ def uoo(inp: DynArray[Foobar, 2]) -> DynArray[DynArray[Foobar, 2], 2]:
     print("Passed list output tests")
 
 
+def test_nested_dynarray_empty_and_flag_literal(get_contract):
+    code = """
+flag Foo:
+    Member1
+
+@external
+def foo():
+    tmp: DynArray[DynArray[Foo, 5], 5] = [[], [Foo.Member1]]
+    """
+    get_contract(code)
+
+
 def test_array_accessor(get_contract):
     array_accessor = """
 @external

--- a/tests/functional/syntax/test_nested_list.py
+++ b/tests/functional/syntax/test_nested_list.py
@@ -49,6 +49,15 @@ def foo(x: int128[2][2]) -> int128:
     """,
         TypeMismatch,
     ),
+    (
+        """
+bar: int128[2][2]
+@external
+def foo():
+    self.bar = [[], [1, 2]]
+    """,
+        TypeMismatch,
+    ),
 ]
 
 
@@ -64,6 +73,16 @@ bar: int128[3][3]
 @external
 def foo():
     self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    """,
+    """
+bar: int128[3][3][3]
+@external
+def foo():
+    self.bar = [
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+    ]
     """,
     """
 bar: decimal[3][3]

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -24,7 +24,7 @@ from vyper.semantics import types
 from vyper.semantics.analysis.base import ExprInfo, Modifiability, ModuleInfo, VarAccess, VarInfo
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.namespace import get_namespace
-from vyper.semantics.types.base import TYPE_T, VyperType
+from vyper.semantics.types.base import TYPE_T, BottomT, VyperType
 from vyper.semantics.types.bytestrings import BytesT, StringT
 from vyper.semantics.types.infinity import is_bounded_length
 
@@ -349,28 +349,10 @@ class _ExprAnalyser:
 
     def types_from_List(self, node):
         # literal array
-        if _is_empty_list(node):
-            ret = []
 
-            if len(node.elements) > 0:
-                # empty nested list literals `[[], []]`
-                subtypes = self.get_possible_types_from_node(node.elements[0])
-            else:
-                # empty list literal `[]`
-                # subtype can be anything
-                subtypes = types.PRIMITIVE_TYPES.values()
-
-            for t in subtypes:
-                # 1 is minimum possible length for dynarray,
-                # can be assigned to anything
-                if isinstance(t, VyperType):
-                    ret.append(DArrayT(t, 1))
-                elif isinstance(t, type) and issubclass(t, VyperType):
-                    # for typeclasses like bytestrings, use a generic type acceptor
-                    ret.append(DArrayT(t.any(), 1))
-                else:
-                    raise CompilerPanic(f"busted type {t}", node)
-            return ret
+        if len(node.elements) == 0:
+            # can't have an empty SArrayT
+            return [DArrayT(BottomT(), 1)]
 
         types_list = get_common_types(*node.elements)
 
@@ -430,18 +412,6 @@ class _ExprAnalyser:
         # unary operation: `-foo`
         types_list = self.get_possible_types_from_node(node.operand)
         return _validate_op(node, types_list, "validate_numeric_op")
-
-
-def _is_empty_list(node):
-    # Checks if a node is a `List` node with an empty list for `elements`,
-    # including any nested `List` nodes. ex. `[]` or `[[]]` will return True,
-    # [1] will return False.
-    if not isinstance(node, vy_ast.List):
-        return False
-
-    if not node.elements:
-        return True
-    return all(_is_empty_list(t) for t in node.elements)
 
 
 def _is_type_in_list(obj, types_list):
@@ -598,17 +568,9 @@ def validate_expected_type(node, expected_type):
 
     given_types = _ExprAnalyser().get_possible_types_from_node(node)
 
-    if isinstance(node, vy_ast.List):
-        # special case - for literal arrays we individually validate each item
-        for expected in expected_type:
-            if not isinstance(expected, (DArrayT, SArrayT)):
-                continue
-            if _validate_literal_array(node, expected):
-                return
-    else:
-        for given, expected in itertools.product(given_types, expected_type):
-            if given.is_subtype_of(expected):
-                return
+    for given, expected in itertools.product(given_types, expected_type):
+        if given.is_subtype_of(expected):
+            return
 
     # validation failed, prepare a meaningful error message
     if len(expected_type) > 1:

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -37,6 +37,9 @@ class _GenericTypeAcceptor:
         return self.compare_type(other) and other.compare_type(self)
 
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
+
         if isinstance(other, self.type_):
             return True
         # compare two GenericTypeAcceptors -- they are the same if the base
@@ -407,6 +410,9 @@ class VyperType:
         bool
             Indicates if the types are equivalent.
         """
+        if isinstance(other, BottomT):
+            return True
+
         return isinstance(other, type(self))
 
     def fetch_call_return(self, node: vy_ast.Call) -> Optional["VyperType"]:
@@ -478,6 +484,10 @@ class KwargSettings:
         self.typ = typ
         self.default = default
         self.require_literal = require_literal
+
+
+class BottomT(VyperType):
+    _id = "Never"  # see python's typing.Never
 
 
 class _VoidType(VyperType):

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -487,6 +487,13 @@ class KwargSettings:
 
 
 class BottomT(VyperType):
+    """
+    Bottom type, the ultimate subtype: is a subtype of every other type.
+    It is unhabited: no value has this type.
+
+    It is for example the element type for empty lists: `[]: DynArray[Never, 1]`
+    """
+
     _id = "Never"  # see python's typing.Never
 
 

--- a/vyper/semantics/types/bytestrings.py
+++ b/vyper/semantics/types/bytestrings.py
@@ -1,7 +1,7 @@
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Bytes, ABI_String, ABIType
 from vyper.exceptions import CodegenPanic, StructureException, UnexpectedNodeType, UnexpectedValue
-from vyper.semantics.types.base import VyperType
+from vyper.semantics.types.base import BottomT, VyperType
 from vyper.semantics.types.infinity import INF, WILDCARD, LengthUpperBound, length_to_json
 from vyper.semantics.types.utils import get_index_value
 from vyper.utils import ceil32
@@ -79,6 +79,9 @@ class _BytestringT(VyperType):
         return self
 
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
+
         if not super().compare_type(other):
             return False
 

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -15,7 +15,7 @@ from vyper.exceptions import (
 )
 from vyper.utils import checksum_encode, int_bounds, is_checksum_encoded
 
-from .base import VyperType
+from .base import BottomT, VyperType
 from .bytestrings import BytesT
 from .infinity import INF
 
@@ -126,6 +126,9 @@ class BytesM_T(_PrimT):
             raise InvalidLiteral(f"Cannot mix uppercase and lowercase for {self} literal", node)
 
     def compare_type(self, other: VyperType) -> bool:
+        if isinstance(other, BottomT):
+            return True
+
         if not super().compare_type(other):
             return False
         assert isinstance(other, BytesM_T)
@@ -317,6 +320,9 @@ class IntegerT(NumericT):
         return ABI_GIntM(self.bits, self.is_signed)
 
     def compare_type(self, other: VyperType) -> bool:
+        if isinstance(other, BottomT):
+            return True
+
         # this function is performance sensitive
         # originally:
         # if not super().compare_type(other):
@@ -440,6 +446,8 @@ class SelfT(AddressT):
     _id = "self"
 
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
         # compares true to AddressT
         # This checks if either is a subtype of the other, which doesn't seem correct
         return isinstance(other, type(self)) or isinstance(self, type(other))

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -4,7 +4,7 @@ from vyper import ast as vy_ast
 from vyper.abi_types import ABI_DynamicArray, ABI_StaticArray, ABI_Tuple, ABIType
 from vyper.exceptions import ArrayIndexException, CodegenPanic, InvalidType, StructureException
 from vyper.semantics.data_locations import DataLocation
-from vyper.semantics.types.base import VyperType
+from vyper.semantics.types.base import BottomT, VyperType
 from vyper.semantics.types.infinity import (
     INF,
     WILDCARD,
@@ -66,6 +66,8 @@ class HashMapT(_SubscriptableT):
 
     # TODO not sure this is used?
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
         return (
             super().compare_type(other)
             and self.key_type == other.key_type
@@ -215,6 +217,9 @@ class SArrayT(_SequenceT):
         return self
 
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
+
         if not isinstance(self, type(other)):
             return False
         if self.length != other.length:
@@ -331,6 +336,8 @@ class DArrayT(_SequenceT):
         return self.length >= other.length
 
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
         # TODO allow static array to be assigned to dyn array?
         # if not isinstance(other, (DArrayT, SArrayT)):
         if not isinstance(self, type(other)):
@@ -455,6 +462,8 @@ class TupleT(VyperType):
         return self.member_types[node.value]
 
     def compare_type(self, other):
+        if isinstance(other, BottomT):
+            return True
         if not isinstance(self, type(other)):
             return False
         if self.length != other.length:

--- a/vyper/semantics/types/user.py
+++ b/vyper/semantics/types/user.py
@@ -20,7 +20,7 @@ from vyper.semantics.analysis.utils import (
     validate_kwargs,
 )
 from vyper.semantics.data_locations import DataLocation
-from vyper.semantics.types.base import VyperType
+from vyper.semantics.types.base import BottomT, VyperType
 from vyper.semantics.types.subscriptable import HashMapT
 from vyper.semantics.types.utils import type_from_abi, type_from_annotation
 from vyper.utils import keccak256, method_id_int
@@ -45,6 +45,8 @@ class _UserType(VyperType):
         # only one time. however, the alternative requires reasoning
         # about both the name and source (module or json abi) of
         # the type.
+        if isinstance(other, BottomT):
+            return True
         return self is other
 
     def __hash__(self):


### PR DESCRIPTION
### What I did

Fix #5161

### How I did it

Added a bottom type, this greatly simplifies the logic, now we can just let widening do its magic.

### How to verify it

`pytest`

### Commit message

```
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
