### PR TITLE
fix[venom]: match legacy leniency for in-place ABI decode offsets

### DIFF
--- a/tests/functional/builtins/codegen/test_abi_decode.py
+++ b/tests/functional/builtins/codegen/test_abi_decode.py
@@ -537,6 +537,57 @@ def _replicate(value: int, count: int) -> tuple[int, ...]:
     return (value,) * count
 
 
+def test_abi_arg_wrapped_dynarray_head(env, get_contract):
+    """Calldata/CODE decodes preserve legacy's lenient offset arithmetic."""
+    typ = "DynArray[DynArray[uint256, 1], 1]"
+    code = f"""
+@external
+def f(xs: {typ}) -> uint256:
+    return xs[0][0]
+"""
+    c = get_contract(code)
+
+    # The inner array base is one word after the outer length. Adding this
+    # offset wraps it back to the outer length word, which becomes inner.len.
+    wrapped_head = 2**256 - 0x20
+    payload = _abi_payload_from_tuple((0x20, 1, wrapped_head), 3 * 32)
+
+    ret = env.message_call(c.address, data=method_id("f(uint256[][])") + payload)
+    assert ret == wrapped_head.to_bytes(32, "big")
+
+    # Constructor arguments use CODE instead of CALLDATA and have the same
+    # intentionally lenient semantics.
+    _test_ctor_decode(env, typ, payload, [[wrapped_head]])
+
+
+def test_abi_arg_wrapped_complex_member_head(env, get_contract):
+    """Exercise wrapped offsets navigated through _getelemptr_abi()."""
+    preamble = """
+struct Point:
+    x: uint256
+    ys: DynArray[uint256, 1]
+"""
+    typ = "DynArray[Point, 1]"
+    code = f"""
+{preamble}
+@external
+def f(xs: {typ}) -> (uint256, uint256):
+    return xs[0].x, xs[0].ys[0]
+"""
+    c = get_contract(code)
+
+    # Point.ys is based two words after the outer length. Its offset wraps
+    # back to that length word, while its first element aliases Point's head.
+    wrapped_head = 2**256 - 0x40
+    payload = _abi_payload_from_tuple((0x20, 1, 0x20, 123, wrapped_head), 5 * 32)
+
+    signature = "f((uint256,uint256[])[])"
+    ret = env.message_call(c.address, data=method_id(signature) + payload)
+    assert ret == _abi_payload_from_tuple((123, 0x20), 2 * 32)
+
+    _test_ctor_decode(env, typ, payload, [(123, [0x20])], preamble=preamble)
+
+
 def test_abi_decode_arithmetic_overflow(env, tx_failed, get_contract):
     # test based on GHSA-9p8r-4xp4-gw5w:
     # https://github.com/vyperlang/vyper/security/advisories/GHSA-9p8r-4xp4-gw5w#advisory-comment-91841

--- a/vyper/codegen_venom/abi/abi_decoder.py
+++ b/vyper/codegen_venom/abi/abi_decoder.py
@@ -200,7 +200,11 @@ def clamp_dyn_array(
 
 
 def _getelemptr_abi(
-    ctx: VenomCodegenContext, parent: VyperValue, member_typ: VyperType, static_offset: int
+    ctx: VenomCodegenContext,
+    parent: VyperValue,
+    member_typ: VyperType,
+    static_offset: int,
+    hi: IROperand = None,
 ) -> VyperValue:
     """
     Navigate to ABI-encoded element.
@@ -224,9 +228,14 @@ def _getelemptr_abi(
         # Double dereference: read offset, add to parent base
         offset_val = b.load(static_loc, loc)
         actual_ptr = b.add(parent.operand, offset_val)
-        # Security: prevent underflow attacks
-        # assert actual_ptr >= parent
-        b.assert_(b.iszero(b.lt(actual_ptr, parent.operand)))
+        if hi is not None:
+            # Only hi-bounded (MEMORY) decodes need the no-wrap guard, mirroring
+            # legacy's _dirty_read_risk (MEMORY-only). For calldata/code the data
+            # is read in place from clean immutable regions: a wrapped offset reads
+            # deterministic zero-fill (calldataload/codeload), never an OOB read,
+            # and the value clamps handle safety.
+            # assert actual_ptr >= parent
+            b.assert_(b.iszero(b.lt(actual_ptr, parent.operand)))
         return _make_ptr_value(actual_ptr, loc, member_typ)
     else:
         # Static: data is inline
@@ -352,10 +361,11 @@ def _decode_dyn_array(
         static_loc = b.add(src_data, b.mul(i, IRLiteral(elem_static_size)))
         offset_val = b.load(static_loc, loc)
         elem_src_ptr = b.add(src_data, offset_val)
-        # Security check: prevent underflow
-        b.assert_(b.iszero(b.lt(elem_src_ptr, src_data)))
-        # Bounds check: ensure element static footprint fits within buffer
         if hi is not None:
+            # Only hi-bounded (MEMORY) decodes need the no-wrap guard (see
+            # _getelemptr_abi); calldata/code read in place with zero-fill.
+            b.assert_(b.iszero(b.lt(elem_src_ptr, src_data)))
+            # Bounds check: ensure element static footprint fits within buffer
             elem_end = b.add(elem_src_ptr, IRLiteral(elem_static_size))
             b.assert_(b.iszero(b.gt(elem_end, hi)))
     else:
@@ -409,7 +419,7 @@ def _decode_complex(
 
     for _key, elem_typ in items:
         # Get source pointer (ABI layout) - returns VyperValue
-        elem_src = _getelemptr_abi(ctx, src, elem_typ, abi_offset)
+        elem_src = _getelemptr_abi(ctx, src, elem_typ, abi_offset, hi)
 
         # Get destination pointer (Vyper layout)
         elem_dst = b.add(dst, IRLiteral(vyper_offset))

--- a/vyper/codegen_venom/abi/abi_decoder.py
+++ b/vyper/codegen_venom/abi/abi_decoder.py
@@ -230,10 +230,10 @@ def _getelemptr_abi(
         actual_ptr = b.add(parent.operand, offset_val)
         if hi is not None:
             # Only hi-bounded (MEMORY) decodes need the no-wrap guard, mirroring
-            # legacy's _dirty_read_risk (MEMORY-only). For calldata/code the data
-            # is read in place from clean immutable regions: a wrapped offset reads
-            # deterministic zero-fill (calldataload/codeload), never an OOB read,
-            # and the value clamps handle safety.
+            # legacy's _dirty_read_risk (MEMORY-only). In calldata/code, wrapping
+            # can alias an earlier byte in the same immutable region. Bounded type
+            # clamps still cap decoder work and destination writes; out-of-range
+            # portions of the resulting loads/copies are zero-filled.
             # assert actual_ptr >= parent
             b.assert_(b.iszero(b.lt(actual_ptr, parent.operand)))
         return _make_ptr_value(actual_ptr, loc, member_typ)
@@ -363,7 +363,7 @@ def _decode_dyn_array(
         elem_src_ptr = b.add(src_data, offset_val)
         if hi is not None:
             # Only hi-bounded (MEMORY) decodes need the no-wrap guard (see
-            # _getelemptr_abi); calldata/code read in place with zero-fill.
+            # _getelemptr_abi); calldata/code may alias earlier immutable data.
             b.assert_(b.iszero(b.lt(elem_src_ptr, src_data)))
             # Bounds check: ensure element static footprint fits within buffer
             elem_end = b.add(elem_src_ptr, IRLiteral(elem_static_size))


### PR DESCRIPTION
### What I did

The Venom ABI decoder emits the dynamic-offset underflow ("no-wrap") assert  (`assert actual_ptr >= parent`) unconditionally, including for ABI data read in place from calldata and code. The legacy pipeline only emits this guard for ABI data in memory. So venom is stricter than legacy for every external function with a dynamic calldata argument: an extra guard per argument, plus a spurious revert on malformed-but-harmless head offsets that legacy accepts. This gates the guard on the same condition legacy uses, restoring parity in both behavior and gas.

### How I did it

Thread the `hi` bound — which is set only for MEMORY decodes — into `_getelemptr_abi()` and emit the no-wrap assert only when it is present. Apply the same gating to the element-offset guard in `_decode_dyn_array()`, which already receives `hi`. This mirrors legacy's `_dirty_read_risk`, which is false for calldata/code.

This is safe for calldata/code because a wrapping offset can only alias an earlier byte of the same immutable region: bounded type clamps still cap decoder work and destination writes, and out-of-range portions of the resulting loads are zero-filled.

### How to verify it

New tests in `tests/functional/builtins/codegen/test_abi_decode.py` exercise wrapped head offsets for a nested dynarray and for a dynamic struct member, via both external-call calldata and constructor code decodes, asserting the lenient (legacy-matching) result. The existing `test_abi_decode` suite covers the memory path, where the guard must remain.

### Commit message

```
the venom abi decoder emitted the dynamic-offset "no-wrap" guard
(`assert actual_ptr >= parent`) unconditionally, including for abi data
decoded in place from calldata or code. the legacy pipeline only emits
this guard when there is dirty-read risk, which applies only to MEMORY
buffers (`_dirty_read_risk`). in calldata/code, a wrapping offset can
only alias an earlier byte of the same immutable region -- bounded type
clamps still cap decoder work and destination writes, and out-of-range
portions of the resulting loads are zero-filled -- so the guard is
unnecessary there.

the unconditional guard made venom stricter than legacy for every
external function with a dynamic calldata argument: an extra assert per
dynamic member, plus a spurious revert on malformed-but-harmless head
offsets that legacy accepts.

gate the guard on the same condition legacy uses: thread the `hi` bound
(present only for MEMORY decodes) through `_getelemptr_abi` and emit the
no-wrap assert only when it is set, matching the existing gating in
`_decode_dyn_array`.
```

### Description for the changelog

Venom: only emit the ABI dynamic-offset underflow guard for in-memory decodes, matching legacy behavior and gas for calldata/code decodes.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
