### PR TITLE
fix[lang]: fix `pow_mod256` raising raw python exception

### DIFF
--- a/tests/functional/syntax/test_powmod.py
+++ b/tests/functional/syntax/test_powmod.py
@@ -11,7 +11,15 @@ def foo():
     a: uint256 = pow_mod256(-1, -1)
     """,
         TypeMismatch,
-    )
+    ),
+    (
+        """
+@external
+def foo():
+    a: uint256 = pow_mod256(2, -1)
+    """,
+        TypeMismatch,
+    ),
 ]
 
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1416,6 +1416,9 @@ class PowMod256(BuiltinFunctionT):
             raise UnfoldableNode
 
         left, right = values
+        if left.value < 0 or right.value < 0:
+            # proper error will be raised later, for now just fail folding
+            raise UnfoldableNode()
         value = pow(left.value, right.value, 2**256)
         return vy_ast.Int.from_node(node, value=value)
 


### PR DESCRIPTION
### What I did

Fix #5121 — `pow_mod256` with a negative literal exponent (e.g. `pow_mod256(2, -1)`) raised a raw Python `ValueError` during constant folding instead of a compiler error.

### How I did it

Skip folding in `pow_mod256._try_fold` when either input is negative. Constant folding runs before type checking, so the negative literal hasn't been rejected yet; bailing out of folding lets the type checker report the proper `TypeMismatch`.

### How to verify it

Added a test case to `tests/functional/syntax/test_powmod.py`; `pow_mod256(2, -1)` now reports `TypeMismatch`.

### Commit message

```
when python's `pow` is given a negative exponent and a modulus, it
computes the modular inverse of the base, raising `ValueError` when the
base and the modulus are not coprime. folding vyper's `pow_mod256` uses
python's `pow` with modulus `2**256`, so a negative literal exponent
combined with an even base escaped as a raw python exception instead of
a compiler error.

the root cause is ordering: constant folding runs before type checking,
so the literals have not yet been validated as `uint256` (and thus non-
negative) when folding is attempted. bail out of folding early when
either input is negative, letting the type checker report the proper
`TypeMismatch`.
```

### Description for the changelog

Fix Python exception leaking from `pow_mod256` with negative literal inputs; report a proper compiler error instead.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
