### PR TITLE
fix[venom]: fix stack ordering pass for phi instructions

### DIFF
--- a/tests/unit/compiler/venom/test_stack_order.py
+++ b/tests/unit/compiler/venom/test_stack_order.py
@@ -427,3 +427,20 @@ def test_stack_order_two_trees():
     """
 
     _check_no_change(pre)
+
+def test_stack_order_same_var_in_phi_error(get_contract):
+    code = """
+@external
+def f(_t: uint256) -> uint256:
+    s: uint256 = 0
+    for i: uint256 in range(32):
+        if i == _t:
+            break
+        if i == _t:
+            s = 1
+            break
+    return s
+    """
+
+    c = get_contract(code)
+    assert c.f(5) == 0

--- a/tests/unit/compiler/venom/test_stack_order.py
+++ b/tests/unit/compiler/venom/test_stack_order.py
@@ -428,6 +428,7 @@ def test_stack_order_two_trees():
 
     _check_no_change(pre)
 
+
 def test_stack_order_same_var_in_phi_error(get_contract):
     code = """
 @external

--- a/vyper/venom/analysis/stack_order.py
+++ b/vyper/venom/analysis/stack_order.py
@@ -43,6 +43,7 @@ class StackOrderAnalysis(IRAnalysis):
     _from_to: dict[tuple[IRBasicBlock, IRBasicBlock], Needed]
 
     def analyze(self):
+        print(self.function)
         self._from_to = dict()
         self.liveness = self.analyses_cache.request_analysis(LivenessAnalysis)
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
@@ -55,7 +56,10 @@ class StackOrderAnalysis(IRAnalysis):
             if inst.opcode == "assign":
                 self._handle_assign(inst)
             elif inst.opcode == "phi":
-                self._handle_inst(inst)
+                self._handle_phi(inst)
+                self.stack.pop()
+                self.stack.append(inst.output)
+                continue
             elif inst.is_bb_terminator:
                 self._handle_terminator(inst)
             else:
@@ -138,6 +142,21 @@ class StackOrderAnalysis(IRAnalysis):
             if op not in self.stack:
                 self.stack.append(op)
         self._reorder(ops)
+
+    def _handle_phi(self, inst: IRInstruction):
+        assert inst.opcode == "phi"
+
+        for _, var in inst.phi_operands:
+            assert isinstance(var, IRVariable)
+            if var not in self.stack:
+                self._add_needed(var)
+
+        _, chosen = next(inst.phi_operands)
+        assert isinstance(chosen, IRVariable)
+        if chosen not in self.stack:
+            self.stack.append(chosen)
+
+        self._reorder([chosen])
 
     def _merge(self, orders: list[Needed]) -> Needed:
         if len(orders) == 0:

--- a/vyper/venom/analysis/stack_order.py
+++ b/vyper/venom/analysis/stack_order.py
@@ -151,7 +151,7 @@ class StackOrderAnalysis(IRAnalysis):
             assert isinstance(var, IRVariable)
             if var not in self.stack:
                 self._add_needed(var)
-        
+
         # for reorder we need to simulate only
         # one chosen varible since it should
         # do the same behavior for all of them

--- a/vyper/venom/analysis/stack_order.py
+++ b/vyper/venom/analysis/stack_order.py
@@ -43,7 +43,6 @@ class StackOrderAnalysis(IRAnalysis):
     _from_to: dict[tuple[IRBasicBlock, IRBasicBlock], Needed]
 
     def analyze(self):
-        print(self.function)
         self._from_to = dict()
         self.liveness = self.analyses_cache.request_analysis(LivenessAnalysis)
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)

--- a/vyper/venom/analysis/stack_order.py
+++ b/vyper/venom/analysis/stack_order.py
@@ -146,11 +146,16 @@ class StackOrderAnalysis(IRAnalysis):
     def _handle_phi(self, inst: IRInstruction):
         assert inst.opcode == "phi"
 
+        # add vars to needed if it is
+        # necessary as in other instructions
         for _, var in inst.phi_operands:
             assert isinstance(var, IRVariable)
             if var not in self.stack:
                 self._add_needed(var)
-
+        
+        # for reorder we need to simulate only
+        # one chosen varible since it should
+        # do the same behavior for all of them
         _, chosen = next(inst.phi_operands)
         assert isinstance(chosen, IRVariable)
         if chosen not in self.stack:

--- a/vyper/venom/analysis/stack_order.py
+++ b/vyper/venom/analysis/stack_order.py
@@ -56,8 +56,6 @@ class StackOrderAnalysis(IRAnalysis):
                 self._handle_assign(inst)
             elif inst.opcode == "phi":
                 self._handle_phi(inst)
-                self.stack.pop()
-                self.stack.append(inst.output)
                 continue
             elif inst.is_bb_terminator:
                 self._handle_terminator(inst)
@@ -161,6 +159,8 @@ class StackOrderAnalysis(IRAnalysis):
             self.stack.append(chosen)
 
         self._reorder([chosen])
+        self.stack.pop()
+        self.stack.append(inst.output)
 
     def _merge(self, orders: list[Needed]) -> Needed:
         if len(orders) == 0:


### PR DESCRIPTION
### What I did
Fix the issue with the `phi` handling that was shown here https://github.com/vyperlang/vyper/issues/4957, this issue was also addressed by  https://github.com/vyperlang/vyper/pull/5101. However that PR basically ignored the the issue instead of the doing proper semantics of `phi`

### How I did it

### How to verify it

### Commit message

```
`StackOrderAnalysis` simulates a stack per basic block to compute the
preferred variable ordering at block boundaries. `phi` instructions were
handled by the generic `_handle_inst` path, which pushes every operand
onto the simulated stack and then asserts (in `_reorder`) that the stack
top matches the full operand list. This does not match phi semantics: at
runtime only one incoming value is on the stack (whichever predecessor
branch was taken), and `venom_to_assembly` lowers a phi by renaming that
single stack slot in place rather than consuming all operands. When the
same variable flowed in from multiple predecessors, the simulated stack
held fewer entries than the operand list, tripping the `_reorder`
assertion (GH 4957).

Fix by giving phi its own handler that mirrors the `venom_to_assembly`
lowering: record all incoming variables as needed, but simulate only a
single chosen operand on the stack, then replace it with the phi's
output. Since any incoming value must produce the same stack shape,
simulating one representative operand is sufficient.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()

