### PR TITLE
fix[venom]: support `O1` minimal passes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ xfail_strict = true
 markers = [
     "fuzzing: Run Hypothesis fuzz test suite (deselect with '-m \"not fuzzing\"')",
     "requires_evm_version(version): Mark tests that require at least a specific EVM version and would throw EvmVersionException otherwise",
+    "requires_optimization(what): Mark tests whose expectation is produced by an optimization, so they cannot hold at the minimal levels (--optimize O1/none)",
     "venom_xfail: mark a test case as a regression (expected to fail) under the venom pipeline",
     "hevm: run tests marked for symbolic execution",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ xfail_strict = true
 markers = [
     "fuzzing: Run Hypothesis fuzz test suite (deselect with '-m \"not fuzzing\"')",
     "requires_evm_version(version): Mark tests that require at least a specific EVM version and would throw EvmVersionException otherwise",
-    "requires_optimization(what): Mark tests whose expectation is produced by an optimization, so they cannot hold at the minimal levels (--optimize O1/none)",
+    "skip_at_optimization(*levels, reason): Skip a test at the specified OptimizationLevel values",
     "venom_xfail: mark a test case as a regression (expected to fail) under the venom pipeline",
     "hevm: run tests marked for symbolic execution",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,6 +404,15 @@ def pytest_fixture_setup(fixturedef: pytest.FixtureDef, request):
     exporter.finalize_item(fixturedef)
 
 
+def pytest_runtest_setup(item):
+    marker = item.get_closest_marker("requires_optimization")
+    if marker:
+        assert len(marker.args) == 1
+        level = OptimizationLevel.from_string(item.config.getoption("optimize"))
+        if level.is_minimal():
+            pytest.skip(f"requires {marker.args[0]}, which does not run at --optimize {level}")
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item) -> Generator:
     marker = item.get_closest_marker("requires_evm_version")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,12 +405,19 @@ def pytest_fixture_setup(fixturedef: pytest.FixtureDef, request):
 
 
 def pytest_runtest_setup(item):
-    marker = item.get_closest_marker("requires_optimization")
-    if marker:
-        assert len(marker.args) == 1
-        level = OptimizationLevel.from_string(item.config.getoption("optimize"))
-        if level.is_minimal():
-            pytest.skip(f"requires {marker.args[0]}, which does not run at --optimize {level}")
+    marker = item.get_closest_marker("skip_at_optimization")
+    if marker is None:
+        return
+
+    assert marker.args, "skip_at_optimization requires at least one optimization level"
+    assert all(isinstance(level, OptimizationLevel) for level in marker.args)
+    assert set(marker.kwargs) == {"reason"}
+    reason = marker.kwargs["reason"]
+    assert isinstance(reason, str) and reason
+
+    level = OptimizationLevel.from_string(item.config.getoption("optimize"))
+    if level in marker.args:
+        pytest.skip(f"{reason}; skipped at --optimize {level}")
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,7 @@ def env(gas_limit, evm_version, evm_backend, tracing, account_keys, exporter) ->
 def get_contract_from_ir(env, optimize):
     def ir_compiler(ir, *args, **kwargs):
         ir = IRnode.from_list(ir)
-        if kwargs.pop("optimize", optimize) != OptimizationLevel.NONE:
+        if not kwargs.pop("optimize", optimize).uses_lowering_only_ir():
             ir = optimizer.optimize(ir)
 
         assembly = compile_ir.compile_to_assembly(ir, optimize=optimize)

--- a/tests/functional/codegen/calling_convention/test_internal_call.py
+++ b/tests/functional/codegen/calling_convention/test_internal_call.py
@@ -6,6 +6,7 @@ from hypothesis import given, settings
 
 from tests.utils import decimal_to_int
 from vyper.compiler import compile_code
+from vyper.compiler.settings import OptimizationLevel, Settings
 from vyper.exceptions import ArgumentException, CallViolation
 
 
@@ -49,6 +50,30 @@ def return_hash_of_rzpadded_cow() -> bytes32:
     assert c.return_hash_of_rzpadded_cow() == keccak(b"cow" + b"\x00" * 29)
 
     print("Passed single fixed-size argument self-call test")
+
+
+@pytest.mark.parametrize("opt_level", [OptimizationLevel.NONE, OptimizationLevel.O1])
+def test_internal_call_many_word_arguments_do_not_alias_spills(
+    get_contract, compiler_settings, opt_level
+):
+    params = ", ".join(f"a{i}: uint256" for i in range(16))
+    total = " + ".join(f"a{i}" for i in range(16))
+    code = f"""
+@internal
+def sum_words({params}) -> uint256:
+    return {total}
+
+@external
+def foo({params}) -> uint256:
+    return self.sum_words({", ".join(f"a{i}" for i in range(16))})
+    """
+
+    test_settings = Settings(
+        **dict(compiler_settings.__dict__, experimental_codegen=True, optimize=opt_level)
+    )
+    c = get_contract(code, compiler_settings=test_settings)
+    values = tuple(range(16))
+    assert c.foo(*values) == sum(values)
 
 
 # test that side-effecting self calls do not get optimized out

--- a/tests/functional/codegen/features/iteration/test_for_range.py
+++ b/tests/functional/codegen/features/iteration/test_for_range.py
@@ -1,5 +1,6 @@
 import pytest
 
+from vyper.compiler.settings import OptimizationLevel
 from vyper.exceptions import StaticAssertionException
 from vyper.utils import SizeLimits
 
@@ -273,7 +274,11 @@ def test():
     c.test()
 
 
-@pytest.mark.requires_optimization("constant folding")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the expected compile-time failure depends on constant folding",
+)
 @pytest.mark.parametrize("typ", ["uint8", "int128", "uint256"])
 def test_for_range_oob_compile_time_check(get_contract, tx_failed, typ, experimental_codegen):
     code = f"""
@@ -457,7 +462,11 @@ def foo(_min:int256, _max: int256) -> DynArray[int256, 10]:
         c.foo(SizeLimits.MIN_INT256, SizeLimits.MAX_INT256)
 
 
-@pytest.mark.requires_optimization("constant folding")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the expected compile-time failure depends on constant folding",
+)
 def test_for_range_signed_int_overflow_compile_time_check(
     get_contract, tx_failed, experimental_codegen
 ):

--- a/tests/functional/codegen/features/iteration/test_for_range.py
+++ b/tests/functional/codegen/features/iteration/test_for_range.py
@@ -273,6 +273,7 @@ def test():
     c.test()
 
 
+@pytest.mark.requires_optimization("constant folding")
 @pytest.mark.parametrize("typ", ["uint8", "int128", "uint256"])
 def test_for_range_oob_compile_time_check(get_contract, tx_failed, typ, experimental_codegen):
     code = f"""
@@ -456,6 +457,7 @@ def foo(_min:int256, _max: int256) -> DynArray[int256, 10]:
         c.foo(SizeLimits.MIN_INT256, SizeLimits.MAX_INT256)
 
 
+@pytest.mark.requires_optimization("constant folding")
 def test_for_range_signed_int_overflow_compile_time_check(
     get_contract, tx_failed, experimental_codegen
 ):

--- a/tests/functional/codegen/types/numbers/test_signed_ints.py
+++ b/tests/functional/codegen/types/numbers/test_signed_ints.py
@@ -5,6 +5,7 @@ import random
 import pytest
 
 from vyper import compile_code
+from vyper.compiler.settings import OptimizationLevel
 from vyper.exceptions import (
     InvalidOperation,
     OverflowException,
@@ -88,7 +89,11 @@ def bar(negative:int16) -> int16:
         c.bar(-2)
 
 
-@pytest.mark.requires_optimization("constant folding")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the expected compile-time failure depends on constant folding",
+)
 @pytest.mark.parametrize("base", (0, 1))
 def test_exponent_negative_power_compile_time_check(
     get_contract, tx_failed, base, experimental_codegen

--- a/tests/functional/codegen/types/numbers/test_signed_ints.py
+++ b/tests/functional/codegen/types/numbers/test_signed_ints.py
@@ -88,6 +88,7 @@ def bar(negative:int16) -> int16:
         c.bar(-2)
 
 
+@pytest.mark.requires_optimization("constant folding")
 @pytest.mark.parametrize("base", (0, 1))
 def test_exponent_negative_power_compile_time_check(
     get_contract, tx_failed, base, experimental_codegen

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -739,6 +739,7 @@ def test_array_decimal_return3() -> DynArray[DynArray[decimal, 2], 2]:
     ]
 
 
+@pytest.mark.requires_optimization("code size reduction")
 def test_mult_list(get_contract):
     code = """
 nest3: DynArray[DynArray[DynArray[uint256, 2], 2], 2]

--- a/tests/functional/codegen/types/test_dynamic_array.py
+++ b/tests/functional/codegen/types/test_dynamic_array.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.utils import check_precompile_asserts, decimal_to_int
 from vyper.compiler import compile_code
+from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import (
     ArgumentException,
@@ -739,7 +740,11 @@ def test_array_decimal_return3() -> DynArray[DynArray[decimal, 2], 2]:
     ]
 
 
-@pytest.mark.requires_optimization("code size reduction")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the test contract depends on optimizer code-size reduction",
+)
 def test_mult_list(get_contract):
     code = """
 nest3: DynArray[DynArray[DynArray[uint256, 2], 2], 2]

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -844,7 +844,11 @@ def foo() -> {return_type}:
     assert_compile_failed(lambda: get_contract(code), TypeMismatch)
 
 
-@pytest.mark.requires_optimization("code size reduction")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the test contract depends on optimizer code-size reduction",
+)
 def test_array_copy_oog(env, get_contract, tx_failed, optimize, experimental_codegen, request):
     # GHSA-vgf2-gvx8-xwc3
     code = """
@@ -882,7 +886,11 @@ def foo(x: uint256[3000]) -> uint256:
         c.foo(array, gas=gas_used)
 
 
-@pytest.mark.requires_optimization("code size reduction")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the test contract depends on optimizer code-size reduction",
+)
 def test_array_copy_oog2(env, get_contract, tx_failed, optimize, experimental_codegen, request):
     # GHSA-vgf2-gvx8-xwc3
     code = """

--- a/tests/functional/codegen/types/test_lists.py
+++ b/tests/functional/codegen/types/test_lists.py
@@ -844,6 +844,7 @@ def foo() -> {return_type}:
     assert_compile_failed(lambda: get_contract(code), TypeMismatch)
 
 
+@pytest.mark.requires_optimization("code size reduction")
 def test_array_copy_oog(env, get_contract, tx_failed, optimize, experimental_codegen, request):
     # GHSA-vgf2-gvx8-xwc3
     code = """
@@ -881,6 +882,7 @@ def foo(x: uint256[3000]) -> uint256:
         c.foo(array, gas=gas_used)
 
 
+@pytest.mark.requires_optimization("code size reduction")
 def test_array_copy_oog2(env, get_contract, tx_failed, optimize, experimental_codegen, request):
     # GHSA-vgf2-gvx8-xwc3
     code = """

--- a/tests/functional/syntax/test_self_balance.py
+++ b/tests/functional/syntax/test_self_balance.py
@@ -1,9 +1,14 @@
 import pytest
 
 from vyper import compiler
+from vyper.compiler.settings import OptimizationLevel
 
 
-@pytest.mark.requires_optimization("the selfbalance peephole rewrite")
+@pytest.mark.skip_at_optimization(
+    OptimizationLevel.O1,
+    OptimizationLevel.NONE,
+    reason="the expected SELFBALANCE opcode depends on the peephole rewrite",
+)
 def test_self_balance(env, get_contract):
     code = """
 @external

--- a/tests/functional/syntax/test_self_balance.py
+++ b/tests/functional/syntax/test_self_balance.py
@@ -1,6 +1,9 @@
+import pytest
+
 from vyper import compiler
 
 
+@pytest.mark.requires_optimization("the selfbalance peephole rewrite")
 def test_self_balance(env, get_contract):
     code = """
 @external

--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.venom_utils import assert_bb_eq, assert_ctx_eq
 from vyper.venom.basicblock import IRBasicBlock, IRLabel, IRLiteral, IRVariable
 from vyper.venom.context import DataItem, DataSection, IRContext
@@ -424,3 +426,62 @@ def test_noinline_annotation():
 
     # printer/parser round trip preserves the flag
     assert_ctx_eq(parsed_ctx, parse_venom(str(parsed_ctx)))
+
+
+def test_eom_annotation():
+    # `eom` is the end of a function's static frame. Once allocas have been
+    # concretized it is not recoverable from the instruction stream, but the
+    # backend needs it to place spill slots above the frame, so it has to
+    # survive the text-format round trip.
+    source = """
+    function main [eom=13024] {
+        main:
+            stop
+    }
+
+    function f [fmp_lowered, eom=160] {
+        f:
+            stop
+    }
+
+    function g {
+        g:
+            stop
+    }
+    """
+
+    parsed_ctx = parse_venom(source)
+
+    fn_eom = parsed_ctx.mem_allocator.fn_eom
+    assert fn_eom[parsed_ctx.get_function(IRLabel("main"))] == 13024
+    assert fn_eom[parsed_ctx.get_function(IRLabel("f"))] == 160
+    # a function without the annotation must not get an entry -- a default of 0
+    # would silently place spill slots at the bottom of memory
+    assert parsed_ctx.get_function(IRLabel("g")) not in fn_eom
+
+    # printer/parser round trip preserves the value
+    reparsed = parse_venom(str(parsed_ctx))
+    assert_ctx_eq(parsed_ctx, reparsed)
+    assert reparsed.mem_allocator.fn_eom[reparsed.get_function(IRLabel("main"))] == 13024
+
+
+@pytest.mark.parametrize(
+    "annotation, expected_error",
+    [
+        ("[eom]", "requires a value"),
+        ("[noinline=1]", "takes no value"),
+        ("[eom=1, eom=2]", "duplicate function annotation"),
+        ("[bogus]", "unknown function annotation"),
+        ("[eom=-32]", "negative `eom` annotation"),
+    ],
+)
+def test_invalid_annotations(annotation, expected_error):
+    source = f"""
+    function main {annotation} {{
+        main:
+            stop
+    }}
+    """
+
+    with pytest.raises(ValueError, match=expected_error):
+        parse_venom(source)

--- a/tests/functional/venom/parser/test_parsing.py
+++ b/tests/functional/venom/parser/test_parsing.py
@@ -434,7 +434,7 @@ def test_eom_annotation():
     # backend needs it to place spill slots above the frame, so it has to
     # survive the text-format round trip.
     source = """
-    function main [eom=13024] {
+    function main [fmp_lowered, eom=13024] {
         main:
             stop
     }
@@ -473,6 +473,7 @@ def test_eom_annotation():
         ("[eom=1, eom=2]", "duplicate function annotation"),
         ("[bogus]", "unknown function annotation"),
         ("[eom=-32]", "negative `eom` annotation"),
+        ("[eom=64]", "`eom` requires `fmp_lowered`"),
     ],
 )
 def test_invalid_annotations(annotation, expected_error):

--- a/tests/unit/compiler/test_default_settings.py
+++ b/tests/unit/compiler/test_default_settings.py
@@ -17,17 +17,16 @@ def test_default_opt_level():
 
 def test_codegen_opt_level(optimize):
     gas_levels = (OptimizationLevel.GAS, OptimizationLevel.O2, OptimizationLevel.O3)
-    none_levels = (OptimizationLevel.NONE, OptimizationLevel.O1)
+    lowering_only_levels = (OptimizationLevel.NONE, OptimizationLevel.O1)
     codesize_levels = (OptimizationLevel.CODESIZE, OptimizationLevel.Os)
 
     assert core._opt_gas() == (optimize in gas_levels)
-    assert core._opt_none() == (optimize in none_levels)
+    assert core._opt_lowering_only_ir() == (optimize in lowering_only_levels)
     assert core._opt_codesize() == (optimize in codesize_levels)
 
     # the three must partition OptimizationLevel: codegen dispatches on them
-    # with `if/elif/else: assert _opt_none()`, so a level matching none of
-    # them is a CodegenPanic rather than a mis-optimization.
-    assert sum([core._opt_gas(), core._opt_none(), core._opt_codesize()]) == 1
+    # exhaustively, so a new level cannot silently select the wrong shape.
+    assert sum([core._opt_gas(), core._opt_lowering_only_ir(), core._opt_codesize()]) == 1
 
 
 def test_debug_mode(pytestconfig):

--- a/tests/unit/compiler/test_default_settings.py
+++ b/tests/unit/compiler/test_default_settings.py
@@ -16,9 +16,18 @@ def test_default_opt_level():
 
 
 def test_codegen_opt_level(optimize):
-    assert core._opt_gas() == (optimize in (OptimizationLevel.GAS, OptimizationLevel.O3))
-    assert core._opt_none() == (optimize == OptimizationLevel.NONE)
-    assert core._opt_codesize() == (optimize == OptimizationLevel.CODESIZE)
+    gas_levels = (OptimizationLevel.GAS, OptimizationLevel.O2, OptimizationLevel.O3)
+    none_levels = (OptimizationLevel.NONE, OptimizationLevel.O1)
+    codesize_levels = (OptimizationLevel.CODESIZE, OptimizationLevel.Os)
+
+    assert core._opt_gas() == (optimize in gas_levels)
+    assert core._opt_none() == (optimize in none_levels)
+    assert core._opt_codesize() == (optimize in codesize_levels)
+
+    # the three must partition OptimizationLevel: codegen dispatches on them
+    # with `if/elif/else: assert _opt_none()`, so a level matching none of
+    # them is a CodegenPanic rather than a mis-optimization.
+    assert sum([core._opt_gas(), core._opt_none(), core._opt_codesize()]) == 1
 
 
 def test_debug_mode(pytestconfig):

--- a/tests/unit/compiler/test_source_map.py
+++ b/tests/unit/compiler/test_source_map.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 from vyper.compiler import compile_code
 from vyper.compiler.output import _compress_source_map
+from vyper.compiler.settings import OptimizationLevel
 from vyper.compiler.utils import expand_source_map
 
 TEST_CODE = """
@@ -37,23 +38,16 @@ def test_jump_map(optimize, experimental_codegen):
     pos_map = source_map["pc_pos_map"]
     jump_map = source_map["pc_jump_map"]
 
-    if optimize.is_minimal():
-        # some jumps which don't get optimized out when optimizer is off
-        # (slightly different behavior depending if venom pipeline is enabled):
-        if experimental_codegen:
-            expected_jumps = 0
-            # the internal call survives because inlining is off at these levels
-            expected_internals = 2
-        else:
-            expected_jumps = 3
-            expected_internals = 2
+    if experimental_codegen:
+        expected_jumps = 0
+        # Internal calls survive in the lowering-only IR pipelines because
+        # inlining is off. Assembly optimization at O1 does not change that.
+        expected_internals = 2 if optimize.uses_lowering_only_ir() else 0
     else:
-        if experimental_codegen:
-            expected_jumps = 0
-            expected_internals = 0
-        else:
-            expected_jumps = 1
-            expected_internals = 2
+        # Only NONE disables the legacy assembly optimizer. O1 uses the same
+        # lowering-only IR pipeline but still receives assembly peepholes.
+        expected_jumps = 3 if optimize == OptimizationLevel.NONE else 1
+        expected_internals = 2
 
     assert len([v for v in jump_map.values() if v == "o"]) == expected_jumps
     assert len([v for v in jump_map.values() if v == "i"]) == expected_internals
@@ -61,7 +55,7 @@ def test_jump_map(optimize, experimental_codegen):
     code_lines = [i + "\n" for i in TEST_CODE.split("\n")]
     for pc in [k for k, v in jump_map.items() if v == "o"]:
         if pc not in pos_map:
-            assert optimize.is_minimal()
+            assert optimize.uses_lowering_only_ir()
             continue  # some jump is not being optimized out
 
         lineno, col_offset, _, end_col_offset = pos_map[pc]
@@ -69,7 +63,7 @@ def test_jump_map(optimize, experimental_codegen):
 
     for pc in [k for k, v in jump_map.items() if v == "i"]:
         if pc not in pos_map:
-            assert optimize.is_minimal()
+            assert optimize.uses_lowering_only_ir()
             continue  # some jump is not being optimized out
         lineno, col_offset, _, end_col_offset = pos_map[pc]
         assert code_lines[lineno - 1][col_offset:end_col_offset].startswith("self.")

--- a/tests/unit/compiler/test_source_map.py
+++ b/tests/unit/compiler/test_source_map.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 
 from vyper.compiler import compile_code
 from vyper.compiler.output import _compress_source_map
-from vyper.compiler.settings import OptimizationLevel
 from vyper.compiler.utils import expand_source_map
 
 TEST_CODE = """
@@ -38,12 +37,13 @@ def test_jump_map(optimize, experimental_codegen):
     pos_map = source_map["pc_pos_map"]
     jump_map = source_map["pc_jump_map"]
 
-    if optimize == OptimizationLevel.NONE:
+    if optimize.is_minimal():
         # some jumps which don't get optimized out when optimizer is off
         # (slightly different behavior depending if venom pipeline is enabled):
         if experimental_codegen:
             expected_jumps = 0
-            expected_internals = 0
+            # the internal call survives because inlining is off at these levels
+            expected_internals = 2
         else:
             expected_jumps = 3
             expected_internals = 2
@@ -61,7 +61,7 @@ def test_jump_map(optimize, experimental_codegen):
     code_lines = [i + "\n" for i in TEST_CODE.split("\n")]
     for pc in [k for k, v in jump_map.items() if v == "o"]:
         if pc not in pos_map:
-            assert optimize == OptimizationLevel.NONE
+            assert optimize.is_minimal()
             continue  # some jump is not being optimized out
 
         lineno, col_offset, _, end_col_offset = pos_map[pc]
@@ -69,7 +69,7 @@ def test_jump_map(optimize, experimental_codegen):
 
     for pc in [k for k, v in jump_map.items() if v == "i"]:
         if pc not in pos_map:
-            assert optimize == OptimizationLevel.NONE
+            assert optimize.is_minimal()
             continue  # some jump is not being optimized out
         lineno, col_offset, _, end_col_offset = pos_map[pc]
         assert code_lines[lineno - 1][col_offset:end_col_offset].startswith("self.")

--- a/tests/unit/compiler/venom/test_concretize_mem.py
+++ b/tests/unit/compiler/venom/test_concretize_mem.py
@@ -1,10 +1,44 @@
+import pytest
+
 from tests.venom_utils import PrePostChecker, parse_from_basic_block
+from vyper.exceptions import CompilerPanic
 from vyper.venom.analysis import IRAnalysesCache
+from vyper.venom.parser import parse_venom
 from vyper.venom.passes import AssignElimination, ConcretizeMemLocPass, RemoveUnusedVariablesPass
 
 _check_pre_post = PrePostChecker(
     [ConcretizeMemLocPass, AssignElimination, RemoveUnusedVariablesPass], default_hevm=False
 )
+
+
+def test_fmp_lowered_function_preserves_round_tripped_eom():
+    ctx = parse_venom("""
+        function main [fmp_lowered, eom=544] {
+            main:
+                stop
+        }
+        """)
+    fn = ctx.entry_function
+    assert fn is not None
+
+    ConcretizeMemLocPass(IRAnalysesCache(fn), fn).run_pass()
+
+    assert ctx.mem_allocator.fn_eom[fn] == 544
+
+
+def test_fmp_lowered_function_rejects_remaining_alloca():
+    ctx = parse_venom("""
+        function main [fmp_lowered, eom=544] {
+            main:
+                %ptr = alloca 32
+                stop
+        }
+        """)
+    fn = ctx.entry_function
+    assert fn is not None
+
+    with pytest.raises(CompilerPanic, match="fmp_lowered but still contains alloca"):
+        ConcretizeMemLocPass(IRAnalysesCache(fn), fn).run_pass()
 
 
 def test_valid_overlap():

--- a/tests/unit/compiler/venom/test_pass_ordering.py
+++ b/tests/unit/compiler/venom/test_pass_ordering.py
@@ -3,6 +3,7 @@ import pytest
 import vyper.venom as venom
 from vyper.compiler.settings import OptimizationLevel, VenomOptimizationFlags
 from vyper.exceptions import CompilerPanic
+from vyper.venom.context import IRContext
 from vyper.venom.optimization_levels.pass_order import validate_pass_order
 from vyper.venom.passes.base_pass import IRPass
 from vyper.venom.passes.cfg_normalization import CFGNormalization
@@ -23,6 +24,30 @@ def test_builtin_optimization_pipelines_are_valid(level):
     flags = VenomOptimizationFlags(level=level)
     pipeline = venom._build_fn_pass_pipeline(flags)
     assert len(pipeline) > 0
+
+
+def test_none_has_an_independent_copy_of_the_o1_pipeline():
+    none_pipeline = venom.OPTIMIZATION_PASSES[OptimizationLevel.NONE]
+    o1_pipeline = venom.OPTIMIZATION_PASSES[OptimizationLevel.O1]
+
+    assert none_pipeline == o1_pipeline
+    assert none_pipeline is not o1_pipeline
+
+
+@pytest.mark.parametrize(
+    "level,no_optimize", [(OptimizationLevel.NONE, True), (OptimizationLevel.O1, False)]
+)
+def test_none_and_o1_have_distinct_assembly_optimization_policies(monkeypatch, level, no_optimize):
+    calls = []
+
+    def generate_evm_assembly(self, no_optimize=False):
+        calls.append(no_optimize)
+        return []
+
+    monkeypatch.setattr(venom.VenomCompiler, "generate_evm_assembly", generate_evm_assembly)
+
+    assert venom.generate_assembly_experimental(IRContext(), level) == []
+    assert calls == [no_optimize]
 
 
 def test_validate_requires_pass_before():

--- a/tests/unit/compiler/venom/test_pass_ordering.py
+++ b/tests/unit/compiler/venom/test_pass_ordering.py
@@ -206,3 +206,14 @@ def test_error_message_stops_at_instead():
     message = str(exc.value).splitlines()[0]
     assert message.endswith("instead.")
     assert "Pipeline context:" not in message
+
+
+@pytest.mark.parametrize("level", [OptimizationLevel.NONE, OptimizationLevel.O1])
+def test_disable_simplify_cfg_is_ignored_at_lowering_only_levels(level):
+    # the lowering-only pipelines contain no optional passes; in particular
+    # venom_to_assembly requires SimplifyCFGPass to have run, so the disable
+    # flag must not remove it
+    flags = VenomOptimizationFlags(level=level, disable_simplify_cfg=True)
+    pipeline = venom._build_fn_pass_pipeline(flags)
+    pass_classes = [pass_cls for pass_cls, _ in pipeline]
+    assert SimplifyCFGPass in pass_classes

--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -55,6 +55,34 @@ def test_set_current_function_clears_missing_fn_eom() -> None:
     assert compiler.spiller._next_spill_offset is None
 
 
+def test_function_spill_regions_are_disjoint_and_above_static_frames() -> None:
+    ctx = parse_venom("""
+        function first {
+            main:
+                stop
+        }
+
+        function second {
+            main:
+                stop
+        }
+        """)
+    compiler = VenomCompiler(ctx)
+    spiller = compiler.spiller
+    first, second = list(ctx.functions.values())
+
+    ctx.mem_allocator.fn_eom[first] = 64
+    ctx.mem_allocator.fn_eom[second] = 256
+    spiller.reset_for_codegen()
+
+    spiller.set_current_function(first)
+    assert spiller._next_spill_offset == 256
+    assert spiller._get_spill_slot(dry_run=False) == 256
+
+    spiller.set_current_function(second)
+    assert spiller._next_spill_offset == 288
+
+
 def test_swap_spills_deep_stack() -> None:
     compiler = VenomCompiler(IRContext())
     compiler.spiller._next_spill_offset = 0x10000  # Set up for unit test

--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -94,6 +94,32 @@ def test_function_spill_regions_are_disjoint_and_above_static_frames() -> None:
     assert spiller._next_spill_offset == 288
 
 
+def test_removed_function_does_not_inflate_spill_offsets() -> None:
+    # spill sizing takes the max over all fn_eom entries, so a stale entry
+    # left behind when an unreachable function is removed would push every
+    # live function's spill region (and the initial FMP) up to the dead
+    # frame's end.
+    ctx = parse_venom("""
+        function main [fmp_lowered, eom=64] {
+            main:
+                stop
+        }
+
+        function dead [fmp_lowered, eom=65536] {
+            dead:
+                stop
+        }
+        """)
+    run_passes_on(ctx, VenomOptimizationFlags(level=OptimizationLevel.O1))
+
+    assert [fn.name.value for fn in ctx.functions.values()] == ["main"]
+    assert set(ctx.mem_allocator.fn_eom.keys()) == set(ctx.functions.values())
+
+    compiler = VenomCompiler(ctx)
+    compiler.spiller.reset_for_codegen()
+    assert compiler.spiller._next_function_spill_offset == 64
+
+
 def test_round_tripped_eom_survives_o1_pass_rerun(env) -> None:
     params = ", ".join(f"a{i}: uint256" for i in range(16))
     args = ", ".join(f"a{i}" for i in range(16))

--- a/tests/unit/compiler/venom/test_stack_spill.py
+++ b/tests/unit/compiler/venom/test_stack_spill.py
@@ -1,6 +1,11 @@
 import pytest
 
+from vyper.compiler import compile_code
+from vyper.compiler.phases import generate_bytecode
+from vyper.compiler.settings import OptimizationLevel, Settings, VenomOptimizationFlags
 from vyper.ir.compile_ir import Label
+from vyper.utils import method_id
+from vyper.venom import generate_assembly_experimental, run_passes_on
 from vyper.venom.basicblock import IRLiteral, IROperand, IRVariable
 from vyper.venom.context import IRContext
 from vyper.venom.parser import parse_venom
@@ -26,6 +31,12 @@ def _dummy_dfg():
             return False
 
     return _DummyDFG()
+
+
+def _deploy_runtime(env, runtime_bytecode):
+    bytecode_len_hex = hex(len(runtime_bytecode))[2:].rjust(6, "0")
+    initcode = bytes.fromhex("62" + bytecode_len_hex + "3d81600b3d39f3") + runtime_bytecode
+    return env.deploy([], initcode)
 
 
 def test_set_current_function_clears_missing_fn_eom() -> None:
@@ -81,6 +92,40 @@ def test_function_spill_regions_are_disjoint_and_above_static_frames() -> None:
 
     spiller.set_current_function(second)
     assert spiller._next_spill_offset == 288
+
+
+def test_round_tripped_eom_survives_o1_pass_rerun(env) -> None:
+    params = ", ".join(f"a{i}: uint256" for i in range(16))
+    args = ", ".join(f"a{i}" for i in range(16))
+    total = " + ".join(f"a{i}" for i in range(16))
+    source = f"""
+@internal
+def sum_words({params}) -> uint256:
+    return {total}
+
+@external
+def foo({params}) -> uint256:
+    return self.sum_words({args})
+    """
+    settings = Settings(experimental_codegen=True, optimize=OptimizationLevel.O1)
+    lowered = compile_code(source, output_formats=["ir_runtime"], settings=settings)["ir_runtime"]
+    ctx = parse_venom(str(lowered))
+
+    eoms_before = {fn.name.value: eom for fn, eom in ctx.mem_allocator.fn_eom.items()}
+    run_passes_on(ctx, VenomOptimizationFlags(level=OptimizationLevel.O1))
+    eoms_after = {fn.name.value: eom for fn, eom in ctx.mem_allocator.fn_eom.items()}
+
+    assert eoms_after == eoms_before
+
+    asm = generate_assembly_experimental(ctx, optimize=OptimizationLevel.O1)
+    runtime_bytecode, _ = generate_bytecode(asm)
+    contract = _deploy_runtime(env, runtime_bytecode)
+
+    values = tuple(range(16))
+    signature = f"foo({','.join(['uint256'] * 16)})"
+    calldata = method_id(signature) + b"".join(value.to_bytes(32, "big") for value in values)
+    result = env.message_call(contract.address, data=calldata)
+    assert int.from_bytes(result, "big") == sum(values)
 
 
 def test_swap_spills_deep_stack() -> None:

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -146,8 +146,8 @@ def _parse_args(argv):
         "-O",
         "--optimize",
         help="Optimization level (defaults to 'gas'). Valid options: "
-        "1 (minimal - lowering only), 2 (gas/default), 3 (aggressive - experimental), "
-        "s (size), or legacy names: none (alias for 1), gas, codesize",
+        "1 (lowering-only IR), 2 (gas/default), 3 (aggressive - experimental), "
+        "s (size), or legacy names: none (also disables assembly optimization), gas, codesize",
         metavar="LEVEL",
         dest="optimize",
     )

--- a/vyper/cli/vyper_compile.py
+++ b/vyper/cli/vyper_compile.py
@@ -146,7 +146,7 @@ def _parse_args(argv):
         "-O",
         "--optimize",
         help="Optimization level (defaults to 'gas'). Valid options: "
-        "1 (basic), 2 (gas/default), 3 (aggressive - experimental), "
+        "1 (minimal - lowering only), 2 (gas/default), 3 (aggressive - experimental), "
         "s (size), or legacy names: none (alias for 1), gas, codesize",
         metavar="LEVEL",
         dest="optimize",

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1,6 +1,6 @@
 import vyper.codegen.context as ctx
 from vyper.codegen.ir_node import Encoding, IRnode
-from vyper.compiler.settings import _opt_codesize, _opt_gas, _opt_none
+from vyper.compiler.settings import _opt_codesize, _opt_gas, _opt_lowering_only_ir
 from vyper.evm.address_space import (
     CALLDATA,
     DATA,
@@ -1180,7 +1180,7 @@ def _complex_make_setter(left, right, hi=None):
                 # kind of arbitrary, but cut off when code used > ~160 bytes
                 should_batch_copy = len_ >= 32 * 10
             else:
-                assert _opt_none()
+                assert _opt_lowering_only_ir()
                 # don't care, just generate the most readable version
                 should_batch_copy = True
         else:

--- a/vyper/codegen/module.py
+++ b/vyper/codegen/module.py
@@ -442,7 +442,7 @@ def generate_ir_for_module(module_t: ModuleT) -> tuple[IRnode, IRnode]:
 
     # TODO: add option to specifically force linear selector section,
     # useful for testing and downstream tooling.
-    if core._opt_none():
+    if core._opt_lowering_only_ir():
         selector_section = _selector_section_linear(external_functions, module_t)
     # dense vs sparse global overhead is amortized after about 4 methods.
     # (--debug will force dense selector table anyway if _opt_codesize is selected.)

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -23,7 +23,7 @@ from vyper.codegen_venom.abi.abi_decoder import _getelemptr_abi, abi_decode_to_b
 from vyper.codegen_venom.buffer import Ptr
 from vyper.codegen_venom.constants import SELECTOR_BYTES, SELECTOR_SHIFT_BITS
 from vyper.codegen_venom.value import VyperValue
-from vyper.compiler.settings import Settings, _opt_codesize, _opt_none
+from vyper.compiler.settings import Settings, _opt_codesize, _opt_lowering_only_ir
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import CompilerPanic
 from vyper.semantics.data_locations import DataLocation
@@ -128,11 +128,11 @@ def generate_runtime_venom(module_t: ModuleT, settings: Settings) -> IRContext:
 
     # Generate selector dispatch
     # Selection logic matches legacy codegen:
-    # - opt_none: linear search (O(n))
+    # - lowering-only IR: linear search (O(n))
     # - opt_codesize with >4 functions: dense jumptable (O(1), codesize-optimized)
     # - >3 functions: sparse jumptable (O(1) average, gas-optimized)
     # - otherwise: linear search
-    if _opt_none():
+    if _opt_lowering_only_ir():
         _generate_selector_section_linear(
             runtime_builder, module_t, external_functions, default_function
         )

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -28,30 +28,39 @@ class OptimizationLevel(Enum):
     NONE = 1
     GAS = 2
     CODESIZE = 3
-    # TODO: O1 (minimal passes) is currently disabled because it can cause
-    # "stack too deep" errors. Re-enable once stack spilling machinery is
-    # implemented to allow compilation with minimal optimization passes.
+    O1 = 5  # Minimal passes -- lowering only, used as the formal verification input
     O2 = 6  # Standard "stable" optimizations (default)
     O3 = 7  # Aggressive optimizations -- experimental possibly unsafe
     Os = 8  # Optimize for size
 
     @classmethod
     def from_string(cls, val):
-        match val:
+        # case-insensitive: `-O O1` reaches here lowercased by the CLI
+        match val.lower():
             case "none":
                 return cls.NONE
-            # O1 maps to O2 for now until stack spilling is implemented
-            case "O1" | "O2" | "gas":
+            case "o1":
+                return cls.O1
+            case "o2" | "gas":
                 return cls.GAS
-            case "codesize" | "Os":
+            case "codesize" | "os":
                 return cls.CODESIZE
-            case "O3" | "o3":
+            case "o3":
                 return cls.O3
         raise ValueError(f"unrecognized optimization level: {val}")
 
     @classmethod
     def default(cls):
         return cls.GAS
+
+    def is_minimal(self) -> bool:
+        """
+        The minimal-transformation levels: only what is needed to lower to
+        legal bytecode, no optimization anywhere in the pipeline (venom
+        passes, legacy IR optimizer, or assembly peephole). O1 is the level
+        formal verification consumes; `none` is an alias for it.
+        """
+        return self in (OptimizationLevel.NONE, OptimizationLevel.O1)
 
     def __str__(self):
         return self._name_ if self._name_.startswith("O") else self._name_.lower()
@@ -217,7 +226,7 @@ class Settings:
 
 
 def should_run_legacy_optimizer(settings: Settings):
-    if settings.optimize == OptimizationLevel.NONE:
+    if settings.optimize is not None and settings.optimize.is_minimal():
         return False
     if settings.experimental_codegen and not VENOM_ENABLE_LEGACY_OPTIMIZER:
         return False
@@ -299,16 +308,27 @@ def anchor_settings(new_settings: Settings) -> Generator:
         set_global_settings(tmp)
 
 
+# These three partition OptimizationLevel: codegen dispatches on them with
+# `if/elif/else assert _opt_none()`, so a level which matches none of them is
+# a CodegenPanic. Keep them exhaustive when adding a level.
+_OPT_CODESIZE_LEVELS = (OptimizationLevel.CODESIZE, OptimizationLevel.Os)
+_OPT_GAS_LEVELS = (OptimizationLevel.GAS, OptimizationLevel.O2, OptimizationLevel.O3)
+# the minimal levels also get the frontend's simplest codegen shapes
+_OPT_NONE_LEVELS = tuple(level for level in OptimizationLevel if level.is_minimal())
+
+assert set(_OPT_CODESIZE_LEVELS + _OPT_GAS_LEVELS + _OPT_NONE_LEVELS) == set(OptimizationLevel)
+
+
 def _opt_codesize():
-    return _settings.optimize == OptimizationLevel.CODESIZE
+    return _settings.optimize in _OPT_CODESIZE_LEVELS
 
 
 def _opt_gas():
-    return _settings.optimize == OptimizationLevel.GAS or _settings.optimize == OptimizationLevel.O3
+    return _settings.optimize in _OPT_GAS_LEVELS
 
 
 def _opt_none():
-    return _settings.optimize == OptimizationLevel.NONE
+    return _settings.optimize in _OPT_NONE_LEVELS
 
 
 def _is_debug_mode():

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -25,10 +25,10 @@ if (_venom_elo := os.environ.get("VENOM_ENABLE_LEGACY_OPTIMIZER")) is not None:
 
 # TODO: use StringEnum (requires refactoring vyper.utils to avoid import cycle)
 class OptimizationLevel(Enum):
-    NONE = 1
+    NONE = 1  # No optional IR or assembly optimization
     GAS = 2
     CODESIZE = 3
-    O1 = 5  # Minimal passes -- lowering only, used as the formal verification input
+    O1 = 5  # Lowering-only IR used as the formal verification input
     O2 = 6  # Standard "stable" optimizations (default)
     O3 = 7  # Aggressive optimizations -- experimental possibly unsafe
     Os = 8  # Optimize for size
@@ -53,12 +53,11 @@ class OptimizationLevel(Enum):
     def default(cls):
         return cls.GAS
 
-    def is_minimal(self) -> bool:
+    def uses_lowering_only_ir(self) -> bool:
         """
-        The minimal-transformation levels: only what is needed to lower to
-        legal bytecode, no optimization anywhere in the pipeline (venom
-        passes, legacy IR optimizer, or assembly peephole). O1 is the level
-        formal verification consumes; `none` is an alias for it.
+        Whether frontend and IR processing should perform only the transforms
+        needed to lower to legal bytecode. Final assembly optimization is a
+        separate policy: it runs at O1, but not at NONE.
         """
         return self in (OptimizationLevel.NONE, OptimizationLevel.O1)
 
@@ -226,7 +225,7 @@ class Settings:
 
 
 def should_run_legacy_optimizer(settings: Settings):
-    if settings.optimize is not None and settings.optimize.is_minimal():
+    if settings.optimize is not None and settings.optimize.uses_lowering_only_ir():
         return False
     if settings.experimental_codegen and not VENOM_ENABLE_LEGACY_OPTIMIZER:
         return False
@@ -308,15 +307,18 @@ def anchor_settings(new_settings: Settings) -> Generator:
         set_global_settings(tmp)
 
 
-# These three partition OptimizationLevel: codegen dispatches on them with
-# `if/elif/else assert _opt_none()`, so a level which matches none of them is
-# a CodegenPanic. Keep them exhaustive when adding a level.
+# These three partition OptimizationLevel for frontend code-shape decisions.
+# Keep them exhaustive when adding a level.
 _OPT_CODESIZE_LEVELS = (OptimizationLevel.CODESIZE, OptimizationLevel.Os)
 _OPT_GAS_LEVELS = (OptimizationLevel.GAS, OptimizationLevel.O2, OptimizationLevel.O3)
-# the minimal levels also get the frontend's simplest codegen shapes
-_OPT_NONE_LEVELS = tuple(level for level in OptimizationLevel if level.is_minimal())
+# Both lowering-only IR levels use the frontend's simplest codegen shapes.
+_OPT_LOWERING_ONLY_LEVELS = tuple(
+    level for level in OptimizationLevel if level.uses_lowering_only_ir()
+)
 
-assert set(_OPT_CODESIZE_LEVELS + _OPT_GAS_LEVELS + _OPT_NONE_LEVELS) == set(OptimizationLevel)
+assert set(_OPT_CODESIZE_LEVELS + _OPT_GAS_LEVELS + _OPT_LOWERING_ONLY_LEVELS) == set(
+    OptimizationLevel
+)
 
 
 def _opt_codesize():
@@ -327,8 +329,8 @@ def _opt_gas():
     return _settings.optimize in _OPT_GAS_LEVELS
 
 
-def _opt_none():
-    return _settings.optimize in _OPT_NONE_LEVELS
+def _opt_lowering_only_ir():
+    return _settings.optimize in _OPT_LOWERING_ONLY_LEVELS
 
 
 def _is_debug_mode():

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -100,14 +100,19 @@ def _normalize_pass_config(pass_config: PassConfig) -> PassRunConfig:
 
 def _build_fn_pass_pipeline(flags: VenomOptimizationFlags) -> list[PassRunConfig]:
     passes = OPTIMIZATION_PASSES[flags.level]
+    # The lowering-only pipelines contain no optional passes -- every pass is
+    # required to produce legal assembly (e.g. venom_to_assembly requires
+    # SimplifyCFGPass to have run) -- so the disable flags do not apply there.
+    lowering_only = flags.level.uses_lowering_only_ir()
     pass_pipeline: list[PassRunConfig] = []
     for pass_config in passes:
         pass_cls, kwargs = _normalize_pass_config(pass_config)
 
         # Check if pass should be skipped based on user flags.
-        flag_name = PASS_FLAG_MAP.get(pass_cls)
-        if flag_name is not None and getattr(flags, flag_name):
-            continue
+        if not lowering_only:
+            flag_name = PASS_FLAG_MAP.get(pass_cls)
+            if flag_name is not None and getattr(flags, flag_name):
+                continue
 
         pass_pipeline.append((pass_cls, kwargs))
 

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -11,6 +11,7 @@ from vyper.venom.analysis.fcg import FCGGlobalAnalysis
 from vyper.venom.check_venom import check_calling_convention, check_mem_ops, check_post_lowering
 from vyper.venom.context import IRContext
 from vyper.venom.function import IRFunction
+from vyper.venom.optimization_levels.O1 import PASSES_O1
 from vyper.venom.optimization_levels.O2 import PASSES_O2
 from vyper.venom.optimization_levels.O3 import PASSES_O3
 from vyper.venom.optimization_levels.Os import PASSES_Os
@@ -39,10 +40,8 @@ from vyper.venom.venom_to_assembly import VenomCompiler
 DEFAULT_OPT_LEVEL = OptimizationLevel.default()
 
 # Pass configuration for each optimization level
-# TODO: O1 (minimal passes) is currently disabled because it can cause
-# "stack too deep" errors. Re-enable once stack spilling machinery is
-# implemented to allow compilation with minimal optimization passes.
 OPTIMIZATION_PASSES: Dict[OptimizationLevel, List[PassConfig]] = {
+    OptimizationLevel.O1: PASSES_O1,
     OptimizationLevel.O2: PASSES_O2,
     OptimizationLevel.O3: PASSES_O3,
     OptimizationLevel.Os: PASSES_Os,
@@ -50,8 +49,8 @@ OPTIMIZATION_PASSES: Dict[OptimizationLevel, List[PassConfig]] = {
 
 # Legacy aliases for backwards compatibility
 OPTIMIZATION_PASSES[OptimizationLevel.NONE] = OPTIMIZATION_PASSES[
-    OptimizationLevel.O2
-]  # none -> O2
+    OptimizationLevel.O1
+]  # none -> O1
 OPTIMIZATION_PASSES[OptimizationLevel.GAS] = OPTIMIZATION_PASSES[OptimizationLevel.O2]  # gas -> O2
 OPTIMIZATION_PASSES[OptimizationLevel.CODESIZE] = OPTIMIZATION_PASSES[
     OptimizationLevel.Os
@@ -62,7 +61,7 @@ def generate_assembly_experimental(
     venom_ctx: IRContext, optimize: OptimizationLevel = DEFAULT_OPT_LEVEL
 ) -> list[AssemblyInstruction]:
     compiler = VenomCompiler(venom_ctx)
-    return compiler.generate_evm_assembly(optimize == OptimizationLevel.NONE)
+    return compiler.generate_evm_assembly(optimize.is_minimal())
 
 
 # Mapping of pass classes to their disable flag names
@@ -123,20 +122,26 @@ def _run_global_passes(
     # Clean unreachable blocks before passes that require dominator analysis
     for fn in ctx.get_functions():
         SimplifyCFGPass(ir_analyses[fn], fn).run_pass()
-    # Intentionally run invoke-copy forwarding twice in the full pipeline:
-    # 1) here (pre-inlining) to shrink obvious frontend-emitted staging copies
-    # 2) again in O2/O3/Os per-function pipelines to catch shapes created later.
-    # Keep this note in sync with optimization_levels/* where the second run is listed.
-    for fn in ctx.get_functions():
-        InternalReturnCopyForwardingPass(ir_analyses[fn], fn).run_pass()
-        ReadonlyInvokeArgCopyForwardingPass(ir_analyses[fn], fn).run_pass()
+
+    # at the minimal levels, skip the global optimizations and run only the
+    # desugaring that the backend requires.
+    minimal = flags.level.is_minimal()
+
+    if not minimal:
+        # Intentionally run invoke-copy forwarding twice in the full pipeline:
+        # 1) here (pre-inlining) to shrink obvious frontend-emitted staging copies
+        # 2) again in O2/O3/Os per-function pipelines to catch shapes created later.
+        # Keep this note in sync with optimization_levels/* where the second run is listed.
+        for fn in ctx.get_functions():
+            InternalReturnCopyForwardingPass(ir_analyses[fn], fn).run_pass()
+            ReadonlyInvokeArgCopyForwardingPass(ir_analyses[fn], fn).run_pass()
 
     _run_pre_inline_dret_desugar(ctx, ir_analyses)
     # the desugar rewrites callee bodies, so the readonly facts must be
     # recomputed before the inliner reads them
     ctx.global_analyses_cache.invalidate_analysis(ReadonlyMemoryArgsGlobalAnalysis)
 
-    if not flags.disable_inlining:
+    if not minimal and not flags.disable_inlining:
         FunctionInlinerPass(ir_analyses, ctx, flags).run_pass()
 
 

--- a/vyper/venom/__init__.py
+++ b/vyper/venom/__init__.py
@@ -41,6 +41,10 @@ DEFAULT_OPT_LEVEL = OptimizationLevel.default()
 
 # Pass configuration for each optimization level
 OPTIMIZATION_PASSES: Dict[OptimizationLevel, List[PassConfig]] = {
+    # NONE is a distinct level even though it currently shares O1's IR
+    # pipeline. Its pass list is independent, and it alone disables the
+    # final assembly optimizer.
+    OptimizationLevel.NONE: PASSES_O1.copy(),
     OptimizationLevel.O1: PASSES_O1,
     OptimizationLevel.O2: PASSES_O2,
     OptimizationLevel.O3: PASSES_O3,
@@ -48,9 +52,6 @@ OPTIMIZATION_PASSES: Dict[OptimizationLevel, List[PassConfig]] = {
 }
 
 # Legacy aliases for backwards compatibility
-OPTIMIZATION_PASSES[OptimizationLevel.NONE] = OPTIMIZATION_PASSES[
-    OptimizationLevel.O1
-]  # none -> O1
 OPTIMIZATION_PASSES[OptimizationLevel.GAS] = OPTIMIZATION_PASSES[OptimizationLevel.O2]  # gas -> O2
 OPTIMIZATION_PASSES[OptimizationLevel.CODESIZE] = OPTIMIZATION_PASSES[
     OptimizationLevel.Os
@@ -61,7 +62,7 @@ def generate_assembly_experimental(
     venom_ctx: IRContext, optimize: OptimizationLevel = DEFAULT_OPT_LEVEL
 ) -> list[AssemblyInstruction]:
     compiler = VenomCompiler(venom_ctx)
-    return compiler.generate_evm_assembly(optimize.is_minimal())
+    return compiler.generate_evm_assembly(optimize == OptimizationLevel.NONE)
 
 
 # Mapping of pass classes to their disable flag names
@@ -123,11 +124,11 @@ def _run_global_passes(
     for fn in ctx.get_functions():
         SimplifyCFGPass(ir_analyses[fn], fn).run_pass()
 
-    # at the minimal levels, skip the global optimizations and run only the
-    # desugaring that the backend requires.
-    minimal = flags.level.is_minimal()
+    # The lowering-only IR pipelines skip global optimizations and run only
+    # the desugaring that the backend requires.
+    lowering_only = flags.level.uses_lowering_only_ir()
 
-    if not minimal:
+    if not lowering_only:
         # Intentionally run invoke-copy forwarding twice in the full pipeline:
         # 1) here (pre-inlining) to shrink obvious frontend-emitted staging copies
         # 2) again in O2/O3/Os per-function pipelines to catch shapes created later.
@@ -141,7 +142,7 @@ def _run_global_passes(
     # recomputed before the inliner reads them
     ctx.global_analyses_cache.invalidate_analysis(ReadonlyMemoryArgsGlobalAnalysis)
 
-    if not minimal and not flags.disable_inlining:
+    if not lowering_only and not flags.disable_inlining:
         FunctionInlinerPass(ir_analyses, ctx, flags).run_pass()
 
 

--- a/vyper/venom/context.py
+++ b/vyper/venom/context.py
@@ -71,6 +71,10 @@ class IRContext:
 
     def remove_function(self, fn: IRFunction) -> None:
         del self.functions[fn.name]
+        # spill sizing takes the max over all fn_eom entries, so a stale
+        # entry for a removed function would inflate every live function's
+        # spill region (see StackSpiller.reset_for_codegen)
+        self.mem_allocator.fn_eom.pop(fn, None)
 
     def create_function(self, name: str) -> IRFunction:
         label = IRLabel(name, True)

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -224,6 +224,12 @@ class IRFunction:
         attrs = self._fmp_signature.attrs if self._fmp_signature is not None else []
         if self.noinline:
             attrs.append("noinline")
+        # the end of this function's static frame, once it is known (i.e. after
+        # ConcretizeMemLocPass). Codegen places spill slots above it, and it
+        # cannot be recovered from the instruction stream, so it has to be
+        # written out for the text format to round-trip.
+        if self.ctx is not None and (eom := self.ctx.mem_allocator.fn_eom.get(self)) is not None:
+            attrs.append(f"eom={eom}")
         annotation = f" [{', '.join(attrs)}]" if attrs else ""
         ret = f"function {self.name}{annotation} {{\n"
         for bb in self.get_basic_blocks():

--- a/vyper/venom/optimization_levels/O1.py
+++ b/vyper/venom/optimization_levels/O1.py
@@ -1,0 +1,37 @@
+# We keep thise in separate files to allow for
+# easier management of different optimization levels
+# and diffing between them.
+
+from typing import List
+
+from vyper.venom.optimization_levels.types import PassConfig
+from vyper.venom.passes import (
+    CFGNormalization,
+    ConcretizeMemLocPass,
+    DFTPass,
+    FmpLoweringPass,
+    LowerDloadPass,
+    MakeSSA,
+    SimplifyCFGPass,
+    SingleUseExpansion,
+)
+
+# Minimal pipeline: only the passes required to lower frontend venom to
+# legal assembly. Everything here is a lowering step, not an optimization.
+# This is the level used as the input to formal verification, so any pass
+# added here needs a correctness (not performance) justification.
+PASSES_O1: List[PassConfig] = [
+    MakeSSA,
+    LowerDloadPass,
+    ConcretizeMemLocPass,
+    FmpLoweringPass,
+    # FmpLoweringPass emits a multiply-assigned FMP runner, so SSA must be
+    # rebuilt afterwards (see FmpLoweringPass.required_successors)
+    MakeSSA,
+    # venom_to_assembly asserts that every `jmp` target is a real join point;
+    # that is only guaranteed after cfg simplification
+    SimplifyCFGPass,
+    SingleUseExpansion,
+    DFTPass,
+    CFGNormalization,
+]

--- a/vyper/venom/optimization_levels/__init__.py
+++ b/vyper/venom/optimization_levels/__init__.py
@@ -1,9 +1,6 @@
-# TODO: O1 (minimal passes) is currently disabled because it can cause
-# "stack too deep" errors. Re-enable once stack spilling machinery is
-# implemented to allow compilation with minimal optimization passes.
-# from vyper.venom.optimization_levels.O1 import PASSES_O1
+from vyper.venom.optimization_levels.O1 import PASSES_O1
 from vyper.venom.optimization_levels.O2 import PASSES_O2
 from vyper.venom.optimization_levels.O3 import PASSES_O3
 from vyper.venom.optimization_levels.Os import PASSES_Os
 
-__all__ = ["PASSES_O2", "PASSES_O3", "PASSES_Os"]
+__all__ = ["PASSES_O1", "PASSES_O2", "PASSES_O3", "PASSES_Os"]

--- a/vyper/venom/optimization_levels/pass_order.py
+++ b/vyper/venom/optimization_levels/pass_order.py
@@ -46,6 +46,7 @@ def validate_pass_order(pass_classes: Sequence[type[IRPass]], pipeline_name: str
             pipeline_name,
             direction="after",
         )
+        _validate_ordered_after(idx, pass_cls, pipeline_name, first_idx=first_idx)
 
 
 def _index_pass_positions(pass_names: list[str]) -> tuple[dict[str, int], dict[str, int]]:
@@ -92,6 +93,24 @@ def _validate_non_immediate(
             relation=relation,
             pipeline_name=pipeline_name,
         )
+
+
+def _validate_ordered_after(
+    idx: int, pass_cls: type[IRPass], pipeline_name: str, first_idx: dict[str, int]
+) -> None:
+    """
+    Ordering-only constraint: a listed pass may be absent, but if it is present
+    its first occurrence must come before this pass.
+    """
+    for candidate in _normalize_refs(pass_cls.ordered_after):
+        if candidate in first_idx and first_idx[candidate] > idx:
+            _raise_pass_order_error(
+                idx=idx,
+                pass_cls=pass_cls,
+                expected=(candidate,),
+                relation="must run after (when present)",
+                pipeline_name=pipeline_name,
+            )
 
 
 def _validate_immediate(

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -32,7 +32,9 @@ VENOM_GRAMMAR = """
 
     function: "function" func_name annotations? "{" block_content "}"
 
-    annotations: "[" IDENT ("," IDENT)* "]"
+    annotations: "[" annotation ("," annotation)* "]"
+
+    annotation: IDENT ("=" CONST)?
 
     block_content: (label_decl | statement)*
 
@@ -95,10 +97,12 @@ def _set_last_label(ctx: IRContext):
 
 # the calling convention is carried only by syntax (opcodes) and the
 # explicit function-header annotation -- there is no shape inference.
-_KNOWN_ANNOTATIONS = frozenset(["fmp_lowered", "fmp_publishes", "noinline"])
+_KNOWN_FLAG_ANNOTATIONS = frozenset(["fmp_lowered", "fmp_publishes", "noinline"])
+# annotations of the form `name=<int>`
+_KNOWN_VALUED_ANNOTATIONS = frozenset(["eom"])
 
 
-def _apply_annotations(fn: IRFunction, annotations: Optional[list[str]]):
+def _apply_annotations(fn: IRFunction, annotations: Optional[list[tuple[str, Optional[int]]]]):
     """
     Apply function-header annotations and reconstruct the FMP signature from
     its annotations and the `fmp_param` opcode.
@@ -106,20 +110,38 @@ def _apply_annotations(fn: IRFunction, annotations: Optional[list[str]]):
     if annotations is None:
         return
 
-    for attr in annotations:
-        if attr not in _KNOWN_ANNOTATIONS:
+    attrs: dict[str, Optional[int]] = {}
+    for attr, value in annotations:
+        if attr in attrs:
+            raise ValueError(f"duplicate function annotation `{attr}` on {fn.name}")
+        if attr in _KNOWN_FLAG_ANNOTATIONS:
+            if value is not None:
+                raise ValueError(f"function annotation `{attr}` takes no value on {fn.name}")
+        elif attr in _KNOWN_VALUED_ANNOTATIONS:
+            if value is None:
+                raise ValueError(f"function annotation `{attr}` requires a value on {fn.name}")
+        else:
             raise ValueError(f"unknown function annotation `{attr}` on {fn.name}")
-    if len(set(annotations)) != len(annotations):
-        raise ValueError(f"duplicate function annotation on {fn.name}")
+        attrs[attr] = value
 
-    fn.noinline = "noinline" in annotations
+    fn.noinline = "noinline" in attrs
 
-    if "fmp_lowered" not in annotations:
-        if "fmp_publishes" in annotations:
+    eom = attrs.get("eom")
+    if eom is not None:
+        # end of the function's static frame. Not recoverable from the
+        # instruction stream once allocas have been concretized, but codegen
+        # needs it to place spill slots above the frame, so it has to survive
+        # the round trip (see StackSpiller._get_spill_slot).
+        if eom < 0:
+            raise ValueError(f"negative `eom` annotation on {fn.name}")
+        fn.ctx.mem_allocator.fn_eom[fn] = eom
+
+    if "fmp_lowered" not in attrs:
+        if "fmp_publishes" in attrs:
             raise ValueError(f"`fmp_publishes` requires `fmp_lowered` on {fn.name}")
         return
 
-    publishes = "fmp_publishes" in annotations
+    publishes = "fmp_publishes" in attrs
     has_fmp_param = any(
         inst.opcode == "fmp_param" for bb in fn.get_basic_blocks() for inst in bb.instructions
     )
@@ -152,7 +174,10 @@ class _LabelDecl:
 
 
 class _Annotations(list):
-    """Represents a function-header annotation list in the parse tree."""
+    """
+    Represents a function-header annotation list in the parse tree, as
+    (name, value) pairs. `value` is None for flag-style annotations.
+    """
 
 
 class VenomTransformer(Transformer):
@@ -218,7 +243,12 @@ class VenomTransformer(Transformer):
         return name, annotations, block_content
 
     def annotations(self, children) -> _Annotations:
-        return _Annotations(str(child) for child in children)
+        return _Annotations(children)
+
+    def annotation(self, children) -> tuple[str, Optional[int]]:
+        name = str(children[0])
+        value = int(str(children[1]), 0) if len(children) > 1 else None
+        return name, value
 
     def block_content(self, children) -> list:
         # children contains label_decls and statements

--- a/vyper/venom/parser.py
+++ b/vyper/venom/parser.py
@@ -139,6 +139,11 @@ def _apply_annotations(fn: IRFunction, annotations: Optional[list[tuple[str, Opt
     if "fmp_lowered" not in attrs:
         if "fmp_publishes" in attrs:
             raise ValueError(f"`fmp_publishes` requires `fmp_lowered` on {fn.name}")
+        if "eom" in attrs:
+            # `eom` is only meaningful once the function is fully lowered;
+            # otherwise ConcretizeMemLocPass would rerun and clobber it
+            # (see ConcretizeMemLocPass._is_already_concretized).
+            raise ValueError(f"`eom` requires `fmp_lowered` on {fn.name}")
         return
 
     publishes = "fmp_publishes" in attrs

--- a/vyper/venom/passes/base_pass.py
+++ b/vyper/venom/passes/base_pass.py
@@ -41,10 +41,16 @@ class IRPass:
     # - required_successors: passes that must appear after this pass.
     # - required_immediate_predecessors: pass immediately before this pass.
     # - required_immediate_successors: pass immediately after this pass.
+    # - ordered_after: ordering-only. If any of these passes is in the
+    #   pipeline it must appear before this pass, but none of them has to be
+    #   present. Use this (rather than required_predecessors) when the
+    #   constraint exists to preserve an optimization opportunity rather than
+    #   to satisfy a real dependency, so that minimal pipelines can drop it.
     required_predecessors: ClassVar[tuple[PassRef, ...]] = ()
     required_successors: ClassVar[tuple[PassRef, ...]] = ()
     required_immediate_predecessors: ClassVar[tuple[PassRef, ...]] = ()
     required_immediate_successors: ClassVar[tuple[PassRef, ...]] = ()
+    ordered_after: ClassVar[tuple[PassRef, ...]] = ()
 
     def __init__(self, analyses_cache: IRAnalysesCache, function: IRFunction):
         self.function = function

--- a/vyper/venom/passes/concretize_mem_loc.py
+++ b/vyper/venom/passes/concretize_mem_loc.py
@@ -1,3 +1,4 @@
+from vyper.exceptions import CompilerPanic
 from vyper.utils import OrderedSet
 from vyper.venom.analysis import BasePtrAnalysis, DFGAnalysis, MemLivenessAnalysis
 from vyper.venom.basicblock import IRBasicBlock
@@ -12,6 +13,15 @@ class ConcretizeMemLocPass(IRPass):
 
     def run_pass(self):
         self.allocator = self.function.ctx.mem_allocator
+
+        # The built-in pipelines freeze the FMP signature only after memory
+        # locations have been concretized. For text-round-tripped functions,
+        # `eom` is the authoritative record of that now-invisible static
+        # frame. Running this pass again would see no allocas and overwrite
+        # the restored EOM with zero, allowing stack spills to alias the frame.
+        if self._is_already_concretized():
+            return
+
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
         self.updater = InstUpdater(self.dfg)
         self.base_ptrs = self.analyses_cache.request_analysis(BasePtrAnalysis)
@@ -50,6 +60,18 @@ class ConcretizeMemLocPass(IRPass):
         self.analyses_cache.invalidate_analysis(MemLivenessAnalysis)
         self.analyses_cache.invalidate_analysis(DFGAnalysis)
         self.analyses_cache.invalidate_analysis(BasePtrAnalysis)
+
+    def _is_already_concretized(self) -> bool:
+        fn = self.function
+        if fn._fmp_signature is None or fn not in self.allocator.fn_eom:
+            return False
+
+        if any(inst.opcode == "alloca" for bb in fn.get_basic_blocks() for inst in bb.instructions):
+            raise CompilerPanic(
+                f"Function {fn.name} is marked fmp_lowered but still contains alloca"
+            )
+
+        return True
 
     def _handle_bb(self, bb: IRBasicBlock):
         for inst in bb.instructions:

--- a/vyper/venom/passes/lower_dload.py
+++ b/vyper/venom/passes/lower_dload.py
@@ -9,8 +9,10 @@ class LowerDloadPass(IRPass):
     Lower dload and dloadbytes instructions
     """
 
-    # Run after MemMergePass so `dload` patterns are still available for merge opportunities.
-    required_predecessors = ("MemMergePass",)
+    # Run after MemMergePass so `dload` patterns are still available for merge
+    # opportunities. This is an optimization concern, not a dependency, so
+    # pipelines which do not run MemMergePass at all (O1) are still valid.
+    ordered_after = ("MemMergePass",)
 
     def run_pass(self):
         dfg = self.analyses_cache.request_analysis(DFGAnalysis)

--- a/vyper/venom/stack_spiller.py
+++ b/vyper/venom/stack_spiller.py
@@ -21,17 +21,33 @@ class StackSpiller:
         self.ctx = ctx
         self._spill_free_slots: list[int] = []
         self._next_spill_offset: Optional[int] = None
+        self._next_function_spill_offset = 0
         self._current_function: Optional[IRFunction] = None
         self.peak_spill_end = 0
 
-    def reset_peak_spill_end(self) -> None:
+    def reset_for_codegen(self) -> None:
+        self._spill_free_slots = []
+        self._next_spill_offset = None
         self.peak_spill_end = 0
+        self._next_function_spill_offset = max(self.ctx.mem_allocator.fn_eom.values(), default=0)
+        self._current_function = None
 
     def set_current_function(self, fn: Optional[IRFunction]) -> None:
         """Set the current function being processed."""
+        # A caller's static frame and live spills remain accessible to its
+        # callees. In particular, memory-passed arguments are pointers into
+        # the caller's frame. Give every function a disjoint spill region
+        # above every static frame so callee spills cannot clobber either.
+        if self._current_function is not None and self._next_spill_offset is not None:
+            self._next_function_spill_offset = max(
+                self._next_function_spill_offset, self._next_spill_offset
+            )
+
         self._current_function = fn
         if fn is not None and fn in self.ctx.mem_allocator.fn_eom:
-            self._next_spill_offset = self.ctx.mem_allocator.fn_eom[fn]
+            static_eom = max(self.ctx.mem_allocator.fn_eom.values(), default=0)
+            self._next_function_spill_offset = max(self._next_function_spill_offset, static_eom)
+            self._next_spill_offset = self._next_function_spill_offset
         else:
             # reset on function exit / unknown fn: a stale offset from the
             # previous function would let a spill land in that function's

--- a/vyper/venom/venom_to_assembly.py
+++ b/vyper/venom/venom_to_assembly.py
@@ -207,7 +207,7 @@ class VenomCompiler:
     def generate_evm_assembly(self, no_optimize: bool = False) -> list[AssemblyInstruction]:
         self.visited_basicblocks = OrderedSet()
         self.label_counter = 0
-        self.spiller.reset_peak_spill_end()
+        self.spiller.reset_for_codegen()
         self._uses_initial_fmp_const = False
         self._analyses_cache = None
         self._stack_cleanup_safety = None
@@ -273,13 +273,11 @@ class VenomCompiler:
 
     def _initial_fmp_value(self) -> int:
         # Initial FMP must live above every function's static frame
-        # AND above every function's spill region. Spill slots start
-        # at fn_eom[fn] and grow upward; `peak_spill_end` tracks the
-        # maximum `fn_eom + N*32` reached across all functions during
-        # codegen. Placing the initial FMP at or above that value
-        # guarantees that the dynamic allocation region (bumped from
-        # FMP by each `bump` instruction) never aliases with any
-        # function's spill area.
+        # AND above every function's spill region. Spill regions start above
+        # the largest static frame and are disjoint between functions;
+        # `peak_spill_end` tracks the end of the last allocated region.
+        # Placing the initial FMP at or above that value guarantees that the
+        # dynamic allocation region never aliases with a spill area.
         eoms = [self.ctx.mem_allocator.fn_eom.get(fn, 0) for fn in self.ctx.functions.values()]
         max_eom = max(eoms, default=0)
         return ceil32(max(max_eom, self.spiller.peak_spill_end))


### PR DESCRIPTION
### What I did

Reinstated O1 as a distinct lowering-only IR optimization level instead of mapping it to O2.

This PR also:

  - Keeps `NONE` and O1 as distinct optimization levels.
  - Gives `NONE` an independent copy of the O1 IR pass pipeline.
  - Runs final assembly optimization at O1, while `NONE` remains fully unoptimized.
  - Preserves per-function static memory boundaries across Venom text round trips.
  - Places stack-spill regions above every static memory frame and keeps function spill regions disjoint.
  - Places the initial free-memory pointer above both static frames and spill regions.
  - Adds explicit pass-order constraints and optimization-specific test skips.

### How I did it

Added an O1 pipeline containing only the passes required to lower frontend Venom into legal assembly.

Introduced `uses_lowering_only_ir()` for decisions shared by `NONE` and O1, while keeping assembly optimization policy separate.

Added `[eom=N]` serialization and parsing for each function's static memory boundary. `ConcretizeMemLocPass` now preserves finalized `[fmp_lowered, eom=N]` functions and rejects contradictory functions that still contain `alloca`.

Updated stack spilling to allocate disjoint regions above the largest static frame and account for those regions when selecting the initial free-memory pointer.

### How to verify it

### Commit message

```
reinstate o1 with the minimum venom passes required to produce legal
assembly while keeping none as a separate level that also disables final
assembly optimization. preserve each function's static memory boundary
when venom is serialized and parsed again so rerunning the pipeline cannot
place stack spills over existing memory. allocate spill regions above all
static frames, keep them disjoint between functions, and move the initial
free-memory pointer beyond those regions. add regression coverage for pass
ordering, memory-layout round trips, spilling, and optimization policies
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
