### PR TITLE
feat[venom]: halting paths stack optimization

### DIFF
--- a/tests/unit/compiler/venom/test_stack_cleanup.py
+++ b/tests/unit/compiler/venom/test_stack_cleanup.py
@@ -195,33 +195,30 @@ def test_stack_cleanup_elision_requires_a_known_entry_function():
     assert not safety.can_skip_cleanup(halt, 0)
 
 
-def test_stack_bound_rejects_recursive_internal_calls():
-    def candidate_is_safe(callee_body):
-        ctx = parse_venom(f"""
-            function test {{
-            entry:
-                jnz 1, @candidate, @other
-            candidate:
-                invoke @callee
-                stop
-            other:
-                stop
-            }}
+def test_stack_bound_allows_internal_calls():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            jnz 1, @candidate, @other
+        candidate:
+            invoke @callee
+            stop
+        other:
+            stop
+        }
 
-            function callee {{
-            callee:
-                %retpc = param
-                {callee_body}
-                ret %retpc
-            }}
-        """)
-        fn, _, must_halt, safety = _get_stack_cleanup_analyses(ctx)
-        candidate = fn.get_basic_block("candidate")
-        assert candidate in must_halt.must_halt
-        return safety.can_skip_cleanup(candidate, 0)
+        function callee {
+        callee:
+            %retpc = param
+            nop
+            ret %retpc
+        }
+    """)
+    fn, _, must_halt, safety = _get_stack_cleanup_analyses(ctx)
+    candidate = fn.get_basic_block("candidate")
 
-    assert candidate_is_safe("nop")
-    assert not candidate_is_safe("invoke @callee")
+    assert candidate in must_halt.must_halt
+    assert safety.can_skip_cleanup(candidate, 0)
 
 
 def test_callee_stack_bound_includes_the_caller_frame():

--- a/tests/unit/compiler/venom/test_stack_cleanup.py
+++ b/tests/unit/compiler/venom/test_stack_cleanup.py
@@ -1,24 +1,22 @@
 import pytest
 
 from vyper.compiler.settings import OptimizationLevel
-from vyper.ir.compile_ir import Label
+from vyper.evm.assembler.instructions import Label
 from vyper.venom import generate_assembly_experimental
 from vyper.venom.analysis import CFGAnalysis, IRAnalysesCache, LivenessAnalysis, MustHaltAnalysis
-from vyper.venom.basicblock import IRLabel, IRVariable
+from vyper.venom.basicblock import IRLabel
 from vyper.venom.context import IRContext
 from vyper.venom.parser import parse_venom
-from vyper.venom.stack_model import StackModel
-from vyper.venom.stack_safety import StackCleanupSafety, _EVM_STACK_LIMIT
+from vyper.venom.stack_safety import StackCleanupSafety
 from vyper.venom.venom_to_assembly import VenomCompiler
 
 
 def _get_stack_cleanup_analyses(ctx, fn_name="test"):
-    analyses_caches = {candidate: IRAnalysesCache(candidate) for candidate in ctx.get_functions()}
     fn = ctx.get_function(IRLabel(fn_name))
-    ac = analyses_caches[fn]
+    ac = IRAnalysesCache(fn)
     liveness = ac.request_analysis(LivenessAnalysis)
     must_halt = ac.request_analysis(MustHaltAnalysis)
-    safety = StackCleanupSafety(ctx, analyses_caches)
+    safety = ac.request_analysis(StackCleanupSafety)
     return fn, liveness, must_halt, safety
 
 
@@ -45,9 +43,16 @@ def test_cleanup_stack():
 
 
 @pytest.mark.parametrize(
-    "terminator", ["return 0, 32", "revert 0, 32", "stop", "invalid", "selfdestruct 0"]
+    ("terminator", "evm_opcode"),
+    [
+        ("return 0, 32", "RETURN"),
+        ("revert 0, 32", "REVERT"),
+        ("stop", "STOP"),
+        ("invalid", "INVALID"),
+        ("selfdestruct 0", "SELFDESTRUCT"),
+    ],
 )
-def test_cleanup_elided_for_direct_and_transitive_message_halts(terminator):
+def test_direct_and_transitive_message_halts(terminator, evm_opcode):
     ctx = parse_venom(f"""
         function test {{
         entry:
@@ -74,8 +79,7 @@ def test_cleanup_elided_for_direct_and_transitive_message_halts(terminator):
     assert expected == {bb.label.value for bb in must_halt.must_halt}
 
     asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
-    assert "POP" not in _block_opcodes(asm, "direct")
-    assert "POP" not in _block_opcodes(asm, "chain")
+    assert evm_opcode in asm
     assert fn.get_basic_block("direct").is_halting
     assert not fn.get_basic_block("chain").is_halting
 
@@ -157,14 +161,18 @@ def test_must_halt_analysis_is_cached_and_invalidated_with_cfg():
     ac = IRAnalysesCache(fn)
 
     first = ac.request_analysis(MustHaltAnalysis)
+    first_safety = ac.request_analysis(StackCleanupSafety)
     assert ac.request_analysis(MustHaltAnalysis) is first
+    assert ac.request_analysis(StackCleanupSafety) is first_safety
     assert fn.entry in first.must_halt
 
     fn.entry.instructions[-1].opcode = "ret"
     ac.invalidate_analysis(CFGAnalysis)
 
     second = ac.request_analysis(MustHaltAnalysis)
+    second_safety = ac.request_analysis(StackCleanupSafety)
     assert second is not first
+    assert second_safety is not first_safety
     assert fn.entry not in second.must_halt
 
 
@@ -236,13 +244,9 @@ def test_callee_stack_bound_includes_the_caller_frame():
     """)
     fn, _, _, safety = _get_stack_cleanup_analyses(ctx, "callee")
     halt = fn.get_basic_block("halt")
-    growth = safety._max_growth_from_block(halt, set(), {fn})
-    caller_height = safety._max_caller_stack_height(fn, set())
+    safe_height = safety.max_safe_current_height(halt)
 
-    assert growth is not None
-    assert caller_height is not None and caller_height > 0
-    safe_height = _EVM_STACK_LIMIT - caller_height - growth
-    assert safety.max_safe_current_height(halt) == safe_height
+    assert safe_height is not None
     assert safety.can_skip_cleanup(halt, safe_height)
     assert not safety.can_skip_cleanup(halt, safe_height + 1)
 
@@ -290,39 +294,19 @@ def test_cleanup_falls_back_near_evm_stack_limit():
             stop
         }
     """)
-    fn, liveness, _, safety = _get_stack_cleanup_analyses(ctx)
+    fn, _, _, safety = _get_stack_cleanup_analyses(ctx)
     halt = fn.get_basic_block("halt")
-    junk = fn.entry.instructions[0].output
-
-    compiler = VenomCompiler(ctx)
-    compiler.cfg = liveness.cfg
-    compiler.liveness = liveness
-    compiler._stack_cleanup_safety = safety
 
     safe_height = safety.max_safe_current_height(halt)
     assert safe_height is not None
+    assert safety.can_skip_cleanup(halt, safe_height)
+    assert not safety.can_skip_cleanup(halt, safe_height + 1)
 
-    def stack_at_height(height):
-        stack = StackModel()
-        for i in range(height - 1):
-            stack.push(IRVariable(f"%padding_{i}"))
-        stack.push(junk)
-        return stack
-
-    safe_stack = stack_at_height(safe_height)
-    safe_asm = []
-    compiler.clean_stack_from_cfg_in(safe_asm, halt, safe_stack)
-    assert safe_asm == []
-    assert safe_stack.height == safe_height
-
-    unsafe_stack = stack_at_height(safe_height + 1)
-    unsafe_asm = []
-    compiler.clean_stack_from_cfg_in(unsafe_asm, halt, unsafe_stack)
-    assert unsafe_asm == ["POP"]
-    assert unsafe_stack.height == safe_height
+    asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
+    assert "POP" not in _block_opcodes(asm, "halt")
 
 
-def test_retained_values_do_not_desynchronize_recursive_codegen_or_spill_slots():
+def test_cleanup_elision_does_not_induce_spilling():
     loads = "\n".join(f"%v{i} = mload {i * 32}" for i in range(24))
     left_sum = "\n".join(
         ["%a0 = add %v0, %v23"] + [f"%a{i} = add %a{i - 1}, %v{i}" for i in range(1, 12)]
@@ -357,14 +341,11 @@ def test_retained_values_do_not_desynchronize_recursive_codegen_or_spill_slots()
         return compiler, asm
 
     compiler, asm = compile_source()
-    _, second_asm = compile_source()
+    left_ops = _block_opcodes(asm, "left")
+    right_ops = _block_opcodes(asm, "right")
 
-    assert [str(item) for item in asm] == [str(item) for item in second_asm]
-    assert "POP" not in _block_opcodes(asm, "left")
-    assert "POP" not in _block_opcodes(asm, "right")
-    assert compiler.spiller.peak_spill_end > spill_base
-
-    allocated_slots = set(range(spill_base, compiler.spiller.peak_spill_end, 32))
-    free_slots = compiler.spiller._spill_free_slots
-    assert set(free_slots) == allocated_slots
-    assert len(free_slots) == len(allocated_slots)
+    # Left-path junk is interleaved with live values and is cleaned.  Right-
+    # path junk is a harmless bottom prefix and is retained.  Neither path
+    # needs the bulk memory spill caused by retaining arbitrary junk.
+    assert left_ops.count("POP") > right_ops.count("POP")
+    assert compiler.spiller.peak_spill_end == 0

--- a/tests/unit/compiler/venom/test_stack_cleanup.py
+++ b/tests/unit/compiler/venom/test_stack_cleanup.py
@@ -3,19 +3,23 @@ import pytest
 from vyper.compiler.settings import OptimizationLevel
 from vyper.ir.compile_ir import Label
 from vyper.venom import generate_assembly_experimental
-from vyper.venom.analysis import IRAnalysesCache, LivenessAnalysis
+from vyper.venom.analysis import CFGAnalysis, IRAnalysesCache, LivenessAnalysis, MustHaltAnalysis
 from vyper.venom.basicblock import IRLabel, IRVariable
 from vyper.venom.context import IRContext
 from vyper.venom.parser import parse_venom
 from vyper.venom.stack_model import StackModel
-from vyper.venom.venom_to_assembly import VenomCompiler, _EVM_STACK_LIMIT, _MustHaltRegions
+from vyper.venom.stack_safety import StackCleanupSafety, _EVM_STACK_LIMIT
+from vyper.venom.venom_to_assembly import VenomCompiler
 
 
-def _get_must_halt_regions(ctx, fn_name="test"):
+def _get_stack_cleanup_analyses(ctx, fn_name="test"):
+    analyses_caches = {candidate: IRAnalysesCache(candidate) for candidate in ctx.get_functions()}
     fn = ctx.get_function(IRLabel(fn_name))
-    ac = IRAnalysesCache(fn)
+    ac = analyses_caches[fn]
     liveness = ac.request_analysis(LivenessAnalysis)
-    return fn, liveness, _MustHaltRegions(ctx, liveness.cfg, liveness)
+    must_halt = ac.request_analysis(MustHaltAnalysis)
+    safety = StackCleanupSafety(ctx, analyses_caches)
+    return fn, liveness, must_halt, safety
 
 
 def _block_opcodes(asm, label):
@@ -65,9 +69,9 @@ def test_cleanup_elided_for_direct_and_transitive_message_halts(terminator):
         }}
     """)
 
-    fn, _, regions = _get_must_halt_regions(ctx)
+    fn, _, must_halt, _ = _get_stack_cleanup_analyses(ctx)
     expected = {"entry", "direct", "chain", "terminal_a", "terminal_b"}
-    assert expected == {bb.label.value for bb in regions.must_halt}
+    assert expected == {bb.label.value for bb in must_halt.must_halt}
 
     asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
     assert "POP" not in _block_opcodes(asm, "direct")
@@ -97,9 +101,9 @@ def test_only_guaranteed_halting_branch_region_retains_junk():
                 stop
             }}
         """)
-        fn, _, regions = _get_must_halt_regions(ctx)
+        fn, _, must_halt, _ = _get_stack_cleanup_analyses(ctx)
         asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
-        return fn, regions, _block_opcodes(asm, "candidate")
+        return fn, must_halt, _block_opcodes(asm, "candidate")
 
     all_halt_fn, all_halt_regions, all_halt_ops = compile_candidate("stop")
     mixed_fn, mixed_regions, mixed_ops = compile_candidate("ret %retpc")
@@ -119,8 +123,8 @@ def test_internal_returns_are_not_message_halts(terminator):
         }}
     """)
 
-    fn, _, regions = _get_must_halt_regions(ctx)
-    assert fn.entry not in regions.must_halt
+    fn, _, must_halt, _ = _get_stack_cleanup_analyses(ctx)
+    assert fn.entry not in must_halt.must_halt
 
 
 def test_loop_with_halting_exit_is_not_must_halt():
@@ -135,10 +139,52 @@ def test_loop_with_halting_exit_is_not_must_halt():
         }
     """)
 
-    fn, _, regions = _get_must_halt_regions(ctx)
-    assert fn.get_basic_block("halt") in regions.must_halt
-    assert fn.get_basic_block("loop") not in regions.must_halt
-    assert fn.get_basic_block("entry") not in regions.must_halt
+    fn, _, must_halt, _ = _get_stack_cleanup_analyses(ctx)
+    assert fn.get_basic_block("halt") in must_halt.must_halt
+    assert fn.get_basic_block("loop") not in must_halt.must_halt
+    assert fn.get_basic_block("entry") not in must_halt.must_halt
+
+
+def test_must_halt_analysis_is_cached_and_invalidated_with_cfg():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            stop
+        }
+    """)
+    fn = ctx.entry_function
+    assert fn is not None
+    ac = IRAnalysesCache(fn)
+
+    first = ac.request_analysis(MustHaltAnalysis)
+    assert ac.request_analysis(MustHaltAnalysis) is first
+    assert fn.entry in first.must_halt
+
+    fn.entry.instructions[-1].opcode = "ret"
+    ac.invalidate_analysis(CFGAnalysis)
+
+    second = ac.request_analysis(MustHaltAnalysis)
+    assert second is not first
+    assert fn.entry not in second.must_halt
+
+
+def test_stack_cleanup_elision_requires_a_known_entry_function():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            jnz 1, @halt, @other_halt
+        halt:
+            stop
+        other_halt:
+            stop
+        }
+    """)
+    ctx.entry_function = None
+
+    fn, _, must_halt, safety = _get_stack_cleanup_analyses(ctx)
+    halt = fn.get_basic_block("halt")
+    assert halt in must_halt
+    assert not safety.can_skip_cleanup(halt, 0)
 
 
 def test_stack_bound_rejects_recursive_internal_calls():
@@ -161,10 +207,10 @@ def test_stack_bound_rejects_recursive_internal_calls():
                 ret %retpc
             }}
         """)
-        fn, _, regions = _get_must_halt_regions(ctx)
+        fn, _, must_halt, safety = _get_stack_cleanup_analyses(ctx)
         candidate = fn.get_basic_block("candidate")
-        assert candidate in regions.must_halt
-        return regions.can_skip_cleanup(candidate, 0)
+        assert candidate in must_halt.must_halt
+        return safety.can_skip_cleanup(candidate, 0)
 
     assert candidate_is_safe("nop")
     assert not candidate_is_safe("invoke @callee")
@@ -188,16 +234,17 @@ def test_callee_stack_bound_includes_the_caller_frame():
             stop
         }
     """)
-    fn, _, regions = _get_must_halt_regions(ctx, "callee")
+    fn, _, _, safety = _get_stack_cleanup_analyses(ctx, "callee")
     halt = fn.get_basic_block("halt")
-    growth = regions._max_growth_from_block(halt, set(), {fn})
-    caller_height = regions._caller_stack_height
+    growth = safety._max_growth_from_block(halt, set(), {fn})
+    caller_height = safety._max_caller_stack_height(fn, set())
 
     assert growth is not None
     assert caller_height is not None and caller_height > 0
     safe_height = _EVM_STACK_LIMIT - caller_height - growth
-    assert regions.can_skip_cleanup(halt, safe_height)
-    assert not regions.can_skip_cleanup(halt, safe_height + 1)
+    assert safety.max_safe_current_height(halt) == safe_height
+    assert safety.can_skip_cleanup(halt, safe_height)
+    assert not safety.can_skip_cleanup(halt, safe_height + 1)
 
 
 def test_retained_junk_loses_its_identity_before_a_halting_phi_join():
@@ -222,8 +269,8 @@ def test_retained_junk_loses_its_identity_before_a_halting_phi_join():
         }
     """)
 
-    _, _, regions = _get_must_halt_regions(ctx)
-    assert {"entry", "p1", "p2", "join"} == {bb.label.value for bb in regions.must_halt}
+    _, _, must_halt, _ = _get_stack_cleanup_analyses(ctx)
+    assert {"entry", "p1", "p2", "join"} == {bb.label.value for bb in must_halt.must_halt}
 
     asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
     assert "RETURN" in asm
@@ -243,18 +290,17 @@ def test_cleanup_falls_back_near_evm_stack_limit():
             stop
         }
     """)
-    fn, liveness, regions = _get_must_halt_regions(ctx)
+    fn, liveness, _, safety = _get_stack_cleanup_analyses(ctx)
     halt = fn.get_basic_block("halt")
     junk = fn.entry.instructions[0].output
 
     compiler = VenomCompiler(ctx)
     compiler.cfg = liveness.cfg
     compiler.liveness = liveness
-    compiler._must_halt_regions = regions
+    compiler._stack_cleanup_safety = safety
 
-    growth = regions._max_growth_from_block(halt, set(), {fn})
-    assert growth is not None
-    safe_height = _EVM_STACK_LIMIT - growth
+    safe_height = safety.max_safe_current_height(halt)
+    assert safe_height is not None
 
     def stack_at_height(height):
         stack = StackModel()

--- a/tests/unit/compiler/venom/test_stack_cleanup.py
+++ b/tests/unit/compiler/venom/test_stack_cleanup.py
@@ -1,6 +1,29 @@
+import pytest
+
 from vyper.compiler.settings import OptimizationLevel
+from vyper.ir.compile_ir import Label
 from vyper.venom import generate_assembly_experimental
+from vyper.venom.analysis import IRAnalysesCache, LivenessAnalysis
+from vyper.venom.basicblock import IRLabel, IRVariable
 from vyper.venom.context import IRContext
+from vyper.venom.parser import parse_venom
+from vyper.venom.stack_model import StackModel
+from vyper.venom.venom_to_assembly import VenomCompiler, _EVM_STACK_LIMIT, _MustHaltRegions
+
+
+def _get_must_halt_regions(ctx, fn_name="test"):
+    fn = ctx.get_function(IRLabel(fn_name))
+    ac = IRAnalysesCache(fn)
+    liveness = ac.request_analysis(LivenessAnalysis)
+    return fn, liveness, _MustHaltRegions(ctx, liveness.cfg, liveness)
+
+
+def _block_opcodes(asm, label):
+    start = next(
+        i for i, item in enumerate(asm) if isinstance(item, Label) and str(item) == f"LABEL {label}"
+    )
+    end = next((i for i in range(start + 1, len(asm)) if isinstance(asm[i], Label)), len(asm))
+    return [item for item in asm[start:end] if isinstance(item, str)]
 
 
 def test_cleanup_stack():
@@ -15,3 +38,287 @@ def test_cleanup_stack():
 
     asm = generate_assembly_experimental(ctx, optimize=OptimizationLevel.GAS)
     assert asm == ["PUSH1", 10, "DUP1", "ADD", "POP", "JUMP"]
+
+
+@pytest.mark.parametrize(
+    "terminator", ["return 0, 32", "revert 0, 32", "stop", "invalid", "selfdestruct 0"]
+)
+def test_cleanup_elided_for_direct_and_transitive_message_halts(terminator):
+    ctx = parse_venom(f"""
+        function test {{
+        entry:
+            %direct_value = calldataload 0
+            %chain_value = calldataload 32
+            %outer_cond = calldataload 64
+            %chain_cond = calldataload 96
+            jnz %outer_cond, @direct, @chain
+        direct:
+            mstore 0, %direct_value
+            {terminator}
+        chain:
+            mstore 32, %chain_value
+            jnz %chain_cond, @terminal_a, @terminal_b
+        terminal_a:
+            {terminator}
+        terminal_b:
+            {terminator}
+        }}
+    """)
+
+    fn, _, regions = _get_must_halt_regions(ctx)
+    expected = {"entry", "direct", "chain", "terminal_a", "terminal_b"}
+    assert expected == {bb.label.value for bb in regions.must_halt}
+
+    asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
+    assert "POP" not in _block_opcodes(asm, "direct")
+    assert "POP" not in _block_opcodes(asm, "chain")
+    assert fn.get_basic_block("direct").is_halting
+    assert not fn.get_basic_block("chain").is_halting
+
+
+def test_only_guaranteed_halting_branch_region_retains_junk():
+    def compile_candidate(right_terminator):
+        ctx = parse_venom(f"""
+            function test {{
+            entry:
+                %retpc = param
+                %junk = calldataload 0
+                %outer = calldataload 32
+                jnz %outer, @candidate, @outer_halt
+            candidate:
+                %inner = calldataload 64
+                jnz %inner, @left, @right
+            left:
+                stop
+            right:
+                {right_terminator}
+            outer_halt:
+                mstore 0, %junk
+                stop
+            }}
+        """)
+        fn, _, regions = _get_must_halt_regions(ctx)
+        asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
+        return fn, regions, _block_opcodes(asm, "candidate")
+
+    all_halt_fn, all_halt_regions, all_halt_ops = compile_candidate("stop")
+    mixed_fn, mixed_regions, mixed_ops = compile_candidate("ret %retpc")
+
+    assert all_halt_fn.get_basic_block("candidate") in all_halt_regions.must_halt
+    assert mixed_fn.get_basic_block("candidate") not in mixed_regions.must_halt
+    assert "POP" not in all_halt_ops
+    assert "POP" in mixed_ops
+
+
+@pytest.mark.parametrize("terminator", ["ret 0", "dret 0, 0", "retfmp 0, 0"])
+def test_internal_returns_are_not_message_halts(terminator):
+    ctx = parse_venom(f"""
+        function test {{
+        entry:
+            {terminator}
+        }}
+    """)
+
+    fn, _, regions = _get_must_halt_regions(ctx)
+    assert fn.entry not in regions.must_halt
+
+
+def test_loop_with_halting_exit_is_not_must_halt():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            jmp @loop
+        loop:
+            jnz 1, @loop, @halt
+        halt:
+            stop
+        }
+    """)
+
+    fn, _, regions = _get_must_halt_regions(ctx)
+    assert fn.get_basic_block("halt") in regions.must_halt
+    assert fn.get_basic_block("loop") not in regions.must_halt
+    assert fn.get_basic_block("entry") not in regions.must_halt
+
+
+def test_stack_bound_rejects_recursive_internal_calls():
+    def candidate_is_safe(callee_body):
+        ctx = parse_venom(f"""
+            function test {{
+            entry:
+                jnz 1, @candidate, @other
+            candidate:
+                invoke @callee
+                stop
+            other:
+                stop
+            }}
+
+            function callee {{
+            callee:
+                %retpc = param
+                {callee_body}
+                ret %retpc
+            }}
+        """)
+        fn, _, regions = _get_must_halt_regions(ctx)
+        candidate = fn.get_basic_block("candidate")
+        assert candidate in regions.must_halt
+        return regions.can_skip_cleanup(candidate, 0)
+
+    assert candidate_is_safe("nop")
+    assert not candidate_is_safe("invoke @callee")
+
+
+def test_callee_stack_bound_includes_the_caller_frame():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            invoke @callee
+            stop
+        }
+
+        function callee {
+        entry:
+            %retpc = param
+            jnz 1, @halt, @other_halt
+        halt:
+            stop
+        other_halt:
+            stop
+        }
+    """)
+    fn, _, regions = _get_must_halt_regions(ctx, "callee")
+    halt = fn.get_basic_block("halt")
+    growth = regions._max_growth_from_block(halt, set(), {fn})
+    caller_height = regions._caller_stack_height
+
+    assert growth is not None
+    assert caller_height is not None and caller_height > 0
+    safe_height = _EVM_STACK_LIMIT - caller_height - growth
+    assert regions.can_skip_cleanup(halt, safe_height)
+    assert not regions.can_skip_cleanup(halt, safe_height + 1)
+
+
+def test_retained_junk_loses_its_identity_before_a_halting_phi_join():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            %cond = calldataload 0
+            %a = calldataload 32
+            %b = calldataload 64
+            %c = calldataload 96
+            jnz %cond, @p1, @p2
+        p1:
+            jmp @join
+        p2:
+            jmp @join
+        join:
+            %x = phi @p1, %a, @p2, %b
+            %y = phi @p1, %a, @p2, %c
+            %z = add %x, %y
+            mstore 0, %z
+            return 0, 32
+        }
+    """)
+
+    _, _, regions = _get_must_halt_regions(ctx)
+    assert {"entry", "p1", "p2", "join"} == {bb.label.value for bb in regions.must_halt}
+
+    asm = VenomCompiler(ctx).generate_evm_assembly(no_optimize=True)
+    assert "RETURN" in asm
+
+
+def test_cleanup_falls_back_near_evm_stack_limit():
+    ctx = parse_venom("""
+        function test {
+        entry:
+            %junk = calldataload 0
+            %cond = calldataload 32
+            jnz %cond, @halt, @use_junk
+        halt:
+            stop
+        use_junk:
+            mstore 0, %junk
+            stop
+        }
+    """)
+    fn, liveness, regions = _get_must_halt_regions(ctx)
+    halt = fn.get_basic_block("halt")
+    junk = fn.entry.instructions[0].output
+
+    compiler = VenomCompiler(ctx)
+    compiler.cfg = liveness.cfg
+    compiler.liveness = liveness
+    compiler._must_halt_regions = regions
+
+    growth = regions._max_growth_from_block(halt, set(), {fn})
+    assert growth is not None
+    safe_height = _EVM_STACK_LIMIT - growth
+
+    def stack_at_height(height):
+        stack = StackModel()
+        for i in range(height - 1):
+            stack.push(IRVariable(f"%padding_{i}"))
+        stack.push(junk)
+        return stack
+
+    safe_stack = stack_at_height(safe_height)
+    safe_asm = []
+    compiler.clean_stack_from_cfg_in(safe_asm, halt, safe_stack)
+    assert safe_asm == []
+    assert safe_stack.height == safe_height
+
+    unsafe_stack = stack_at_height(safe_height + 1)
+    unsafe_asm = []
+    compiler.clean_stack_from_cfg_in(unsafe_asm, halt, unsafe_stack)
+    assert unsafe_asm == ["POP"]
+    assert unsafe_stack.height == safe_height
+
+
+def test_retained_values_do_not_desynchronize_recursive_codegen_or_spill_slots():
+    loads = "\n".join(f"%v{i} = mload {i * 32}" for i in range(24))
+    left_sum = "\n".join(
+        ["%a0 = add %v0, %v23"] + [f"%a{i} = add %a{i - 1}, %v{i}" for i in range(1, 12)]
+    )
+    right_sum = "\n".join(
+        ["%b0 = add %v12, %v23"] + [f"%b{i} = add %b{i - 1}, %v{i + 12}" for i in range(1, 11)]
+    )
+    source = f"""
+        function test {{
+        entry:
+            {loads}
+            %cond = mload 800
+            jnz %cond, @left, @right
+        left:
+            {left_sum}
+            mstore 0, %a11
+            stop
+        right:
+            {right_sum}
+            mstore 0, %b10
+            stop
+        }}
+    """
+    spill_base = 0x10000
+
+    def compile_source():
+        ctx = parse_venom(source)
+        fn = ctx.get_function(IRLabel("test"))
+        ctx.mem_allocator.fn_eom[fn] = spill_base
+        compiler = VenomCompiler(ctx)
+        asm = compiler.generate_evm_assembly(no_optimize=True)
+        return compiler, asm
+
+    compiler, asm = compile_source()
+    _, second_asm = compile_source()
+
+    assert [str(item) for item in asm] == [str(item) for item in second_asm]
+    assert "POP" not in _block_opcodes(asm, "left")
+    assert "POP" not in _block_opcodes(asm, "right")
+    assert compiler.spiller.peak_spill_end > spill_base
+
+    allocated_slots = set(range(spill_base, compiler.spiller.peak_spill_end, 32))
+    free_slots = compiler.spiller._spill_free_slots
+    assert set(free_slots) == allocated_slots
+    assert len(free_slots) == len(allocated_slots)

--- a/vyper/venom/analysis/__init__.py
+++ b/vyper/venom/analysis/__init__.py
@@ -10,6 +10,7 @@ from .load_analysis import LoadAnalysis
 from .mem_alias import MemoryAliasAnalysis
 from .mem_liveness import MemLivenessAnalysis
 from .mem_ssa import MemSSA
+from .must_halt import MustHaltAnalysis
 from .reachable import ReachableAnalysis
 from .readonly_memory_args import ReadonlyMemoryArgsGlobalAnalysis
 from .stack_order import StackOrderAnalysis

--- a/vyper/venom/analysis/cfg.py
+++ b/vyper/venom/analysis/cfg.py
@@ -118,6 +118,7 @@ class CFGAnalysis(IRAnalysis):
             DFGAnalysis,
             DominatorTreeAnalysis,
             LivenessAnalysis,
+            MustHaltAnalysis,
             ReachableAnalysis,
         )
 
@@ -132,4 +133,5 @@ class CFGAnalysis(IRAnalysis):
 
         self.analyses_cache.invalidate_analysis(DominatorTreeAnalysis)
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
+        self.analyses_cache.invalidate_analysis(MustHaltAnalysis)
         self.analyses_cache.invalidate_analysis(ReachableAnalysis)

--- a/vyper/venom/analysis/cfg.py
+++ b/vyper/venom/analysis/cfg.py
@@ -121,6 +121,7 @@ class CFGAnalysis(IRAnalysis):
             MustHaltAnalysis,
             ReachableAnalysis,
         )
+        from vyper.venom.stack_safety import StackCleanupSafety
 
         # just in case somebody is holding onto a bad reference to this
         del self._cfg_in
@@ -135,3 +136,4 @@ class CFGAnalysis(IRAnalysis):
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
         self.analyses_cache.invalidate_analysis(MustHaltAnalysis)
         self.analyses_cache.invalidate_analysis(ReachableAnalysis)
+        self.analyses_cache.invalidate_analysis(StackCleanupSafety)

--- a/vyper/venom/analysis/fcg.py
+++ b/vyper/venom/analysis/fcg.py
@@ -57,4 +57,7 @@ class FCGGlobalAnalysis(IRGlobalAnalysis):
         return [fn for fn in self.ctx.get_functions() if fn not in self._reachable]
 
     def invalidate(self):
-        pass
+        # Imported lazily to avoid an analysis-package import cycle.
+        from vyper.venom.stack_safety import StackCleanupSafety
+
+        self.global_analyses_cache.invalidate_analysis(StackCleanupSafety)

--- a/vyper/venom/analysis/must_halt.py
+++ b/vyper/venom/analysis/must_halt.py
@@ -16,17 +16,19 @@ class MustHaltAnalysis(IRAnalysis):
 
     def analyze(self) -> None:
         self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
-        blocks = tuple(self.function.get_basic_blocks())
-        result = {bb for bb in blocks if bb.is_halting}
+        result = {bb for bb in self.function.get_basic_blocks() if bb.is_halting}
 
-        changed = True
-        while changed:
-            changed = False
-            for bb in blocks:
-                successors = self.cfg.cfg_out(bb)
-                if bb not in result and successors and all(succ in result for succ in successors):
-                    result.add(bb)
-                    changed = True
+        # DFS postorder visits every acyclic successor before its predecessor.
+        # A successor reached through a back edge remains absent, deliberately
+        # excluding cycles from the least fixed point.
+        for bb in self.cfg.dfs_post_walk:
+            successors = self.cfg.cfg_out(bb)
+            if (
+                bb not in result
+                and len(successors) > 0
+                and all(succ in result for succ in successors)
+            ):
+                result.add(bb)
 
         self.must_halt = frozenset(result)
 
@@ -34,5 +36,9 @@ class MustHaltAnalysis(IRAnalysis):
         return bb in self.must_halt
 
     def invalidate(self) -> None:
+        # Imported lazily to avoid an analysis-package import cycle.
+        from vyper.venom.stack_safety import StackCleanupSafety
+
         del self.must_halt
         del self.cfg
+        self.analyses_cache.invalidate_analysis(StackCleanupSafety)

--- a/vyper/venom/analysis/must_halt.py
+++ b/vyper/venom/analysis/must_halt.py
@@ -1,0 +1,38 @@
+from vyper.venom.analysis.analysis import IRAnalysis
+from vyper.venom.analysis.cfg import CFGAnalysis
+from vyper.venom.basicblock import IRBasicBlock
+
+
+class MustHaltAnalysis(IRAnalysis):
+    """
+    Find blocks from which every CFG path ends the current message call.
+
+    The least fixed point intentionally excludes cycles: a loop with a
+    halting exit is not guaranteed to take that exit.
+    """
+
+    cfg: CFGAnalysis
+    must_halt: frozenset[IRBasicBlock]
+
+    def analyze(self) -> None:
+        self.cfg = self.analyses_cache.request_analysis(CFGAnalysis)
+        blocks = tuple(self.function.get_basic_blocks())
+        result = {bb for bb in blocks if bb.is_halting}
+
+        changed = True
+        while changed:
+            changed = False
+            for bb in blocks:
+                successors = self.cfg.cfg_out(bb)
+                if bb not in result and successors and all(succ in result for succ in successors):
+                    result.add(bb)
+                    changed = True
+
+        self.must_halt = frozenset(result)
+
+    def __contains__(self, bb: IRBasicBlock) -> bool:
+        return bb in self.must_halt
+
+    def invalidate(self) -> None:
+        del self.must_halt
+        del self.cfg

--- a/vyper/venom/stack_safety.py
+++ b/vyper/venom/stack_safety.py
@@ -1,66 +1,93 @@
 from __future__ import annotations
 
-from vyper.venom.analysis import (
-    FCGGlobalAnalysis,
-    IRAnalysesCache,
-    IRGlobalAnalysesCache,
-    LivenessAnalysis,
-    MustHaltAnalysis,
-)
+from vyper.exceptions import CompilerPanic
+from vyper.venom.analysis import CFGAnalysis, FCGGlobalAnalysis, IRGlobalAnalysis, MustHaltAnalysis
 from vyper.venom.basicblock import IRBasicBlock, IRLabel, IRVariable
-from vyper.venom.context import IRContext
 from vyper.venom.function import IRFunction
 
 _EVM_STACK_LIMIT = 1024
 
 
-class StackCleanupSafety:
+class StackCleanupSafety(IRGlobalAnalysis):
+    """Prove that dead stack slots can remain in a must-halt region.
+
+    The first cleanup elision on a runtime path starts from an accurate physical
+    stack height.  Its bound covers every distinct SSA value reachable after
+    that edge, the largest instruction transient, and transitive callees.  It
+    therefore also covers later elisions, whose codegen model height may depend
+    on which predecessor was visited first.
+
+    CFG or function-call cycles make the regional bound unknown and disable the
+    elision.  Codegen verifies the predicted heights against the EVM operations
+    it emits; an underestimated lowering bound is a compile-time failure rather
+    than a possible runtime stack overflow.
     """
-    Prove that dead values can remain on the physical stack in a must-halt region.
 
-    This is a code-generation helper rather than an IR analysis: its bound is
-    interpreted against the physical StackModel height known only during EVM
-    lowering. The helper lives for one assembly-generation run and shares the
-    same per-function analysis caches used by that run.
-
-    Stack growth is deliberately overestimated from all distinct SSA values
-    reachable in the region plus the largest instruction/callee transient.
-    CFG or function-call cycles make the bound unknown and disable the elision.
-    """
-
-    def __init__(self, ctx: IRContext, analyses_caches: dict[IRFunction, IRAnalysesCache]) -> None:
-        self.ctx = ctx
-        self._analyses_caches = analyses_caches
+    def analyze(self) -> None:
         self._block_summaries: dict[IRBasicBlock, tuple[frozenset[IRVariable], int] | None] = {}
         self._function_growth: dict[IRFunction, int | None] = {}
         self._function_frame_growth: dict[IRFunction, int] = {}
         self._caller_stack_heights: dict[IRFunction, int | None] = {}
+        self._safe_current_heights: dict[IRBasicBlock, int | None] = {}
 
-        self._entry_function = ctx.entry_function
+        self._entry_function = self.ctx.entry_function
         self._fcg: FCGGlobalAnalysis | None = None
-        if ctx.entry_function is not None:
-            global_cache = IRGlobalAnalysesCache(ctx, analyses_caches)
-            self._fcg = global_cache.request_analysis(FCGGlobalAnalysis)
+        if self._entry_function is not None:
+            self._fcg = self.global_analyses_cache.request_analysis(FCGGlobalAnalysis)
 
     def max_safe_current_height(self, bb: IRBasicBlock) -> int | None:
-        """Return the largest current physical height for which elision is safe."""
+        """Return the largest current function-local height safe for elision."""
+        if bb in self._safe_current_heights:
+            return self._safe_current_heights[bb]
+
         fn = bb.parent
         if bb not in self._get_must_halt(fn):
+            self._safe_current_heights[bb] = None
             return None
 
         caller_stack_height = self._max_caller_stack_height(fn, set())
         if caller_stack_height is None:
+            self._safe_current_heights[bb] = None
             return None
 
         growth = self._max_growth_from_block(bb, set(), {fn})
         if growth is None:
+            self._safe_current_heights[bb] = None
             return None
 
-        return _EVM_STACK_LIMIT - caller_stack_height - growth
+        ret = _EVM_STACK_LIMIT - caller_stack_height - growth
+        self._safe_current_heights[bb] = ret
+        return ret
+
+    def stack_height_bound(self, bb: IRBasicBlock, current_height: int) -> int | None:
+        """Return the promised maximum local height, or ``None`` if unsafe."""
+        max_current_height = self.max_safe_current_height(bb)
+        if max_current_height is None or current_height > max_current_height:
+            return None
+
+        growth = self._max_growth_from_block(bb, set(), {bb.parent})
+        assert growth is not None  # established by max_safe_current_height()
+        return current_height + growth
 
     def can_skip_cleanup(self, bb: IRBasicBlock, current_height: int) -> bool:
-        max_height = self.max_safe_current_height(bb)
-        return max_height is not None and current_height <= max_height
+        return self.stack_height_bound(bb, current_height) is not None
+
+    def verify_codegen(self, function_peak_heights: dict[IRFunction, int]) -> None:
+        """Verify the frame and regional terms used to compose stack bounds."""
+        for fn, actual_height in function_peak_heights.items():
+            frame_height = self._max_function_frame_growth(fn)
+            if actual_height > frame_height:
+                raise CompilerPanic(
+                    f"Stack cleanup safety underestimated {fn.name}: "
+                    f"codegen reached {actual_height}, frame bound was {frame_height}"
+                )
+
+            regional_height = self._max_growth_from_function(fn, set())
+            if regional_height is not None and actual_height > regional_height:
+                raise CompilerPanic(
+                    f"Stack cleanup safety underestimated {fn.name}: "
+                    f"codegen reached {actual_height}, regional bound was {regional_height}"
+                )
 
     def _max_caller_stack_height(
         self, fn: IRFunction, active_functions: set[IRFunction]
@@ -82,7 +109,7 @@ class StackCleanupSafety:
                 heights.append(caller_height + self._max_function_frame_growth(caller))
         active_functions.remove(fn)
 
-        height = max(heights) if heights else None
+        height = max(heights) if len(heights) > 0 else None
         self._caller_stack_heights[fn] = height
         return height
 
@@ -90,46 +117,23 @@ class StackCleanupSafety:
         if fn in self._function_frame_growth:
             return self._function_frame_growth[fn]
 
-        liveness = self._get_liveness(fn)
-        must_halt = self._get_must_halt(fn)
-        terminal_variables: set[IRVariable] = set()
-        early_return_outputs: set[IRVariable] = set()
-        max_live = 0
-        max_block_outputs = 0
-        max_operands = 0
-
+        # At most one persistent slot exists for each SSA value.  Operand
+        # copies and lowering details are temporary and are covered by the
+        # largest per-instruction transient.  Codegen verifies this term.
+        variables: set[IRVariable] = set()
+        max_transient = 0
         for bb in fn.get_basic_blocks():
-            max_block_outputs = max(
-                max_block_outputs, sum(inst.num_outputs for inst in bb.instructions)
-            )
             for inst in bb.instructions:
-                live = liveness.live_vars_at(inst)
-                max_live = max(max_live, len(live))
-                max_operands = max(max_operands, len(inst.operands))
-                if inst.opcode in ("offset", "phi"):
-                    early_return_outputs.update(inst.get_outputs())
-                if bb in must_halt:
-                    terminal_variables.update(inst.get_input_variables())
-                    terminal_variables.update(inst.get_outputs())
-                    terminal_variables.update(live)
+                variables.update(inst.get_input_variables())
+                variables.update(inst.get_outputs())
+                max_transient = max(max_transient, len(inst.operands) + 2)
 
-        # Outside a must-halt region, ordinary cleanup keeps the frame near
-        # the live set. Inside one, every SSA value in the region may coexist
-        # as retained junk. Track outputs from codegen paths which bypass
-        # normal dead-output cleanup (`offset` and `phi`) across blocks too.
-        growth = (
-            max_live
-            + len(terminal_variables)
-            + len(early_return_outputs)
-            + max_block_outputs
-            + max_operands
-            + 2
-        )
+        growth = len(variables) + max_transient
         self._function_frame_growth[fn] = growth
         return growth
 
     def _max_growth_from_function(
-        self, fn: IRFunction, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+        self, fn: IRFunction, active_functions: set[IRFunction]
     ) -> int | None:
         if fn in self._function_growth:
             return self._function_growth[fn]
@@ -138,7 +142,7 @@ class StackCleanupSafety:
 
         active_functions.add(fn)
         try:
-            growth = self._max_growth_from_block(fn.entry, active_blocks, active_functions)
+            growth = self._max_growth_from_block(fn.entry, set(), active_functions)
         finally:
             active_functions.remove(fn)
         self._function_growth[fn] = growth
@@ -163,26 +167,18 @@ class StackCleanupSafety:
 
         active_blocks.add(bb)
         try:
-            # A distinct SSA value can occupy at most one persistent physical
-            # slot. A consumed copy of each operand can coexist with those slots;
-            # two more cover lowering details such as jump labels, bump's DUP,
-            # and the one-slot transient used by deep stack spilling.
             variables: set[IRVariable] = set()
             max_transient = 0
-            liveness = self._get_liveness(bb.parent)
             for inst in bb.instructions:
                 variables.update(inst.get_input_variables())
                 variables.update(inst.get_outputs())
-                variables.update(liveness.live_vars_at(inst))
                 inst_transient = len(inst.operands) + 2
 
                 if inst.opcode == "invoke":
                     target = inst.operands[0]
                     assert isinstance(target, IRLabel)
                     callee = self.ctx.get_function(target)
-                    callee_growth = self._max_growth_from_function(
-                        callee, active_blocks, active_functions
-                    )
+                    callee_growth = self._max_growth_from_function(callee, active_functions)
                     if callee_growth is None:
                         self._block_summaries[bb] = None
                         return None
@@ -190,7 +186,8 @@ class StackCleanupSafety:
 
                 max_transient = max(max_transient, inst_transient)
 
-            for successor in bb.out_bbs:
+            cfg = self._get_cfg(bb.parent)
+            for successor in cfg.cfg_out(bb):
                 successor_summary = self._stack_growth_summary(
                     successor, active_blocks, active_functions
                 )
@@ -207,9 +204,18 @@ class StackCleanupSafety:
         finally:
             active_blocks.remove(bb)
 
-    def _get_liveness(self, fn: IRFunction) -> LivenessAnalysis:
-        return self._analyses_caches[fn].request_analysis(LivenessAnalysis)
+    def _get_cfg(self, fn: IRFunction) -> CFGAnalysis:
+        return self.analyses_caches[fn].request_analysis(CFGAnalysis)
 
     def _get_must_halt(self, fn: IRFunction) -> frozenset[IRBasicBlock]:
-        analysis = self._analyses_caches[fn].request_analysis(MustHaltAnalysis)
+        analysis = self.analyses_caches[fn].request_analysis(MustHaltAnalysis)
         return analysis.must_halt
+
+    def invalidate(self) -> None:
+        del self._block_summaries
+        del self._function_growth
+        del self._function_frame_growth
+        del self._caller_stack_heights
+        del self._safe_current_heights
+        del self._entry_function
+        del self._fcg

--- a/vyper/venom/stack_safety.py
+++ b/vyper/venom/stack_safety.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from vyper.venom.analysis import (
+    FCGGlobalAnalysis,
+    IRAnalysesCache,
+    IRGlobalAnalysesCache,
+    LivenessAnalysis,
+    MustHaltAnalysis,
+)
+from vyper.venom.basicblock import IRBasicBlock, IRLabel, IRVariable
+from vyper.venom.context import IRContext
+from vyper.venom.function import IRFunction
+
+_EVM_STACK_LIMIT = 1024
+
+
+class StackCleanupSafety:
+    """
+    Prove that dead values can remain on the physical stack in a must-halt region.
+
+    This is a code-generation helper rather than an IR analysis: its bound is
+    interpreted against the physical StackModel height known only during EVM
+    lowering. The helper lives for one assembly-generation run and shares the
+    same per-function analysis caches used by that run.
+
+    Stack growth is deliberately overestimated from all distinct SSA values
+    reachable in the region plus the largest instruction/callee transient.
+    CFG or function-call cycles make the bound unknown and disable the elision.
+    """
+
+    def __init__(self, ctx: IRContext, analyses_caches: dict[IRFunction, IRAnalysesCache]) -> None:
+        self.ctx = ctx
+        self._analyses_caches = analyses_caches
+        self._block_summaries: dict[IRBasicBlock, tuple[frozenset[IRVariable], int] | None] = {}
+        self._function_growth: dict[IRFunction, int | None] = {}
+        self._function_frame_growth: dict[IRFunction, int] = {}
+        self._caller_stack_heights: dict[IRFunction, int | None] = {}
+
+        self._entry_function = ctx.entry_function
+        self._fcg: FCGGlobalAnalysis | None = None
+        if ctx.entry_function is not None:
+            global_cache = IRGlobalAnalysesCache(ctx, analyses_caches)
+            self._fcg = global_cache.request_analysis(FCGGlobalAnalysis)
+
+    def max_safe_current_height(self, bb: IRBasicBlock) -> int | None:
+        """Return the largest current physical height for which elision is safe."""
+        fn = bb.parent
+        if bb not in self._get_must_halt(fn):
+            return None
+
+        caller_stack_height = self._max_caller_stack_height(fn, set())
+        if caller_stack_height is None:
+            return None
+
+        growth = self._max_growth_from_block(bb, set(), {fn})
+        if growth is None:
+            return None
+
+        return _EVM_STACK_LIMIT - caller_stack_height - growth
+
+    def can_skip_cleanup(self, bb: IRBasicBlock, current_height: int) -> bool:
+        max_height = self.max_safe_current_height(bb)
+        return max_height is not None and current_height <= max_height
+
+    def _max_caller_stack_height(
+        self, fn: IRFunction, active_functions: set[IRFunction]
+    ) -> int | None:
+        if fn in self._caller_stack_heights:
+            return self._caller_stack_heights[fn]
+        if fn in active_functions:
+            return None
+
+        active_functions.add(fn)
+        heights = [0] if fn is self._entry_function else []
+        if self._fcg is not None:
+            callers = {call_site.parent.parent for call_site in self._fcg.get_call_sites(fn)}
+            for caller in callers:
+                caller_height = self._max_caller_stack_height(caller, active_functions)
+                if caller_height is None:
+                    heights = []
+                    break
+                heights.append(caller_height + self._max_function_frame_growth(caller))
+        active_functions.remove(fn)
+
+        height = max(heights) if heights else None
+        self._caller_stack_heights[fn] = height
+        return height
+
+    def _max_function_frame_growth(self, fn: IRFunction) -> int:
+        if fn in self._function_frame_growth:
+            return self._function_frame_growth[fn]
+
+        liveness = self._get_liveness(fn)
+        must_halt = self._get_must_halt(fn)
+        terminal_variables: set[IRVariable] = set()
+        early_return_outputs: set[IRVariable] = set()
+        max_live = 0
+        max_block_outputs = 0
+        max_operands = 0
+
+        for bb in fn.get_basic_blocks():
+            max_block_outputs = max(
+                max_block_outputs, sum(inst.num_outputs for inst in bb.instructions)
+            )
+            for inst in bb.instructions:
+                live = liveness.live_vars_at(inst)
+                max_live = max(max_live, len(live))
+                max_operands = max(max_operands, len(inst.operands))
+                if inst.opcode in ("offset", "phi"):
+                    early_return_outputs.update(inst.get_outputs())
+                if bb in must_halt:
+                    terminal_variables.update(inst.get_input_variables())
+                    terminal_variables.update(inst.get_outputs())
+                    terminal_variables.update(live)
+
+        # Outside a must-halt region, ordinary cleanup keeps the frame near
+        # the live set. Inside one, every SSA value in the region may coexist
+        # as retained junk. Track outputs from codegen paths which bypass
+        # normal dead-output cleanup (`offset` and `phi`) across blocks too.
+        growth = (
+            max_live
+            + len(terminal_variables)
+            + len(early_return_outputs)
+            + max_block_outputs
+            + max_operands
+            + 2
+        )
+        self._function_frame_growth[fn] = growth
+        return growth
+
+    def _max_growth_from_function(
+        self, fn: IRFunction, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+    ) -> int | None:
+        if fn in self._function_growth:
+            return self._function_growth[fn]
+        if fn in active_functions:
+            return None
+
+        active_functions.add(fn)
+        try:
+            growth = self._max_growth_from_block(fn.entry, active_blocks, active_functions)
+        finally:
+            active_functions.remove(fn)
+        self._function_growth[fn] = growth
+        return growth
+
+    def _max_growth_from_block(
+        self, bb: IRBasicBlock, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+    ) -> int | None:
+        summary = self._stack_growth_summary(bb, active_blocks, active_functions)
+        if summary is None:
+            return None
+        variables, transient = summary
+        return len(variables) + transient
+
+    def _stack_growth_summary(
+        self, bb: IRBasicBlock, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+    ) -> tuple[frozenset[IRVariable], int] | None:
+        if bb in self._block_summaries:
+            return self._block_summaries[bb]
+        if bb in active_blocks:
+            return None
+
+        active_blocks.add(bb)
+        try:
+            # A distinct SSA value can occupy at most one persistent physical
+            # slot. A consumed copy of each operand can coexist with those slots;
+            # two more cover lowering details such as jump labels, bump's DUP,
+            # and the one-slot transient used by deep stack spilling.
+            variables: set[IRVariable] = set()
+            max_transient = 0
+            liveness = self._get_liveness(bb.parent)
+            for inst in bb.instructions:
+                variables.update(inst.get_input_variables())
+                variables.update(inst.get_outputs())
+                variables.update(liveness.live_vars_at(inst))
+                inst_transient = len(inst.operands) + 2
+
+                if inst.opcode == "invoke":
+                    target = inst.operands[0]
+                    assert isinstance(target, IRLabel)
+                    callee = self.ctx.get_function(target)
+                    callee_growth = self._max_growth_from_function(
+                        callee, active_blocks, active_functions
+                    )
+                    if callee_growth is None:
+                        self._block_summaries[bb] = None
+                        return None
+                    inst_transient += callee_growth
+
+                max_transient = max(max_transient, inst_transient)
+
+            for successor in bb.out_bbs:
+                successor_summary = self._stack_growth_summary(
+                    successor, active_blocks, active_functions
+                )
+                if successor_summary is None:
+                    self._block_summaries[bb] = None
+                    return None
+                successor_variables, successor_transient = successor_summary
+                variables.update(successor_variables)
+                max_transient = max(max_transient, successor_transient)
+
+            summary = (frozenset(variables), max_transient)
+            self._block_summaries[bb] = summary
+            return summary
+        finally:
+            active_blocks.remove(bb)
+
+    def _get_liveness(self, fn: IRFunction) -> LivenessAnalysis:
+        return self._analyses_caches[fn].request_analysis(LivenessAnalysis)
+
+    def _get_must_halt(self, fn: IRFunction) -> frozenset[IRBasicBlock]:
+        analysis = self._analyses_caches[fn].request_analysis(MustHaltAnalysis)
+        return analysis.must_halt

--- a/vyper/venom/stack_safety.py
+++ b/vyper/venom/stack_safety.py
@@ -17,10 +17,11 @@ class StackCleanupSafety(IRGlobalAnalysis):
     therefore also covers later elisions, whose codegen model height may depend
     on which predecessor was visited first.
 
-    CFG or function-call cycles make the regional bound unknown and disable the
-    elision.  Codegen verifies the predicted heights against the EVM operations
-    it emits; an underestimated lowering bound is a compile-time failure rather
-    than a possible runtime stack overflow.
+    CFG cycles make the regional bound unknown and disable the elision.
+    Recursive function calls are invalid Venom.  Codegen verifies the predicted
+    heights against the EVM operations it emits; an underestimated lowering
+    bound is a compile-time failure rather than a possible runtime stack
+    overflow.
     """
 
     def analyze(self) -> None:
@@ -94,8 +95,7 @@ class StackCleanupSafety(IRGlobalAnalysis):
     ) -> int | None:
         if fn in self._caller_stack_heights:
             return self._caller_stack_heights[fn]
-        if fn in active_functions:
-            return None
+        assert fn not in active_functions, "recursive function call"
 
         active_functions.add(fn)
         heights = [0] if fn is self._entry_function else []
@@ -137,8 +137,7 @@ class StackCleanupSafety(IRGlobalAnalysis):
     ) -> int | None:
         if fn in self._function_growth:
             return self._function_growth[fn]
-        if fn in active_functions:
-            return None
+        assert fn not in active_functions, "recursive function call"
 
         active_functions.add(fn)
         try:

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Iterable
 
 from vyper.evm.assembler.instructions import CONST, CONSTREF, DATA_ITEM, PUSH, PUSH_OFST, DataHeader
+from vyper.evm.opcodes import get_opcodes
 from vyper.exceptions import CompilerPanic
 from vyper.ir.compile_ir import (
     PUSHLABEL,
@@ -12,7 +13,13 @@ from vyper.ir.compile_ir import (
     optimize_assembly,
 )
 from vyper.utils import OrderedSet, ceil32, wrap256
-from vyper.venom.analysis import CFGAnalysis, DFGAnalysis, IRAnalysesCache, LivenessAnalysis
+from vyper.venom.analysis import (
+    CFGAnalysis,
+    DFGAnalysis,
+    IRAnalysesCache,
+    IRGlobalAnalysesCache,
+    LivenessAnalysis,
+)
 from vyper.venom.basicblock import (
     PSEUDO_INSTRUCTION,
     TEST_INSTRUCTIONS,
@@ -24,8 +31,8 @@ from vyper.venom.basicblock import (
     IRVariable,
 )
 from vyper.venom.context import IRContext, IRFunction
-from vyper.venom.stack_safety import StackCleanupSafety
 from vyper.venom.stack_model import StackModel
+from vyper.venom.stack_safety import StackCleanupSafety
 from vyper.venom.stack_spiller import StackSpiller
 
 DEBUG_SHOW_COST = False
@@ -119,11 +126,31 @@ _INITIAL_FMP_CONST = "__initial_fmp__"
 class _DeadStackItem(IROperand):
     """An intentionally retained physical stack slot with no logical value."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(object())
 
     def __repr__(self) -> str:
         return "<dead>"
+
+
+def _assembly_peak_stack_growth(assembly: Iterable[AssemblyInstruction]) -> int:
+    """Return the largest EVM stack increase in a straight-line assembly fragment."""
+    height = 0
+    peak = 0
+    opcodes = get_opcodes()
+
+    for item in assembly:
+        if isinstance(item, (PUSHLABEL, PUSH_OFST)):
+            height += 1
+        elif isinstance(item, str):
+            opcode = opcodes.get(item.upper())
+            if opcode is None:
+                raise CompilerPanic(f"Unknown assembly stack effect for {item}")
+            _, inputs, outputs, _ = opcode
+            height += outputs - inputs
+        peak = max(peak, height)
+
+    return peak
 
 
 def apply_line_numbers(inst: IRInstruction, asm) -> list[str]:
@@ -169,7 +196,9 @@ class VenomCompiler:
         self.visited_basicblocks = OrderedSet()
         self.spiller = StackSpiller(ctx)
         self._uses_initial_fmp_const = False
+        self._analyses_cache: IRAnalysesCache | None = None
         self._stack_cleanup_safety: StackCleanupSafety | None = None
+        self._function_peak_stack_heights: dict[IRFunction, int] = {}
 
     def mklabel(self, name: str) -> Label:
         self.label_counter += 1
@@ -180,15 +209,19 @@ class VenomCompiler:
         self.label_counter = 0
         self.spiller.reset_peak_spill_end()
         self._uses_initial_fmp_const = False
+        self._analyses_cache = None
         self._stack_cleanup_safety = None
+        self._function_peak_stack_heights = {}
 
         asm: list[AssemblyInstruction] = []
+        previous_global_cache = self.ctx.global_analyses_cache
         analyses_caches = {fn: IRAnalysesCache(fn) for fn in self.ctx.functions.values()}
-        self._stack_cleanup_safety = StackCleanupSafety(self.ctx, analyses_caches)
+        self.ctx.global_analyses_cache = IRGlobalAnalysesCache(self.ctx, analyses_caches)
 
         try:
             for fn in self.ctx.functions.values():
                 ac = analyses_caches[fn]
+                self._analyses_cache = ac
 
                 self.liveness = ac.request_analysis(LivenessAnalysis)
                 self.dfg = ac.request_analysis(DFGAnalysis)
@@ -198,9 +231,13 @@ class VenomCompiler:
 
                 self.spiller.set_current_function(fn)
                 self.spiller.reset_spill_slots()
-                self._generate_evm_for_basicblock_r(asm, fn.entry, StackModel(), {})
-                self.spiller.set_current_function(None)
+                self._generate_evm_for_basicblock_r(asm, fn.entry, StackModel(), {}, None)
+
+            if self._stack_cleanup_safety is not None:
+                self._stack_cleanup_safety.verify_codegen(self._function_peak_stack_heights)
         finally:
+            self.ctx.global_analyses_cache = previous_global_cache
+            self._analyses_cache = None
             self._stack_cleanup_safety = None
             self.spiller.set_current_function(None)
 
@@ -395,7 +432,7 @@ class VenomCompiler:
             assert op not in seen, (inst, op, seen)
             seen.add(op)
 
-    def _prepare_stack_for_function(self, asm, fn: IRFunction, stack: StackModel):
+    def _prepare_stack_for_function(self, asm, fn: IRFunction, stack: StackModel) -> int:
         last_param_inst = None
         for inst in fn.entry.instructions:
             if not inst.is_param:
@@ -407,9 +444,11 @@ class VenomCompiler:
 
             stack.push(inst.output)
 
+        initial_height = stack.height
+
         # no params (only applies for global entry function)
         if last_param_inst is None:
-            return
+            return initial_height
 
         to_pop: list[IRVariable] = []
         for var in stack._stack:
@@ -420,6 +459,42 @@ class VenomCompiler:
         self.popmany(asm, to_pop, stack)
 
         self._optimistic_swap(asm, last_param_inst, next_liveness, stack)
+        return initial_height
+
+    def _get_stack_cleanup_safety(self) -> StackCleanupSafety:
+        if self._stack_cleanup_safety is None:
+            assert self._analyses_cache is not None
+            self._stack_cleanup_safety = self._analyses_cache.request_analysis(StackCleanupSafety)
+        return self._stack_cleanup_safety
+
+    @staticmethod
+    def _assert_dead_stack_prefix(stack: StackModel) -> None:
+        live_item_seen = False
+        for item in stack._stack:
+            if isinstance(item, _DeadStackItem):
+                if live_item_seen:
+                    raise CompilerPanic("Retained dead stack item is above a live item")
+            else:
+                live_item_seen = True
+
+    def _observe_stack_height(
+        self,
+        fn: IRFunction,
+        initial_height: int,
+        assembly: Iterable[AssemblyInstruction],
+        final_height: int,
+        promised_height: int | None,
+        location: object,
+    ) -> None:
+        actual_height = max(initial_height + _assembly_peak_stack_growth(assembly), final_height)
+        previous_height = self._function_peak_stack_heights.get(fn, 0)
+        self._function_peak_stack_heights[fn] = max(previous_height, actual_height)
+
+        if promised_height is not None and actual_height > promised_height:
+            raise CompilerPanic(
+                f"Stack cleanup safety underestimated {location}: "
+                f"codegen reached {actual_height}, bound was {promised_height}"
+            )
 
     def popmany(self, asm, to_pop: Iterable[IRVariable], stack):
         to_pop = [var for var in to_pop if stack.get_depth(var) is not StackModel.NOT_IN_STACK]
@@ -450,7 +525,12 @@ class VenomCompiler:
             self.pop(asm, stack)
 
     def _generate_evm_for_basicblock_r(
-        self, asm: list, basicblock: IRBasicBlock, stack: StackModel, spilled: dict[IROperand, int]
+        self,
+        asm: list,
+        basicblock: IRBasicBlock,
+        stack: StackModel,
+        spilled: dict[IROperand, int],
+        stack_height_bound: int | None,
     ) -> None:
         if basicblock in self.visited_basicblocks:
             return
@@ -467,10 +547,40 @@ class VenomCompiler:
 
         fn = basicblock.parent
         if basicblock == fn.entry:
-            self._prepare_stack_for_function(asm, fn, stack)
+            prepare_start = len(asm)
+            initial_height = self._prepare_stack_for_function(asm, fn, stack)
+            self._observe_stack_height(
+                fn,
+                initial_height,
+                asm[prepare_start:],
+                stack.height,
+                stack_height_bound,
+                f"entry preparation for {fn.name}",
+            )
 
+        cleanup_start = len(asm)
+        cleanup_initial_height = stack.height
+        incoming_stack_height_bound = stack_height_bound
         if len(self.cfg.cfg_in(basicblock)) == 1:
-            self.clean_stack_from_cfg_in(asm, basicblock, stack)
+            stack_height_bound = self.clean_stack_from_cfg_in(
+                asm, basicblock, stack, stack_height_bound
+            )
+        self._observe_stack_height(
+            fn,
+            cleanup_initial_height,
+            asm[cleanup_start:],
+            stack.height,
+            incoming_stack_height_bound,
+            f"entry to {basicblock.label}",
+        )
+        self._observe_stack_height(
+            fn,
+            stack.height,
+            (),
+            stack.height,
+            stack_height_bound,
+            f"cleanup elision at {basicblock.label}",
+        )
 
         all_insts = [inst for inst in basicblock.instructions if not inst.is_param]
 
@@ -484,11 +594,18 @@ class VenomCompiler:
             else:
                 next_liveness = self.liveness.out_vars(basicblock)
 
-            asm.extend(
-                self._generate_evm_for_instruction(
-                    inst, stack, next_liveness, spilled, is_halting_block
-                )
+            if stack_height_bound is not None:
+                self._assert_dead_stack_prefix(stack)
+            initial_height = stack.height
+            instruction_asm = self._generate_evm_for_instruction(
+                inst, stack, next_liveness, spilled, is_halting_block
             )
+            if stack_height_bound is not None:
+                self._assert_dead_stack_prefix(stack)
+            self._observe_stack_height(
+                fn, initial_height, instruction_asm, stack.height, stack_height_bound, inst
+            )
+            asm.extend(instruction_asm)
 
         if DEBUG_SHOW_COST:
             print(" ".join(map(str, asm)), file=sys.stderr)
@@ -497,14 +614,20 @@ class VenomCompiler:
         ref.extend(asm)
 
         for bb in self.cfg.cfg_out(basicblock):
-            self._generate_evm_for_basicblock_r(ref, bb, stack.copy(), spilled.copy())
+            self._generate_evm_for_basicblock_r(
+                ref, bb, stack.copy(), spilled.copy(), stack_height_bound
+            )
 
-    # pop values from stack at entry to bb
-    # note this produces the same result(!) no matter which basic block
-    # we enter from in the CFG.
+    # Pop values from the stack at entry to bb.  Live values have the same
+    # ordering and depth on every incoming path.  A must-halt path may retain
+    # a dead prefix below them, so its physical height can intentionally differ.
     def clean_stack_from_cfg_in(
-        self, asm: list, basicblock: IRBasicBlock, stack: StackModel
-    ) -> None:
+        self,
+        asm: list,
+        basicblock: IRBasicBlock,
+        stack: StackModel,
+        stack_height_bound: int | None = None,
+    ) -> int | None:
         # the input block is a splitter block, like jnz or djmp
         assert len(in_bbs := self.cfg.cfg_in(basicblock)) == 1
         in_bb = in_bbs.first()
@@ -519,20 +642,63 @@ class VenomCompiler:
         # bb it jumps into).
         layout = self.liveness.out_vars(in_bb)
         to_pop = list(layout.difference(inputs))
+        self._assert_dead_stack_prefix(stack)
+        physical_to_pop = [
+            var for var in to_pop if stack.get_depth(var) is not StackModel.NOT_IN_STACK
+        ]
+        if len(physical_to_pop) == 0:
+            return stack_height_bound
 
-        stack_cleanup_safety = self._stack_cleanup_safety
-        assert stack_cleanup_safety is not None
-        if stack_cleanup_safety.can_skip_cleanup(basicblock, stack.height):
-            # The values stay on the physical EVM stack, but they are dead on
-            # this edge. Forget their logical identities so a later halting
-            # join cannot mistake retained junk for an incoming phi value.
-            for var in to_pop:
-                depth = stack.get_depth(var)
-                if depth is not StackModel.NOT_IN_STACK:
-                    stack.poke(depth, _DeadStackItem())
-            return
+        live_depths = [
+            depth
+            for var in inputs
+            if (depth := stack.get_depth(var)) is not StackModel.NOT_IN_STACK
+        ]
+        deepest_live_depth = min(live_depths) if len(live_depths) > 0 else None
 
-        self.popmany(asm, to_pop, stack)
+        # A dead slot below every live slot can never deepen or reorder a
+        # future operand.  Retaining only this prefix therefore cannot create
+        # extra SWAP/DUP/spill work; every omitted POP is an unconditional gas
+        # saving.  Dead slots interleaved with live values are cleaned normally.
+        retainable = []
+        for var in physical_to_pop:
+            depth = stack.get_depth(var)
+            assert depth is not StackModel.NOT_IN_STACK
+            if deepest_live_depth is None or depth < deepest_live_depth:
+                retainable.append(var)
+
+        if len(retainable) == 0:
+            self.popmany(asm, physical_to_pop, stack)
+            return stack_height_bound
+
+        to_cleanup = [var for var in physical_to_pop if var not in retainable]
+        projected_height = stack.height - len(to_cleanup)
+
+        # The first elision sees an accurate path height and establishes a
+        # whole-region promise.  Later elisions reuse that promise instead of
+        # consulting a model height which may come from another predecessor.
+        promised_height = stack_height_bound
+        if promised_height is None:
+            promised_height = self._get_stack_cleanup_safety().stack_height_bound(
+                basicblock, projected_height
+            )
+
+        if promised_height is None:
+            self.popmany(asm, physical_to_pop, stack)
+            return stack_height_bound
+
+        self.popmany(asm, to_cleanup, stack)
+        assert stack.height == projected_height
+
+        # Forget the logical identities so a later halting phi join cannot
+        # mistake retained junk for an incoming value.
+        for var in retainable:
+            depth = stack.get_depth(var)
+            assert depth is not StackModel.NOT_IN_STACK
+            stack.poke(depth, _DeadStackItem())
+
+        self._assert_dead_stack_prefix(stack)
+        return promised_height
 
     def _generate_evm_for_instruction(
         self,

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -114,6 +114,237 @@ _REVERT_POSTAMBLE = [Label("revert"), *PUSH(0), "DUP1", "REVERT"]
 # analysis completes) and resolved at assembly time.
 _INITIAL_FMP_CONST = "__initial_fmp__"
 
+_EVM_STACK_LIMIT = 1024
+
+
+class _DeadStackItem(IROperand):
+    """An intentionally retained physical stack slot with no logical value."""
+
+    def __init__(self):
+        super().__init__(object())
+
+    def __repr__(self) -> str:
+        return "<dead>"
+
+
+class _MustHaltRegions:
+    """
+    Per-function, codegen-lifetime analysis for guaranteed-halting regions.
+
+    Stack growth is deliberately overestimated from all distinct SSA values
+    reachable in the region plus the largest instruction/callee transient.
+    Cycles make the bound unknown.
+    """
+
+    def __init__(self, ctx: IRContext, cfg: CFGAnalysis, liveness: LivenessAnalysis):
+        self.ctx = ctx
+        self.cfg = cfg
+        self.function = cfg.function
+        self._liveness = {self.function: liveness}
+        self._must_halt = {self.function: self._compute_must_halt(self.function, self.cfg)}
+        self.must_halt = self._must_halt[self.function]
+        self._block_summaries: dict[IRBasicBlock, tuple[frozenset[IRVariable], int] | None] = {}
+        self._function_growth: dict[IRFunction, int | None] = {}
+        self._function_frame_growth: dict[IRFunction, int] = {}
+        self._caller_stack_heights: dict[IRFunction, int | None] = {}
+
+        functions = list(ctx.get_functions())
+        self._entry_function = ctx.entry_function
+        if self._entry_function is None and functions:
+            self._entry_function = functions[0]
+
+        self._callers: dict[IRFunction, set[IRFunction]] = {fn: set() for fn in functions}
+        for caller in functions:
+            for bb in caller.get_basic_blocks():
+                for inst in bb.instructions:
+                    if inst.opcode != "invoke":
+                        continue
+                    target = inst.operands[0]
+                    if isinstance(target, IRLabel) and target in ctx.functions:
+                        self._callers[ctx.get_function(target)].add(caller)
+
+        self._caller_stack_height = self._max_caller_stack_height(self.function, set())
+
+    def _compute_must_halt(self, fn: IRFunction, cfg: CFGAnalysis) -> set[IRBasicBlock]:
+        blocks = list(fn.get_basic_blocks())
+        result = {bb for bb in blocks if bb.is_halting}
+
+        changed = True
+        while changed:
+            changed = False
+            for bb in blocks:
+                successors = cfg.cfg_out(bb)
+                if bb not in result and successors and all(succ in result for succ in successors):
+                    result.add(bb)
+                    changed = True
+
+        return result
+
+    def can_skip_cleanup(self, bb: IRBasicBlock, current_height: int) -> bool:
+        if bb not in self.must_halt or self._caller_stack_height is None:
+            return False
+
+        growth = self._max_growth_from_block(bb, set(), {self.function})
+        return (
+            growth is not None
+            and self._caller_stack_height + current_height + growth <= _EVM_STACK_LIMIT
+        )
+
+    def _max_caller_stack_height(
+        self, fn: IRFunction, active_functions: set[IRFunction]
+    ) -> int | None:
+        if fn in self._caller_stack_heights:
+            return self._caller_stack_heights[fn]
+        if fn in active_functions:
+            return None
+
+        active_functions.add(fn)
+        heights = [0] if fn is self._entry_function else []
+        for caller in self._callers.get(fn, set()):
+            caller_height = self._max_caller_stack_height(caller, active_functions)
+            if caller_height is None:
+                active_functions.remove(fn)
+                self._caller_stack_heights[fn] = None
+                return None
+            heights.append(caller_height + self._max_function_frame_growth(caller))
+        active_functions.remove(fn)
+
+        height = max(heights) if heights else None
+        self._caller_stack_heights[fn] = height
+        return height
+
+    def _max_function_frame_growth(self, fn: IRFunction) -> int:
+        if fn in self._function_frame_growth:
+            return self._function_frame_growth[fn]
+
+        liveness = self._get_liveness(fn)
+        must_halt = self._get_must_halt(fn)
+        terminal_variables: set[IRVariable] = set()
+        early_return_outputs: set[IRVariable] = set()
+        max_live = 0
+        max_block_outputs = 0
+        max_operands = 0
+
+        for bb in fn.get_basic_blocks():
+            max_block_outputs = max(
+                max_block_outputs, sum(inst.num_outputs for inst in bb.instructions)
+            )
+            for inst in bb.instructions:
+                live = liveness.live_vars_at(inst)
+                max_live = max(max_live, len(live))
+                max_operands = max(max_operands, len(inst.operands))
+                if inst.opcode in ("offset", "phi"):
+                    early_return_outputs.update(inst.get_outputs())
+                if bb in must_halt:
+                    terminal_variables.update(inst.get_input_variables())
+                    terminal_variables.update(inst.get_outputs())
+                    terminal_variables.update(live)
+
+        # Outside a must-halt region, ordinary cleanup keeps the frame near
+        # the live set. Inside one, every SSA value in the region may coexist
+        # as retained junk. Track outputs from codegen paths which bypass
+        # normal dead-output cleanup (`offset` and `phi`) across blocks too.
+        growth = (
+            max_live
+            + len(terminal_variables)
+            + len(early_return_outputs)
+            + max_block_outputs
+            + max_operands
+            + 2
+        )
+        self._function_frame_growth[fn] = growth
+        return growth
+
+    def _max_growth_from_function(
+        self, fn: IRFunction, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+    ) -> int | None:
+        if fn in self._function_growth:
+            return self._function_growth[fn]
+        if fn in active_functions:
+            return None
+
+        active_functions.add(fn)
+        growth = self._max_growth_from_block(fn.entry, active_blocks, active_functions)
+        active_functions.remove(fn)
+        self._function_growth[fn] = growth
+        return growth
+
+    def _max_growth_from_block(
+        self, bb: IRBasicBlock, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+    ) -> int | None:
+        summary = self._stack_growth_summary(bb, active_blocks, active_functions)
+        if summary is None:
+            return None
+        variables, transient = summary
+        return len(variables) + transient
+
+    def _stack_growth_summary(
+        self, bb: IRBasicBlock, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
+    ) -> tuple[frozenset[IRVariable], int] | None:
+        if bb in self._block_summaries:
+            return self._block_summaries[bb]
+        if bb in active_blocks:
+            return None
+
+        active_blocks.add(bb)
+
+        # A distinct SSA value can occupy at most one persistent physical
+        # slot. A consumed copy of each operand can coexist with those slots;
+        # two more cover lowering details such as jump labels, bump's DUP, and
+        # the one-slot transient used by deep stack spilling.
+        variables: set[IRVariable] = set()
+        max_transient = 0
+        liveness = self._get_liveness(bb.parent)
+        for inst in bb.instructions:
+            variables.update(inst.get_input_variables())
+            variables.update(inst.get_outputs())
+            variables.update(liveness.live_vars_at(inst))
+            inst_transient = len(inst.operands) + 2
+
+            if inst.opcode == "invoke":
+                target = inst.operands[0]
+                assert isinstance(target, IRLabel)
+                callee = self.ctx.get_function(target)
+                callee_growth = self._max_growth_from_function(
+                    callee, active_blocks, active_functions
+                )
+                if callee_growth is None:
+                    active_blocks.remove(bb)
+                    self._block_summaries[bb] = None
+                    return None
+                inst_transient += callee_growth
+
+            max_transient = max(max_transient, inst_transient)
+
+        for successor in bb.out_bbs:
+            successor_summary = self._stack_growth_summary(
+                successor, active_blocks, active_functions
+            )
+            if successor_summary is None:
+                active_blocks.remove(bb)
+                self._block_summaries[bb] = None
+                return None
+            successor_variables, successor_transient = successor_summary
+            variables.update(successor_variables)
+            max_transient = max(max_transient, successor_transient)
+
+        active_blocks.remove(bb)
+        summary = (frozenset(variables), max_transient)
+        self._block_summaries[bb] = summary
+        return summary
+
+    def _get_liveness(self, fn: IRFunction) -> LivenessAnalysis:
+        if fn not in self._liveness:
+            ac = IRAnalysesCache(fn)
+            self._liveness[fn] = ac.request_analysis(LivenessAnalysis)
+        return self._liveness[fn]
+
+    def _get_must_halt(self, fn: IRFunction) -> set[IRBasicBlock]:
+        if fn not in self._must_halt:
+            liveness = self._get_liveness(fn)
+            self._must_halt[fn] = self._compute_must_halt(fn, liveness.cfg)
+        return self._must_halt[fn]
+
 
 def apply_line_numbers(inst: IRInstruction, asm) -> list[str]:
     ret = []
@@ -158,6 +389,7 @@ class VenomCompiler:
         self.visited_basicblocks = OrderedSet()
         self.spiller = StackSpiller(ctx)
         self._uses_initial_fmp_const = False
+        self._must_halt_regions: _MustHaltRegions | None = None
 
     def mklabel(self, name: str) -> Label:
         self.label_counter += 1
@@ -168,6 +400,7 @@ class VenomCompiler:
         self.label_counter = 0
         self.spiller.reset_peak_spill_end()
         self._uses_initial_fmp_const = False
+        self._must_halt_regions = None
 
         asm: list[AssemblyInstruction] = []
 
@@ -180,11 +413,15 @@ class VenomCompiler:
 
             assert self.cfg.is_normalized(), "Non-normalized CFG!"
 
+            self._must_halt_regions = _MustHaltRegions(self.ctx, self.cfg, self.liveness)
             self.spiller.set_current_function(fn)
             self.spiller.reset_spill_slots()
 
-            self._generate_evm_for_basicblock_r(asm, fn.entry, StackModel(), {})
-            self.spiller.set_current_function(None)
+            try:
+                self._generate_evm_for_basicblock_r(asm, fn.entry, StackModel(), {})
+            finally:
+                self._must_halt_regions = None
+                self.spiller.set_current_function(None)
 
         # Declare the initial-FMP CONST if anything referenced it (the
         # entry function's FMP root is an explicit `initial_fmp`
@@ -501,6 +738,19 @@ class VenomCompiler:
         # bb it jumps into).
         layout = self.liveness.out_vars(in_bb)
         to_pop = list(layout.difference(inputs))
+
+        must_halt_regions = self._must_halt_regions
+        assert must_halt_regions is not None
+        if must_halt_regions.can_skip_cleanup(basicblock, stack.height):
+            # The values stay on the physical EVM stack, but they are dead on
+            # this edge. Forget their logical identities so a later halting
+            # join cannot mistake retained junk for an incoming phi value.
+            for var in to_pop:
+                depth = stack.get_depth(var)
+                if depth is not StackModel.NOT_IN_STACK:
+                    stack.poke(depth, _DeadStackItem())
+            return
+
         self.popmany(asm, to_pop, stack)
 
     def _generate_evm_for_instruction(

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -24,6 +24,7 @@ from vyper.venom.basicblock import (
     IRVariable,
 )
 from vyper.venom.context import IRContext, IRFunction
+from vyper.venom.stack_safety import StackCleanupSafety
 from vyper.venom.stack_model import StackModel
 from vyper.venom.stack_spiller import StackSpiller
 
@@ -114,8 +115,6 @@ _REVERT_POSTAMBLE = [Label("revert"), *PUSH(0), "DUP1", "REVERT"]
 # analysis completes) and resolved at assembly time.
 _INITIAL_FMP_CONST = "__initial_fmp__"
 
-_EVM_STACK_LIMIT = 1024
-
 
 class _DeadStackItem(IROperand):
     """An intentionally retained physical stack slot with no logical value."""
@@ -125,225 +124,6 @@ class _DeadStackItem(IROperand):
 
     def __repr__(self) -> str:
         return "<dead>"
-
-
-class _MustHaltRegions:
-    """
-    Per-function, codegen-lifetime analysis for guaranteed-halting regions.
-
-    Stack growth is deliberately overestimated from all distinct SSA values
-    reachable in the region plus the largest instruction/callee transient.
-    Cycles make the bound unknown.
-    """
-
-    def __init__(self, ctx: IRContext, cfg: CFGAnalysis, liveness: LivenessAnalysis):
-        self.ctx = ctx
-        self.cfg = cfg
-        self.function = cfg.function
-        self._liveness = {self.function: liveness}
-        self._must_halt = {self.function: self._compute_must_halt(self.function, self.cfg)}
-        self.must_halt = self._must_halt[self.function]
-        self._block_summaries: dict[IRBasicBlock, tuple[frozenset[IRVariable], int] | None] = {}
-        self._function_growth: dict[IRFunction, int | None] = {}
-        self._function_frame_growth: dict[IRFunction, int] = {}
-        self._caller_stack_heights: dict[IRFunction, int | None] = {}
-
-        functions = list(ctx.get_functions())
-        self._entry_function = ctx.entry_function
-        if self._entry_function is None and functions:
-            self._entry_function = functions[0]
-
-        self._callers: dict[IRFunction, set[IRFunction]] = {fn: set() for fn in functions}
-        for caller in functions:
-            for bb in caller.get_basic_blocks():
-                for inst in bb.instructions:
-                    if inst.opcode != "invoke":
-                        continue
-                    target = inst.operands[0]
-                    if isinstance(target, IRLabel) and target in ctx.functions:
-                        self._callers[ctx.get_function(target)].add(caller)
-
-        self._caller_stack_height = self._max_caller_stack_height(self.function, set())
-
-    def _compute_must_halt(self, fn: IRFunction, cfg: CFGAnalysis) -> set[IRBasicBlock]:
-        blocks = list(fn.get_basic_blocks())
-        result = {bb for bb in blocks if bb.is_halting}
-
-        changed = True
-        while changed:
-            changed = False
-            for bb in blocks:
-                successors = cfg.cfg_out(bb)
-                if bb not in result and successors and all(succ in result for succ in successors):
-                    result.add(bb)
-                    changed = True
-
-        return result
-
-    def can_skip_cleanup(self, bb: IRBasicBlock, current_height: int) -> bool:
-        if bb not in self.must_halt or self._caller_stack_height is None:
-            return False
-
-        growth = self._max_growth_from_block(bb, set(), {self.function})
-        return (
-            growth is not None
-            and self._caller_stack_height + current_height + growth <= _EVM_STACK_LIMIT
-        )
-
-    def _max_caller_stack_height(
-        self, fn: IRFunction, active_functions: set[IRFunction]
-    ) -> int | None:
-        if fn in self._caller_stack_heights:
-            return self._caller_stack_heights[fn]
-        if fn in active_functions:
-            return None
-
-        active_functions.add(fn)
-        heights = [0] if fn is self._entry_function else []
-        for caller in self._callers.get(fn, set()):
-            caller_height = self._max_caller_stack_height(caller, active_functions)
-            if caller_height is None:
-                active_functions.remove(fn)
-                self._caller_stack_heights[fn] = None
-                return None
-            heights.append(caller_height + self._max_function_frame_growth(caller))
-        active_functions.remove(fn)
-
-        height = max(heights) if heights else None
-        self._caller_stack_heights[fn] = height
-        return height
-
-    def _max_function_frame_growth(self, fn: IRFunction) -> int:
-        if fn in self._function_frame_growth:
-            return self._function_frame_growth[fn]
-
-        liveness = self._get_liveness(fn)
-        must_halt = self._get_must_halt(fn)
-        terminal_variables: set[IRVariable] = set()
-        early_return_outputs: set[IRVariable] = set()
-        max_live = 0
-        max_block_outputs = 0
-        max_operands = 0
-
-        for bb in fn.get_basic_blocks():
-            max_block_outputs = max(
-                max_block_outputs, sum(inst.num_outputs for inst in bb.instructions)
-            )
-            for inst in bb.instructions:
-                live = liveness.live_vars_at(inst)
-                max_live = max(max_live, len(live))
-                max_operands = max(max_operands, len(inst.operands))
-                if inst.opcode in ("offset", "phi"):
-                    early_return_outputs.update(inst.get_outputs())
-                if bb in must_halt:
-                    terminal_variables.update(inst.get_input_variables())
-                    terminal_variables.update(inst.get_outputs())
-                    terminal_variables.update(live)
-
-        # Outside a must-halt region, ordinary cleanup keeps the frame near
-        # the live set. Inside one, every SSA value in the region may coexist
-        # as retained junk. Track outputs from codegen paths which bypass
-        # normal dead-output cleanup (`offset` and `phi`) across blocks too.
-        growth = (
-            max_live
-            + len(terminal_variables)
-            + len(early_return_outputs)
-            + max_block_outputs
-            + max_operands
-            + 2
-        )
-        self._function_frame_growth[fn] = growth
-        return growth
-
-    def _max_growth_from_function(
-        self, fn: IRFunction, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
-    ) -> int | None:
-        if fn in self._function_growth:
-            return self._function_growth[fn]
-        if fn in active_functions:
-            return None
-
-        active_functions.add(fn)
-        growth = self._max_growth_from_block(fn.entry, active_blocks, active_functions)
-        active_functions.remove(fn)
-        self._function_growth[fn] = growth
-        return growth
-
-    def _max_growth_from_block(
-        self, bb: IRBasicBlock, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
-    ) -> int | None:
-        summary = self._stack_growth_summary(bb, active_blocks, active_functions)
-        if summary is None:
-            return None
-        variables, transient = summary
-        return len(variables) + transient
-
-    def _stack_growth_summary(
-        self, bb: IRBasicBlock, active_blocks: set[IRBasicBlock], active_functions: set[IRFunction]
-    ) -> tuple[frozenset[IRVariable], int] | None:
-        if bb in self._block_summaries:
-            return self._block_summaries[bb]
-        if bb in active_blocks:
-            return None
-
-        active_blocks.add(bb)
-
-        # A distinct SSA value can occupy at most one persistent physical
-        # slot. A consumed copy of each operand can coexist with those slots;
-        # two more cover lowering details such as jump labels, bump's DUP, and
-        # the one-slot transient used by deep stack spilling.
-        variables: set[IRVariable] = set()
-        max_transient = 0
-        liveness = self._get_liveness(bb.parent)
-        for inst in bb.instructions:
-            variables.update(inst.get_input_variables())
-            variables.update(inst.get_outputs())
-            variables.update(liveness.live_vars_at(inst))
-            inst_transient = len(inst.operands) + 2
-
-            if inst.opcode == "invoke":
-                target = inst.operands[0]
-                assert isinstance(target, IRLabel)
-                callee = self.ctx.get_function(target)
-                callee_growth = self._max_growth_from_function(
-                    callee, active_blocks, active_functions
-                )
-                if callee_growth is None:
-                    active_blocks.remove(bb)
-                    self._block_summaries[bb] = None
-                    return None
-                inst_transient += callee_growth
-
-            max_transient = max(max_transient, inst_transient)
-
-        for successor in bb.out_bbs:
-            successor_summary = self._stack_growth_summary(
-                successor, active_blocks, active_functions
-            )
-            if successor_summary is None:
-                active_blocks.remove(bb)
-                self._block_summaries[bb] = None
-                return None
-            successor_variables, successor_transient = successor_summary
-            variables.update(successor_variables)
-            max_transient = max(max_transient, successor_transient)
-
-        active_blocks.remove(bb)
-        summary = (frozenset(variables), max_transient)
-        self._block_summaries[bb] = summary
-        return summary
-
-    def _get_liveness(self, fn: IRFunction) -> LivenessAnalysis:
-        if fn not in self._liveness:
-            ac = IRAnalysesCache(fn)
-            self._liveness[fn] = ac.request_analysis(LivenessAnalysis)
-        return self._liveness[fn]
-
-    def _get_must_halt(self, fn: IRFunction) -> set[IRBasicBlock]:
-        if fn not in self._must_halt:
-            liveness = self._get_liveness(fn)
-            self._must_halt[fn] = self._compute_must_halt(fn, liveness.cfg)
-        return self._must_halt[fn]
 
 
 def apply_line_numbers(inst: IRInstruction, asm) -> list[str]:
@@ -389,7 +169,7 @@ class VenomCompiler:
         self.visited_basicblocks = OrderedSet()
         self.spiller = StackSpiller(ctx)
         self._uses_initial_fmp_const = False
-        self._must_halt_regions: _MustHaltRegions | None = None
+        self._stack_cleanup_safety: StackCleanupSafety | None = None
 
     def mklabel(self, name: str) -> Label:
         self.label_counter += 1
@@ -400,28 +180,29 @@ class VenomCompiler:
         self.label_counter = 0
         self.spiller.reset_peak_spill_end()
         self._uses_initial_fmp_const = False
-        self._must_halt_regions = None
+        self._stack_cleanup_safety = None
 
         asm: list[AssemblyInstruction] = []
+        analyses_caches = {fn: IRAnalysesCache(fn) for fn in self.ctx.functions.values()}
+        self._stack_cleanup_safety = StackCleanupSafety(self.ctx, analyses_caches)
 
-        for fn in self.ctx.functions.values():
-            ac = IRAnalysesCache(fn)
+        try:
+            for fn in self.ctx.functions.values():
+                ac = analyses_caches[fn]
 
-            self.liveness = ac.request_analysis(LivenessAnalysis)
-            self.dfg = ac.request_analysis(DFGAnalysis)
-            self.cfg = ac.request_analysis(CFGAnalysis)
+                self.liveness = ac.request_analysis(LivenessAnalysis)
+                self.dfg = ac.request_analysis(DFGAnalysis)
+                self.cfg = ac.request_analysis(CFGAnalysis)
 
-            assert self.cfg.is_normalized(), "Non-normalized CFG!"
+                assert self.cfg.is_normalized(), "Non-normalized CFG!"
 
-            self._must_halt_regions = _MustHaltRegions(self.ctx, self.cfg, self.liveness)
-            self.spiller.set_current_function(fn)
-            self.spiller.reset_spill_slots()
-
-            try:
+                self.spiller.set_current_function(fn)
+                self.spiller.reset_spill_slots()
                 self._generate_evm_for_basicblock_r(asm, fn.entry, StackModel(), {})
-            finally:
-                self._must_halt_regions = None
                 self.spiller.set_current_function(None)
+        finally:
+            self._stack_cleanup_safety = None
+            self.spiller.set_current_function(None)
 
         # Declare the initial-FMP CONST if anything referenced it (the
         # entry function's FMP root is an explicit `initial_fmp`
@@ -739,9 +520,9 @@ class VenomCompiler:
         layout = self.liveness.out_vars(in_bb)
         to_pop = list(layout.difference(inputs))
 
-        must_halt_regions = self._must_halt_regions
-        assert must_halt_regions is not None
-        if must_halt_regions.can_skip_cleanup(basicblock, stack.height):
+        stack_cleanup_safety = self._stack_cleanup_safety
+        assert stack_cleanup_safety is not None
+        if stack_cleanup_safety.can_skip_cleanup(basicblock, stack.height):
             # The values stay on the physical EVM stack, but they are dead on
             # this edge. Forget their logical identities so a later halting
             # join cannot mistake retained junk for an incoming phi value.


### PR DESCRIPTION
### What I did

Skip dead-value stack cleanup (POPs) at basic-block entry when the block is in
a must-halt region — every path from it ends the message call — and it is
provably safe to leave the dead slots on the stack.

### How I did it

Two new analyses plus a codegen hook:

- `MustHaltAnalysis` (per-function): the set of blocks from which every CFG
  path halts the call. Computed as a least fixed point over DFS postorder that
  deliberately excludes cycles — a loop with a halting exit is not guaranteed
  to take it.
- `StackCleanupSafety` (global): proves retained dead slots cannot overflow
  the 1024-slot EVM stack. It composes a bound from the maximum caller stack
  height (via the FCG), per-function frame growth (one persistent slot per
  distinct SSA value plus the largest per-instruction transient), and regional
  growth from the block onward, including transitive callees. Any CFG or
  call-graph cycle makes the bound unknown and disables the elision.
- `venom_to_assembly`: in `clean_stack_from_cfg_in`, retain only dead slots
  that sit *below* every live slot, so operand depths are unchanged and every
  omitted POP is an unconditional gas saving. Retained slots are replaced with
  anonymous `_DeadStackItem`s in the stack model so a later halting phi join
  cannot mistake junk for an incoming value. The first elision on a path
  establishes a whole-region height promise that later elisions reuse.

The bounds are verified defensively: codegen measures the actual peak stack
height of every assembly fragment it emits and raises `CompilerPanic` if a
promise was underestimated — a bad bound is a compile-time failure, never a
runtime stack overflow.

### How to verify it

`tests/unit/compiler/venom/test_stack_cleanup.py` covers: direct and
transitive halts, loops with halting exits (not must-halt), internal `ret`
not counting as a message halt, recursion and unknown-entry fallbacks, the
caller-frame term in callee bounds, identity-loss before halting phi joins,
fallback near the stack limit, and that elision induces no spilling.

### Commit message

```
at CFG splitter edges, codegen pops stack items that are dead in the
successor block. when every path from the block ends the message call
(return/revert/stop/...), those POPs are wasted gas — the EVM discards
the stack at halt anyway. but skipping cleanup unconditionally is not
safe: retained slots deepen the physical stack, which could overflow the
1024-slot limit, and dead slots sitting above live values would deepen
operand access and add SWAP/DUP work.

introduce `MustHaltAnalysis`, which computes the blocks from which every
path halts the call (a least fixed point that deliberately excludes
cycles — a loop with a halting exit is not guaranteed to take it), and
`StackCleanupSafety`, a global analysis that proves retained slots
cannot overflow the stack. it bounds the worst-case physical height from
three composable terms: the maximum caller stack height (via the
function call graph), per-function frame growth (one persistent slot per
distinct SSA value plus the largest per-instruction transient), and
regional growth from the block onward, including transitive callees. any
CFG or call-graph cycle makes the bound unknown and disables the
elision.

codegen only retains dead slots that form a prefix below every live
slot, so operand depths are unchanged and every omitted POP is an
unconditional gas saving. retained slots are replaced with anonymous
dead items in the stack model so a later halting phi join cannot mistake
junk for an incoming value. the analysis bounds are verified
defensively: codegen measures the actual peak stack height of the
assembly it emits and panics if a promise was underestimated, turning a
bad bound into a compile-time failure instead of a possible runtime
stack overflow.
```

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
