### PR TITLE
fix[lang]: reject over-long string-literal revert reasons

### DIFF
--- a/tests/functional/codegen/features/test_assert.py
+++ b/tests/functional/codegen/features/test_assert.py
@@ -1,5 +1,7 @@
 import pytest
 
+from vyper.exceptions import InvalidType
+
 
 def test_assert_refund(env, get_contract, tx_failed):
     code = """
@@ -100,6 +102,42 @@ def test():
 @pytest.mark.parametrize("code", invalid_code)
 def test_invalid_assertions(get_contract, assert_compile_failed, code):
     assert_compile_failed(lambda: get_contract(code))
+
+
+def test_reason_string_literal_exceeds_max_length(get_contract, assert_compile_failed):
+    # a string-literal revert reason longer than 1024 bytes must be rejected,
+    # just like an over-long `String[N]` variable would be. See issue #3252.
+    long_reason = "a" * 1025
+    raise_code = f"""
+@external
+def foo():
+    raise "{long_reason}"
+    """
+    assert_code = f"""
+@external
+def foo():
+    assert False, "{long_reason}"
+    """
+    assert_compile_failed(lambda: get_contract(raise_code), InvalidType)
+    assert_compile_failed(lambda: get_contract(assert_code), InvalidType)
+
+
+def test_reason_string_literal_at_max_length(get_contract):
+    # a string-literal revert reason of exactly 1024 bytes is still valid, for
+    # both `raise` and `assert`. See issue #3252.
+    max_reason = "a" * 1024
+    raise_code = f"""
+@external
+def foo():
+    raise "{max_reason}"
+    """
+    assert_code = f"""
+@external
+def foo():
+    assert False, "{max_reason}"
+    """
+    assert get_contract(raise_code) is not None
+    assert get_contract(assert_code) is not None
 
 
 valid_code = [

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -495,8 +495,8 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
         if isinstance(msg_node, vy_ast.Str):
             if not msg_node.value.strip():
                 raise StructureException("Reason string cannot be empty", msg_node)
-            self.expr_visitor.visit(msg_node, get_exact_type_from_node(msg_node))
-            return
+            # fall through to the `String[1024]` length check below, so that an
+            # over-long string literal is rejected just like a variable would be
 
         try:
             validate_expected_type(msg_node, StringT(1024))


### PR DESCRIPTION
### What I did

Fixes #3252

`assert`/`raise` reason strings are documented as limited to 1024 bytes, and this is enforced for variables (via `validate_expected_type(msg_node, StringT(1024))`). But a string **literal** longer than 1024 bytes was accepted, so this compiled:

```vyper
@external
def foo():
    raise "<1025-byte string>"
```

while the equivalent `String[1025]` variable is correctly rejected.

### How I did it

The `vy_ast.Str` branch of `_validate_revert_reason` checked non-emptiness and then `return`ed early, skipping the length check. Removed the early `return`/visit so a string literal falls through to the same `validate_expected_type(msg_node, StringT(1024))` check (which also performs the identical `expr_visitor.visit`). An over-long literal now raises the same `InvalidType("revert reason must fit within String[1024]")` as the variable case, and the two paths can no longer drift.

The empty-literal case still short-circuits first with `Reason string cannot be empty`.

### How to verify it

New tests in `tests/functional/codegen/features/test_assert.py`: a 1025-byte literal reason raises `InvalidType` for both `raise` and `assert`, and a 1024-byte literal still compiles (boundary). Both fail on master and pass with this change.

### Commit message

```
`assert`/`raise` reason strings are limited to `String[1024]`, but the
limit was only enforced for variables. a string literal longer than 1024
bytes compiled fine, because the literal branch of
`_validate_revert_reason` returned early after checking non-emptiness,
skipping the `validate_expected_type(msg_node, StringT(1024))` check.

remove the early return so string literals fall through to the same
check as variables. over-long literals now raise the same `InvalidType`
error, and the two validation paths can no longer drift.
```

### Description for the changelog

Reject `assert`/`raise` reason string literals longer than 1024 bytes, matching the existing check for string variables.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
