### PR TITLE
fix[parser]: reject bare await keyword

### DIFF
--- a/tests/unit/ast/test_parser.py
+++ b/tests/unit/ast/test_parser.py
@@ -1,5 +1,8 @@
+import pytest
+
 from tests.ast_utils import deepequals
 from vyper.ast.parse import parse_to_ast
+from vyper.exceptions import SyntaxException
 
 
 def test_ast_equal():
@@ -34,3 +37,19 @@ def test() -> int128:
     ast2 = parse_to_ast(code2)
 
     assert not deepequals(ast1, ast2)
+
+
+def test_await_raises_syntax_exception():
+    code = """@external
+def f():
+    await something
+"""
+
+    with pytest.raises(SyntaxException) as exc_info:
+        parse_to_ast(code)
+
+    exc = exc_info.value
+    assert exc.message == "The `await` keyword is not allowed."
+    annotation = exc.annotations[0]
+    assert (annotation.lineno, annotation.col_offset) == (3, 4)
+    assert annotation.full_source_code == code

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -409,6 +409,13 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
     def visit_Await(self, node):
         start_pos = node.lineno, node.col_offset
         self.generic_visit(node)
+        if start_pos not in self._pre_parser.keyword_translations:
+            raise SyntaxException(
+                "The `await` keyword is not allowed.",
+                self._source_code,
+                node.lineno,
+                node.col_offset,
+            )
         node.ast_type = self._pre_parser.keyword_translations[start_pos]
         return node
 


### PR DESCRIPTION
### What I did

Fixes #5142.

User-written `await` now reports a normal `SyntaxException` at its source position instead of leaking a `KeyError`.

### How I did it

The AST visitor checks whether an `Await` node has a pre-parser keyword translation. Nodes produced for `extcall`, `staticcall`, and `log` keep their existing behavior; a native `await` without a translation raises the parser diagnostic.

### How to verify it

`pytest tests/unit/ast/test_parser.py -q`

The regression test checks the message, line, column, and source annotation. Related AST, external-call, logging, and event tests also pass.

### Commit message

```
`await` is a Python keyword that parses into an `Await` AST node, but
vyper only produces `Await` nodes internally via the pre-parser as a
carrier for `extcall`, `staticcall`, and `log`. `visit_Await`
unconditionally indexed `keyword_translations` by source position, so a
user-written `await` — for which no translation was registered —
surfaced as a bare `KeyError: (line, col)` with no diagnostic or source
location.

Guard the lookup: if the position is missing from the translation map,
the node was written by the user, so raise a `SyntaxException` pinned to
the `await` token. Pre-parser-synthesized `Await` nodes still hit the
translation path unchanged.

Fixes GH 5142.
```

### Description for the changelog

Report a compiler syntax error for unsupported `await` expressions instead of a raw Python `KeyError`.

### Cute Animal Picture

![Cute baby python reviewing code](https://raw.githubusercontent.com/Functionhx/vyper/pr-assets/pr-5185-cute-python.jpg)

