### PR TITLE
fix[lang]: forbid assignment to values

### DIFF
--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -1,7 +1,13 @@
 import pytest
 
 from vyper.evm.opcodes import version_check
-from vyper.exceptions import CodegenPanic, ImmutableViolation, InvalidType, TypeMismatch
+from vyper.exceptions import (
+    CodegenPanic,
+    ImmutableViolation,
+    InvalidType,
+    StructureException,
+    TypeMismatch,
+)
 
 
 def test_augassign(get_contract):
@@ -382,6 +388,34 @@ def foo(x: int128):
     x += 5
 """
     assert_compile_failed(lambda: get_contract(code), ImmutableViolation)
+
+
+def test_invalid_assign_to_call_return(assert_compile_failed, get_contract):
+    code = """
+@internal
+def g() -> uint256[3]:
+    return [1, 2, 3]
+
+@external
+def f():
+    self.g()[0] = 5
+"""
+    with pytest.raises(StructureException) as e:
+        get_contract(code)
+
+    assert e.value.message == "Cannot modify `self.g()[0]` since it is not a reference"
+
+
+def test_invalid_assign_to_self_balance(assert_compile_failed, get_contract):
+    code = """
+@external
+def f():
+    self.balance = 100
+"""
+    with pytest.raises(StructureException) as e:
+        get_contract(code)
+
+    assert e.value.message == "Cannot modify `self.balance` since it is not a reference"
 
 
 def test_valid_literal_increment(get_contract):

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -403,7 +403,7 @@ def f():
     with pytest.raises(StructureException) as e:
         get_contract(code)
 
-    assert e.value.message == "Cannot modify `self.g()[0]` since it is not a reference"
+    assert e.value.message == "`self.g()[0]` is not a valid assignment target"
 
 
 def test_invalid_assign_to_self_balance(assert_compile_failed, get_contract):
@@ -415,7 +415,7 @@ def f():
     with pytest.raises(StructureException) as e:
         get_contract(code)
 
-    assert e.value.message == "Cannot modify `self.balance` since it is not a reference"
+    assert e.value.message == "`self.balance` is not a valid assignment target"
 
 
 def test_valid_literal_increment(get_contract):

--- a/tests/functional/codegen/features/test_assignment.py
+++ b/tests/functional/codegen/features/test_assignment.py
@@ -418,6 +418,63 @@ def f():
     assert e.value.message == "`self.balance` is not a valid assignment target"
 
 
+def test_invalid_assign_to_storage_addr_balance(assert_compile_failed, get_contract):
+    code = """
+addr: address
+
+@external
+def f():
+    self.addr.balance = 1
+"""
+    with pytest.raises(StructureException) as e:
+        get_contract(code)
+
+    assert e.value.message == "`self.addr.balance` is not a valid assignment target"
+
+
+def test_invalid_assign_to_storage_addr_codehash(assert_compile_failed, get_contract):
+    code = """
+addr: address
+
+@external
+def f():
+    self.addr.codehash = empty(bytes32)
+"""
+    with pytest.raises(StructureException) as e:
+        get_contract(code)
+
+    assert e.value.message == "`self.addr.codehash` is not a valid assignment target"
+
+
+def test_invalid_assign_to_iface_address(assert_compile_failed, get_contract):
+    code = """
+interface IFoo:
+    def foo() -> uint256: nonpayable
+
+f: IFoo
+
+@external
+def g():
+    self.f.address = empty(address)
+"""
+    with pytest.raises(StructureException) as e:
+        get_contract(code)
+
+    assert e.value.message == "`self.f.address` is not a valid assignment target"
+
+
+def test_read_addr_balance_still_works(get_contract):
+    code = """
+addr: address
+
+@external
+def f() -> uint256:
+    return self.addr.balance
+"""
+    c = get_contract(code)
+    assert c.f() == 0
+
+
 def test_valid_literal_increment(get_contract):
     code = """
 storx: uint256

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -11,10 +11,10 @@ from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
     ArgumentException,
     ArrayIndexException,
-    CompilerPanic,
     ImmutableViolation,
     OverflowException,
     StateAccessViolation,
+    StructureException,
     TypeMismatch,
 )
 
@@ -1892,8 +1892,7 @@ def boo() -> uint256:
     assert c.foo() == [1, 2, 3, 4]
 
 
-@pytest.mark.xfail(raises=CompilerPanic)
-def test_dangling_reference(get_contract, tx_failed):
+def test_dangling_reference(get_contract, assert_compile_failed):
     code = """
 a: DynArray[DynArray[uint256, 5], 5]
 
@@ -1902,9 +1901,10 @@ def foo():
     self.a = [[1]]
     self.a.pop().append(2)
     """
-    c = get_contract(code)
-    with tx_failed():
-        c.foo()
+    with pytest.raises(StructureException) as e:
+        get_contract(code)
+
+    assert e.value.message == "Cannot modify `self.a.pop()` since it is not a reference"
 
 
 def test_dynarray_append_single_field_struct_storage(get_contract):

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -1904,7 +1904,7 @@ def foo():
     with pytest.raises(StructureException) as e:
         get_contract(code)
 
-    assert e.value.message == "Cannot modify `self.a.pop()` since it is not a reference"
+    assert e.value.message == "`self.a.pop()` is not a valid assignment target"
 
 
 def test_dynarray_append_single_field_struct_storage(get_contract):

--- a/tests/functional/codegen/types/test_identifier_naming.py
+++ b/tests/functional/codegen/types/test_identifier_naming.py
@@ -41,7 +41,7 @@ def test({constant}: int128):
     )
 
 
-SELF_NAMESPACE_MEMBERS = set(AddressT._type_members.keys())
+SELF_NAMESPACE_MEMBERS = set(AddressT._builtin_members.keys())
 DISALLOWED_FN_NAMES = SELF_NAMESPACE_MEMBERS | RESERVED_KEYWORDS
 ALLOWED_FN_NAMES = ALL_RESERVED_KEYWORDS - DISALLOWED_FN_NAMES
 

--- a/tests/functional/syntax/names/test_variable_names.py
+++ b/tests/functional/syntax/names/test_variable_names.py
@@ -23,6 +23,16 @@ def foo(i: int128) -> int128:
     false : int128 = i
     return false
     """,
+    """
+@external
+def foo():
+    convert = convert # builtin !
+    """,
+    """
+@external
+def foo():
+    as_wei_value = as_wei_value # builtin !
+    """,
 ]
 
 

--- a/tests/functional/syntax/test_flag.py
+++ b/tests/functional/syntax/test_flag.py
@@ -4,7 +4,6 @@ from vyper import compiler
 from vyper.exceptions import (
     FlagDeclarationException,
     InvalidOperation,
-    InvalidReference,
     NamespaceCollision,
     StructureException,
     TypeMismatch,
@@ -134,7 +133,7 @@ flag Status:
 def test_assign_to_flag():
   Status.ACTIVE = 2
         """,
-        InvalidReference,
+        StructureException,
     ),
 ]
 

--- a/tests/unit/semantics/analysis/test_for_loop.py
+++ b/tests/unit/semantics/analysis/test_for_loop.py
@@ -210,6 +210,44 @@ def foo():
     analyze_module_single(vyper_module)
 
 
+def test_modify_iterator_sibling_named_self():
+    # a struct field named `self` is a disjoint sibling of the loop iterator
+    code = """
+struct Foo:
+    self: uint256
+    arr: uint256[3]
+
+f: Foo
+
+@external
+def foo():
+    for i: uint256 in self.f.arr:
+        self.f.self = i
+    """
+    vyper_module = parse_to_ast(code)
+    analyze_module_single(vyper_module)
+
+
+def test_modify_iterator_self_field_self():
+    # writing the same field named `self` used as the iterator is a real conflict
+    code = """
+struct Foo:
+    self: uint256[3]
+
+f: Foo
+
+@external
+def foo():
+    for i: uint256 in self.f.self:
+        self.f.self[0] = i
+    """
+    vyper_module = parse_to_ast(code)
+    with pytest.raises(ImmutableViolation) as e:
+        analyze_module_single(vyper_module)
+
+    assert e.value._message == "Cannot modify loop variable `f`"
+
+
 def test_modify_subscript_barrier():
     # test that Subscript nodes are a barrier for analysis
     code = """

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -35,7 +35,6 @@ from vyper.exceptions import (
     CodegenPanic,
     CompilerPanic,
     EvmVersionException,
-    StructureException,
     TypeCheckFailure,
     TypeMismatch,
     UnimplementedException,

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -825,6 +825,6 @@ class Expr:
     @classmethod
     def parse_pointer_expr(cls, expr, context):
         o = cls(expr, context).ir_node
-        if not o.location:
-            raise StructureException("Looking for a variable location, instead got a value", expr)
+        # Looking for a variable location, instead got a value
+        assert o.location
         return o

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -567,6 +567,11 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         if info.modifiability == Modifiability.CONSTANT:
             raise ImmutableViolation("Constant value cannot be written to.")
 
+        if info.location == DataLocation.UNSET:
+            raise StructureException(
+                f"Cannot modify `{target.node_source_code}` since it is not a reference", target
+            )
+
         var_access = _get_variable_access(target)
         assert var_access is not None
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -187,9 +187,9 @@ def _validate_pure_access(node: vy_ast.Attribute | vy_ast.Name, typ: VyperType) 
 
 
 # analyse the variable access for the attribute chain for a node
-# e.x. `x` will return varinfo for `x`
-# `module.foo` will return VarAccess for `module.foo`
-# `self.my_struct.x.y` will return VarAccess for `self.my_struct.x.y`
+# e.x. `x` will return `VarAccess(<x>, ())`
+# `module.foo` will return `VarAccess(<module.foo>, ())`
+# `self.my_struct.x.y` will return `VarAccess(<self.my_struct>, ('x', 'y'))`
 def _get_variable_access(node: vy_ast.ExprNode) -> Optional[VarAccess]:
     path: list[str | object] = []
     info = get_expr_info(node)
@@ -210,9 +210,6 @@ def _get_variable_access(node: vy_ast.ExprNode) -> Optional[VarAccess]:
         node = node.value
         info = get_expr_info(node)
 
-    # ignore `self.` as it interferes with VarAccess comparison across modules
-    if len(path) > 0 and path[-1] == "self":
-        path.pop()
     path.reverse()
 
     return VarAccess(info.var_info, tuple(path))

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -207,7 +207,6 @@ def _get_variable_access(node: vy_ast.ExprNode) -> Optional[VarAccess]:
         if (attr := info.attr) is not None:
             path.append(attr)
 
-        assert isinstance(node, (vy_ast.Subscript, vy_ast.Attribute))  # help mypy
         node = node.value
         info = get_expr_info(node)
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -569,7 +569,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
 
         if info.location == DataLocation.UNSET:
             raise StructureException(
-                f"Cannot modify `{target.node_source_code}` since it is not a reference", target
+                f"`{target.node_source_code}` is not a valid assignment target", target
             )
 
         var_access = _get_variable_access(target)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -169,7 +169,7 @@ def _validate_pure_access(node: vy_ast.Attribute | vy_ast.Name, typ: VyperType) 
             )
         # allow type exprs in the value node, e.g. MyFlag.A
         parent_info = get_expr_info(node.value, is_callable=True)
-        if isinstance(parent_info.typ, AddressT) and node.attr in AddressT._type_members:
+        if isinstance(parent_info.typ, AddressT) and node.attr in AddressT._builtin_members:
             raise StateAccessViolation("not allowed to query address members in pure functions")
 
     if (varinfo := info.var_info) is None:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -23,6 +23,7 @@ from vyper.exceptions import (
 from vyper.semantics import types
 from vyper.semantics.analysis.base import ExprInfo, Modifiability, ModuleInfo, VarAccess, VarInfo
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
+from vyper.semantics.data_locations import DataLocation
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.base import TYPE_T, VyperType
 from vyper.semantics.types.bytestrings import BytesT, StringT
@@ -109,6 +110,13 @@ class _ExprAnalyser:
 
             if isinstance(t, ModuleInfo):
                 return ExprInfo.from_moduleinfo(t, attr=attr)
+
+            if info.typ._type_members and attr in info.typ._type_members:
+                # things like `addr.balance` should not inherit the location of `addr`
+                # since `addr` can be assignable, while `addr.balance` never is
+                return ExprInfo(
+                    t, attr=attr, location=DataLocation.UNSET, modifiability=info.modifiability
+                )
 
             return info.copy_with_type(t, attr=attr)
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -111,7 +111,7 @@ class _ExprAnalyser:
             if isinstance(t, ModuleInfo):
                 return ExprInfo.from_moduleinfo(t, attr=attr)
 
-            if info.typ._type_members and attr in info.typ._type_members:
+            if info.typ._builtin_members and attr in info.typ._builtin_members:
                 # things like `addr.balance` should not inherit the location of `addr`
                 # since `addr` can be assignable, while `addr.balance` never is
                 return ExprInfo(

--- a/vyper/semantics/environment.py
+++ b/vyper/semantics/environment.py
@@ -17,7 +17,7 @@ class _EnvType(VyperType):
 
 class _Block(_EnvType):
     _id = "block"
-    _type_members = {
+    _builtin_members = {
         "coinbase": AddressT(),
         "difficulty": UINT256_T,
         "prevrandao": BYTES32_T,
@@ -32,12 +32,12 @@ class _Block(_EnvType):
 
 class _Chain(_EnvType):
     _id = "chain"
-    _type_members = {"id": UINT256_T}
+    _builtin_members = {"id": UINT256_T}
 
 
 class _Msg(_EnvType):
     _id = "msg"
-    _type_members = {
+    _builtin_members = {
         "data": BytesT(INF),
         "gas": UINT256_T,
         "mana": UINT256_T,
@@ -57,7 +57,7 @@ _inf = _Inf()
 
 class _Tx(_EnvType):
     _id = "tx"
-    _type_members = {"origin": AddressT(), "gasprice": UINT256_T}
+    _builtin_members = {"origin": AddressT(), "gasprice": UINT256_T}
 
 
 CONSTANT_ENVIRONMENT_VARS = {

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -83,7 +83,7 @@ class VyperType:
     typeclass: str = None  # type: ignore
 
     _id: str  # rename to `_name`
-    _type_members: Optional[Dict] = None
+    _builtin_members: Optional[Dict] = None
     _valid_literal: Tuple = ()
     _invalid_locations: Tuple = ()
     _is_prim_word: bool = False
@@ -106,8 +106,8 @@ class VyperType:
         self.members: Dict = {}
 
         # add members that are on the class instance.
-        if self._type_members is not None:
-            for k, v in self._type_members.items():
+        if self._builtin_members is not None:
+            for k, v in self._builtin_members.items():
                 # for builtin members like `contract.address` -- skip namespace
                 # validation, as it introduces a dependency cycle
                 self.add_member(k, v)

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 class InterfaceT(_UserType):
     typeclass = "interface"
 
-    _type_members = {"address": AddressT()}
+    _builtin_members = {"address": AddressT()}
     _is_prim_word = True
     is_valid_element_type = True
     _as_hashmap_key = True

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -407,7 +407,7 @@ class DecimalT(NumericT):
 class AddressT(_PrimT):
     _id = "address"
     _valid_literal = (vy_ast.Hex,)
-    _type_members = {
+    _builtin_members = {
         "balance": UINT(256),
         "codehash": BytesM_T(32),
         "codesize": UINT(256),


### PR DESCRIPTION
### What I did

Fix #5138
Fix #5151
Fix #3933

In short: we didn't check what was on the lhs of assignments enough, so things like `self.g()[0] = 5` were allowed => failed asserts

### How I did it

Check that the lhs of assignments has a location (memory/transient/storage), and if not, raise an exception.
This catches even tricky cases, like the long-standing `self.nostedArray.pop().append()` which otherwise have correct type and mutability

### How to verify it

`pytest`

### Commit message

```
the left hand-side of assignments used to only be checked to have
correct mutability and location. however some expressions fulfilled
these criterion without representing a concrete offset in
memory/transient/storage, for example 'self.g()[0] = 5'. this commit
addresses that by directly checking that the lhs has a location.
```

### Description for the changelog

Compiler no longer panics when trying to assign to expressions

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
