### PR TITLE
fix[ux]: show readable type names in type-mismatch errors

### DIFF
--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -117,6 +117,24 @@ def test_block_fail(assert_compile_failed, get_contract, bad_code, exc):
     assert_compile_failed(lambda: get_contract(bad_code), exc)
 
 
+def test_concat_type_mismatch_message_uses_readable_type_names():
+    # `concat`'s accepted `bytesM` type must be shown by its user-facing name,
+    # not the internal `bytes_m` typeclass (nor a `GenericTypeAcceptor` repr).
+    # See issue #4955.
+    code = """
+@external
+def foo() -> Bytes[64]:
+    return concat(123, b"x")
+    """
+    with pytest.raises(TypeMismatch) as exc_info:
+        compiler.compile_code(code)
+
+    message = str(exc_info.value)
+    assert "GenericTypeAcceptor" not in message
+    assert "bytes_m" not in message
+    assert "bytesM" in message
+
+
 valid_list = [
     """
 @external

--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -118,9 +118,6 @@ def test_block_fail(assert_compile_failed, get_contract, bad_code, exc):
 
 
 def test_concat_type_mismatch_message_uses_readable_type_names():
-    # `concat`'s accepted `bytesM` type must be shown by its user-facing name,
-    # not the internal `bytes_m` typeclass (nor a `GenericTypeAcceptor` repr).
-    # See issue #4955.
     code = """
 @external
 def foo() -> Bytes[64]:

--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -126,13 +126,12 @@ def test_concat_type_mismatch_message_uses_readable_type_names():
 def foo() -> Bytes[64]:
     return concat(123, b"x")
     """
-    with pytest.raises(TypeMismatch) as exc_info:
+    with pytest.raises(TypeMismatch) as e:
         compiler.compile_code(code)
 
-    message = str(exc_info.value)
-    assert "GenericTypeAcceptor" not in message
-    assert "bytes_m" not in message
-    assert "bytesM" in message
+    assert e.value.message == (
+        "Expected one of Bytes, String, bytesM but literal can only be cast as int104 or uint96."
+    )
 
 
 valid_list = [

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -53,3 +53,38 @@ def foo() -> uint256:
 @pytest.mark.parametrize("good_code", valid_list)
 def test_list_success(good_code):
     assert compile_code(good_code) is not None
+
+
+def test_len_type_mismatch_message_uses_readable_type_names():
+    # `len()`'s accepted types must be shown as `String`, `Bytes`, `DynArray`,
+    # not internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
+    code = """
+@external
+def foo(inp: int128) -> uint256:
+    return len(inp)
+    """
+    with pytest.raises(TypeMismatch) as exc_info:
+        compile_code(code)
+
+    message = str(exc_info.value)
+    assert "GenericTypeAcceptor" not in message
+    assert "String" in message
+    assert "Bytes" in message
+    assert "DynArray" in message
+
+
+def test_index_type_mismatch_message_uses_readable_type_names():
+    # Exercises the `typeclass` fallback of the type-name formatting: `IntegerT`
+    # is parametric so its `_id` is a property, falling back to `typeclass`
+    # ("integer"). The message must not leak `GenericTypeAcceptor(...)`.
+    code = """
+@external
+def foo(x: DynArray[uint256, 3]) -> uint256:
+    return x[b"ab"]
+    """
+    with pytest.raises(TypeMismatch) as exc_info:
+        compile_code(code)
+
+    message = str(exc_info.value)
+    assert "GenericTypeAcceptor" not in message
+    assert "integer" in message

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -74,9 +74,10 @@ def foo(inp: int128) -> uint256:
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # Exercises the `typeclass` fallback of the type-name formatting: `IntegerT`
-    # is parametric so its `_id` is a property, falling back to `typeclass`
-    # ("integer"). The message must not leak `GenericTypeAcceptor(...)`.
+    # Exercises the `_generic_id` fallback of the type-name formatting:
+    # `IntegerT` is parametric so its `_id` is a property with no class-level
+    # value, falling back to `_generic_id` ("integer"). The message must not
+    # leak `GenericTypeAcceptor(...)`.
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -56,36 +56,31 @@ def test_list_success(good_code):
 
 
 def test_len_type_mismatch_message_uses_readable_type_names():
-    # `len()`'s accepted types must be shown as `String`, `Bytes`, `DynArray`,
-    # not internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
+    # `len()`'s accepted types must be shown by their user-facing names, not as
+    # internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
     code = """
 @external
 def foo(inp: int128) -> uint256:
     return len(inp)
     """
-    with pytest.raises(TypeMismatch) as exc_info:
+    with pytest.raises(TypeMismatch) as e:
         compile_code(code)
 
-    message = str(exc_info.value)
-    assert "GenericTypeAcceptor" not in message
-    assert "String" in message
-    assert "Bytes" in message
-    assert "DynArray" in message
+    assert e.value.message == (
+        "Given reference has type int128, expected one of String, Bytes, DynArray"
+    )
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # Exercises the `_generic_id` fallback of the type-name formatting:
-    # `IntegerT` is parametric so its `_id` is a property with no class-level
-    # value, falling back to `_generic_id` ("integer"). The message must not
-    # leak `GenericTypeAcceptor(...)`.
+    # Exercises the `_generic_id` fallback: `IntegerT` is parametric, so its
+    # `_id` is a property with no value at the class level and the name comes
+    # from `_generic_id` ("integer") instead.
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:
     return x[b"ab"]
     """
-    with pytest.raises(TypeMismatch) as exc_info:
+    with pytest.raises(TypeMismatch) as e:
         compile_code(code)
 
-    message = str(exc_info.value)
-    assert "GenericTypeAcceptor" not in message
-    assert "integer" in message
+    assert e.value.message == "Expected integer but literal can only be cast as Bytes[2]."

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -56,8 +56,6 @@ def test_list_success(good_code):
 
 
 def test_len_type_mismatch_message_uses_readable_type_names():
-    # `len()`'s accepted types must be shown by their user-facing names, not as
-    # internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
     code = """
 @external
 def foo(inp: int128) -> uint256:
@@ -72,9 +70,7 @@ def foo(inp: int128) -> uint256:
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # Exercises the `_generic_id` fallback: `IntegerT` is parametric, so its
-    # `_id` is a property with no value at the class level and the name comes
-    # from `_generic_id` ("integer") instead.
+    # exercises the `_generic_id` fallback (`IntegerT._id` is per-instance)
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -17,10 +17,6 @@ from vyper.exceptions import (
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.data_locations import DataLocation
 
-# user-facing spelling for internal `typeclass` identifiers that differ from
-# the syntax users write (e.g. the `bytesM` family: `bytes1`..`bytes32`)
-_TYPECLASS_DISPLAY_NAMES = {"bytes_m": "bytesM"}
-
 
 # Some fake type with an overridden `compare_type` which accepts any RHS
 # type of type `type_`
@@ -30,17 +26,15 @@ class _GenericTypeAcceptor:
 
     def __str__(self):
         # User-facing type name (e.g. `String`, `Bytes`, `DynArray`) used in
-        # error messages, instead of the internal Python class repr. `_id` is a
-        # plain class attribute on most types, but a property on parametric
-        # types (e.g. `IntegerT`, `BytesM_T`), so fall back to `typeclass`
-        # (mapped to its user-facing spelling), then the class name, keeping
-        # this total (never returns a non-string).
+        # error messages, instead of the internal Python class repr. Prefer the
+        # class-level `_id`; parametric types (e.g. `IntegerT`, `BytesM_T`)
+        # define `_id` as a property, so it has no value at the class level that
+        # `.any()` hands us -- fall back to their `_generic_id`.
         name = getattr(self.type_, "_id", None)
         if not isinstance(name, str):
-            typeclass = getattr(self.type_, "typeclass", None)
-            name = _TYPECLASS_DISPLAY_NAMES.get(typeclass, typeclass)
+            name = self.type_._generic_id
         if not isinstance(name, str):
-            name = self.type_.__name__
+            raise CompilerPanic(f"{self.type_.__name__} has no user-facing name")
         return name
 
     def __init__(self, type_):
@@ -102,6 +96,10 @@ class VyperType:
     typeclass: str = None  # type: ignore
 
     _id: str  # rename to `_name`
+    # user-facing name for parametric types whose `_id` is an instance
+    # property (e.g. `bytesM`, `integer`), so it has no value at the class
+    # level. see `_GenericTypeAcceptor.__str__`.
+    _generic_id: str = None  # type: ignore
     _type_members: Optional[Dict] = None
     _valid_literal: Tuple = ()
     _invalid_locations: Tuple = ()
@@ -517,6 +515,8 @@ def map_void(typ: Optional[VyperType]) -> VyperType:
 # position, ex. constructors (events, interfaces and structs), and also
 # certain builtins which take types as parameters
 class TYPE_T(VyperType):
+    _generic_id = "type"
+
     def __init__(self, typedef):
         super().__init__()
 

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -17,12 +17,31 @@ from vyper.exceptions import (
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.data_locations import DataLocation
 
+# user-facing spelling for internal `typeclass` identifiers that differ from
+# the syntax users write (e.g. the `bytesM` family: `bytes1`..`bytes32`)
+_TYPECLASS_DISPLAY_NAMES = {"bytes_m": "bytesM"}
+
 
 # Some fake type with an overridden `compare_type` which accepts any RHS
 # type of type `type_`
 class _GenericTypeAcceptor:
     def __repr__(self):
         return f"GenericTypeAcceptor({self.type_})"
+
+    def __str__(self):
+        # User-facing type name (e.g. `String`, `Bytes`, `DynArray`) used in
+        # error messages, instead of the internal Python class repr. `_id` is a
+        # plain class attribute on most types, but a property on parametric
+        # types (e.g. `IntegerT`, `BytesM_T`), so fall back to `typeclass`
+        # (mapped to its user-facing spelling), then the class name, keeping
+        # this total (never returns a non-string).
+        name = getattr(self.type_, "_id", None)
+        if not isinstance(name, str):
+            typeclass = getattr(self.type_, "typeclass", None)
+            name = _TYPECLASS_DISPLAY_NAMES.get(typeclass, typeclass)
+        if not isinstance(name, str):
+            name = self.type_.__name__
+        return name
 
     def __init__(self, type_):
         self.type_ = type_

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -25,11 +25,6 @@ class _GenericTypeAcceptor:
         return f"GenericTypeAcceptor({self.type_})"
 
     def __str__(self):
-        # User-facing type name (e.g. `String`, `Bytes`, `DynArray`) used in
-        # error messages, instead of the internal Python class repr. Prefer the
-        # class-level `_id`; parametric types (e.g. `IntegerT`, `BytesM_T`)
-        # define `_id` as a property, so it has no value at the class level that
-        # `.any()` hands us -- fall back to their `_generic_id`.
         name = getattr(self.type_, "_id", None)
         if not isinstance(name, str):
             name = self.type_._generic_id
@@ -96,10 +91,10 @@ class VyperType:
     typeclass: str = None  # type: ignore
 
     _id: str  # rename to `_name`
-    # user-facing name for parametric types whose `_id` is an instance
-    # property (e.g. `bytesM`, `integer`), so it has no value at the class
-    # level. see `_GenericTypeAcceptor.__str__`.
-    _generic_id: str = None  # type: ignore
+    # user-facing name for types whose `_id` is the fully applied type
+    # (e.g. `uint256`, `bytes4`) rather than the type constructor, so there
+    # is no generic name to read off the class. see `_GenericTypeAcceptor`.
+    _generic_id: Optional[str] = None
     _type_members: Optional[Dict] = None
     _valid_literal: Tuple = ()
     _invalid_locations: Tuple = ()
@@ -515,8 +510,6 @@ def map_void(typ: Optional[VyperType]) -> VyperType:
 # position, ex. constructors (events, interfaces and structs), and also
 # certain builtins which take types as parameters
 class TYPE_T(VyperType):
-    _generic_id = "type"
-
     def __init__(self, typedef):
         super().__init__()
 

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -57,6 +57,7 @@ RANGE_1_32 = list(range(1, 33))
 # one-word bytesM with m possible bytes set, e.g. bytes1..bytes32
 class BytesM_T(_PrimT):
     typeclass = "bytes_m"
+    _generic_id = "bytesM"
 
     _valid_literal = (vy_ast.Hex,)
 
@@ -266,6 +267,7 @@ class IntegerT(NumericT):
     """
 
     typeclass = "integer"
+    _generic_id = "integer"
 
     _valid_literal = (vy_ast.Int,)
     _equality_attrs = ("is_signed", "bits")


### PR DESCRIPTION
Fixes #4955.

### What I did

`_GenericTypeAcceptor` (used to represent the set of types a builtin accepts) rendered as its internal Python class repr in error messages. For example, `len()` on a wrong type or a module produced:

```
expected one of GenericTypeAcceptor(<class 'vyper.semantics.types.bytestrings.StringT'>), GenericTypeAcceptor(<class 'vyper.semantics.types.bytestrings.BytesT'>), GenericTypeAcceptor(<class 'vyper.semantics.types.subscriptable.DArrayT'>)
```

Now it produces:

```
expected one of String, Bytes, DynArray
```

### How

The type-mismatch message renders acceptors via `str(...)` (`analysis/utils.py`), which fell back to `__repr__`. I added a `__str__` that resolves the user-facing type name — `_id` when it's a plain class string (`String`/`Bytes`/`DynArray`), falling back to `typeclass` for parametric types whose `_id` is a property (e.g. `IntegerT` → `integer`), then the class name — so it is always a string. `__repr__` is left as the unambiguous debug form (which also keeps it total, so e.g. `TYPE_T.any()` doesn't raise).

### Tests

Added two regression tests to `tests/functional/syntax/test_len.py`: one asserting a `len()` type-mismatch message shows `String`/`Bytes`/`DynArray` (and no `GenericTypeAcceptor`), and one for the `typeclass` fallback branch (indexing with the wrong type → `integer`). Both fail on the current code and pass with this change; `black`/`isort`/`flake8` are clean.
