### PR TITLE
fix[venom]: ctor return empty deploy fixes #5048

### DIFF
--- a/tests/functional/codegen/features/test_constructor.py
+++ b/tests/functional/codegen/features/test_constructor.py
@@ -302,6 +302,104 @@ def __init__():
     assert c.I_BYTES32() == bytes.fromhex(CONST_BYTES32.removeprefix("0x"))
 
 
+def test_constructor_ending_with_return(env, get_contract):
+    code = """
+VALUE: public(immutable(uint256))
+
+x: public(uint256)
+
+@deploy
+def __init__():
+    self.VALUE = 42
+    self.x = 1
+    return
+    """
+    c = get_contract(code)
+    assert len(env.get_code(c.address)) > 0
+    assert c.VALUE() == 42
+    assert c.x() == 1
+
+
+@pytest.mark.parametrize("a,expected_x", [(42, 42), (1, 999)])
+def test_constructor_conditional_return(env, get_contract, a, expected_x):
+    code = """
+x: public(uint256)
+
+@deploy
+def __init__(a: uint256):
+    self.x = a
+    if a > 10:
+        return
+    self.x = 999
+    """
+    c = get_contract(code, a)
+    assert len(env.get_code(c.address)) > 0
+    assert c.x() == expected_x
+
+
+@pytest.mark.parametrize("a,expected_x", [(0, 5), (1, 1), (2, 2)])
+def test_constructor_nested_return(env, get_contract, a, expected_x):
+    code = """
+x: public(uint256)
+
+@deploy
+def __init__(a: uint256):
+    if a > 0:
+        self.x = a
+        if a > 1:
+            return
+        return
+    self.x = 5
+    """
+    c = get_contract(code, a)
+    assert len(env.get_code(c.address)) > 0
+    assert c.x() == expected_x
+
+
+@pytest.mark.parametrize("a", [0, 3, 9])
+def test_constructor_return_in_loop(env, get_contract, a):
+    code = """
+V: public(immutable(uint256))
+
+total: public(uint256)
+
+@deploy
+def __init__(a: uint256):
+    self.V = a * 7
+    for i: uint256 in range(5):
+        if i == a:
+            return
+        self.total += i
+    """
+    c = get_contract(code, a)
+    assert len(env.get_code(c.address)) > 0
+    assert c.V() == a * 7
+    assert c.total() == sum(range(min(a, 5)))
+
+
+@pytest.mark.parametrize("a,expected_counter", [(42, 0), (1, 999)])
+def test_constructor_conditional_return_with_immutables(env, get_contract, a, expected_counter):
+    code = """
+VALUE: public(immutable(uint256))
+NAME: public(immutable(String[8]))
+
+counter: public(uint256)
+
+@deploy
+def __init__(a: uint256):
+    self.NAME = "vyper"
+    self.VALUE = a
+    if a > 10:
+        return
+    self.counter = 999
+    """
+    c = get_contract(code, a)
+    assert len(env.get_code(c.address)) > 0
+    assert c.VALUE() == a
+    assert c.NAME() == "vyper"
+    assert c.counter() == expected_counter
+
+
 @pytest.mark.parametrize("should_fail", [True, False])
 def test_constructor_payability(env, get_contract, tx_failed, should_fail):
     code = f"""

--- a/tests/unit/compiler/venom/test_simplify_cfg.py
+++ b/tests/unit/compiler/venom/test_simplify_cfg.py
@@ -276,7 +276,7 @@ def test_merge_jump_dedup_phi_when_direct_edge():
 
     entry:
         %x = source
-        jnz %cond, @join, @join
+        jmp @join
 
     other:
         %o = source
@@ -317,6 +317,36 @@ def test_merge_jump_conflicting_phi_operands():
     """
 
     _check_no_change(pre, hevm=False)
+
+
+def test_merge_jump_converging_arms():
+    """
+    Regression test: bypassing both arms of a `jnz` can make them converge on
+    the same block; the branch must become a `jmp` so that it does not end up
+    with a single cfg successor.
+    """
+    pre = """
+    _global:
+        %cond = source
+        jnz %cond, @then, @else
+
+    then:
+        jmp @join
+
+    else:
+        jmp @join
+
+    join:
+        sink %cond
+    """
+
+    post = """
+    _global:
+        %cond = source
+        sink %cond
+    """
+
+    _check_pre_post(pre, post)
 
 
 def test_data_section_label_chain():

--- a/tests/unit/compiler/venom/test_simplify_cfg.py
+++ b/tests/unit/compiler/venom/test_simplify_cfg.py
@@ -247,6 +247,9 @@ def test_merge_jump_target_has_no_phi():
 def test_merge_jump_dedup_phi_when_direct_edge():
     """
     If the bypassed block's target is already a successor, avoid duplicating phi labels.
+    Both arms of `entry`'s `jnz` then converge on `@join`, so it must be
+    canonicalized to a `jmp` - a `jnz` with a single cfg successor breaks
+    consumers like `BranchOptimizationPass`.
     """
     pre = """
     _global:
@@ -317,36 +320,6 @@ def test_merge_jump_conflicting_phi_operands():
     """
 
     _check_no_change(pre, hevm=False)
-
-
-def test_merge_jump_converging_arms():
-    """
-    Regression test: bypassing both arms of a `jnz` can make them converge on
-    the same block; the branch must become a `jmp` so that it does not end up
-    with a single cfg successor.
-    """
-    pre = """
-    _global:
-        %cond = source
-        jnz %cond, @then, @else
-
-    then:
-        jmp @join
-
-    else:
-        jmp @join
-
-    join:
-        sink %cond
-    """
-
-    post = """
-    _global:
-        %cond = source
-        sink %cond
-    """
-
-    _check_pre_post(pre, post)
 
 
 def test_data_section_label_chain():

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -84,6 +84,10 @@ class VenomCodegenContext:
     # Return handling
     return_buffer: Optional[IRVariable] = None
     return_pc: Optional[IRVariable] = None  # For internal function returns
+    # Exit block of `__init__` itself (not of internal functions inlined into
+    # the deploy code, which return normally). Set only while lowering the
+    # constructor body; `return` jumps here instead of halting.
+    ctor_exit_label: Optional[IRLabel] = None
 
     # Loop variable tracking (prevents assignment to loop variables)
     forvars: dict[str, bool] = field(default_factory=dict)

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -1383,18 +1383,28 @@ def _generate_constructor(
     # Nonreentrant lock
     codegen_ctx.emit_nonreentrant_lock(func_t)
 
+    # Single exit block, so that the deploy epilogue is the constructor's only
+    # terminator (cf. legacy codegen, where the `deploy` fragment positionally
+    # follows the ctor exit sequence). `return` in the body jumps here; halting
+    # instead would deploy a contract with empty runtime code.
+    exit_block = builder.create_block("ctor_exit")
+    codegen_ctx.ctor_exit_label = exit_block.label
+
     # Constructor body
     for stmt in func_ast.body:
         Stmt(stmt, codegen_ctx).lower()
 
-    # Unlock
     if not builder.is_terminated():
-        codegen_ctx.emit_nonreentrant_unlock(func_t)
+        builder.jmp(exit_block.label)
 
-        # Deploy epilogue: copy runtime code to memory and return
-        _emit_deploy_epilogue(
-            builder, runtime_codesize, immutables_len, codegen_ctx.immutables_alloca
-        )
+    builder.append_block(exit_block)
+    builder.set_block(exit_block)
+
+    # Unlock
+    codegen_ctx.emit_nonreentrant_unlock(func_t)
+
+    # Deploy epilogue: copy runtime code to memory and return
+    _emit_deploy_epilogue(builder, runtime_codesize, immutables_len, codegen_ctx.immutables_alloca)
 
 
 def _register_constructor_args(ctx: VenomCodegenContext, func_t: ContractFunctionT) -> None:

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -860,11 +860,27 @@ class Stmt:
             ret_val = self.ctx.unwrap(ret_vv)
             ret_src_typ = ret_vv.typ
 
-        # Dispatch: internal vs external
+        # Dispatch: internal vs constructor vs external
         if self.ctx.return_pc is not None:
             self._lower_internal_return(ret_val, func_t, ret_src_typ)
+        elif self.ctx.ctor_exit_label is not None:
+            self._lower_ctor_return(ret_val)
         else:
             self._lower_external_return(ret_val, func_t, ret_src_typ)
+
+    def _lower_ctor_return(self, ret_val: Optional[IROperand]) -> None:
+        """Lower `return` in `@deploy def __init__`.
+
+        The constructor must not halt on its own: the deploy epilogue (which
+        returns the runtime code and immutables) is its only valid terminator.
+        Halting here would create an account with empty code, so jump to the
+        single exit block which emits the epilogue instead.
+        """
+        # `__init__` cannot declare a return type, so it never returns a value
+        assert ret_val is None  # guaranteed by semantic analysis
+        exit_label = self.ctx.ctor_exit_label
+        assert exit_label is not None
+        self.builder.jmp(exit_label)
 
     def _lower_internal_return(
         self, ret_val: Optional[IROperand], func_t: ContractFunctionT, ret_src_typ=None

--- a/vyper/venom/passes/simplify_cfg.py
+++ b/vyper/venom/passes/simplify_cfg.py
@@ -50,6 +50,13 @@ class SimplifyCFGPass(IRPass):
         assert b.label in jump_inst.operands, f"{b.label} {jump_inst.operands}"
         jump_inst.operands[jump_inst.operands.index(b.label)] = next_bb.label
 
+        # Bypassing the jump can make both arms of a `jnz` converge on the same
+        # block. Canonicalize to `jmp`, otherwise consumers which expect a `jnz`
+        # to have two successors (e.g. BranchOptimizationPass) see only one.
+        if jump_inst.opcode == "jnz" and jump_inst.operands[1] == jump_inst.operands[2]:
+            jump_inst.opcode = "jmp"
+            jump_inst.operands = [jump_inst.operands[1]]
+
         self._schedule_label_replacement(b.label, next_bb.label)
 
         # Update CFG


### PR DESCRIPTION
### What I did

Fixes two bugs, one exposed by the other.

1. A contract compiled through the venom pipeline whose `__init__` contains a reachable `return` deploys with **empty runtime code**. The `return` lowered to a `stop`, halting the deploy code before the epilogue that returns the runtime bytecode.

2. `SimplifyCFGPass` could leave behind a `jnz` whose two arms point at the same block, which then crashes `BranchOptimizationPass`.

Both are venom-pipeline only; legacy codegen is unaffected.

```vyper
x: public(uint256)

@deploy
def __init__():
    self.x = 1
    return   # <- account deployed with no code
```

### How I did it

The constructor now gets a dedicated exit block which holds the nonreentrant unlock and the deploy epilogue. `return` inside `__init__` is dispatched to a new `_lower_ctor_return` (a third case alongside internal/external return, keyed on `ctx.ctor_exit_label`) which jumps to that block instead of halting. This makes the deploy epilogue the constructor's only terminator by construction, rather than only when the body happens to fall through — mirroring legacy codegen, where the `deploy` fragment positionally follows the ctor body.

That change made a previously unreachable CFG shape reachable: `if cond: return` in a constructor produces two arms that both end up jumping to the ctor exit. When `SimplifyCFGPass` bypasses the now-empty arm blocks, it rewrites the `jnz` operands to the same label, and `BranchOptimizationPass` — which unpacks `cfg_out(bb)` into exactly two successors — raises on it. The `jnz` is now canonicalized to a `jmp` in the same rewrite that creates the degeneracy.

### How to verify it

### Commit message

```
in the venom pipeline, `return` inside `@deploy def __init__()` was
lowered through the same path as an external function return, which for
a void return emits `stop`. halting the deploy code returns zero bytes
of runtime code, so any constructor with a reachable `return` deployed
an account with empty code. legacy codegen cannot hit this: there the
`deploy` fragment positionally follows the constructor body, so exiting
the body falls through into it.

give the constructor a single exit block holding the nonreentrant unlock
and the deploy epilogue, and lower `return` in `__init__` as a jump to
it. the epilogue is then the constructor's only terminator by
construction, instead of only when the body happens to end in
fallthrough.

this exposed a latent bug in `SimplifyCFGPass`. when it bypasses an
empty block by rewriting a predecessor's jump target, both arms of a
`jnz` can end up pointing at the same block - an `if` whose body is a
bare `return` now leaves both arms converging on the ctor exit.
`BranchOptimizationPass` unpacks `cfg_out(bb)` into exactly two
successors and blew up on such a branch. canonicalize the degenerate
`jnz` to a `jmp` as part of the same rewrite.
```

### Description for the changelog

Fix a venom codegen bug where a `return` in the constructor deployed a contract with empty runtime code.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
