### PR TITLE
refactor[tool]: reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# -*- mode: gitignore; -*-
+.github/
+docs/
+examples/
+logos/
+
+Dockerfile
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# egg-related
+vyper.egg-info/
+build/
+dist/
+.eggs/
+
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Coverage tests
+.coverage*
+.cache/
+htmlcov/
+coverage.xml
+
+# IDEs
+.idea/
+.vscode/
+
+.tox/
+.mypy_cache/
+.hypothesis/
+
+*.spec
+
+# mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ Make sure you have `pip` (version 25.1 or above), `setuptools`, and `pytest` ins
 * `make mypy` to type check your changes
 * `make lint` to check your files are correctly formatted (also runs mypy)
 
+### Docker Setup
+
+Note: This is only useful for contributors, if you just want to use vyper, look [here](https://docs.vyperlang.org/en/latest/installing-vyper.html#docker).
+
+#### Build the image:
+
+`docker build . -t vyper -f Dockerfile`
+
+#### Check it runs:
+
+`docker run -v $(pwd):/code vyper --help`
+
+#### Run vyper:
+
+It works like `vyper` locally, with the difference that you should add `/code/` before the local path:
+
+`docker run -v $(pwd):/code vyper /code/<path to vy file>`
+
+Example:
+* `vyper -f abi_python examples/name_registry/name_registry.vy` becomes
+* `docker run -v $(pwd):/code vyper -f abi_python /code/examples/name_registry/name_registry.vy`
+
 ### Other Tips
 
 #### Checking performance


### PR DESCRIPTION
### What I did

Remove some un-needed files from the docker image, so that it is smaller (`892MB` -> `597MB`)

Close: #3120

Since they were missing, add basic docker building instructions

### How I did it

Copied the .dockerignore file from #3120, and make a few amendments

Note that because of the `RUN git reset --hard` and `RUN pip install ...` some ignored files are present in the final image.
(The first re-fetches some, and the second re-creates some)

### How to verify it

After:
```
git switch master
docker build . -t vyper-master -f Dockerfile
git switch -
docker build . -t vyper-pr -f Dockerfile
```
`docker image ls` returns:
```
IMAGE                         ID             DISK USAGE   CONTENT SIZE   EXTRA
vyper-master:latest           573d99c0b4c1        892MB             0B
vyper-pr:latest               ccde729f609b        597MB             0B
```


`docker run -v $(pwd):/code vyper-pr ...` behaves as expected

### Commit message

TODO

### Description for the changelog

Reduce the size of the docker image

### Cute Animal Picture

![whale shark](https://www.treehugger.com/thmb/8xNIwZLw1lyQq7DJM8vpOqS7v1U=/3153x2102/filters:no_upscale():max_bytes(150000):strip_icc()/GettyImages-1247022865-feb309c462bd48f3a412896659ef356a.jpg)
