### PR TITLE
refactor[codegen]: remove dead debugger code

### DIFF
--- a/tests/evm_backends/pyevm_env.py
+++ b/tests/evm_backends/pyevm_env.py
@@ -48,8 +48,6 @@ class PyEvmEnv(BaseEnv):
             logger = logging.getLogger("eth.vm.computation.BaseComputation")
             setup_DEBUG2_logging()
             logger.setLevel("DEBUG2")
-            # from vdb import vdb
-            # vdb.set_evm_opcode_debugger()
 
         spec = getattr(chain_builder.builders, evm_version + "_at")(block_number)
         self._chain: ChainAPI = chain_builder.build(MainnetChain, spec).from_genesis(

--- a/tests/unit/compiler/ir/test_compile_ir.py
+++ b/tests/unit/compiler/ir/test_compile_ir.py
@@ -1,8 +1,6 @@
 import pytest
 
 from vyper.codegen.ir_node import IRnode
-from vyper.evm.opcodes import version_check
-from vyper.ir import compile_ir
 from vyper.ir.s_expressions import parse_s_exp
 
 fail_list = [
@@ -63,5 +61,3 @@ def test_ir_from_s_expression(get_contract_from_ir):
     ir = IRnode.from_list(s_expressions[0])
     c = get_contract_from_ir(ir, abi=abi)
     assert c.test(-123456) == -123456
-
-

--- a/tests/unit/compiler/ir/test_compile_ir.py
+++ b/tests/unit/compiler/ir/test_compile_ir.py
@@ -65,13 +65,3 @@ def test_ir_from_s_expression(get_contract_from_ir):
     assert c.test(-123456) == -123456
 
 
-def test_pc_debugger():
-    debugger_ir = ["seq", ["mstore", 0, 32], ["pc_debugger"]]
-    ir_nodes = IRnode.from_list(debugger_ir)
-    _, line_number_map = compile_ir.assembly_to_evm(compile_ir.compile_to_assembly(ir_nodes))
-    if version_check(begin="shanghai"):
-        offset = 4  # push0 saves a byte
-    else:
-        offset = 5
-
-    assert line_number_map["pc_breakpoints"][0] == offset

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -19,7 +19,7 @@ from vyper.codegen.core import (
 )
 from vyper.codegen.expr import Expr
 from vyper.codegen.return_ import make_return_stmt
-from vyper.exceptions import CodegenPanic, StructureException, TypeCheckFailure, tag_exceptions
+from vyper.exceptions import CodegenPanic, TypeCheckFailure, tag_exceptions
 from vyper.semantics.types import DArrayT, ErrorT, TupleT
 from vyper.semantics.types.shortcuts import UINT256_T
 

--- a/vyper/codegen/stmt.py
+++ b/vyper/codegen/stmt.py
@@ -46,12 +46,6 @@ class Stmt:
     def parse_Pass(self):
         return IRnode.from_list("pass")
 
-    def parse_Name(self):
-        if self.stmt.id == "vdb":
-            return IRnode("debugger")
-        else:
-            raise StructureException(f"Unsupported statement type: {type(self.stmt)}", self.stmt)
-
     def parse_AnnAssign(self):
         ltyp = self.stmt.target._metadata["type"]
         varname = self.stmt.target.id

--- a/vyper/evm/assembler/core.py
+++ b/vyper/evm/assembler/core.py
@@ -56,9 +56,7 @@ def _assembly_to_evm(
     # now that all symbols have been resolved, generate bytecode
     # using the symbol map
     for item in assembly:
-        if item in ("DEBUG",):
-            continue  # skippable opcodes
-        elif isinstance(item, CONST):
+        if isinstance(item, CONST):
             continue  # CONST things do not show up in bytecode
         elif isinstance(item, DataHeader):
             continue  # DataHeader does not show up in bytecode

--- a/vyper/evm/assembler/instructions.py
+++ b/vyper/evm/assembler/instructions.py
@@ -69,7 +69,6 @@ class TaggedInstruction(str):
 
     def __init__(self, sstr, ast_source=None, error_msg=None):
         self.error_msg = error_msg
-        self.pc_debugger = False
 
         self.ast_source = ast_source
 
@@ -175,14 +174,6 @@ def JUMP(label: Label):
 
 def JUMPI(label: Label):
     return [PUSHLABEL(label), "JUMPI"]
-
-
-def mkdebug(pc_debugger, ast_source):
-    # compile debug instructions
-    # (this is dead code -- CMC 2025-05-08)
-    i = TaggedInstruction("DEBUG", ast_source)
-    i.pc_debugger = pc_debugger
-    return [i]
 
 
 AssemblyInstruction = (

--- a/vyper/evm/assembler/symbols.py
+++ b/vyper/evm/assembler/symbols.py
@@ -82,9 +82,6 @@ def resolve_symbols(
         elif item in ("JUMPI", "JUMPDEST"):
             source_map["pc_jump_map"][pc] = "-"
 
-        if item == "DEBUG":
-            continue  # "debug" opcode does not go into bytecode
-
         if isinstance(item, CONST):
             continue  # CONST declarations do not go into bytecode
 
@@ -146,16 +143,10 @@ def note_line_num(line_number_map, pc, item):
         if item.error_msg is not None:
             line_number_map["error_map"][pc] = item.error_msg
 
-    note_breakpoint(line_number_map, pc, item)
-
 
 # NOTE: this is dead code, we don't emit DEBUG anymore.
 def note_breakpoint(line_number_map, pc, item):
     # Record line number attached to pc
     if item == "DEBUG":
-        # Is PC debugger, create PC breakpoint.
-        if item.pc_debugger:
-            line_number_map["pc_breakpoints"].add(pc)
         # Create line number breakpoint.
-        else:
-            line_number_map["breakpoints"].add(item.lineno + 1)
+        line_number_map["breakpoints"].add(item.lineno + 1)

--- a/vyper/evm/assembler/symbols.py
+++ b/vyper/evm/assembler/symbols.py
@@ -142,11 +142,3 @@ def note_line_num(line_number_map, pc, item):
 
         if item.error_msg is not None:
             line_number_map["error_map"][pc] = item.error_msg
-
-
-# NOTE: this is dead code, we don't emit DEBUG anymore.
-def note_breakpoint(line_number_map, pc, item):
-    # Record line number attached to pc
-    if item == "DEBUG":
-        # Create line number breakpoint.
-        line_number_map["breakpoints"].add(item.lineno + 1)

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -198,7 +198,6 @@ PSEUDO_OPCODES: OpcodeMap = {
     "CEIL32": (None, 1, 1, 20),
     "SET": (None, 2, 0, 20),
     "NE": (None, 2, 1, 6),
-    "DEBUGGER": (None, 0, 0, 0),
     "ILOAD": (None, 1, 1, 6),
     "ISTORE": (None, 2, 0, 6),
     "DLOAD": (None, 1, 1, 9),

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -20,7 +20,6 @@ from vyper.evm.assembler.instructions import (
     AssemblyInstruction,
     DataHeader,
     TaggedInstruction,
-    mkdebug,
 )
 from vyper.evm.assembler.optimizer import optimize_assembly
 from vyper.evm.assembler.symbols import CONSTREF, Label
@@ -737,10 +736,6 @@ class _IRnodeLowerer:
         if code.value == "exit_to":
             # currently removed by _rewrite_return_sequences
             raise CodegenPanic("exit_to not implemented yet!")
-
-        # inject debug opcode.
-        if code.value == "pc_debugger":
-            return mkdebug(pc_debugger=True, ast_source=code.ast_source)
 
         raise CompilerPanic(f"invalid IRnode: {type(code)} {code}")  # pragma: no cover
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -739,10 +739,6 @@ class _IRnodeLowerer:
             raise CodegenPanic("exit_to not implemented yet!")
 
         # inject debug opcode.
-        if code.value == "debugger":
-            return mkdebug(pc_debugger=False, ast_source=code.ast_source)
-
-        # inject debug opcode.
         if code.value == "pc_debugger":
             return mkdebug(pc_debugger=True, ast_source=code.ast_source)
 

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -467,7 +467,6 @@ VALID_IR_MACROS = {
     "dloadbytes",
     "ceil32",
     "continue",
-    "debugger",
     "ge",
     "if",
     "select",


### PR DESCRIPTION
### What I did

Rebase #3414
Remove now-dead `note_breakpoint`

Closes #3414 

### How I did it

Re-make every commit by manually replicating their changes onto master
(Since the base code had been split into multiple files, git was getting confused)

### How to verify it

All tests pass

### Commit message

```
This PR removes dead code referencing `vdb`,
the vyper debugger, which used to be part of the
codebase.
```

### Description for the changelog

(refactor, no user-facing change)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
