### PR TITLE
fix[ux]: improve checksum error messages

### DIFF
--- a/tests/functional/syntax/exceptions/test_type_mismatch_exception.py
+++ b/tests/functional/syntax/exceptions/test_type_mismatch_exception.py
@@ -43,10 +43,6 @@ event Foo:
 def foo():
     log Foo(message="abcd")
     """,
-    # Address literal must be checksummed
-    """
-a: constant(address) = 0x3cd751e6b0078be393132286c442345e5dc49699
-    """,
     # test constant folding inside `convert()`
     """
 BAR: constant(Bytes[5]) = b"vyper"

--- a/tests/functional/syntax/test_ann_assign.py
+++ b/tests/functional/syntax/test_ann_assign.py
@@ -3,8 +3,8 @@ from pytest import raises
 
 from vyper import compiler
 from vyper.exceptions import (
-    InstantiationException,
     BadChecksumAddress,
+    InstantiationException,
     InvalidAttribute,
     TypeMismatch,
     UndeclaredDefinition,

--- a/tests/functional/syntax/test_ann_assign.py
+++ b/tests/functional/syntax/test_ann_assign.py
@@ -4,6 +4,7 @@ from pytest import raises
 from vyper import compiler
 from vyper.exceptions import (
     InstantiationException,
+    BadChecksumAddress,
     InvalidAttribute,
     TypeMismatch,
     UndeclaredDefinition,
@@ -124,6 +125,14 @@ def foo() -> bool:
     return True
 """,
         TypeMismatch,
+    ),
+    (
+        """
+@external
+def foo():
+    x: address = 0x6b175474e89094c44da98b954eedeac495271d0F
+    """,
+        BadChecksumAddress,
     ),
 ]
 

--- a/tests/functional/syntax/test_constants.py
+++ b/tests/functional/syntax/test_constants.py
@@ -175,7 +175,7 @@ def hello() :
     # invalid checksum address
     (
         """
-foo: constant(address) = 0x6b175474e89094c44da98b954eedeac495271d0F
+a: constant(address) = 0x3cd751e6b0078be393132286c442345e5dc49699
     """,
         BadChecksumAddress,
     ),

--- a/tests/functional/syntax/test_constants.py
+++ b/tests/functional/syntax/test_constants.py
@@ -4,6 +4,7 @@ from pytest import raises
 from vyper import compiler
 from vyper.exceptions import (
     ArgumentException,
+    BadChecksumAddress,
     ImmutableViolation,
     NamespaceCollision,
     StateAccessViolation,
@@ -170,6 +171,13 @@ def hello() :
     x.a =  2
     """,
         ImmutableViolation,
+    ),
+    # invalid checksum address
+    (
+        """
+foo: constant(address) = 0x6b175474e89094c44da98b954eedeac495271d0F
+    """,
+        BadChecksumAddress,
     ),
 ]
 

--- a/tests/unit/ast/nodes/test_hex.py
+++ b/tests/unit/ast/nodes/test_hex.py
@@ -2,7 +2,6 @@ import pytest
 
 from tests.utils import analyze_module_single
 from vyper import ast as vy_ast
-from vyper import semantics
 from vyper.exceptions import BadChecksumAddress, InvalidLiteral
 
 code_invalid_checksum = [

--- a/tests/unit/ast/nodes/test_hex.py
+++ b/tests/unit/ast/nodes/test_hex.py
@@ -10,23 +10,9 @@ code_invalid_checksum = [
 foo: constant(address) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,
     """
-foo: constant(address[1]) = [0x6b175474e89094c44da98b954eedeac495271d0F]
-    """,
-    """
 @external
 def foo():
     bar: address = 0x6b175474e89094c44da98b954eedeac495271d0F
-    """,
-    """
-@external
-def foo():
-    bar: address[1] = [0x6b175474e89094c44da98b954eedeac495271d0F]
-    """,
-    """
-@external
-def foo():
-    for i: address in [0x6b175474e89094c44da98b954eedeac495271d0F]:
-        pass
     """,
 ]
 
@@ -39,6 +25,20 @@ def test_bad_checksum_address(code):
 
 
 code_invalid_literal = [
+    """
+foo: constant(address[1]) = [0x6b175474e89094c44da98b954eedeac495271d0F]
+    """,
+    """
+@external
+def foo():
+    for i: address in [0x6b175474e89094c44da98b954eedeac495271d0F]:
+        pass
+    """,
+    """
+@external
+def foo():
+    bar: address[1] = [0x6b175474e89094c44da98b954eedeac495271d0F]
+    """,
     """
 foo: constant(bytes20) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,

--- a/tests/unit/ast/nodes/test_hex.py
+++ b/tests/unit/ast/nodes/test_hex.py
@@ -2,7 +2,8 @@ import pytest
 
 from tests.utils import analyze_module_single
 from vyper import ast as vy_ast
-from vyper.exceptions import InvalidLiteral
+from vyper import semantics
+from vyper.exceptions import BadChecksumAddress, InvalidLiteral
 
 code_invalid_checksum = [
     """
@@ -27,6 +28,17 @@ def foo():
     for i: address in [0x6b175474e89094c44da98b954eedeac495271d0F]:
         pass
     """,
+]
+
+
+@pytest.mark.parametrize("code", code_invalid_checksum)
+def test_bad_checksum_address(code):
+    with pytest.raises(BadChecksumAddress):
+        vyper_module = vy_ast.parse_to_ast(code)
+        analyze_module_single(vyper_module)
+
+
+code_invalid_literal = [
     """
 foo: constant(bytes20) = 0x6b175474e89094c44da98b954eedeac495271d0F
     """,
@@ -36,8 +48,8 @@ foo: constant(bytes4) = 0X12345678
 ]
 
 
-@pytest.mark.parametrize("code", code_invalid_checksum)
-def test_invalid_checksum(code):
+@pytest.mark.parametrize("code", code_invalid_literal)
+def test_invalid_literal(code):
     with pytest.raises(InvalidLiteral):
         vyper_module = vy_ast.parse_to_ast(code)
         analyze_module_single(vyper_module)

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -264,6 +264,10 @@ class InvalidLiteral(VyperException):
     """Invalid literal value."""
 
 
+class BadChecksumAddress(InvalidLiteral):
+    """Invalid literal address value."""
+
+
 class InvalidAttribute(VyperException):
     """Reference to an attribute that does not exist."""
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, List
 
 from vyper import ast as vy_ast
 from vyper.exceptions import (
+    BadChecksumAddress,
     CompilerPanic,
     InstantiationException,
     InvalidAttribute,
@@ -335,6 +336,13 @@ class _ExprAnalyser:
             raise OverflowException(
                 "Numeric literal is outside of allowable range for number types", node
             )
+        if isinstance(node, vy_ast.Hex) and len(node.value) == 42:
+            raise BadChecksumAddress(
+                "If this is an address, the correct checksummed form is: "
+                f"{checksum_encode(node.value)}",
+                node,
+            )
+
         raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node)
 
     def types_from_IfExp(self, node):

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -341,7 +341,7 @@ class _ExprAnalyser:
         # add a hint on address checksum mismatch
         if isinstance(node, vy_ast.Hex) and node.n_bytes == 20:
             assert not is_checksum_encoded(node.value)
-            hint = AddressT()._checksum_error_msg(node)
+            hint = AddressT._checksum_error_msg(node)
 
         raise InvalidLiteral(msg, node, hint=hint)
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, List
 
 from vyper import ast as vy_ast
 from vyper.exceptions import (
+    BadChecksumAddress,
     CompilerPanic,
     InstantiationException,
     InvalidAttribute,
@@ -335,12 +336,17 @@ class _ExprAnalyser:
             raise OverflowException(
                 "Numeric literal is outside of allowable range for number types", node
             )
+
+        hint = ""
         if isinstance(node, vy_ast.Hex) and len(node.value) == 42:
             # call `validate_literal` for its side effect of throwing an exception for
             # address checksum mismatch
-            AddressT().validate_literal(node)
+            try:
+                AddressT().validate_literal(node)
+            except BadChecksumAddress as e:
+                hint += e.message
 
-        raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node)
+        raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node, hint=hint)
 
     def types_from_IfExp(self, node):
         validate_expected_type(node.test, BoolT())

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, List
 
 from vyper import ast as vy_ast
 from vyper.exceptions import (
-    BadChecksumAddress,
     CompilerPanic,
     InstantiationException,
     InvalidAttribute,
@@ -34,7 +33,7 @@ if TYPE_CHECKING:
 
 from vyper.semantics.types.primitives import AddressT, BoolT, BytesM_T, IntegerT
 from vyper.semantics.types.subscriptable import DArrayT, SArrayT, TupleT
-from vyper.utils import OrderedSet, checksum_encode, int_to_fourbytes
+from vyper.utils import OrderedSet, int_to_fourbytes, is_checksum_encoded
 from vyper.warnings import Deprecation, vyper_warn
 
 
@@ -338,14 +337,13 @@ class _ExprAnalyser:
             )
 
         msg = f"Could not determine type for literal value '{node.value}'"
-        if isinstance(node, vy_ast.Hex) and len(node.value) == 42:
-            # call `validate_literal` to add a hint on address checksum mismatch
-            try:
-                AddressT().validate_literal(node)
-            except BadChecksumAddress as e:
-                raise InvalidLiteral(msg, node, hint=e.args[0])
+        hint = None
+        # add a hint on address checksum mismatch
+        if isinstance(node, vy_ast.Hex) and node.n_bytes == 20:
+            assert not is_checksum_encoded(node.value)
+            hint = AddressT()._checksum_error_msg(node)
 
-        raise InvalidLiteral(msg, node)
+        raise InvalidLiteral(msg, node, hint=hint)
 
     def types_from_IfExp(self, node):
         validate_expected_type(node.test, BoolT())
@@ -617,10 +615,10 @@ def validate_expected_type(node, expected_type):
     try:
         given_types = _ExprAnalyser().get_possible_types_from_node(node)
     except InvalidLiteral as i:
-        # call `validate_literal` for its side effect of throwing an exception for
-        # address checksum mismatch only if the expected type is an address
-        if AddressT() in expected_type and isinstance(node, vy_ast.Hex) and len(node.value) == 42:
-            AddressT().validate_literal(node)
+        # throw more specific error if the cause of the failure was an incorrect checksum
+        if AddressT() in expected_type and isinstance(node, vy_ast.Hex) and node.n_bytes == 20:
+            assert not is_checksum_encoded(node.value)
+            AddressT().raise_bad_checksum(node)
         raise i
 
     if isinstance(node, vy_ast.List):

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, List
 
 from vyper import ast as vy_ast
 from vyper.exceptions import (
-    BadChecksumAddress,
     CompilerPanic,
     InstantiationException,
     InvalidAttribute,
@@ -337,11 +336,9 @@ class _ExprAnalyser:
                 "Numeric literal is outside of allowable range for number types", node
             )
         if isinstance(node, vy_ast.Hex) and len(node.value) == 42:
-            raise BadChecksumAddress(
-                "If this is an address, the correct checksummed form is: "
-                f"{checksum_encode(node.value)}",
-                node,
-            )
+            # call `validate_literal` for its side effect of throwing an exception for
+            # address checksum mismatch
+            AddressT().validate_literal(node)
 
         raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node)
 
@@ -664,7 +661,9 @@ def validate_expected_type(node, expected_type):
 
         suggestion_str = ""
         if expected_type[0] == AddressT() and given_types[0] == BytesM_T(20):
-            suggestion_str = f" Did you mean {checksum_encode(node.value)}?"
+            # call `validate_literal` for its side effect of throwing an exception for
+            # address checksum mismatch
+            AddressT().validate_literal(node)
 
         raise TypeMismatch(
             f"Expected {expected_str} but literal can only be cast as {given_str}.{suggestion_str}",

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -337,16 +337,15 @@ class _ExprAnalyser:
                 "Numeric literal is outside of allowable range for number types", node
             )
 
-        hint = ""
+        msg = f"Could not determine type for literal value '{node.value}'"
         if isinstance(node, vy_ast.Hex) and len(node.value) == 42:
-            # call `validate_literal` for its side effect of throwing an exception for
-            # address checksum mismatch
+            # call `validate_literal` to add a hint on address checksum mismatch
             try:
                 AddressT().validate_literal(node)
             except BadChecksumAddress as e:
-                hint += e.message
+                raise InvalidLiteral(msg, node, hint=e.args[0])
 
-        raise InvalidLiteral(f"Could not determine type for literal value '{node.value}'", node, hint=hint)
+        raise InvalidLiteral(msg, node)
 
     def types_from_IfExp(self, node):
         validate_expected_type(node.test, BoolT())
@@ -615,7 +614,14 @@ def validate_expected_type(node, expected_type):
             # fail block
             pass
 
-    given_types = _ExprAnalyser().get_possible_types_from_node(node)
+    try:
+        given_types = _ExprAnalyser().get_possible_types_from_node(node)
+    except InvalidLiteral as i:
+        # call `validate_literal` for its side effect of throwing an exception for
+        # address checksum mismatch only if the expected type is an address
+        if AddressT() in expected_type and isinstance(node, vy_ast.Hex) and len(node.value) == 42:
+            AddressT().validate_literal(node)
+        raise i
 
     if isinstance(node, vy_ast.List):
         # special case - for literal arrays we individually validate each item

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -618,7 +618,7 @@ def validate_expected_type(node, expected_type):
         # throw more specific error if the cause of the failure was an incorrect checksum
         if AddressT() in expected_type and isinstance(node, vy_ast.Hex) and node.n_bytes == 20:
             assert not is_checksum_encoded(node.value)
-            AddressT().raise_bad_checksum(node)
+            AddressT.raise_bad_checksum(node)
         raise i
 
     if isinstance(node, vy_ast.List):

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -7,6 +7,7 @@ from typing import Any, Tuple, Union
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Address, ABI_Bool, ABI_BytesM, ABI_GIntM, ABIType
 from vyper.exceptions import (
+    BadChecksumAddress,
     CompilerPanic,
     InvalidLiteral,
     InvalidOperation,
@@ -427,7 +428,7 @@ class AddressT(_PrimT):
 
         addr = node.value
         if not is_checksum_encoded(addr):
-            raise InvalidLiteral(
+            raise BadChecksumAddress(
                 "Address checksum mismatch. If you are sure this is the right "
                 f"address, the correct checksummed form is: {checksum_encode(addr)}",
                 node,

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 from functools import cached_property
-from typing import Any, Tuple, Union
+from typing import Any, NoReturn, Tuple, Union
 
 from vyper import ast as vy_ast
 from vyper.abi_types import ABI_Address, ABI_Bool, ABI_BytesM, ABI_GIntM, ABIType
@@ -426,13 +426,16 @@ class AddressT(_PrimT):
         if node.n_bytes != 20:
             raise InvalidLiteral(f"Invalid address. Expected 20 bytes, got {node.n_bytes}.", node)
 
-        addr = node.value
-        if not is_checksum_encoded(addr):
-            raise BadChecksumAddress(
-                "Address checksum mismatch. If you are sure this is the right "
-                f"address, the correct checksummed form is: {checksum_encode(addr)}",
-                node,
-            )
+        if not is_checksum_encoded(node.value):
+            self.raise_bad_checksum(node)
+
+    def _checksum_error_msg(self, node: vy_ast.Hex) -> str:
+        msg = "Address checksum mismatch. If you are sure this is the right "
+        msg += f"address, the correct checksummed form is: {checksum_encode(node.value)}"
+        return msg
+
+    def raise_bad_checksum(self, node: vy_ast.Hex) -> NoReturn:
+        raise BadChecksumAddress(self._checksum_error_msg(node), node)
 
 
 # type for "self"

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -429,13 +429,15 @@ class AddressT(_PrimT):
         if not is_checksum_encoded(node.value):
             self.raise_bad_checksum(node)
 
-    def _checksum_error_msg(self, node: vy_ast.Hex) -> str:
+    @staticmethod
+    def _checksum_error_msg(node: vy_ast.Hex) -> str:
         msg = "Address checksum mismatch. If you are sure this is the right "
         msg += f"address, the correct checksummed form is: {checksum_encode(node.value)}"
         return msg
 
-    def raise_bad_checksum(self, node: vy_ast.Hex) -> NoReturn:
-        raise BadChecksumAddress(self._checksum_error_msg(node), node)
+    @staticmethod
+    def raise_bad_checksum(node: vy_ast.Hex) -> NoReturn:
+        raise BadChecksumAddress(AddressT._checksum_error_msg(node), node)
 
 
 # type for "self"

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -429,15 +429,15 @@ class AddressT(_PrimT):
         if not is_checksum_encoded(node.value):
             self.raise_bad_checksum(node)
 
-    @staticmethod
-    def _checksum_error_msg(node: vy_ast.Hex) -> str:
+    @classmethod
+    def _checksum_error_msg(cls, node: vy_ast.Hex) -> str:
         msg = "Address checksum mismatch. If you are sure this is the right "
         msg += f"address, the correct checksummed form is: {checksum_encode(node.value)}"
         return msg
 
-    @staticmethod
-    def raise_bad_checksum(node: vy_ast.Hex) -> NoReturn:
-        raise BadChecksumAddress(AddressT._checksum_error_msg(node), node)
+    @classmethod
+    def raise_bad_checksum(cls, node: vy_ast.Hex) -> NoReturn:
+        raise BadChecksumAddress(cls._checksum_error_msg(node), node)
 
 
 # type for "self"


### PR DESCRIPTION
### What I did

Rebase #3621
Fix #3611
Refactor a bit the raising logic to make it nicer, see b19b32e858d605cab8efd74413980e00c1f7fe35


Closes #3621

### How I did it

### How to verify it

Run tests, includes new tests

### Commit message

```
introduce a `BadChecksumAddress` exception (subclass of
`InvalidLiteral`) and raise it consistently for 20-byte hex literals
with a mismatched checksum, whether used in a `constant`, an annotated
assignment, or in a context where the expected type isn't known. when
the literal's type can't be determined, surface the checksum suggestion
as a hint. also clean up the raising logic in `AddressT` by extracting
the message builder and `raise_bad_checksum` helper.
```

### Description for the changelog

Improve error messages involving address literals with incorrect checksums

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
