### PR TITLE
refactor[lang]: streamline type inference

### DIFF
--- a/tests/functional/codegen/types/test_flag.py
+++ b/tests/functional/codegen/types/test_flag.py
@@ -1,8 +1,3 @@
-import pytest
-
-from vyper.exceptions import StateAccessViolation
-
-
 def test_values_should_be_increasing_ints(get_contract):
     code = """
 flag Action:
@@ -310,7 +305,6 @@ def get_key(f: Foobar, i: uint256) -> uint256:
     assert c.get_key(1, 777) == 777
 
 
-@pytest.mark.xfail(raises=StateAccessViolation)
 def test_flag_constant(get_contract):
     code = """
 flag F:

--- a/tests/functional/syntax/exceptions/test_invalid_reference.py
+++ b/tests/functional/syntax/exceptions/test_invalid_reference.py
@@ -44,6 +44,45 @@ a: public(constant(uint256)) = 1
 def foo():
     b: uint256 = self.a
     """,
+    """
+flag F:
+    A
+    B
+x: bool
+@external
+def foo():
+    self.x = (F == F)
+    """,
+    """
+flag F:
+    A
+    B
+x: bool
+@external
+def foo():
+    self.x = (F != F)
+    """,
+    """
+flag F:
+    A
+@external
+def foo() -> uint256:
+    return F + 1
+    """,
+    """
+flag F:
+    A
+@external
+def foo() -> F:
+    return -F
+    """,
+    """
+flag F:
+    A
+@external
+def foo() -> bool:
+    return F.A in [F]
+    """,
 ]
 
 

--- a/tests/functional/syntax/test_flag.py
+++ b/tests/functional/syntax/test_flag.py
@@ -3,13 +3,12 @@ import pytest
 from vyper import compiler
 from vyper.exceptions import (
     FlagDeclarationException,
+    ImmutableViolation,
     InvalidOperation,
-    InvalidReference,
     NamespaceCollision,
     StructureException,
     TypeMismatch,
     UnknownAttribute,
-    ImmutableViolation
 )
 
 fail_list = [

--- a/tests/functional/syntax/test_flag.py
+++ b/tests/functional/syntax/test_flag.py
@@ -9,6 +9,7 @@ from vyper.exceptions import (
     StructureException,
     TypeMismatch,
     UnknownAttribute,
+    ImmutableViolation
 )
 
 fail_list = [
@@ -134,7 +135,7 @@ flag Status:
 def test_assign_to_flag():
   Status.ACTIVE = 2
         """,
-        InvalidReference,
+        ImmutableViolation,
     ),
 ]
 

--- a/vyper/semantics/analysis/common.py
+++ b/vyper/semantics/analysis/common.py
@@ -1,16 +1,14 @@
-from typing import Tuple
+from typing import Generic, TypeVar
 
 from vyper.exceptions import StructureException, tag_exceptions
 
+Result = TypeVar("Result")
 
-class VyperNodeVisitorBase:
-    ignored_types: Tuple = ()
+
+class VyperNodeVisitorBase(Generic[Result]):
     scope_name = ""
 
-    def visit(self, node, *args):
-        if isinstance(node, self.ignored_types):
-            return
-
+    def visit(self, node, *args) -> Result:
         # iterate over the MRO until we find a matching visitor function
         # this lets us use a single function to broadly target several
         # node types with a shared parent

--- a/vyper/semantics/analysis/common.py
+++ b/vyper/semantics/analysis/common.py
@@ -8,7 +8,7 @@ Result = TypeVar("Result")
 class VyperNodeVisitorBase(Generic[Result]):
     scope_name = ""
 
-    def visit(self, node, *args) -> Result:
+    def visit(self, node, *args, **kwargs) -> Result:
         # iterate over the MRO until we find a matching visitor function
         # this lets us use a single function to broadly target several
         # node types with a shared parent
@@ -18,7 +18,7 @@ class VyperNodeVisitorBase(Generic[Result]):
             with tag_exceptions(node):
                 visitor_fn = getattr(self, f"visit_{ast_type}", None)
                 if visitor_fn:
-                    return visitor_fn(node, *args)
+                    return visitor_fn(node, *args, **kwargs)
 
         node_type = type(node).__name__
         raise StructureException(

--- a/vyper/semantics/analysis/constant_folding.py
+++ b/vyper/semantics/analysis/constant_folding.py
@@ -9,7 +9,7 @@ def constant_fold(module_ast: vy_ast.Module):
     ConstantFolder(module_ast).run()
 
 
-class ConstantFolder(VyperNodeVisitorBase):
+class ConstantFolder(VyperNodeVisitorBase[None]):
     def __init__(self, module_ast):
         self._constants = {}
         self._module_ast = module_ast

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -21,6 +21,7 @@ from vyper.exceptions import (
     TypeMismatch,
     VariableDeclarationException,
     VyperException,
+    InvalidReference,
 )
 
 # TODO consolidate some of these imports
@@ -209,7 +210,9 @@ def _get_variable_access(node: vy_ast.ExprNode) -> Optional[VarAccess]:
 
         assert isinstance(node, (vy_ast.Subscript, vy_ast.Attribute))  # help mypy
         node = node.value
-        info = get_expr_info(node)
+        info = get_expr_info(node, allow_type_exprs=True)
+        if isinstance(info.typ, TYPE_T):
+            return None
 
     # ignore `self.` as it interferes with VarAccess comparison across modules
     if len(path) > 0 and path[-1] == "self":
@@ -226,7 +229,7 @@ def _get_variable_access(node: vy_ast.ExprNode) -> Optional[VarAccess]:
 # be refactored into data on ExprInfo.
 def _get_module_chain(node: vy_ast.ExprNode) -> list[ModuleInfo]:
     ret: list[ModuleInfo] = []
-    info = get_expr_info(node)
+    info = get_expr_info(node, allow_type_exprs=True)
 
     while True:
         if info.module_info is not None:
@@ -236,7 +239,7 @@ def _get_module_chain(node: vy_ast.ExprNode) -> list[ModuleInfo]:
             break
 
         node = node.value
-        info = get_expr_info(node)
+        info = get_expr_info(node, allow_type_exprs=True)
 
     ret.reverse()
     return ret
@@ -542,6 +545,9 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
         # Run this first so that "not a variable" errors have priority over
         # "assigning to a constant" errors
         var_access = _get_variable_access(target)
+        if var_access is None and isinstance(target, vy_ast.Attribute):
+            # raises for type expressions (e.g. Flag.MEMBER = x)
+            raise InvalidReference(f"not a variable or literal: '{target.value._expr_info.typ.typedef}'", target.value)
         assert var_access is not None
 
         info._writes.add(var_access)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -168,7 +168,7 @@ def _validate_pure_access(node: vy_ast.Attribute | vy_ast.Name, typ: VyperType) 
                 "not allowed to query environment variables in pure functions"
             )
         # allow type exprs in the value node, e.g. MyFlag.A
-        parent_info = get_expr_info(node.value, is_callable=True)
+        parent_info = get_expr_info(node.value, allow_type_exprs=True)
         if isinstance(parent_info.typ, AddressT) and node.attr in AddressT._type_members:
             raise StateAccessViolation("not allowed to query address members in pure functions")
 
@@ -923,7 +923,7 @@ class ExprVisitor(VyperNodeVisitorBase[None]):
         return self.visit(node.value, typ)
 
     def visit_Call(self, node: vy_ast.Call, typ: VyperType) -> None:
-        func_info = get_expr_info(node.func, is_callable=True)
+        func_info = get_expr_info(node.func, allow_type_exprs=True)
         func_type = func_info.typ
 
         # TODO: unify the APIs for different callable types so that

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -381,8 +381,7 @@ def check_module_uses_for_abstract(
     return root_module_info
 
 
-class FunctionAnalyzer(VyperNodeVisitorBase):
-    ignored_types = (vy_ast.Pass,)
+class FunctionAnalyzer(VyperNodeVisitorBase[None]):
     scope_name = "function"
 
     def __init__(self, fn_node: vy_ast.FunctionDef, namespace: dict) -> None:
@@ -806,8 +805,11 @@ class FunctionAnalyzer(VyperNodeVisitorBase):
 
         self.expr_visitor.visit(node.value, self.func.return_type)
 
+    def visit_Pass(self, node):
+        pass
 
-class ExprVisitor(VyperNodeVisitorBase):
+
+class ExprVisitor(VyperNodeVisitorBase[None]):
     def __init__(self, function_analyzer: Optional[FunctionAnalyzer] = None):
         self.function_analyzer = function_analyzer
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -12,7 +12,6 @@ from vyper.exceptions import (
     ExceptionList,
     FunctionDeclarationException,
     ImmutableViolation,
-    InvalidReference,
     InvalidType,
     IteratorException,
     NonPayableViolation,
@@ -540,7 +539,6 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
                 "Left-hand side of assignment cannot be a HashMap without a key"
             )
 
-
         if (
             info.location in (DataLocation.STORAGE, DataLocation.TRANSIENT)
             and func_t.mutability <= StateMutability.VIEW
@@ -571,7 +569,6 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
 
         if info.modifiability == Modifiability.CONSTANT:
             raise ImmutableViolation("Constant value cannot be written to.")
-
 
         var_access = _get_variable_access(target)
         assert var_access is not None

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -12,6 +12,7 @@ from vyper.exceptions import (
     ExceptionList,
     FunctionDeclarationException,
     ImmutableViolation,
+    InvalidReference,
     InvalidType,
     IteratorException,
     NonPayableViolation,
@@ -21,7 +22,6 @@ from vyper.exceptions import (
     TypeMismatch,
     VariableDeclarationException,
     VyperException,
-    InvalidReference,
 )
 
 # TODO consolidate some of these imports
@@ -547,7 +547,9 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
         var_access = _get_variable_access(target)
         if var_access is None and isinstance(target, vy_ast.Attribute):
             # raises for type expressions (e.g. Flag.MEMBER = x)
-            raise InvalidReference(f"not a variable or literal: '{target.value._expr_info.typ.typedef}'", target.value)
+            raise InvalidReference(
+                f"not a variable or literal: '{target.value._expr_info.typ.typedef}'", target.value
+            )
         assert var_access is not None
 
         info._writes.add(var_access)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -539,6 +539,13 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
                 "Left-hand side of assignment cannot be a HashMap without a key"
             )
 
+        # Run this first so that "not a variable" errors have priority over
+        # "assigning to a constant" errors
+        var_access = _get_variable_access(target)
+        assert var_access is not None
+
+        info._writes.add(var_access)
+
         if (
             info.location in (DataLocation.STORAGE, DataLocation.TRANSIENT)
             and func_t.mutability <= StateMutability.VIEW
@@ -569,11 +576,6 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
 
         if info.modifiability == Modifiability.CONSTANT:
             raise ImmutableViolation("Constant value cannot be written to.")
-
-        var_access = _get_variable_access(target)
-        assert var_access is not None
-
-        info._writes.add(var_access)
 
     def _handle_module_access(self, target: vy_ast.ExprNode):
         root_module_info = check_module_uses(target)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -211,8 +211,6 @@ def _get_variable_access(node: vy_ast.ExprNode) -> Optional[VarAccess]:
         assert isinstance(node, (vy_ast.Subscript, vy_ast.Attribute))  # help mypy
         node = node.value
         info = get_expr_info(node, allow_type_exprs=True)
-        if isinstance(info.typ, TYPE_T):
-            return None
 
     # ignore `self.` as it interferes with VarAccess comparison across modules
     if len(path) > 0 and path[-1] == "self":
@@ -542,17 +540,6 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
                 "Left-hand side of assignment cannot be a HashMap without a key"
             )
 
-        # Run this first so that "not a variable" errors have priority over
-        # "assigning to a constant" errors
-        var_access = _get_variable_access(target)
-        if var_access is None and isinstance(target, vy_ast.Attribute):
-            # raises for type expressions (e.g. Flag.MEMBER = x)
-            raise InvalidReference(
-                f"not a variable or literal: '{target.value._expr_info.typ.typedef}'", target.value
-            )
-        assert var_access is not None
-
-        info._writes.add(var_access)
 
         if (
             info.location in (DataLocation.STORAGE, DataLocation.TRANSIENT)
@@ -584,6 +571,12 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
 
         if info.modifiability == Modifiability.CONSTANT:
             raise ImmutableViolation("Constant value cannot be written to.")
+
+
+        var_access = _get_variable_access(target)
+        assert var_access is not None
+
+        info._writes.add(var_access)
 
     def _handle_module_access(self, target: vy_ast.ExprNode):
         root_module_info = check_module_uses(target)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -1072,7 +1072,7 @@ class ExprVisitor(VyperNodeVisitorBase[None]):
                 ltyp = get_common_types(node.left, *node.right.elements).pop()
 
                 rlen = len(node.right.elements)
-                rtyp = SArrayT(ltyp, rlen)
+                rtyp: VyperType = SArrayT(ltyp, rlen)
             else:
                 rtyp = get_exact_type_from_node(node.right)
                 if isinstance(rtyp, FlagT):
@@ -1132,10 +1132,11 @@ class ExprVisitor(VyperNodeVisitorBase[None]):
                     assert isinstance(node.slice, vy_ast.Int)  # help mypy
                     value_type = possible_type.member_types[node.slice.value]
                 else:
+                    assert isinstance(possible_type, (SArrayT, DArrayT, HashMapT))
                     value_type = possible_type.value_type
 
                 if typ.compare_type(value_type):
-                    base_type = possible_type
+                    base_type: VyperType = possible_type
                     break
             else:
                 # this should have been caught in

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -488,7 +488,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
             return
 
         if isinstance(msg_node, vy_ast.Call):
-            call_type = get_exact_type_from_node(msg_node.func)
+            call_type = get_exact_type_from_node(msg_node.func, allow_type_exprs=True)
             if is_type_t(call_type, ErrorT):
                 self.expr_visitor.visit(msg_node, call_type.typedef)
                 self.func.mark_raised_error(call_type.typedef)
@@ -635,7 +635,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
 
         func = call_node.func
 
-        fn_type = get_exact_type_from_node(func)
+        fn_type = get_exact_type_from_node(func, allow_type_exprs=True)
 
         if is_type_t(fn_type, EventT):
             raise StructureException("To call an event you must use the `log` statement", node)
@@ -771,7 +771,7 @@ class FunctionAnalyzer(VyperNodeVisitorBase[None]):
         # postcondition of Log.validate()
         assert isinstance(node.value, vy_ast.Call)
 
-        f = get_exact_type_from_node(node.value.func)
+        f = get_exact_type_from_node(node.value.func, allow_type_exprs=True)
         if is_type_t(f, ErrorT):
             raise StructureException(
                 "To raise a custom error you must use `raise` or `assert`", node
@@ -894,7 +894,7 @@ class ExprVisitor(VyperNodeVisitorBase[None]):
         if self.func and self.func.mutability == StateMutability.PURE:
             _validate_pure_access(node, typ)
 
-        value_type = get_exact_type_from_node(node.value)
+        value_type = get_exact_type_from_node(node.value, allow_type_exprs=True)
 
         _validate_address_code(node, value_type)
 

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -675,9 +675,9 @@ class ModuleAnalyzer(VyperNodeVisitorBase[None]):
         # CMC 2024-04-13 TODO: reduce nesting in this function
 
         for export_ann in export_annotations:
-            # set is_callable=True to give better error messages for imported
+            # set allow_type_exprs=True to give better error messages for imported
             # types, e.g. exports: some_module.MyEvent
-            info = get_expr_info(export_ann, is_callable=True)
+            info = get_expr_info(export_ann, allow_type_exprs=True)
 
             if info.var_info is not None:
                 decl = info.var_info.decl_node

--- a/vyper/semantics/analysis/module.py
+++ b/vyper/semantics/analysis/module.py
@@ -423,7 +423,7 @@ def _validate_overrides(func_t: ContractFunctionT, node: vy_ast.FunctionDef):
         abstract_t.set_overridden_by(func_t)
 
 
-class ModuleAnalyzer(VyperNodeVisitorBase):
+class ModuleAnalyzer(VyperNodeVisitorBase[None]):
     scope_name = "module"
 
     def __init__(self, module_node: vy_ast.Module, namespace: Namespace) -> None:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -22,6 +22,7 @@ from vyper.exceptions import (
 )
 from vyper.semantics import types
 from vyper.semantics.analysis.base import ExprInfo, Modifiability, ModuleInfo, VarAccess, VarInfo
+from vyper.semantics.analysis.common import VyperNodeVisitorBase
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.namespace import get_namespace
 from vyper.semantics.types.base import TYPE_T, VyperType
@@ -62,20 +63,22 @@ def uses_state(var_accesses: Iterable[VarAccess]) -> bool:
     return any(s.variable.is_state_variable() for s in var_accesses)
 
 
-class _ExprAnalyser:
+class _ExprAnalyser(VyperNodeVisitorBase[list[VyperType]]):
     """
     Node type-checker class.
 
-    Type-check logic is implemented in `type_from_<NODE_CLASS>` methods, organized
+    Type-check logic is implemented in `visit_<NODE_CLASS>` methods, organized
     according to the Vyper ast node class. Calls to `get_exact_type_from_node` and
     `get_possible_types_from_node` are forwarded to this class, where the node
     class's method resolution order is examined to decide which method to call.
     """
 
+    scope_name = "expression"
+
     def __init__(self):
         self.namespace = get_namespace()
 
-    def _get_possible_types_r(self, node) -> list[VyperType]:
+    def visit(self, node) -> list[VyperType]:
         # Early termination if typedef is propagated in metadata
         if "type" in node._metadata:
             return [node._metadata["type"]]
@@ -84,30 +87,22 @@ class _ExprAnalyser:
         # try to return it if found.
         k = "possible_types_from_node"
         if k not in node._metadata:
-            fn = self._find_fn(node)
-            ret = fn(node)
+            ret = super().visit(node)
 
-            if all(isinstance(i, IntegerT) for i in ret):
-                # for numeric types, sort according by number of bits descending
+            if all(isinstance(t, IntegerT) for t in ret):
+                # for numeric types, sort according to number of bits descending
                 # this ensures literals are cast with the largest possible type
-                ret.sort(key=lambda k: (k.bits, not k.is_signed), reverse=True)
+                def sorting_function(t: VyperType):
+                    assert isinstance(t, IntegerT)
+                    return (t.bits, not t.is_signed)
+
+                ret.sort(key=sorting_function, reverse=True)
 
             node._metadata[k] = ret
 
         return node._metadata[k].copy()
 
-    def _find_fn(self, node):
-        # look for a type-check method for each class in the given class mro
-        for name in [i.__name__ for i in type(node).mro()]:
-            if name == "VyperNode":
-                break
-            fn = getattr(self, f"types_from_{name}", None)
-            if fn is not None:
-                return fn
-
-        raise StructureException("Cannot determine type of this object", node)
-
-    def types_from_Attribute(self, node):
+    def visit_Attribute(self, node):
         is_self_reference = node.get("value.id") == "self"
 
         # variable attribute, e.g. `foo.bar`
@@ -142,12 +137,12 @@ class _ExprAnalyser:
                 f"Storage variable '{name}' has not been declared.", node, hint=hint
             ) from None
 
-    def types_from_BinOp(self, node):
+    def visit_BinOp(self, node):
         # binary operation: `x + y`
         if isinstance(node.op, (vy_ast.LShift, vy_ast.RShift)):
             # ad-hoc handling for LShift and RShift, since operands
             # can be different types
-            types_list = self._get_possible_types_r(node.left)
+            types_list = self.visit(node.left)
             # check rhs is unsigned integer
             validate_expected_type(node.right, IntegerT.unsigneds())
         else:
@@ -162,13 +157,13 @@ class _ExprAnalyser:
 
         return _validate_op(node, types_list, "validate_numeric_op")
 
-    def types_from_BoolOp(self, node):
+    def visit_BoolOp(self, node):
         # boolean operation: `x and y`
         types_list = get_common_types(*node.values)
         _validate_op(node, types_list, "validate_boolean_op")
         return [BoolT()]
 
-    def types_from_Compare(self, node):
+    def visit_Compare(self, node):
         # comparisons, e.g. `x < y`
 
         # TODO fixme circular import
@@ -176,8 +171,8 @@ class _ExprAnalyser:
 
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
-            left = self._get_possible_types_r(node.left)
-            right = self._get_possible_types_r(node.right)
+            left = self.visit(node.left)
+            right = self.visit(node.right)
             if any(isinstance(t, FlagT) for t in left):
                 types_list = get_common_types(node.left, node.right)
                 _validate_op(node, types_list, "validate_comparator")
@@ -201,15 +196,15 @@ class _ExprAnalyser:
             _validate_op(node, types_list, "validate_comparator")
         return [BoolT()]
 
-    def types_from_ExtCall(self, node):
+    def visit_ExtCall(self, node):
         call_node = node.value
-        return self._find_fn(call_node)(call_node)
+        return self.visit(call_node)
 
-    def types_from_StaticCall(self, node):
+    def visit_StaticCall(self, node):
         call_node = node.value
-        return self._find_fn(call_node)(call_node)
+        return self.visit(call_node)
 
-    def types_from_Call(self, node):
+    def visit_Call(self, node):
         # function calls, e.g. `foo()` or `MyStruct()`
         var = get_exact_type_from_node(node.func)
         return_value = var.fetch_call_return(node)
@@ -219,7 +214,7 @@ class _ExprAnalyser:
             return [return_value]
         raise InvalidType(f"{var} did not return a value", node)
 
-    def types_from_Constant(self, node):
+    def visit_Constant(self, node):
         # literal value (integer, string, etc)
         types_list = []
         for t in types.PRIMITIVE_TYPES.values():
@@ -251,25 +246,25 @@ class _ExprAnalyser:
             )
         raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node)
 
-    def types_from_IfExp(self, node):
+    def visit_IfExp(self, node):
         validate_expected_type(node.test, BoolT())
         types_list = get_common_types(node.body, node.orelse)
 
         if not types_list:
-            a = self._get_possible_types_r(node.body)[0]
-            b = self._get_possible_types_r(node.orelse)[0]
+            a = self.visit(node.body)[0]
+            b = self.visit(node.orelse)[0]
             raise TypeMismatch(f"Dislike types: {a} and {b}", node)
 
         return types_list
 
-    def types_from_List(self, node):
+    def visit_List(self, node):
         # literal array
         if _is_empty_list(node):
             ret = []
 
             if len(node.elements) > 0:
                 # empty nested list literals `[[], []]`
-                subtypes = self._get_possible_types_r(node.elements[0])
+                subtypes = self.visit(node.elements[0])
             else:
                 # empty list literal `[]`
                 # subtype can be anything
@@ -297,7 +292,7 @@ class _ExprAnalyser:
             return ret
         raise InvalidLiteral("Array contains multiple, incompatible types", node)
 
-    def types_from_Name(self, node):
+    def visit_Name(self, node):
         # variable name, e.g. `foo`
         name = node.id
 
@@ -330,10 +325,10 @@ class _ExprAnalyser:
         except VyperException as exc:
             raise exc.with_annotation(node) from None
 
-    def types_from_Subscript(self, node):
+    def visit_Subscript(self, node):
         # index access, e.g. `foo[1]`
         if isinstance(node.value, (vy_ast.List, vy_ast.Subscript)):
-            types_list = self._get_possible_types_r(node.value)
+            types_list = self.visit(node.value)
             ret = []
             for t in types_list:
                 t.validate_index_type(node.slice)
@@ -344,13 +339,13 @@ class _ExprAnalyser:
         t.validate_index_type(node.slice)
         return [t.get_subscripted_type(node.slice)]
 
-    def types_from_Tuple(self, node):
+    def visit_Tuple(self, node):
         types_list = [get_exact_type_from_node(i) for i in node.elements]
         return [TupleT(types_list)]
 
-    def types_from_UnaryOp(self, node):
+    def visit_UnaryOp(self, node):
         # unary operation: `-foo`
-        types_list = self._get_possible_types_r(node.operand)
+        types_list = self.visit(node.operand)
         return _validate_op(node, types_list, "validate_numeric_op")
 
 
@@ -401,7 +396,7 @@ def get_possible_types_from_node(node, allow_type_exprs=True) -> list[VyperType]
     if "type" in node._metadata:
         return [node._metadata["type"]]
 
-    ret = _ExprAnalyser()._get_possible_types_r(node)
+    ret = _ExprAnalyser().visit(node)
 
     if not allow_type_exprs:
         invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -75,51 +75,6 @@ class _ExprAnalyser:
     def __init__(self):
         self.namespace = get_namespace()
 
-    def get_expr_info(self, node: vy_ast.VyperNode, allow_type_exprs: bool = False) -> ExprInfo:
-        t = get_exact_type_from_node(node, allow_type_exprs=allow_type_exprs)
-
-        # if it's a Name, we have varinfo for it
-        if isinstance(node, vy_ast.Name):
-            info = self.namespace[node.id]
-
-            if isinstance(info, VarInfo):
-                return ExprInfo.from_varinfo(info)
-
-            if isinstance(info, ModuleInfo):
-                return ExprInfo.from_moduleinfo(info)
-
-            if isinstance(info, VyperType):
-                return ExprInfo(TYPE_T(info), modifiability=Modifiability.CONSTANT)
-
-            raise CompilerPanic(f"unreachable! {info}", node)
-
-        if isinstance(node, vy_ast.Attribute):
-            # if it's an Attr, we check the parent exprinfo and
-            # propagate the parent exprinfo members down into the new expr
-            # note: Attribute(expr value, identifier attr)
-
-            # allow the value node to be a type expr (e.g., MyFlag.A)
-            info = self.get_expr_info(node.value, allow_type_exprs=True)
-            attr = node.attr
-
-            t = info.typ.get_member(attr, node)
-
-            # it's a top-level variable
-            if isinstance(t, VarInfo):
-                return ExprInfo.from_varinfo(t, attr=attr)
-
-            if isinstance(t, ModuleInfo):
-                return ExprInfo.from_moduleinfo(t, attr=attr)
-
-            return info.copy_with_type(t, attr=attr)
-
-        # If it's a Subscript, propagate the subscriptable varinfo
-        if isinstance(node, vy_ast.Subscript):
-            info = self.get_expr_info(node.value)
-            return info.copy_with_type(t)
-
-        return ExprInfo(t)
-
     def _get_possible_types_r(self, node) -> list[VyperType]:
         # Early termination if typedef is propagated in metadata
         if "type" in node._metadata:
@@ -480,9 +435,58 @@ def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs=True) -> V
     return types_list[0]
 
 
+def _get_expr_info_helper(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> ExprInfo:
+    t = get_exact_type_from_node(node, allow_type_exprs=allow_type_exprs)
+
+    # if it's a Name, we have varinfo for it
+    if isinstance(node, vy_ast.Name):
+        info = get_namespace()[node.id]
+
+        if isinstance(info, VarInfo):
+            return ExprInfo.from_varinfo(info)
+
+        if isinstance(info, ModuleInfo):
+            return ExprInfo.from_moduleinfo(info)
+
+        if isinstance(info, VyperType):
+            return ExprInfo(TYPE_T(info), modifiability=Modifiability.CONSTANT)
+
+        raise CompilerPanic(f"unreachable! {info}", node)
+
+    if isinstance(node, vy_ast.Attribute):
+        # if it's an Attr, we check the parent exprinfo and
+        # propagate the parent exprinfo members down into the new expr
+        # note: Attribute(expr value, identifier attr)
+
+        # allow the value node to be a type expr (e.g., MyFlag.A)
+        info = get_expr_info(node.value, allow_type_exprs=True)
+        attr = node.attr
+
+        t = info.typ.get_member(attr, node)
+
+        # it's a top-level variable
+        if isinstance(t, VarInfo):
+            return ExprInfo.from_varinfo(t, attr=attr)
+
+        if isinstance(t, ModuleInfo):
+            return ExprInfo.from_moduleinfo(t, attr=attr)
+
+        return info.copy_with_type(t, attr=attr)
+
+    # If it's a Subscript, propagate the subscriptable varinfo
+    if isinstance(node, vy_ast.Subscript):
+        info = get_expr_info(node.value)
+        return info.copy_with_type(t)
+
+    return ExprInfo(t)
+
 def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> ExprInfo:
     if node._expr_info is None:
-        node._expr_info = _ExprAnalyser().get_expr_info(node, allow_type_exprs)
+        node._expr_info = _get_expr_info_helper(node, allow_type_exprs=allow_type_exprs)
+
+    if not allow_type_exprs and isinstance(node._expr_info.typ, TYPE_T):
+        raise InvalidReference(f"not a variable or literal: '{node._expr_info.typ.typedef}'", node)
+
     return node._expr_info
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -161,17 +161,26 @@ class _ExprAnalyser:
         if "type" in node._metadata:
             return [node._metadata["type"]]
 
+        ret = self._get_possible_types_r(node)
+
+        if not include_type_exprs:
+            invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
+            if invalid is not None:
+                raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
+
+        return ret
+
+    def _get_possible_types_r(self, node) -> list[VyperType]:
+        # Early termination if typedef is propagated in metadata
+        if "type" in node._metadata:
+            return [node._metadata["type"]]
+
         # this method is a perf hotspot, so we cache the result and
         # try to return it if found.
-        k = f"possible_types_from_node_{include_type_exprs}"
+        k = f"possible_types_from_node"
         if k not in node._metadata:
             fn = self._find_fn(node)
             ret = fn(node)
-
-            if not include_type_exprs:
-                invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
-                if invalid is not None:
-                    raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
 
             if all(isinstance(i, IntegerT) for i in ret):
                 # for numeric types, sort according by number of bits descending
@@ -181,6 +190,7 @@ class _ExprAnalyser:
             node._metadata[k] = ret
 
         return node._metadata[k].copy()
+
 
     def _find_fn(self, node):
         # look for a type-check method for each class in the given class mro
@@ -233,7 +243,7 @@ class _ExprAnalyser:
         if isinstance(node.op, (vy_ast.LShift, vy_ast.RShift)):
             # ad-hoc handling for LShift and RShift, since operands
             # can be different types
-            types_list = get_possible_types_from_node(node.left)
+            types_list = self._get_possible_types_r(node.left)
             # check rhs is unsigned integer
             validate_expected_type(node.right, IntegerT.unsigneds())
         else:
@@ -262,8 +272,8 @@ class _ExprAnalyser:
 
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
-            left = self.get_possible_types_from_node(node.left)
-            right = self.get_possible_types_from_node(node.right)
+            left = self._get_possible_types_r(node.left)
+            right = self._get_possible_types_r(node.right)
             if any(isinstance(t, FlagT) for t in left):
                 types_list = get_common_types(node.left, node.right)
                 _validate_op(node, types_list, "validate_comparator")
@@ -342,8 +352,8 @@ class _ExprAnalyser:
         types_list = get_common_types(node.body, node.orelse)
 
         if not types_list:
-            a = get_possible_types_from_node(node.body)[0]
-            b = get_possible_types_from_node(node.orelse)[0]
+            a = self._get_possible_types_r(node.body)[0]
+            b = self._get_possible_types_r(node.orelse)[0]
             raise TypeMismatch(f"Dislike types: {a} and {b}", node)
 
         return types_list
@@ -355,7 +365,7 @@ class _ExprAnalyser:
 
             if len(node.elements) > 0:
                 # empty nested list literals `[[], []]`
-                subtypes = self.get_possible_types_from_node(node.elements[0])
+                subtypes = self._get_possible_types_r(node.elements[0])
             else:
                 # empty list literal `[]`
                 # subtype can be anything
@@ -419,7 +429,7 @@ class _ExprAnalyser:
     def types_from_Subscript(self, node):
         # index access, e.g. `foo[1]`
         if isinstance(node.value, (vy_ast.List, vy_ast.Subscript)):
-            types_list = self.get_possible_types_from_node(node.value)
+            types_list = self._get_possible_types_r(node.value)
             ret = []
             for t in types_list:
                 t.validate_index_type(node.slice)
@@ -436,7 +446,7 @@ class _ExprAnalyser:
 
     def types_from_UnaryOp(self, node):
         # unary operation: `-foo`
-        types_list = self.get_possible_types_from_node(node.operand)
+        types_list = self._get_possible_types_r(node.operand)
         return _validate_op(node, types_list, "validate_numeric_op")
 
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -63,14 +63,13 @@ def uses_state(var_accesses: Iterable[VarAccess]) -> bool:
     return any(s.variable.is_state_variable() for s in var_accesses)
 
 
-class _ExprAnalyser(VyperNodeVisitorBase[list[VyperType]]):
+class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
     """
-    Node type-checker class.
+    Returns all types an expression can have.
+    (Or its type if it has already been computed.)
 
-    Type-check logic is implemented in `visit_<NODE_CLASS>` methods, organized
-    according to the Vyper ast node class. Calls to `get_exact_type_from_node` and
-    `get_possible_types_from_node` are forwarded to this class, where the node
-    class's method resolution order is examined to decide which method to call.
+    Do not call directly, instead go through `get_exact_type_from_node` or
+    `get_possible_types_from_node`.
     """
 
     scope_name = "expression"
@@ -392,11 +391,8 @@ def get_possible_types_from_node(node, allow_type_exprs=True) -> list[VyperType]
     List
         List of one or more VyperType objects.
     """
-    # Early termination if typedef is propagated in metadata
-    if "type" in node._metadata:
-        return [node._metadata["type"]]
 
-    ret = _ExprAnalyser().visit(node)
+    ret = _TypeSynthesizer().visit(node)
 
     if not allow_type_exprs:
         invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -176,12 +176,13 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
         # TODO fixme circular import
         from vyper.semantics.types.user import FlagT
 
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
-            left = self.visit(node.left)
-            right = self.visit(node.right)
             if any(isinstance(t, FlagT) for t in left):
-                types_list = get_common_types(node.left, node.right)
+                types_list = supremum(left, right)
                 _validate_op(node, types_list, "validate_comparator")
                 return [BoolT()]
 
@@ -193,13 +194,13 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
                 raise InvalidOperation(
                     "Right operand must be Array for membership comparison", node.right
                 )
-            types_list = [i for i in left if _is_type_in_list(i, [i.value_type for i in right])]
+            types_list = supremum(left, [t.value_type for t in right])
             if not types_list:
                 raise TypeMismatch(
                     "Cannot perform membership comparison between dislike types", node
                 )
         else:
-            types_list = get_common_types(node.left, node.right)
+            types_list = supremum(left, right)
             _validate_op(node, types_list, "validate_comparator")
         return [BoolT()]
 
@@ -255,12 +256,13 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
     def visit_IfExp(self, node):
         validate_expected_type(node.test, BoolT())
-        types_list = get_common_types(node.body, node.orelse)
+
+        then_t = self.visit(node.body)
+        else_t = self.visit(node.orelse)
+        types_list = supremum(then_t, else_t)
 
         if not types_list:
-            a = self.visit(node.body)[0]
-            b = self.visit(node.orelse)[0]
-            raise TypeMismatch(f"Dislike types: {a} and {b}", node)
+            raise TypeMismatch(f"Dislike types: {then_t[0]} and {else_t[0]}", node)
 
         return types_list
 
@@ -483,7 +485,26 @@ def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> Expr
     return node._expr_info
 
 
-def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> List:
+def supremum(*branches: List[VyperType]) -> List[VyperType]:
+    assert len(branches) >= 1
+
+    common_types = branches[0]
+    for branch in branches[1:]:
+        tmp = []
+        for c in common_types:
+            for t in branch:
+                # TODO: This can add either the supertype or the subtype to tmp depending on
+                # the order
+                if t.compare_type(c) or c.compare_type(t):
+                    tmp.append(c)
+                    break
+
+        common_types = tmp
+
+    return common_types
+
+
+def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> List[VyperType]:
     # this function is a performance hotspot
     """
     Return a list of common possible types between one or more nodes.
@@ -500,21 +521,8 @@ def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> Li
     list
         List of zero or more `BaseType` objects.
     """
-    common_types = get_possible_types_from_node(nodes[0])
 
-    for item in nodes[1:]:
-        new_types = get_possible_types_from_node(item)
-
-        tmp = []
-        for c in common_types:
-            for t in new_types:
-                # TODO: This can add either the supertype or the subtype to tmp depending on
-                # the order
-                if t.compare_type(c) or c.compare_type(t):
-                    tmp.append(c)
-                    break
-
-        common_types = tmp
+    common_types = supremum(*(get_possible_types_from_node(node) for node in nodes))
 
     if filter_fn is not None:
         common_types = [i for i in common_types if filter_fn(i)]

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -63,6 +63,11 @@ def uses_state(var_accesses: Iterable[VarAccess]) -> bool:
     return any(s.variable.is_state_variable() for s in var_accesses)
 
 
+def _raise_if_type(t: VyperType, node: vy_ast.VyperNode):
+    if isinstance(t, TYPE_T):
+        raise InvalidReference(f"not a variable or literal: '{t.typedef}'", node)
+
+
 class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
     """
     Returns all types an expression can have.
@@ -99,9 +104,8 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
         ret = node._metadata[k].copy()
 
         if not allow_type_exprs:
-            invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
-            if invalid is not None:
-                raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
+            for t in ret:
+                _raise_if_type(t, node)
 
         return ret
 
@@ -366,21 +370,6 @@ def _is_empty_list(node):
     return all(_is_empty_list(t) for t in node.elements)
 
 
-def _is_type_in_list(obj, types_list):
-    # check if a type object is in a list of types
-    return any(i.is_equivalent_to(obj) for i in types_list)
-
-
-# NOTE: dead fn
-def _filter(type_, fn_name, node):
-    # filter function used when evaluating boolean ops and comparators
-    try:
-        getattr(type_, fn_name)(node)
-        return True
-    except InvalidOperation:
-        return False
-
-
 def get_possible_types_from_node(node, allow_type_exprs: bool = False) -> list[VyperType]:
     """
     Return a list of possible types for the given node.
@@ -418,8 +407,13 @@ def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs: bool = Fa
         The type of `node`
     """
 
-    if "type" in node._metadata:
-        return node._metadata["type"]
+    # Return cached value if available
+    typ = node._metadata.get("type")
+    if typ is not None:
+        if not allow_type_exprs:
+            # Cache might have been filled when `allow_type_expr` was `True`
+            _raise_if_type(typ, node)
+        return typ
 
     types_list = get_possible_types_from_node(node, allow_type_exprs=allow_type_exprs)
 
@@ -480,8 +474,8 @@ def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> Expr
         node._expr_info = _get_expr_info_helper(node, allow_type_exprs=allow_type_exprs)
 
     # in case we cached a value when `allow_type_exprs` was True
-    if not allow_type_exprs and isinstance(node._expr_info.typ, TYPE_T):
-        raise InvalidReference(f"not a variable or literal: '{node._expr_info.typ.typedef}'", node)
+    if not allow_type_exprs:
+        _raise_if_type(node._expr_info.typ, node)
 
     return node._expr_info
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -77,7 +77,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
     def __init__(self):
         self.namespace = get_namespace()
 
-    def visit(self, node) -> list[VyperType]:
+    def visit(self, node, allow_type_exprs: bool = False) -> list[VyperType]:
         # Early termination if typedef is propagated in metadata
         if "type" in node._metadata:
             return [node._metadata["type"]]
@@ -86,20 +86,28 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
         # try to return it if found.
         k = "possible_types_from_node"
         if k not in node._metadata:
-            ret = super().visit(node)
+            # we don't pass `allow_type_exprs` to the `visit_...` nodes, as they shouldn't handle it
+            possible_types = super().visit(node)
 
-            if all(isinstance(t, IntegerT) for t in ret):
+            if all(isinstance(t, IntegerT) for t in possible_types):
                 # for numeric types, sort according to number of bits descending
                 # this ensures literals are cast with the largest possible type
                 def sorting_function(t: VyperType):
                     assert isinstance(t, IntegerT)
                     return (t.bits, not t.is_signed)
 
-                ret.sort(key=sorting_function, reverse=True)
+                possible_types.sort(key=sorting_function, reverse=True)
 
-            node._metadata[k] = ret
+            node._metadata[k] = possible_types
 
-        return node._metadata[k].copy()
+        ret = node._metadata[k].copy()
+
+        if not allow_type_exprs:
+            invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
+            if invalid is not None:
+                raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
+
+        return ret
 
     def visit_Attribute(self, node):
         is_self_reference = node.get("value.id") == "self"
@@ -170,8 +178,8 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
-            left = get_possible_types_from_node(node.left)
-            right = get_possible_types_from_node(node.right)
+            left = self.visit(node.left)
+            right = self.visit(node.right)
             if any(isinstance(t, FlagT) for t in left):
                 types_list = get_common_types(node.left, node.right)
                 _validate_op(node, types_list, "validate_comparator")
@@ -263,7 +271,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
             if len(node.elements) > 0:
                 # empty nested list literals `[[], []]`
-                subtypes = get_possible_types_from_node(node.elements[0])
+                subtypes = self.visit(node.elements[0])
             else:
                 # empty list literal `[]`
                 # subtype can be anything
@@ -327,7 +335,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
     def visit_Subscript(self, node):
         # index access, e.g. `foo[1]`
         if isinstance(node.value, (vy_ast.List, vy_ast.Subscript)):
-            types_list = get_possible_types_from_node(node.value)
+            types_list = self.visit(node.value)
             ret = []
             for t in types_list:
                 t.validate_index_type(node.slice)
@@ -344,7 +352,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
     def visit_UnaryOp(self, node):
         # unary operation: `-foo`
-        types_list = get_possible_types_from_node(node.operand)
+        types_list = self.visit(node.operand)
         return _validate_op(node, types_list, "validate_numeric_op")
 
 
@@ -392,14 +400,7 @@ def get_possible_types_from_node(node, allow_type_exprs: bool = False) -> list[V
         List of one or more VyperType objects.
     """
 
-    ret = _TypeSynthesizer().visit(node)
-
-    if not allow_type_exprs:
-        invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
-        if invalid is not None:
-            raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
-
-    return ret
+    return _TypeSynthesizer().visit(node, allow_type_exprs=allow_type_exprs)
 
 
 def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs: bool = False) -> VyperType:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -105,7 +105,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
         is_self_reference = node.get("value.id") == "self"
 
         # variable attribute, e.g. `foo.bar`
-        t = get_exact_type_from_node(node.value)
+        t = get_exact_type_from_node(node.value, allow_type_exprs=True)
         name = node.attr
 
         def _raise_invalid_reference(name, node):
@@ -170,8 +170,8 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
-            left = self.visit(node.left)
-            right = self.visit(node.right)
+            left = get_possible_types_from_node(node.left)
+            right = get_possible_types_from_node(node.right)
             if any(isinstance(t, FlagT) for t in left):
                 types_list = get_common_types(node.left, node.right)
                 _validate_op(node, types_list, "validate_comparator")
@@ -205,7 +205,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
     def visit_Call(self, node):
         # function calls, e.g. `foo()` or `MyStruct()`
-        var = get_exact_type_from_node(node.func)
+        var = get_exact_type_from_node(node.func, allow_type_exprs=True)
         return_value = var.fetch_call_return(node)
         if return_value:
             if isinstance(return_value, list):
@@ -263,7 +263,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
             if len(node.elements) > 0:
                 # empty nested list literals `[[], []]`
-                subtypes = self.visit(node.elements[0])
+                subtypes = get_possible_types_from_node(node.elements[0])
             else:
                 # empty list literal `[]`
                 # subtype can be anything
@@ -327,7 +327,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
     def visit_Subscript(self, node):
         # index access, e.g. `foo[1]`
         if isinstance(node.value, (vy_ast.List, vy_ast.Subscript)):
-            types_list = self.visit(node.value)
+            types_list = get_possible_types_from_node(node.value)
             ret = []
             for t in types_list:
                 t.validate_index_type(node.slice)
@@ -344,7 +344,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
     def visit_UnaryOp(self, node):
         # unary operation: `-foo`
-        types_list = self.visit(node.operand)
+        types_list = get_possible_types_from_node(node.operand)
         return _validate_op(node, types_list, "validate_numeric_op")
 
 
@@ -375,7 +375,7 @@ def _filter(type_, fn_name, node):
         return False
 
 
-def get_possible_types_from_node(node, allow_type_exprs=True) -> list[VyperType]:
+def get_possible_types_from_node(node, allow_type_exprs: bool = False) -> list[VyperType]:
     """
     Return a list of possible types for the given node.
 
@@ -402,7 +402,7 @@ def get_possible_types_from_node(node, allow_type_exprs=True) -> list[VyperType]
     return ret
 
 
-def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs=True) -> VyperType:
+def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs: bool = False) -> VyperType:
     """
     Return *the* type of a given node.
 
@@ -575,7 +575,7 @@ def validate_expected_type(node, expected_type):
             # fail block
             pass
 
-    given_types = get_possible_types_from_node(node, allow_type_exprs=False)
+    given_types = get_possible_types_from_node(node)
 
     if isinstance(node, vy_ast.List):
         # special case - for literal arrays we individually validate each item
@@ -679,7 +679,7 @@ def check_modifiability(node: vy_ast.ExprNode, modifiability: Modifiability) -> 
         return all(check_modifiability(item, modifiability) for item in node.elements)
 
     if isinstance(node, vy_ast.Call):
-        call_type = get_exact_type_from_node(node.func)
+        call_type = get_exact_type_from_node(node.func, allow_type_exprs=True)
 
         # structs and interfaces
         if hasattr(call_type, "check_modifiability_for_call"):

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -76,7 +76,7 @@ class _ExprAnalyser:
         self.namespace = get_namespace()
 
     def get_expr_info(self, node: vy_ast.VyperNode, is_callable: bool = False) -> ExprInfo:
-        t = self.get_exact_type_from_node(node, include_type_exprs=is_callable)
+        t = get_exact_type_from_node(node, include_type_exprs=is_callable)
 
         # if it's a Name, we have varinfo for it
         if isinstance(node, vy_ast.Name):
@@ -120,56 +120,6 @@ class _ExprAnalyser:
 
         return ExprInfo(t)
 
-    def get_exact_type_from_node(self, node, include_type_exprs=True):
-        """
-        Find exactly one type for a given node.
-
-        Raises StructureException if a single type cannot be determined.
-
-        Arguments
-        ---------
-        node : VyperNode
-            The vyper AST node to find a type for.
-
-        Returns
-        -------
-        Type object
-        """
-        types_list = self.get_possible_types_from_node(node, include_type_exprs=include_type_exprs)
-
-        if len(types_list) > 1:
-            raise StructureException("Ambiguous type", node)
-
-        return types_list[0]
-
-    def get_possible_types_from_node(self, node, include_type_exprs=True) -> list[VyperType]:
-        """
-        Find all possible types for a given node.
-        If the node's metadata contains type information, then that type is returned.
-
-        Arguments
-        ---------
-        node : VyperNode
-            The vyper AST node to find a type for.
-
-        Returns
-        -------
-        List
-            A list of type objects
-        """
-        # Early termination if typedef is propagated in metadata
-        if "type" in node._metadata:
-            return [node._metadata["type"]]
-
-        ret = self._get_possible_types_r(node)
-
-        if not include_type_exprs:
-            invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
-            if invalid is not None:
-                raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
-
-        return ret
-
     def _get_possible_types_r(self, node) -> list[VyperType]:
         # Early termination if typedef is propagated in metadata
         if "type" in node._metadata:
@@ -177,7 +127,7 @@ class _ExprAnalyser:
 
         # this method is a perf hotspot, so we cache the result and
         # try to return it if found.
-        k = f"possible_types_from_node"
+        k = "possible_types_from_node"
         if k not in node._metadata:
             fn = self._find_fn(node)
             ret = fn(node)
@@ -190,7 +140,6 @@ class _ExprAnalyser:
             node._metadata[k] = ret
 
         return node._metadata[k].copy()
-
 
     def _find_fn(self, node):
         # look for a type-check method for each class in the given class mro
@@ -207,7 +156,7 @@ class _ExprAnalyser:
         is_self_reference = node.get("value.id") == "self"
 
         # variable attribute, e.g. `foo.bar`
-        t = self.get_exact_type_from_node(node.value)
+        t = get_exact_type_from_node(node.value)
         name = node.attr
 
         def _raise_invalid_reference(name, node):
@@ -307,7 +256,7 @@ class _ExprAnalyser:
 
     def types_from_Call(self, node):
         # function calls, e.g. `foo()` or `MyStruct()`
-        var = self.get_exact_type_from_node(node.func)
+        var = get_exact_type_from_node(node.func)
         return_value = var.fetch_call_return(node)
         if return_value:
             if isinstance(return_value, list):
@@ -436,12 +385,12 @@ class _ExprAnalyser:
                 ret.append(t.get_subscripted_type(node.slice))
             return ret
 
-        t = self.get_exact_type_from_node(node.value)
+        t = get_exact_type_from_node(node.value)
         t.validate_index_type(node.slice)
         return [t.get_subscripted_type(node.slice)]
 
     def types_from_Tuple(self, node):
-        types_list = [self.get_exact_type_from_node(i) for i in node.elements]
+        types_list = [get_exact_type_from_node(i) for i in node.elements]
         return [TupleT(types_list)]
 
     def types_from_UnaryOp(self, node):
@@ -477,7 +426,7 @@ def _filter(type_, fn_name, node):
         return False
 
 
-def get_possible_types_from_node(node):
+def get_possible_types_from_node(node, include_type_exprs=True) -> list[VyperType]:
     """
     Return a list of possible types for the given node.
 
@@ -491,16 +440,27 @@ def get_possible_types_from_node(node):
     Returns
     -------
     List
-        List of one or more BaseType objects.
+        List of one or more VyperType objects.
     """
-    return _ExprAnalyser().get_possible_types_from_node(node)
+    # Early termination if typedef is propagated in metadata
+    if "type" in node._metadata:
+        return [node._metadata["type"]]
+
+    ret = _ExprAnalyser()._get_possible_types_r(node)
+
+    if not include_type_exprs:
+        invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
+        if invalid is not None:
+            raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
+
+    return ret
 
 
-def get_exact_type_from_node(node):
+def get_exact_type_from_node(node: vy_ast.VyperNode, include_type_exprs=True) -> VyperType:
     """
-    Return exactly one type for a given node.
+    Return *the* type of a given node.
 
-    Raises if there is more than one possible type.
+    Raises StructureException if a single type cannot be determined.
 
     Arguments
     ---------
@@ -509,10 +469,15 @@ def get_exact_type_from_node(node):
 
     Returns
     -------
-    BaseType
-        Type object.
+    VyperType
+        The type of `node`
     """
-    return _ExprAnalyser().get_exact_type_from_node(node)
+    types_list = get_possible_types_from_node(node, include_type_exprs=include_type_exprs)
+
+    if len(types_list) > 1:
+        raise StructureException("Ambiguous type", node)
+
+    return types_list[0]
 
 
 def get_expr_info(node: vy_ast.ExprNode, is_callable: bool = False) -> ExprInfo:
@@ -538,10 +503,10 @@ def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> Li
     list
         List of zero or more `BaseType` objects.
     """
-    common_types = _ExprAnalyser().get_possible_types_from_node(nodes[0])
+    common_types = get_possible_types_from_node(nodes[0])
 
     for item in nodes[1:]:
-        new_types = _ExprAnalyser().get_possible_types_from_node(item)
+        new_types = get_possible_types_from_node(item)
 
         tmp = []
         for c in common_types:
@@ -614,7 +579,7 @@ def validate_expected_type(node, expected_type):
             # fail block
             pass
 
-    given_types = _ExprAnalyser().get_possible_types_from_node(node, include_type_exprs=False)
+    given_types = get_possible_types_from_node(node, include_type_exprs=False)
 
     if isinstance(node, vy_ast.List):
         # special case - for literal arrays we individually validate each item

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -66,10 +66,9 @@ def uses_state(var_accesses: Iterable[VarAccess]) -> bool:
 class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
     """
     Returns all types an expression can have.
-    (Or its type if it has already been computed.)
 
-    Do not call directly, instead go through `get_exact_type_from_node` or
-    `get_possible_types_from_node`.
+    Do not call directly, instead go through `get_possible_types_from_node`
+    (or `get_exact_type_from_node`).
     """
 
     scope_name = "expression"
@@ -78,9 +77,6 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
         self.namespace = get_namespace()
 
     def visit(self, node, allow_type_exprs: bool = False) -> list[VyperType]:
-        # Early termination if typedef is propagated in metadata
-        if "type" in node._metadata:
-            return [node._metadata["type"]]
 
         # this method is a perf hotspot, so we cache the result and
         # try to return it if found.
@@ -421,6 +417,10 @@ def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs: bool = Fa
     VyperType
         The type of `node`
     """
+
+    if "type" in node._metadata:
+        return node._metadata["type"]
+
     types_list = get_possible_types_from_node(node, allow_type_exprs=allow_type_exprs)
 
     if len(types_list) > 1:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -75,8 +75,8 @@ class _ExprAnalyser:
     def __init__(self):
         self.namespace = get_namespace()
 
-    def get_expr_info(self, node: vy_ast.VyperNode, is_callable: bool = False) -> ExprInfo:
-        t = get_exact_type_from_node(node, include_type_exprs=is_callable)
+    def get_expr_info(self, node: vy_ast.VyperNode, allow_type_exprs: bool = False) -> ExprInfo:
+        t = get_exact_type_from_node(node, allow_type_exprs=allow_type_exprs)
 
         # if it's a Name, we have varinfo for it
         if isinstance(node, vy_ast.Name):
@@ -99,7 +99,7 @@ class _ExprAnalyser:
             # note: Attribute(expr value, identifier attr)
 
             # allow the value node to be a type expr (e.g., MyFlag.A)
-            info = self.get_expr_info(node.value, is_callable=True)
+            info = self.get_expr_info(node.value, allow_type_exprs=True)
             attr = node.attr
 
             t = info.typ.get_member(attr, node)
@@ -426,7 +426,7 @@ def _filter(type_, fn_name, node):
         return False
 
 
-def get_possible_types_from_node(node, include_type_exprs=True) -> list[VyperType]:
+def get_possible_types_from_node(node, allow_type_exprs=True) -> list[VyperType]:
     """
     Return a list of possible types for the given node.
 
@@ -448,7 +448,7 @@ def get_possible_types_from_node(node, include_type_exprs=True) -> list[VyperTyp
 
     ret = _ExprAnalyser()._get_possible_types_r(node)
 
-    if not include_type_exprs:
+    if not allow_type_exprs:
         invalid = next((i for i in ret if isinstance(i, TYPE_T)), None)
         if invalid is not None:
             raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
@@ -456,7 +456,7 @@ def get_possible_types_from_node(node, include_type_exprs=True) -> list[VyperTyp
     return ret
 
 
-def get_exact_type_from_node(node: vy_ast.VyperNode, include_type_exprs=True) -> VyperType:
+def get_exact_type_from_node(node: vy_ast.VyperNode, allow_type_exprs=True) -> VyperType:
     """
     Return *the* type of a given node.
 
@@ -472,7 +472,7 @@ def get_exact_type_from_node(node: vy_ast.VyperNode, include_type_exprs=True) ->
     VyperType
         The type of `node`
     """
-    types_list = get_possible_types_from_node(node, include_type_exprs=include_type_exprs)
+    types_list = get_possible_types_from_node(node, allow_type_exprs=allow_type_exprs)
 
     if len(types_list) > 1:
         raise StructureException("Ambiguous type", node)
@@ -480,9 +480,9 @@ def get_exact_type_from_node(node: vy_ast.VyperNode, include_type_exprs=True) ->
     return types_list[0]
 
 
-def get_expr_info(node: vy_ast.ExprNode, is_callable: bool = False) -> ExprInfo:
+def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> ExprInfo:
     if node._expr_info is None:
-        node._expr_info = _ExprAnalyser().get_expr_info(node, is_callable)
+        node._expr_info = _ExprAnalyser().get_expr_info(node, allow_type_exprs)
     return node._expr_info
 
 
@@ -579,7 +579,7 @@ def validate_expected_type(node, expected_type):
             # fail block
             pass
 
-    given_types = get_possible_types_from_node(node, include_type_exprs=False)
+    given_types = get_possible_types_from_node(node, allow_type_exprs=False)
 
     if isinstance(node, vy_ast.List):
         # special case - for literal arrays we individually validate each item

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -120,7 +120,7 @@ class _ExprAnalyser:
 
         return ExprInfo(t)
 
-    def get_exact_type_from_node(self, node, include_type_exprs=False):
+    def get_exact_type_from_node(self, node, include_type_exprs=True):
         """
         Find exactly one type for a given node.
 
@@ -142,7 +142,7 @@ class _ExprAnalyser:
 
         return types_list[0]
 
-    def get_possible_types_from_node(self, node, include_type_exprs=False) -> list[VyperType]:
+    def get_possible_types_from_node(self, node, include_type_exprs=True) -> list[VyperType]:
         """
         Find all possible types for a given node.
         If the node's metadata contains type information, then that type is returned.
@@ -197,7 +197,7 @@ class _ExprAnalyser:
         is_self_reference = node.get("value.id") == "self"
 
         # variable attribute, e.g. `foo.bar`
-        t = self.get_exact_type_from_node(node.value, include_type_exprs=True)
+        t = self.get_exact_type_from_node(node.value)
         name = node.attr
 
         def _raise_invalid_reference(name, node):
@@ -297,7 +297,7 @@ class _ExprAnalyser:
 
     def types_from_Call(self, node):
         # function calls, e.g. `foo()` or `MyStruct()`
-        var = self.get_exact_type_from_node(node.func, include_type_exprs=True)
+        var = self.get_exact_type_from_node(node.func)
         return_value = var.fetch_call_return(node)
         if return_value:
             if isinstance(return_value, list):
@@ -483,7 +483,7 @@ def get_possible_types_from_node(node):
     List
         List of one or more BaseType objects.
     """
-    return _ExprAnalyser().get_possible_types_from_node(node, include_type_exprs=True)
+    return _ExprAnalyser().get_possible_types_from_node(node)
 
 
 def get_exact_type_from_node(node):
@@ -502,7 +502,7 @@ def get_exact_type_from_node(node):
     BaseType
         Type object.
     """
-    return _ExprAnalyser().get_exact_type_from_node(node, include_type_exprs=True)
+    return _ExprAnalyser().get_exact_type_from_node(node)
 
 
 def get_expr_info(node: vy_ast.ExprNode, is_callable: bool = False) -> ExprInfo:
@@ -604,7 +604,7 @@ def validate_expected_type(node, expected_type):
             # fail block
             pass
 
-    given_types = _ExprAnalyser().get_possible_types_from_node(node)
+    given_types = _ExprAnalyser().get_possible_types_from_node(node, include_type_exprs=False)
 
     if isinstance(node, vy_ast.List):
         # special case - for literal arrays we individually validate each item

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -480,6 +480,7 @@ def _get_expr_info_helper(node: vy_ast.ExprNode, allow_type_exprs: bool = False)
 
     return ExprInfo(t)
 
+
 def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> ExprInfo:
     if node._expr_info is None:
         node._expr_info = _get_expr_info_helper(node, allow_type_exprs=allow_type_exprs)

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -479,6 +479,7 @@ def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> Expr
     if node._expr_info is None:
         node._expr_info = _get_expr_info_helper(node, allow_type_exprs=allow_type_exprs)
 
+    # in case we cached a value when `allow_type_exprs` was True
     if not allow_type_exprs and isinstance(node._expr_info.typ, TYPE_T):
         raise InvalidReference(f"not a variable or literal: '{node._expr_info.typ.typedef}'", node)
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -89,7 +89,7 @@ class _ExprAnalyser:
                 return ExprInfo.from_moduleinfo(info)
 
             if isinstance(info, VyperType):
-                return ExprInfo(TYPE_T(info))
+                return ExprInfo(TYPE_T(info), modifiability=Modifiability.CONSTANT)
 
             raise CompilerPanic(f"unreachable! {info}", node)
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -93,11 +93,11 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
             if all(isinstance(t, IntegerT) for t in possible_types):
                 # for numeric types, sort according to number of bits descending
                 # this ensures literals are cast with the largest possible type
-                def sorting_function(t: VyperType):
+                def fn(t: VyperType):
                     assert isinstance(t, IntegerT)
                     return (t.bits, not t.is_signed)
 
-                possible_types.sort(key=sorting_function, reverse=True)
+                possible_types.sort(key=fn, reverse=True)
 
             node._metadata[k] = possible_types
 
@@ -182,7 +182,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
         if isinstance(node.op, (vy_ast.In, vy_ast.NotIn)):
             # x in y
             if any(isinstance(t, FlagT) for t in left):
-                types_list = supremum(left, right)
+                types_list = type_supremum(left, right)
                 _validate_op(node, types_list, "validate_comparator")
                 return [BoolT()]
 
@@ -194,13 +194,13 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
                 raise InvalidOperation(
                     "Right operand must be Array for membership comparison", node.right
                 )
-            types_list = supremum(left, [t.value_type for t in right])
+            types_list = type_supremum(left, [t.value_type for t in right])
             if not types_list:
                 raise TypeMismatch(
                     "Cannot perform membership comparison between dislike types", node
                 )
         else:
-            types_list = supremum(left, right)
+            types_list = type_supremum(left, right)
             _validate_op(node, types_list, "validate_comparator")
         return [BoolT()]
 
@@ -259,7 +259,7 @@ class _TypeSynthesizer(VyperNodeVisitorBase[list[VyperType]]):
 
         then_t = self.visit(node.body)
         else_t = self.visit(node.orelse)
-        types_list = supremum(then_t, else_t)
+        types_list = type_supremum(then_t, else_t)
 
         if not types_list:
             raise TypeMismatch(f"Dislike types: {then_t[0]} and {else_t[0]}", node)
@@ -480,11 +480,11 @@ def get_expr_info(node: vy_ast.ExprNode, allow_type_exprs: bool = False) -> Expr
     return node._expr_info
 
 
-def supremum(*branches: List[VyperType]) -> List[VyperType]:
-    assert len(branches) >= 1
+def type_supremum(*multitypes: List[VyperType]) -> List[VyperType]:
+    assert len(multitypes) >= 1
 
-    common_types = branches[0]
-    for branch in branches[1:]:
+    common_types = multitypes[0]
+    for branch in multitypes[1:]:
         tmp = []
         for c in common_types:
             for t in branch:
@@ -517,7 +517,7 @@ def get_common_types(*nodes: vy_ast.VyperNode, filter_fn: Callable = None) -> Li
         List of zero or more `BaseType` objects.
     """
 
-    common_types = supremum(*(get_possible_types_from_node(node) for node in nodes))
+    common_types = type_supremum(*(get_possible_types_from_node(node) for node in nodes))
 
     if filter_fn is not None:
         common_types = [i for i in common_types if filter_fn(i)]

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, TypeGuard, Union
 
 from vyper import ast as vy_ast
 from vyper.abi_types import ABIType
@@ -543,5 +543,5 @@ class TYPE_T(VyperType):
         raise UnknownAttribute("Value is not attributable", node)
 
 
-def is_type_t(x: VyperType, t: type) -> bool:
+def is_type_t(x: VyperType, t: type) -> TypeGuard["TYPE_T"]:
     return isinstance(x, TYPE_T) and isinstance(x.typedef, t)

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -543,5 +543,5 @@ class TYPE_T(VyperType):
         raise UnknownAttribute("Value is not attributable", node)
 
 
-def is_type_t(x: VyperType, t: type) -> TypeGuard["TYPE_T"]:
+def is_type_t(x: VyperType, t: type) -> TypeGuard[TYPE_T]:
     return isinstance(x, TYPE_T) and isinstance(x.typedef, t)


### PR DESCRIPTION
### What I did

`_ExprAnalyser` used to do three different things:
1. compute the possible types for an expression (its `get_possible_types_from_node`)
2. check if there is only one possible type  (its `get_exact_type_from_node`)
3. compute the expr info for an expression (its `get_expr_info`)

This made it hard to reason about what were its duties and guarantees.

`get_common_types` used to get the types of the nodes, combine them, and filter the result.

This commit splits these responsibilities:
1.  `_TypeSynthesizer` (a `VyperNodeVisitorBase`) computes the possible types
2. `get_exact_type_from_node` checks there is only one possible type
3. `_get_expr_info_helper` computes the expr info, and `get_expr_info` memoizes it
4. `supremum` combines types together
4. `get_common_types` filters the result of getting the supremum of the possible types for each node

Along the way, the different caches have been simplified.
For example there used to be two distinct `get_possible_types_from_node` caches depending on `include_type_exprs`

The `include_type_exprs` was set inconsistently: defaulted to False in `_ExprAnalyzer.get_exact_type_from_node`, but force-set to True in `get_exact_type_from_node`. And some methods used different names for it.
It is now named `allow_type_exprs` across the board.

### How I did it

In addition to the thing above, I updated `VyperNodeVisitorBase` to be able to return a value (since `_TypeSynthesizer` returns one)
There might be other classes with mro-based dispatch logic which could be refactored, this is out of scope of this PR

### How to verify it

Still passes all the tests, a couple new ones were added

### Commit message

```
`_ExprAnalyzer` used to do three different things:

  1. compute the possible types for an expression
     (`get_possible_types_from_node`)
  2. check that there is only one possible type
     (`get_exact_type_from_node`)
  3. compute the expr info for an expression (`get_expr_info`)

this made its duties and guarantees hard to reason about.
`get_common_types` was similarly overloaded: it fetched the types of the
nodes, combined them, and filtered the result.

this commit splits these responsibilities into focused pieces:

  - `_TypeSynthesizer` (a `VyperNodeVisitorBase`) computes the possible
    types
  - `get_exact_type_from_node` checks there is only one possible type
  - `_get_expr_info_helper` computes the expr info, and `get_expr_info`
    memoizes it
  - `supremum` combines types together
  - `get_common_types` filters the result of taking the supremum of the
    possible types of each node

this commit additionally simplifies the corresponding caches. it also
uniformizes the different "should we allow type exprs" parameters under
a single name: `allow_type_exprs`. finally, it adds the ability for
`VyperNodeVisitorBase`'s `visit` to return a value.
```
### Description for the changelog

(refactor, no user-facing changelog)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
