### PR TITLE
fix[docs]: warn when latest vs stable docs

### DIFF
--- a/docs/abstract-modules.rst
+++ b/docs/abstract-modules.rst
@@ -3,6 +3,11 @@
 Abstract Modules
 ################
 
+.. note::
+    Abstract modules are a recent feature. If ``@abstract`` raises
+    ``Unknown decorator: abstract``, your compiler predates the feature — use a compiler
+    that includes it (e.g. built from ``master``).
+
 An abstract module is a special kind of :ref:`module <modules>` which offers points at which its logic can be customized.
 This takes the form of **abstract methods**, :ref:`internal <structure-functions-internal>` methods decorated with ``@abstract``.
 These methods can then be overridden to supply the custom logic.

--- a/docs/abstract-modules.rst
+++ b/docs/abstract-modules.rst
@@ -4,9 +4,9 @@ Abstract Modules
 ################
 
 .. note::
-    Abstract modules are a recent feature. If ``@abstract`` raises
-    ``Unknown decorator: abstract``, your compiler predates the feature — use a compiler
-    that includes it (e.g. built from ``master``).
+    Abstract modules are available in Vyper ``0.5.0`` and up. If ``@abstract`` raises
+    ``Unknown decorator: abstract``, your compiler predates the feature — upgrade to
+    ``0.5.0`` or later.
 
 An abstract module is a special kind of :ref:`module <modules>` which offers points at which its logic can be customized.
 This takes the form of **abstract methods**, :ref:`internal <structure-functions-internal>` methods decorated with ``@abstract``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,8 @@
 # Vyper documentation build configuration file, created by
 # sphinx-quickstart on Wed Jul 26 11:18:29 2017.
 
+import os
+
 extensions = [
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
@@ -42,6 +44,21 @@ html_theme_options = {
     "github_url": "https://github.com/vyperlang",
 }
 html_favicon = "_static/logo.svg"
+
+# Warn readers when they are viewing docs built from a development branch (e.g.
+# the ReadTheDocs "latest" version, which tracks `master`) rather than a
+# released version. These docs describe unreleased features, so point readers to
+# the version-pinned docs at /en/stable/. ReadTheDocs sets these env vars at
+# build time; locally they are unset and no banner is shown.
+# https://docs.readthedocs.io/en/stable/reference/environment-variables.html
+if os.environ.get("READTHEDOCS_VERSION_TYPE") in ("branch", "external"):
+    html_theme_options["announcement"] = (
+        "You are reading the <strong>development</strong> documentation, which "
+        "describes features that may not be in any released version yet. For the "
+        'latest stable release, see the '
+        '<a href="https://docs.vyperlang.org/en/stable/">stable docs</a>, or use '
+        "the version selector to match your installed version."
+    )
 
 # For the "Edit this page ->" link
 html_context = {


### PR DESCRIPTION
### What I did

The docs at `/en/latest/` track `master` and describe features that may not be in any released version yet (e.g. abstract modules), but nothing told readers they were viewing *development* docs. Added a banner that appears on every page of non-stable builds, pointing readers to the stable docs and the version selector.

Furthermore, added a note on `docs/abstract-modules.rst` regarding the `Unknown decorator: abstract` compiler error when attempting to compile contracts with an `@abstract` decorator with a `0.4.x` compiler version.

### How I did it

- `docs/conf.py`: when ReadTheDocs' `READTHEDOCS_VERSION_TYPE` is `branch` (the `latest` version, which tracks `master`) or `external` (PR previews), set the `shibuya` theme's `announcement` option to the banner text. Locally the env var is unset, so no banner renders.
- `docs/abstract-modules.rst`: trimmed the admonition down to the error signpost.

### How to verify it

- `READTHEDOCS_VERSION_TYPE=branch uv run sphinx-build -b html docs _build` → banner on every page.
- Plain `uv run sphinx-build -b html docs _build` (no env var) → no banner.

> [!Note]
> Because it is env-gated, the banner can't be previewed with a bare local build — it only renders on `ReadTheDocs` (or when the `env` var is set manually).

### Commit message

```
The docs at /en/latest/ track `master`, so they describe features that
may not be in any released version yet — abstract modules being the
motivating example. Nothing on the page signaled that readers were
looking at development docs, so a user on 0.4.x would follow the
abstract modules guide and hit `Unknown decorator: abstract` with no
explanation.

Add a site-wide banner via the shibuya theme's `announcement` option,
gated on ReadTheDocs' `READTHEDOCS_VERSION_TYPE` being `branch` (the
`latest` build) or `external` (PR previews). Released builds and local
builds leave the env var unset, so no banner renders there. The banner
points readers to /en/stable/ and the version selector.

Prefer this in-repo, env-gated approach over ReadTheDocs Addons' built-
in version-warning notification because it is versioned and reviewable
in the tree rather than living in the project dashboard.

Also add a targeted note to the abstract-modules page naming the 0.5.0
requirement and the `Unknown decorator: abstract` error, so the specific
confusion is answered where readers land, not only by the global banner.
```

### Note for reviewers

There is a zero-code alternative: RTD Addons ships a built-in "version warning" notification, toggled in the project dashboard. I went with the in-repo banner because it is versioned and reviewable, but a maintainer could instead enable the dashboard setting and drop the `conf.py` change.

### Description for the changelog

docs: warn readers when they are viewing the development docs, and point them to the stable docs / version selector.

### Cute Animal Picture

<img width="5367" height="3583" alt="Curious_quokka_twins_(27802025295)" src="https://github.com/user-attachments/assets/529a3bf8-44a6-43bf-96f0-43c39930fc87" />

