### PR TITLE
refactor[parser]: separate `visit_docstring` concerns

### DIFF
--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -261,11 +261,10 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
 
         return node
 
-    def _visit_docstring(self, node):
+    def _extract_docstring(self, node):
         """
         Move a node docstring from body to `doc_string` and annotate it as `DocStr`.
         """
-        self.generic_visit(node)
 
         if node.body:
             n = node.body[0]
@@ -278,8 +277,6 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                 n.value.ast_type = "DocStr"
                 del node.body[0]
                 node.doc_string = n.value
-
-        return node
 
     def visit_Module(self, node):
         node.lineno = 1
@@ -297,10 +294,15 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         node.resolved_path = self._resolved_path
         node.source_sha256sum = sha256sum(self._source_code)
         node.source_id = self._source_id
-        return self._visit_docstring(node)
+
+        self.generic_visit(node)
+        self._extract_docstring(node)
+        return node
 
     def visit_FunctionDef(self, node):
-        return self._visit_docstring(node)
+        self.generic_visit(node)
+        self._extract_docstring(node)
+        return node
 
     def visit_ClassDef(self, node):
         """


### PR DESCRIPTION
### What I did

Fix confusing `_visit_docstring`: it didn't visit the docstring (as its docstring also implied), but instead traversed the node (triggers many recursive calls) as well 

### How I did it

Rename to `_extract_docstring`, and pull out the call `self.generic_visit` which triggers the recursion.
This follows the separation of concerns principle
It also makes `visit_Module` and `visit_FunctionDef` have a more similar structure to the other `visit_` methods

### How to verify it

`pytest`

Manually verify that the changes preserve semantics exactly

### Commit message

```
_visit_docstring was confusing in that it didn't only handle the
docstring, but also triggered full analysis of the node's body. this is
a violation of the separation of concerns principles, worsened by the
docstring not mentionning that fact. this commit fixes that by renaming
the method to _extract_docstring, and pulling out the full analysis call
(self.generic_visit). as a result, visit_Module and visit_FunctionDef
are now more in line with other visit_ methods (they call generic_visit,
and then refine the result).
```

### Description for the changelog

(refactor, no user-visible change)

### Cute Animal Picture

![Delicious in Dungeon Mimic](https://static.wikia.nocookie.net/delicious-in-dungeon/images/b/b9/Mimic_%28Anime%29.png/revision/latest?cb=20240210200845)
