### PR TITLE
refactor[venom]: remove dead IRFunction/IRBasicBlock `copy()` method

### DIFF
--- a/vyper/venom/basicblock.py
+++ b/vyper/venom/basicblock.py
@@ -773,13 +773,6 @@ class IRBasicBlock:
             return False
         return self.instructions[-1].opcode in HALTING_TERMINATORS
 
-    def copy(self) -> IRBasicBlock:
-        bb = IRBasicBlock(self.label, self.parent)
-        bb.instructions = [inst.copy() for inst in self.instructions]
-        for inst in bb.instructions:
-            inst.parent = bb
-        return bb
-
     def __repr__(self) -> str:
         printer = ir_printer.get()
 

--- a/vyper/venom/function.py
+++ b/vyper/venom/function.py
@@ -171,18 +171,6 @@ class IRFunction:
     def error_msg(self) -> Optional[str]:
         return self._error_msg_stack[-1] if len(self._error_msg_stack) > 0 else None
 
-    def copy(self):
-        new = IRFunction(self.name)
-        new._has_memory_return_buffer_param = self._has_memory_return_buffer_param
-        new._return_value_count = self._return_value_count
-        new._fmp_signature = self._fmp_signature
-        new.noinline = self.noinline
-        for bb in self.get_basic_blocks():
-            new_bb = bb.copy()
-            new.append_basic_block(new_bb)
-
-        return new
-
     def as_graph(self, only_subgraph=False) -> str:
         """
         Return the function as a graphviz dot string. If only_subgraph is True, only return the

--- a/vyper/venom/passes/function_inliner.py
+++ b/vyper/venom/passes/function_inliner.py
@@ -220,7 +220,6 @@ class FunctionInlinerPass(IRGlobalPass):
         new_func_label = IRLabel(f"{prefix}{func.name.value}")
         clone = IRFunction(new_func_label)
         # clear the bb that is added by default
-        # consider using func.copy() intead?
         clone.clear_basic_blocks()
         for bb in func.get_basic_blocks():
             clone.append_basic_block(self._clone_basic_block(clone, bb, prefix))


### PR DESCRIPTION
### What I did

Remove dead copy()'s

This obsoletes #4940, which fixes the method rather than deleting it.

### How I did it

### How to verify it

### Commit message

```
Remove dead copy()'s
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
