### PR TITLE
fix[lang]: reject type names passed as builtin varargs

### DIFF
--- a/tests/functional/syntax/test_abi_encode.py
+++ b/tests/functional/syntax/test_abi_encode.py
@@ -1,7 +1,7 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidLiteral, TypeMismatch, UnfoldableNode
+from vyper.exceptions import InvalidLiteral, InvalidReference, TypeMismatch, UnfoldableNode
 
 fail_list = [
     (
@@ -71,6 +71,14 @@ def foo() -> Bytes[132]:
     return abi_encode(x, y, method_id=b"")
         """,
         InvalidLiteral,  # len(method_id) must be 4
+    ),
+    (
+        """
+@external
+def foo() -> Bytes[32]:
+    return abi_encode(uint256)
+    """,
+        InvalidReference,  # a type name is not a value (vararg), see #4609
     ),
 ]
 

--- a/tests/functional/syntax/test_abi_encode.py
+++ b/tests/functional/syntax/test_abi_encode.py
@@ -1,7 +1,13 @@
 import pytest
 
 from vyper import compiler
-from vyper.exceptions import InvalidLiteral, InvalidOperation, TypeMismatch, UnfoldableNode
+from vyper.exceptions import (
+    InvalidLiteral,
+    InvalidOperation,
+    InvalidReference,
+    TypeMismatch,
+    UnfoldableNode,
+)
 
 fail_list = [
     (
@@ -71,6 +77,16 @@ def foo() -> Bytes[132]:
     return abi_encode(x, y, method_id=b"")
         """,
         InvalidLiteral,  # len(method_id) must be 4
+    ),
+    (
+        """
+@external
+def foo() -> Bytes[32]:
+    return abi_encode(uint256)
+    """,
+        # a type name is not a value (vararg)
+        # see https://github.com/vyperlang/vyper/issues/4609
+        InvalidReference,
     ),
 ]
 

--- a/tests/functional/syntax/test_print.py
+++ b/tests/functional/syntax/test_print.py
@@ -2,7 +2,24 @@ import pytest
 
 from vyper import compiler
 from vyper.compiler.settings import Settings
+from vyper.exceptions import InvalidReference
 from vyper.utils import method_id_int
+
+fail_list = [
+    # a bare type name is not a value (vararg), see #4609
+    """
+@external
+def foo():
+    print(uint256)
+    """
+]
+
+
+@pytest.mark.parametrize("bad_code", fail_list)
+def test_print_fail(bad_code):
+    with pytest.raises(InvalidReference):
+        compiler.compile_code(bad_code)
+
 
 valid_list = [
     """

--- a/tests/functional/syntax/test_print.py
+++ b/tests/functional/syntax/test_print.py
@@ -2,8 +2,25 @@ import pytest
 
 from vyper import compiler
 from vyper.compiler.settings import Settings
-from vyper.exceptions import InvalidOperation
+from vyper.exceptions import InvalidOperation, InvalidReference
 from vyper.utils import method_id_int
+
+fail_list = [
+    # a bare type name is not a value (vararg)
+    # see https://github.com/vyperlang/vyper/issues/4609
+    """
+@external
+def foo():
+    print(uint256)
+    """
+]
+
+
+@pytest.mark.parametrize("bad_code", fail_list)
+def test_print_fail(bad_code):
+    with pytest.raises(InvalidReference):
+        compiler.compile_code(bad_code)
+
 
 valid_list = [
     """

--- a/vyper/builtins/_signatures.py
+++ b/vyper/builtins/_signatures.py
@@ -5,7 +5,7 @@ from vyper import ast as vy_ast
 from vyper.ast.validation import validate_call_args
 from vyper.codegen.expr import Expr
 from vyper.codegen.ir_node import IRnode
-from vyper.exceptions import CompilerPanic, TypeMismatch, UnfoldableNode
+from vyper.exceptions import CompilerPanic, InvalidReference, TypeMismatch, UnfoldableNode
 from vyper.semantics.analysis.base import Modifiability, StateMutability
 from vyper.semantics.analysis.utils import (
     check_modifiability,
@@ -137,7 +137,11 @@ class BuiltinFunctionT(VyperType):
         for arg in varargs:
             # call get_exact_type_from_node for its side effects -
             # ensures the type can be inferred exactly.
-            get_exact_type_from_node(arg)
+            argt = get_exact_type_from_node(arg)
+            # a vararg is always a runtime value; a bare type name (TYPE_T)
+            # is not, and would otherwise slip through to codegen and panic.
+            if isinstance(argt, TYPE_T):
+                raise InvalidReference(f"not a variable or literal: '{argt.typedef}'", arg)
 
     def check_modifiability_for_call(self, node: vy_ast.Call, modifiability: Modifiability) -> bool:
         return self._modifiability <= modifiability


### PR DESCRIPTION
### What I did

Builtins that take variable arguments never semantically checked them, so a bare type name passed as a vararg reached codegen and crashed the compiler with an internal panic. This rejects that case during semantic analysis. Part of https://github.com/vyperlang/vyper/issues/4609

### How I did it

`BuiltinFunctionT._validate_arg_types` inferred each vararg's type only for its side effects and discarded the result. A bare type name like `uint256` infers to `TYPE_T`, which is exactly inferable, so it passed the check and slipped through to codegen, where `TYPE_T` has no `abi_type`/`typ`/`location` and the compiler panicked. The vararg loop now inspects the inferred type and rejects `TYPE_T` with `InvalidReference`, the same "not a variable or literal" error the language already raises for a type name in value position (`x: uint256 = uint256`).

### How to verify it

On master both of these panic:

```vyper
@external
def foo():
    x: Bytes[32] = abi_encode(uint256)   # CompilerPanic: TYPE_T does not implement abi_type

@external
def bar():
    print(uint256)                       # CodegenPanic: 'IntegerT' object has no attribute 'typ'
```

After this change both raise `InvalidReference: not a variable or literal: 'uint256'` at compile time. Regression tests are in `tests/functional/syntax/test_abi_encode.py` and `tests/functional/syntax/test_print.py`.

### Commit message

```
Builtins with variable arguments (abi_encode, print, raw_create,
create_from_blueprint) inferred each vararg's type for its side effects
but never checked the argument was a runtime value. A bare type name
infers to TYPE_T, which passed the vararg check and slipped through to
codegen, where it panicked (`TYPE_T does not implement abi_type`,
`'IntegerT' object has no attribute 'typ'`).

Reject a TYPE_T vararg during semantic analysis with the same "not a
variable or literal" error the language already raises for a type name
in value position (e.g. `x: uint256 = uint256`).

Part of GH 4609
```

### Description for the changelog

Reject a bare type name passed as a builtin vararg (e.g. `abi_encode(uint256)`) with a clear error instead of an internal compiler panic.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()

