### PR TITLE
fix[lang]: constant fold tuple indexes

### DIFF
--- a/tests/functional/syntax/test_hashmap_container_type.py
+++ b/tests/functional/syntax/test_hashmap_container_type.py
@@ -22,6 +22,13 @@ d: HashMap[uint256, (uint256, uint256)]
 
 @external
 def foo() -> uint256:
+    return self.d[0][0]
+    """,
+    """
+d: HashMap[uint256, (uint256, uint256)]
+
+@external
+def foo() -> uint256:
     return self.d[0][1-1]
     """,
     """

--- a/tests/functional/syntax/test_hashmap_container_type.py
+++ b/tests/functional/syntax/test_hashmap_container_type.py
@@ -22,7 +22,22 @@ d: HashMap[uint256, (uint256, uint256)]
 
 @external
 def foo() -> uint256:
-    return self.d[0][0]
+    return self.d[0][1-1]
+    """,
+    """
+d: HashMap[uint256, (uint256, uint256)]
+
+@external
+def foo() -> uint256:
+    return self.d[0][1*1]
+    """,
+    """
+d: HashMap[uint256, (uint256, uint256)]
+one: constant(uint256) = 1
+
+@external
+def foo() -> uint256:
+    return self.d[0][one]
     """,
 ]
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -1127,8 +1127,9 @@ class ExprVisitor(VyperNodeVisitorBase):
 
             for possible_type in possible_base_types:
                 if isinstance(possible_type, TupleT):
-                    assert isinstance(node.slice, vy_ast.Int)  # help mypy
-                    value_type = possible_type.member_types[node.slice.value]
+                    index = node.slice.reduced()
+                    assert isinstance(index, vy_ast.Int)  # help mypy
+                    value_type = possible_type.member_types[index.value]
                 else:
                     value_type = possible_type.value_type
 


### PR DESCRIPTION
### What I did

Fix https://github.com/vyperlang/vyper/issues/5150

### How I did it

Instead of checking the node, check the folded value of the node

### How to verify it

`pytest`

### Commit message

```
before, the index for nested access into a tuple was checked verbatim.
this meant any constant expression which is not a literal would cause a
panic. this commit fixes this by instead checking the folded value.
```

### Description for the changelog

(no changelog, fixes an edge case of #4776 which will be release alongside this)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
