### PR TITLE
feat[venom]: reduce spilling for deep dups

### DIFF
--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -95,16 +95,146 @@ def test_dup_spills_deep_stack() -> None:
     assert isinstance(depth, int) and depth < -16
     dup_idx = 1 - depth
 
-    compiler.spiller.dup(assembly, stack, depth)
+    cost = compiler.spiller.dup(assembly, stack, depth)
 
     expected = before.copy()
     expected.append(target)
     assert stack._stack == expected
 
     ops_str = _ops_only_strings(assembly)
-    assert ops_str.count("MSTORE") == dup_idx
-    assert ops_str.count("MLOAD") == dup_idx + 1
-    assert all(int(op[3:]) <= 16 for op in ops_str if op.startswith("DUP"))
+    spill_count = dup_idx - 16
+    assert ops_str.count("MSTORE") == spill_count
+    assert ops_str.count("MLOAD") == spill_count
+    assert ops_str.count("SWAP1") == spill_count
+    assert [op for op in ops_str if op.startswith("DUP")] == ["DUP16"]
+    assert cost == 1 + 5 * spill_count
+
+
+@pytest.mark.parametrize("dup_idx", range(16, 65))
+def test_dup_stack_model(dup_idx: int) -> None:
+    compiler = VenomCompiler(IRContext())
+    compiler.spiller._next_spill_offset = 0x10000
+    stack, ops = _build_stack(64)
+    assembly: list = []
+
+    target = ops[-dup_idx]
+    before = stack._stack.copy()
+    depth = stack.get_depth(target)
+    assert depth == 1 - dup_idx
+
+    cost = compiler.spiller.dup(assembly, stack, depth)
+
+    assert stack._stack == before + [target]
+
+    spill_count = max(0, dup_idx - 16)
+    ops_str = _ops_only_strings(assembly)
+    assert ops_str.count("MSTORE") == spill_count
+    assert ops_str.count("MLOAD") == spill_count
+    assert ops_str.count("SWAP1") == spill_count
+    assert [op for op in ops_str if op.startswith("DUP")] == [f"DUP{min(dup_idx, 16)}"]
+    assert cost == 1 + 5 * spill_count
+
+
+def test_deep_dup_reuses_spill_slots() -> None:
+    compiler = VenomCompiler(IRContext())
+    spiller = compiler.spiller
+    first_slot = 0x10000
+    spiller._spill_free_slots = [first_slot]
+    spiller._next_spill_offset = first_slot + 32
+    spiller.peak_spill_end = first_slot + 32
+
+    for _ in range(2):
+        stack, ops = _build_stack(18)
+        before = stack._stack.copy()
+        assembly: list = []
+
+        spiller.dup(assembly, stack, stack.get_depth(ops[0]))
+
+        assert stack._stack == before + [ops[0]]
+        assert sorted(spiller._spill_free_slots) == [first_slot, first_slot + 32]
+        assert spiller._next_spill_offset == first_slot + 64
+        assert spiller.peak_spill_end == first_slot + 64
+
+
+def test_deep_dup_dry_run_cost_matches_and_preserves_state() -> None:
+    compiler = VenomCompiler(IRContext())
+    spiller = compiler.spiller
+    first_slot = 0x10000
+    spiller._spill_free_slots = [first_slot]
+    spiller._next_spill_offset = first_slot + 32
+    spiller.peak_spill_end = first_slot + 32
+    snap = spiller.snapshot()
+
+    dry_stack, dry_ops = _build_stack(20)
+    dry_before = dry_stack._stack.copy()
+    dry_assembly: list = []
+    dry_cost = spiller.dup(dry_assembly, dry_stack, dry_stack.get_depth(dry_ops[0]), dry_run=True)
+
+    assert dry_stack._stack == dry_before + [dry_ops[0]]
+    assert spiller.snapshot() == snap
+    assert spiller.peak_spill_end == first_slot + 32
+
+    stack, ops = _build_stack(20)
+    before = stack._stack.copy()
+    assembly: list = []
+    cost = spiller.dup(assembly, stack, stack.get_depth(ops[0]))
+
+    assert stack._stack == before + [ops[0]]
+    assert cost == dry_cost == 21
+    assert _ops_only_strings(assembly) == _ops_only_strings(dry_assembly)
+    assert spiller._next_spill_offset == first_slot + 128
+    assert spiller.peak_spill_end == first_slot + 128
+
+
+def test_deep_dup_peak_spill_end_tracks_partial_prefix() -> None:
+    compiler = VenomCompiler(IRContext())
+    spiller = compiler.spiller
+    first_slot = 0x10000
+    spiller._next_spill_offset = first_slot
+    stack, ops = _build_stack(64)
+
+    spiller.dup([], stack, stack.get_depth(ops[0]))
+
+    spill_count = 64 - 16
+    expected_end = first_slot + spill_count * 32
+    assert spiller._next_spill_offset == expected_end
+    assert spiller.peak_spill_end == expected_end
+    assert len(spiller._spill_free_slots) == spill_count
+
+
+def test_partial_deep_dup_integration() -> None:
+    ctx = IRContext()
+    fn = ctx.create_function("deep_dup")
+    bb = fn.get_basic_block()
+    target = bb.append_instruction("calldataload", 0)
+    values = [bb.append_instruction("calldataload", i) for i in range(1, 17)]
+
+    # Keep the target and all intervening values live so copying target enters
+    # the deep-DUP path at DUP17.
+    acc = bb.append_instruction("add", target, 1)
+    for value in values:
+        acc = bb.append_instruction("add", acc, value)
+    bb.append_instruction("add", acc, target)
+    bb.append_instruction("stop")
+
+    ctx.mem_allocator.fn_eom[fn] = 0x10000
+    compiler = VenomCompiler(ctx)
+    asm = compiler.generate_evm_assembly(no_optimize=True)
+    opcodes = _ops_only_strings(asm)
+
+    assert opcodes.count("MSTORE") == 1
+    assert opcodes.count("MLOAD") == 1
+    assert opcodes.count("DUP16") == 1
+    store_idx = opcodes.index("MSTORE")
+    assert opcodes[store_idx - 1 : store_idx + 5] == [
+        "PUSH3",
+        "MSTORE",
+        "DUP16",
+        "PUSH3",
+        "MLOAD",
+        "SWAP1",
+    ]
+    assert compiler.spiller.peak_spill_end == 0x10020
 
 
 def test_stack_reorder_spills_before_swap() -> None:

--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -105,9 +105,9 @@ def test_dup_spills_deep_stack() -> None:
     spill_count = dup_idx - 16
     assert ops_str.count("MSTORE") == spill_count
     assert ops_str.count("MLOAD") == spill_count
-    assert ops_str.count("SWAP1") == spill_count
+    assert [op for op in ops_str if op.startswith("SWAP")] == [f"SWAP{spill_count}"]
     assert [op for op in ops_str if op.startswith("DUP")] == ["DUP16"]
-    assert cost == 1 + 5 * spill_count
+    assert cost == 2 + 4 * spill_count
 
 
 @pytest.mark.parametrize("dup_idx", range(16, 65))
@@ -130,9 +130,15 @@ def test_dup_stack_model(dup_idx: int) -> None:
     ops_str = _ops_only_strings(assembly)
     assert ops_str.count("MSTORE") == spill_count
     assert ops_str.count("MLOAD") == spill_count
-    assert ops_str.count("SWAP1") == spill_count
     assert [op for op in ops_str if op.startswith("DUP")] == [f"DUP{min(dup_idx, 16)}"]
-    assert cost == 1 + 5 * spill_count
+
+    expected_swaps: list[str] = []
+    if 0 < spill_count <= 16:
+        expected_swaps = [f"SWAP{spill_count}"]
+    elif spill_count > 16:
+        expected_swaps = ["SWAP1"] * spill_count
+    assert [op for op in ops_str if op.startswith("SWAP")] == expected_swaps
+    assert cost == 1 + 4 * spill_count + len(expected_swaps)
 
 
 def test_deep_dup_reuses_spill_slots() -> None:
@@ -180,7 +186,7 @@ def test_deep_dup_dry_run_cost_matches_and_preserves_state() -> None:
     cost = spiller.dup(assembly, stack, stack.get_depth(ops[0]))
 
     assert stack._stack == before + [ops[0]]
-    assert cost == dry_cost == 21
+    assert cost == dry_cost == 18
     assert _ops_only_strings(assembly) == _ops_only_strings(dry_assembly)
     assert spiller._next_spill_offset == first_slot + 128
     assert spiller.peak_spill_end == first_slot + 128

--- a/vyper/venom/stack_spiller.py
+++ b/vyper/venom/stack_spiller.py
@@ -134,8 +134,8 @@ class StackSpiller:
         """
         Dup operation that handles deep stacks via spilling.
 
-        For stacks deeper than 16, spills the stack segment to memory,
-        then restores it with duplication.
+        For stacks deeper than 16, spills only the inaccessible prefix,
+        duplicates the now-reachable operand, then restores the prefix.
 
         Returns the cost (number of operations emitted).
         """
@@ -145,16 +145,27 @@ class StackSpiller:
             assembly.append(f"DUP{dup_idx}")
             return 1
 
-        # For deep stacks, use spill/restore technique
-        chunk_size = dup_idx
-        spill_ops, offsets, cost = self._spill_stack_segment(assembly, stack, chunk_size, dry_run)
+        # Spill only the inaccessible prefix so the source can be reached with
+        # DUP16. Keep the duplicate at the top while rebuilding that prefix.
+        spill_count = dup_idx - 16
+        spill_ops, offsets, cost = self._spill_stack_segment(assembly, stack, spill_count, dry_run)
 
-        indices = list(range(chunk_size))
-        desired_indices = [indices[-1]] + indices
+        reachable_depth = depth + spill_count
+        assert 1 - reachable_depth == 16
+        stack.dup(reachable_depth)
+        assembly.append("DUP16")
+        cost += 1
 
-        cost += self._restore_spilled_segment(
-            assembly, stack, spill_ops, offsets, desired_indices, dry_run
-        )
+        for idx in reversed(range(spill_count)):
+            assembly.extend(PUSH(offsets[idx]))
+            assembly.append("MLOAD")
+            stack.push(spill_ops[idx])
+            cost += 2
+            cost += self.swap(assembly, stack, -1, dry_run)
+
+        if not dry_run:
+            self._spill_free_slots.extend(offsets)
+
         return cost
 
     def _spill_stack_segment(

--- a/vyper/venom/stack_spiller.py
+++ b/vyper/venom/stack_spiller.py
@@ -150,18 +150,34 @@ class StackSpiller:
         spill_count = dup_idx - 16
         spill_ops, offsets, cost = self._spill_stack_segment(assembly, stack, spill_count, dry_run)
 
+        # Removing spill_count items shifts the source closer by the same amount.
         reachable_depth = depth + spill_count
-        assert 1 - reachable_depth == 16
         stack.dup(reachable_depth)
-        assembly.append("DUP16")
+        assembly.append(f"DUP{1 - reachable_depth}")
         cost += 1
 
-        for idx in reversed(range(spill_count)):
+        restore_indices = list(reversed(range(spill_count)))
+        restore_with_single_swap = spill_count <= 16
+        if restore_with_single_swap:
+            # Load the deepest spilled item last. SWAPn then moves it into the
+            # duplicate's old position while lifting the duplicate to the top.
+            restore_indices = restore_indices[1:] + restore_indices[:1]
+
+        for idx in restore_indices:
             assembly.extend(PUSH(offsets[idx]))
             assembly.append("MLOAD")
             stack.push(spill_ops[idx])
             cost += 2
-            cost += self.swap(assembly, stack, -1, dry_run)
+
+            if not restore_with_single_swap:
+                stack.swap(-1)
+                assembly.append("SWAP1")
+                cost += 1
+
+        if restore_with_single_swap:
+            stack.swap(-spill_count)
+            assembly.append(f"SWAP{spill_count}")
+            cost += 1
 
         if not dry_run:
             self._spill_free_slots.extend(offsets)


### PR DESCRIPTION
### What I did

Reduced the cost of `DUP`ing operands deeper than 16 in the Venom stack spiller. Previously the spiller moved the entire stack segment above and including the target to memory and reloaded everything; now it spills only the prefix that blocks `DUP16` reachability.

### How I did it

- spill the top `dup_idx - 16` items instead of all `dup_idx` items, then duplicate the now-reachable operand with `DUP16`
- when the spilled prefix fits in swap range (`spill_count <= 16`), reload it in a permuted order (deepest item last) and finish with a single `SWAPn`, avoiding a `SWAP1` per reloaded item; deeper prefixes keep the per-item `SWAP1`
- emit the `DUP` opcode from the computed depth rather than a hardcoded literal

Cost per deep dup drops from `4 * dup_idx + 2` to `4 * (dup_idx - 16) + 2` ops for dup depths up to 32 (e.g. `DUP17`: 70 → 6 ops), and peak spill memory shrinks by 16 slots.

### How to verify it

`tests/unit/compiler/venom/test_stack_spill.py`:

- `test_dup_stack_model` is parametrized over dup depths 16–64, covering the no-spill case, both restore paths, and the `spill_count == 16/17` boundary; asserts stack model, opcode shape, and cost
- `test_partial_deep_dup_integration` checks the exact emitted opcode sequence around a spill end-to-end
- slot reuse, dry-run state preservation, and peak-memory tracking each have dedicated tests

### Commit message

```
duplicating an operand deeper than 16 previously spilled the entire
stack segment above and including the target to memory (dup_idx items)
and reloaded all of them plus the duplicate, costing 4 * dup_idx + 2 ops
per dup.

only the items that block DUP16 reachability actually need to move:
spill the top dup_idx - 16 items, duplicate the now-reachable operand
with DUP16, then reload the spilled prefix. when the prefix fits in swap
range (spill_count <= 16, i.e. dup depth <= 32), reload it in a permuted
order (deepest item last) so a single SWAPn drops it into the
duplicate's old position while lifting the duplicate to the top; deeper
prefixes fall back to one SWAP1 per reloaded item.

cost drops from 4 * dup_idx + 2 to 4 * (dup_idx - 16) + 2 ops for dup
depths up to 32 (e.g. DUP17: 70 -> 6 ops), and peak spill memory shrinks
by 16 slots per deep dup.
```

### Description for the changelog

perf: spill fewer stack items when duplicating deep stack operands in Venom

### Cute Animal Picture

![]()
