### PR TITLE
feat[venom]: add `noinline` function annotation

### DIFF
--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -400,14 +400,17 @@ def test_noinline_annotation():
     source = """
     function main {
         main:
-            invoke @f
             stop
     }
 
     function f [noinline] {
         f:
-            %retpc = param
-            ret %retpc
+            stop
+    }
+
+    function g [fmp_lowered, noinline] {
+        g:
+            stop
     }
     """
 
@@ -415,23 +418,9 @@ def test_noinline_annotation():
 
     assert parsed_ctx.get_function(IRLabel("main")).noinline is False
     assert parsed_ctx.get_function(IRLabel("f")).noinline is True
+    g = parsed_ctx.get_function(IRLabel("g"))
+    assert g.noinline is True
+    assert g._fmp_signature is not None
 
     # printer/parser round trip preserves the flag
-    assert_ctx_eq(parsed_ctx, parse_venom(str(parsed_ctx)))
-
-
-def test_noinline_annotation_with_fmp_lowered():
-    source = """
-    function main [fmp_lowered, noinline] {
-        main:
-            stop
-    }
-    """
-
-    parsed_ctx = parse_venom(source)
-
-    fn = parsed_ctx.get_function(IRLabel("main"))
-    assert fn.noinline is True
-    assert fn._fmp_signature is not None
-
     assert_ctx_eq(parsed_ctx, parse_venom(str(parsed_ctx)))

--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -394,3 +394,44 @@ def test_multi_output_last_var():
 
     g_fn = parsed_ctx.get_function(IRLabel("g"))
     assert g_fn.last_variable == 0
+
+
+def test_noinline_annotation():
+    source = """
+    function main {
+        main:
+            invoke @f
+            stop
+    }
+
+    function f [noinline] {
+        f:
+            %retpc = param
+            ret %retpc
+    }
+    """
+
+    parsed_ctx = parse_venom(source)
+
+    assert parsed_ctx.get_function(IRLabel("main")).noinline is False
+    assert parsed_ctx.get_function(IRLabel("f")).noinline is True
+
+    # printer/parser round trip preserves the flag
+    assert_ctx_eq(parsed_ctx, parse_venom(str(parsed_ctx)))
+
+
+def test_noinline_annotation_with_fmp_lowered():
+    source = """
+    function main [fmp_lowered, noinline] {
+        main:
+            stop
+    }
+    """
+
+    parsed_ctx = parse_venom(source)
+
+    fn = parsed_ctx.get_function(IRLabel("main"))
+    assert fn.noinline is True
+    assert fn._fmp_signature is not None
+
+    assert_ctx_eq(parsed_ctx, parse_venom(str(parsed_ctx)))

--- a/tests/unit/compiler/venom/test_inliner.py
+++ b/tests/unit/compiler/venom/test_inliner.py
@@ -152,25 +152,16 @@ def test_noinline_annotation():
     }
     """
 
-    ctx = parse_venom(src)
-
-    ir_analyses = {}
-    for fn in ctx.functions.values():
-        ir_analyses[fn] = IRAnalysesCache(fn)
-
     flags = VenomOptimizationFlags(level=OptimizationLevel.CODESIZE)
-    FunctionInlinerPass(ir_analyses, ctx, flags).run_pass()
+
+    def run_inliner(source):
+        ctx = parse_venom(source)
+        analyses = {fn: IRAnalysesCache(fn) for fn in ctx.functions.values()}
+        FunctionInlinerPass(analyses, ctx, flags).run_pass()
+        return ctx
 
     # a single call site would otherwise always be inlined
-    assert IRLabel("f") in ctx.functions
+    assert IRLabel("f") in run_inliner(src).functions
 
     # sanity check: without the annotation, the function gets inlined
-    ctx = parse_venom(src.replace(" [noinline]", ""))
-
-    ir_analyses = {}
-    for fn in ctx.functions.values():
-        ir_analyses[fn] = IRAnalysesCache(fn)
-
-    FunctionInlinerPass(ir_analyses, ctx, flags).run_pass()
-
-    assert IRLabel("f") not in ctx.functions
+    assert IRLabel("f") not in run_inliner(src.replace(" [noinline]", "")).functions

--- a/tests/unit/compiler/venom/test_inliner.py
+++ b/tests/unit/compiler/venom/test_inliner.py
@@ -134,3 +134,43 @@ def test_fcg_analysis_remains_requestable_from_function_cache():
     fcg = IRAnalysesCache(ctx.entry_function).force_analysis(FCGGlobalAnalysis)
 
     assert fcg.get_callees(ctx.entry_function).first() == ctx.get_function(IRLabel("callee"))
+
+
+def test_noinline_annotation():
+    src = """
+    function main {
+    main:
+        %1 = invoke @f
+        sink %1
+    }
+
+    function f [noinline] {
+    f:
+        %retpc = param
+        %1 = 42
+        ret %1, %retpc
+    }
+    """
+
+    ctx = parse_venom(src)
+
+    ir_analyses = {}
+    for fn in ctx.functions.values():
+        ir_analyses[fn] = IRAnalysesCache(fn)
+
+    flags = VenomOptimizationFlags(level=OptimizationLevel.CODESIZE)
+    FunctionInlinerPass(ir_analyses, ctx, flags).run_pass()
+
+    # a single call site would otherwise always be inlined
+    assert IRLabel("f") in ctx.functions
+
+    # sanity check: without the annotation, the function gets inlined
+    ctx = parse_venom(src.replace(" [noinline]", ""))
+
+    ir_analyses = {}
+    for fn in ctx.functions.values():
+        ir_analyses[fn] = IRAnalysesCache(fn)
+
+    FunctionInlinerPass(ir_analyses, ctx, flags).run_pass()
+
+    assert IRLabel("f") not in ctx.functions

--- a/tests/venom_utils.py
+++ b/tests/venom_utils.py
@@ -52,6 +52,7 @@ def assert_bb_eq(bb1: IRBasicBlock, bb2: IRBasicBlock):
 def assert_fn_eq(fn1: IRFunction, fn2: IRFunction):
     assert fn1.name.value == fn2.name.value
     assert fn1._fmp_signature == fn2._fmp_signature
+    assert fn1.noinline == fn2.noinline
     assert len(fn1._basic_block_dict) == len(fn2._basic_block_dict)
 
     for name1, bb1 in fn1._basic_block_dict.items():

--- a/vyper/venom/README.md
+++ b/vyper/venom/README.md
@@ -29,9 +29,10 @@ A function header may carry an optional bracketed annotation list:
 ```llvm
 function my_func [fmp_lowered] { ... }
 function my_producer [fmp_lowered, fmp_publishes] { ... }
+function keep_as_call [noinline] { ... }
 ```
 
-The annotation is the explicit carrier of the FMP (free-memory pointer)
+The FMP annotations are the explicit carrier of the free-memory pointer
 calling-convention facts that are not opcodes (see "Dynamic memory" below):
 `fmp_lowered` declares that the function's FMP convention has been
 materialized (its `fmp_signature` is frozen), and `fmp_publishes` declares
@@ -39,9 +40,10 @@ that every `ret` carries a hidden adopted-FMP value before the return PC.
 Whether the function has a hidden FMP param is *not* annotated: it is
 carried syntactically by the `fmp_param` opcode. A function containing
 lowered FMP artifacts (`fmp_param`, `bump`, `initial_fmp`) without the
-annotation is rejected by the input validator; raw IR needs no annotation.
+annotation is rejected by the input validator; raw IR needs no FMP annotation.
 The printer emits the annotation for every function with a frozen
 signature, so lowered IR round-trips through the parser.
+`noinline` prevents the function inliner from inlining the function at its call sites.
 
 Venom employs two scopes: global and function level.
 

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -29,14 +29,14 @@ class FmpSignature:
     publishes: bool
 
     @property
-    def annotation(self) -> str:
-        # the function-header annotation in the Venom text format.
+    def attrs(self) -> list[str]:
+        # the function-header annotation attributes in the Venom text format.
         # `has_fmp_param` is not part of the annotation: it is carried
         # syntactically by the `fmp_param` opcode.
         attrs = ["fmp_lowered"]
         if self.publishes:
             attrs.append("fmp_publishes")
-        return f"[{', '.join(attrs)}]"
+        return attrs
 
 
 class IRFunction:
@@ -61,6 +61,10 @@ class IRFunction:
     # Frozen FMP convention shape; None until FmpLoweringPass runs.
     _fmp_signature: Optional[FmpSignature]
 
+    # Opt-out flag for FunctionInlinerPass; set via the `[noinline]`
+    # function-header annotation.
+    noinline: bool
+
     # Used during code generation
     _ast_source_stack: list[IRnode]
     _error_msg_stack: list[Optional[str]]
@@ -75,6 +79,7 @@ class IRFunction:
         self._has_memory_return_buffer_param = None
         self._return_value_count = None
         self._fmp_signature = None
+        self.noinline = False
 
         self._ast_source_stack = []
         self._error_msg_stack = []
@@ -167,6 +172,7 @@ class IRFunction:
         new._has_memory_return_buffer_param = self._has_memory_return_buffer_param
         new._return_value_count = self._return_value_count
         new._fmp_signature = self._fmp_signature
+        new.noinline = self.noinline
         for bb in self.get_basic_blocks():
             new_bb = bb.copy()
             new.append_basic_block(new_bb)
@@ -211,9 +217,14 @@ class IRFunction:
         return "\n".join(ret)
 
     def __repr__(self) -> str:
-        annotation = ""
+        attrs = []
         if self._fmp_signature is not None:
-            annotation = f" {self._fmp_signature.annotation}"
+            attrs.extend(self._fmp_signature.attrs)
+        if self.noinline:
+            attrs.append("noinline")
+        annotation = ""
+        if len(attrs) > 0:
+            annotation = f" [{', '.join(attrs)}]"
         ret = f"function {self.name}{annotation} {{\n"
         for bb in self.get_basic_blocks():
             bb_str = textwrap.indent(str(bb), "  ")

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -38,6 +38,10 @@ class FmpSignature:
             attrs.append("fmp_publishes")
         return attrs
 
+    @property
+    def annotation(self) -> str:
+        return f"[{', '.join(self.attrs)}]"
+
 
 class IRFunction:
     """
@@ -217,14 +221,10 @@ class IRFunction:
         return "\n".join(ret)
 
     def __repr__(self) -> str:
-        attrs = []
-        if self._fmp_signature is not None:
-            attrs.extend(self._fmp_signature.attrs)
+        attrs = self._fmp_signature.attrs if self._fmp_signature is not None else []
         if self.noinline:
             attrs.append("noinline")
-        annotation = ""
-        if len(attrs) > 0:
-            annotation = f" [{', '.join(attrs)}]"
+        annotation = f" [{', '.join(attrs)}]" if attrs else ""
         ret = f"function {self.name}{annotation} {{\n"
         for bb in self.get_basic_blocks():
             bb_str = textwrap.indent(str(bb), "  ")

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -100,10 +100,8 @@ _KNOWN_ANNOTATIONS = frozenset(["fmp_lowered", "fmp_publishes", "noinline"])
 
 def _apply_annotations(fn: IRFunction, annotations: Optional[list[str]]):
     """
-    Reconstruct `fn._fmp_signature` from the function-header annotation and
-    the `fmp_param` opcode. Raw functions carry no annotation and keep
-    `_fmp_signature is None`; the input validator (check_venom) rejects
-    un-annotated functions containing lowered FMP artifacts.
+    Apply function-header annotations and reconstruct the FMP signature from
+    its annotations and the `fmp_param` opcode.
     """
     if annotations is None:
         return
@@ -116,13 +114,12 @@ def _apply_annotations(fn: IRFunction, annotations: Optional[list[str]]):
 
     fn.noinline = "noinline" in annotations
 
-    fmp_annotations = [attr for attr in annotations if attr != "noinline"]
-    if len(fmp_annotations) == 0:
+    if "fmp_lowered" not in annotations:
+        if "fmp_publishes" in annotations:
+            raise ValueError(f"`fmp_publishes` requires `fmp_lowered` on {fn.name}")
         return
-    if "fmp_lowered" not in fmp_annotations:
-        raise ValueError(f"`fmp_publishes` requires `fmp_lowered` on {fn.name}")
 
-    publishes = "fmp_publishes" in fmp_annotations
+    publishes = "fmp_publishes" in annotations
     has_fmp_param = any(
         inst.opcode == "fmp_param" for bb in fn.get_basic_blocks() for inst in bb.instructions
     )

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -95,7 +95,7 @@ def _set_last_label(ctx: IRContext):
 
 # the calling convention is carried only by syntax (opcodes) and the
 # explicit function-header annotation -- there is no shape inference.
-_KNOWN_ANNOTATIONS = frozenset(["fmp_lowered", "fmp_publishes"])
+_KNOWN_ANNOTATIONS = frozenset(["fmp_lowered", "fmp_publishes", "noinline"])
 
 
 def _apply_annotations(fn: IRFunction, annotations: Optional[list[str]]):
@@ -113,10 +113,16 @@ def _apply_annotations(fn: IRFunction, annotations: Optional[list[str]]):
             raise ValueError(f"unknown function annotation `{attr}` on {fn.name}")
     if len(set(annotations)) != len(annotations):
         raise ValueError(f"duplicate function annotation on {fn.name}")
-    if "fmp_lowered" not in annotations:
+
+    fn.noinline = "noinline" in annotations
+
+    fmp_annotations = [attr for attr in annotations if attr != "noinline"]
+    if len(fmp_annotations) == 0:
+        return
+    if "fmp_lowered" not in fmp_annotations:
         raise ValueError(f"`fmp_publishes` requires `fmp_lowered` on {fn.name}")
 
-    publishes = "fmp_publishes" in annotations
+    publishes = "fmp_publishes" in fmp_annotations
     has_fmp_param = any(
         inst.opcode == "fmp_param" for bb in fn.get_basic_blocks() for inst in bb.instructions
     )

--- a/vyper/venom/passes/function_inliner.py
+++ b/vyper/venom/passes/function_inliner.py
@@ -75,6 +75,9 @@ class FunctionInlinerPass(IRGlobalPass):
             if call_count == 0:
                 continue
 
+            if func.noinline:
+                continue
+
             # Always inline if there is only one call site.
             if call_count == 1:
                 return func


### PR DESCRIPTION
### What I did

Add a `noinline` function-header annotation to Venom that opts a function out of `FunctionInlinerPass`. Previously the only control over inlining was the global `disable_inlining` flag; there was no way to keep a specific function out-of-line — in particular, a function with a single call site is always inlined unconditionally.

### How I did it

- Reuse the existing bracketed function-header annotation list (previously FMP-only): `function f [noinline] { ... }`.
- `parser.py`: add `noinline` to `_KNOWN_ANNOTATIONS`; `_apply_annotations` sets a bool on `IRFunction`, kept separate from the FMP signature (the flag carries no calling-convention facts). Annotations without `fmp_lowered` no longer error unconditionally, since `noinline` can now appear alone.
- `function.py`: new `noinline` attribute, carried through `copy()`; `FmpSignature.annotation` refactored into an `attrs` list so `__repr__` can merge FMP attributes with `noinline` into a single bracket, making the flag round-trip through the text format.
- `function_inliner.py`: `_select_inline_candidate` skips flagged functions, covering both the single-call-site and cost-threshold branches.
- `tests/venom_utils.py`: `assert_fn_eq` now compares `noinline` so round-trip tests aren't vacuous.

### How to verify it

```bash
pytest tests/functional/venom/parser/test_parsing.py::test_noinline_annotation
pytest tests/unit/compiler/venom/test_inliner.py::test_noinline_annotation
```

The parser test checks parsing and printer/parser round-trip of the flag (alone and combined with FMP annotations); the inliner test checks that a single-call-site function — which would otherwise always be inlined — survives when flagged, and is inlined without the flag.

### Commit message

```
the inliner offered only a global opt-out (`disable_inlining`); there
was no per-function way to keep a call out-of-line while leaving the
rest of the inlining heuristics intact. this matters in particular for
hand-written venom (tests, debugging passes that run downstream of the
inliner) where a call site must survive: a function with a single call
site is unconditionally inlined, so it cannot be kept alive by
restructuring alone.

add a `noinline` flag, carried by the existing bracketed function-header
annotation list (`function f [noinline] { ... }`). the parser sets a
bool on `IRFunction`, kept separate from the FMP signature since the
flag carries no calling-convention facts; the printer emits it so the
flag round-trips through the text format. `FunctionInlinerPass` skips
flagged functions during candidate selection, which covers both the
single-call-site and cost-threshold branches.
```

### Description for the changelog

Add `noinline` function-header annotation to Venom, opting a function out of the function inliner.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
