### PR TITLE
fix[tool]: report output bundle path errors

### DIFF
--- a/tests/unit/cli/vyper_compile/test_compile_files.py
+++ b/tests/unit/cli/vyper_compile/test_compile_files.py
@@ -15,7 +15,7 @@ from vyper.compiler.input_bundle import FilesystemInputBundle, JSONInputBundle
 from vyper.compiler.output_bundle import OutputBundle
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import Settings
-from vyper.exceptions import TypeMismatch
+from vyper.exceptions import BundleError, TypeMismatch
 from vyper.utils import sha256sum
 
 TAMPERED_INTEGRITY_SUM = sha256sum("tampered integrity sum")
@@ -606,6 +606,30 @@ def foo() -> uint256:
         _ = compile_files([archive_path], ["integrity", "bytecode", "layout"])
 
     assert e.value.message in w[0].message.message
+
+
+# test that a file which escapes all search paths (e.g. via a relative
+# import reaching above the search path root) produces a user-facing
+# error instead of a panic (GH 4706)
+def test_output_bundle_escaping_file(make_file, tmp_path, monkeypatch):
+    escaped_source = """
+x: constant(uint256) = 1
+    """
+    contract_source = """
+from .. import escaped
+
+y: constant(uint256) = escaped.x
+    """
+    make_file("escaped.vy", escaped_source)
+    contract_file = make_file("pkg/main.vy", contract_source)
+
+    monkeypatch.chdir(tmp_path / "pkg")
+
+    # sanity: compilation itself succeeds, only bundling fails
+    _ = compile_files([contract_file], ["bytecode"])
+
+    with pytest.raises(BundleError, match="escaped.vy"):
+        compile_files([contract_file], ["archive"])
 
 
 # maybe this belongs in tests/unit/compiler?

--- a/vyper/compiler/output_bundle.py
+++ b/vyper/compiler/output_bundle.py
@@ -11,7 +11,7 @@ import vyper
 from vyper.compiler.input_bundle import CompilerInput, JSONInput, _NotFound
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import Settings
-from vyper.exceptions import CompilerPanic
+from vyper.exceptions import BundleError
 from vyper.utils import safe_relpath
 
 # data structures and routines for constructing "output bundles",
@@ -116,10 +116,15 @@ class OutputBundle:
                     tmp[sp] += 1
                     ok = True
 
-            # this shouldn't happen unless a file escapes its package,
-            # *or* if we have a bug
+            # this happens when a file escapes its package, e.g. a
+            # relative import reaching above all search paths. we cannot
+            # construct a bundle which reproduces this build, so bail
+            # with a user-facing error.
             if not ok:
-                raise CompilerPanic(f"Invalid path: {c.resolved_path}")
+                raise BundleError(
+                    f"cannot bundle `{c.resolved_path}`: it is not contained in any search path",
+                    hint="run the compiler from a common parent directory of all source files",
+                )
 
         sps = [sp for sp, count in tmp.items() if count > 0]
         assert len(sps) > 0

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -373,6 +373,10 @@ class BadArchive(Exception):
     """Bad archive"""
 
 
+class BundleError(VyperException):
+    """Cannot construct an output bundle for this build."""
+
+
 class UnimplementedException(VyperException):
     """Some feature is known to be not implemented"""
 


### PR DESCRIPTION
_co-authored by claude fable 5_

Supersedes #4706.

### What I did

Raise a user-facing error instead of `CompilerPanic` when a source file escapes all search paths during output bundle construction (e.g. a relative import reaching above the search path root). The panic implied a compiler bug and told users to file an issue, but this is a user-configuration problem.

Why not #4706's approach (append `.` to the bundle search paths and emit the bundle anyway): it produces a silently-broken archive. Relative imports resolve from the importing module's parent, not from search paths, and `_anonymize` rewrites `..` segments (`../escaped.vy` → `0/escaped.vy`), so on recompilation the import requests `../escaped.vy`, which doesn't exist in the zip. A reproducible-build artifact that fails verification downstream is worse UX than an upfront error.

The error hint (run the compiler from a common parent directory of all sources) was verified to round-trip: with `..`-free relpaths, anonymization is the identity and the archive recompiles.

Note there is a residual pre-existing hole this PR does not close: adding e.g. `-p ..` puts the escaping file inside a search path, bypassing this check and silently emitting a broken archive. Tracked in #5226.

### How I did it

- new `BundleError(VyperException)` in `vyper/exceptions.py`
- `OutputBundle.used_search_paths` raises it (with hint) instead of `CompilerPanic`

### How to verify it

`test_output_bundle_escaping_file` covers it: compilation of the escaping layout succeeds, `-f archive` raises `BundleError`. Manually:

```
$ cd pkg && vyper -f archive main.vy   # main.vy has `from .. import escaped`
vyper.exceptions.BundleError: cannot bundle `/tmp/esc/escaped.vy`: it is not contained in any search path
  (hint: run the compiler from a common parent directory of all source files)
$ cd .. && vyper -f archive -o out.zip pkg/main.vy && vyper -f bytecode out.zip   # round-trips
```

### Commit message

```
fix[tool]: report output bundle path errors

raise a user-facing `BundleError` instead of `CompilerPanic` when a
source file escapes all search paths during output bundle construction
(e.g. a relative import reaching above the search path root). the
error hints to run the compiler from a common parent directory of all
sources, which makes relpaths `..`-free so the archive recompiles.
```

### Description for the changelog

Bundling a file outside all search paths now raises a `BundleError` with a recovery hint instead of `CompilerPanic`.

### Cute Animal Picture

![]()
