### PR TITLE
fix[venom]: fix tuple unpack of single-word complex types

### DIFF
--- a/tests/functional/codegen/calling_convention/test_return.py
+++ b/tests/functional/codegen/calling_convention/test_return.py
@@ -138,6 +138,70 @@ def test() -> (int128, address, Bytes[10]):
     assert c.out_literals() == c.test() == (1, ZERO_ADDRESS, b"random")
 
 
+def test_return_tuple_assign_single_member_struct(get_contract):
+    code = """
+struct S:
+    a: uint256
+
+@internal
+def _foo() -> (S, uint256):
+    return S(a=42), 1
+
+@external
+def test() -> (uint256, uint256):
+    s: S = S(a=0)
+    b: uint256 = 0
+    s, b = self._foo()
+    return s.a, b
+    """
+
+    c = get_contract(code)
+
+    assert c.test() == (42, 1)
+
+
+def test_return_tuple_assign_single_element_array(get_contract):
+    code = """
+@internal
+def _foo() -> (uint256[1], uint256):
+    return [42], 1
+
+@external
+def test() -> (uint256, uint256):
+    a: uint256[1] = [0]
+    b: uint256 = 0
+    a, b = self._foo()
+    return a[0], b
+    """
+
+    c = get_contract(code)
+
+    assert c.test() == (42, 1)
+
+
+def test_return_tuple_assign_two_member_struct(get_contract):
+    code = """
+struct S:
+    a: uint256
+    b: uint256
+
+@internal
+def _foo() -> (S, uint256):
+    return S(a=42, b=43), 1
+
+@external
+def test() -> (uint256, uint256, uint256):
+    s: S = S(a=0, b=0)
+    c: uint256 = 0
+    s, c = self._foo()
+    return s.a, s.b, c
+    """
+
+    c = get_contract(code)
+
+    assert c.test() == (42, 43, 1)
+
+
 def test_return_tuple_assign_storage(get_contract):
     code = """
 a: int128

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -348,11 +348,11 @@ class VenomCodegenContext:
     def load_memory(self, ptr: IROperand, typ: VyperType) -> IROperand:
         """Load value from memory pointer.
 
-        For primitive types (<=32 bytes), returns the loaded value.
-        For complex types (>32 bytes), returns the pointer itself
-        since caller will work with the pointer.
+        For primitive word types, returns the loaded value.
+        For complex types (including single-word structs and arrays),
+        returns the pointer itself since caller will work with the pointer.
         """
-        if typ.memory_bytes_required <= 32:
+        if typ._is_prim_word:
             assert isinstance(ptr, IRVariable)
             return self.builder.mload(ptr)
         else:


### PR DESCRIPTION
### What I did

Fix a miscompile in the experimental (venom) codegen pipeline: unpacking
a tuple whose element is a complex type that fits in one word — a
single-member struct or `uint256[1]` — from an internal call returned
garbage instead of the stored value. The legacy pipeline is unaffected.

### How I did it

Single-point fix in `load_memory` (`vyper/codegen_venom/context.py`):
discriminate value-vs-pointer on `_is_prim_word` instead of
`memory_bytes_required <= 32`, matching the convention its consumer and
`store_memory` already use. Regression tests added first and shown
failing (both variants returned `0x100000000000000000000`, the memory
word at the wrongly dereferenced address).

### How to verify it

```bash
pytest tests/functional/codegen/calling_convention/test_return.py \
  -k "single_member_struct or single_element_array or two_member_struct" \
  --experimental-codegen -n0 -q
```

Fails on master (2 failed, 1 passed control), passes with this PR; passes
on both with the flag omitted (legacy pipeline was always correct).

### Commit message

```
in the venom frontend codegen, `load_memory` decided whether to return
a loaded value or a pointer based on `memory_bytes_required <= 32`,
while its only consumer, `_lower_tuple_unpack`, distinguishes the two
cases by `_is_prim_word`. for complex types that fit in one word (a
single-member struct, `uint256[1]`) the two predicates disagree:
`load_memory` returned the mloaded *value*, which the unpack path then
used as a *source pointer* for the element copy, copying from a garbage
address.

change `load_memory` to discriminate on `_is_prim_word`, matching the
convention already documented and used by `store_memory` (single-word
structs are handled as pointers). only the experimental codegen
pipeline is affected.
```

### Description for the changelog

Fix miscompilation of tuple unpacking with single-word struct or
single-element array elements under the experimental codegen pipeline.

### Cute Animal Picture

![]()