### PR TITLE
feat[lang]: make interfaces subtypes of `address`

### DIFF
--- a/tests/functional/codegen/test_interfaces.py
+++ b/tests/functional/codegen/test_interfaces.py
@@ -418,6 +418,35 @@ def test(addr: address):
         c.test(address)
 
 
+def test_interface_widens_to_address_in_exprs(env, get_contract):
+    code = """
+interface Foo:
+    def foo(): payable
+
+f: Foo
+
+@internal
+def _take_addr(a: address) -> address:
+    return a
+
+@external
+def test(addr: address) -> address:
+    self.f = Foo(addr)
+    assert addr == self.f # widen from equals
+
+    local_addr: address = self.f # widen from assignment
+    assert local_addr == addr
+
+    passed: address = self._take_addr(self.f) # widen from argument passing
+    assert passed == addr
+
+    return self.f # widen from return
+    """
+    c = get_contract(code)
+    some_address = env.accounts[1]
+    assert c.test(some_address) == some_address
+
+
 # test data returned from external interface gets clamped
 @pytest.mark.parametrize("typ", ("int128", "uint8"))
 def test_external_interface_int_clampers(get_contract, tx_failed, typ):

--- a/tests/functional/syntax/modules/test_implements.py
+++ b/tests/functional/syntax/modules/test_implements.py
@@ -144,3 +144,60 @@ def bar():  # implementation
 
     assert e.value._message == "some_interface implemented more than once"
     assert e.value._hint is None
+
+
+@pytest.mark.parametrize(
+    "var_decl,iface_method,store_stmt",
+    [
+        pytest.param(
+            "foo: public(IERC20)", "def foo() -> address: view", "self.foo = asset_", id="storage"
+        ),
+        pytest.param(  # GH issue 3954
+            "foo: public(immutable(IERC20))",
+            "def foo() -> address: view",
+            "self.foo = asset_",
+            id="immutable",
+        ),
+        pytest.param(
+            "foo: public(HashMap[uint256, IERC20])",
+            "def foo(k: uint256) -> address: view",
+            "self.foo[7] = asset_",
+            id="hashmap",
+        ),
+        pytest.param(
+            "foo: public(DynArray[IERC20, 3])",
+            "def foo(i: uint256) -> address: view",
+            "self.foo.append(asset_)",
+            id="dynarray",
+        ),
+        pytest.param(  # GH issue 4721
+            "foo: public(IERC20)",
+            "def foo() -> IERC20: view",
+            "self.foo = asset_",
+            id="interface_return",
+        ),
+    ],
+)
+def test_implements_with_public_interface(env, var_decl, iface_method, store_stmt):
+    """
+    Tests that `var_decl` correctly implements `iface_method`
+
+    For example `foo: public(IERC20)` implements `def foo() -> address: view`
+    """
+
+    main = f"""
+from ethereum.ercs import IERC20
+
+{var_decl}
+
+interface IAsset:
+    {iface_method}
+
+implements: IAsset
+
+@deploy
+def __init__(asset_: IERC20):
+    {store_stmt}
+    """
+    some_address = env.accounts[1]
+    compile_code(main, some_address)

--- a/tests/functional/syntax/modules/test_implements.py
+++ b/tests/functional/syntax/modules/test_implements.py
@@ -178,7 +178,7 @@ def bar():  # implementation
         ),
     ],
 )
-def test_implements_with_public_interface(env, var_decl, iface_method, store_stmt):
+def test_implements_with_public_interface(var_decl, iface_method, store_stmt):
     """
     Tests that `var_decl` correctly implements `iface_method`
 
@@ -199,5 +199,4 @@ implements: IAsset
 def __init__(asset_: IERC20):
     {store_stmt}
     """
-    some_address = env.accounts[1]
-    compile_code(main, some_address)
+    compile_code(main)

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -266,6 +266,16 @@ def f():
         """,
         InterfaceViolation,
     ),
+    (
+        """
+from ethereum.ercs import IERC20
+
+@external
+def test(a: address):
+    x: IERC20 = a  # Should not narrow
+        """,
+        TypeMismatch,
+    ),
 ]
 
 

--- a/vyper/semantics/types/module.py
+++ b/vyper/semantics/types/module.py
@@ -78,10 +78,6 @@ class InterfaceT(_UserType):
         return TYPE_T(self._helper.get_member(attr, node))
 
     @property
-    def getter_signature(self):
-        return (), AddressT()
-
-    @property
     def abi_type(self) -> ABIType:
         return ABI_Address()
 

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -439,6 +439,12 @@ class AddressT(_PrimT):
                 node,
             )
 
+    def compare_type(self, other):
+        from vyper.semantics.types.module import InterfaceT
+
+        # interfaces can be widened to addresses
+        return isinstance(other, InterfaceT) or super().compare_type(other)
+
 
 # type for "self"
 # refactoring note: it might be best for this to be a ModuleT actually


### PR DESCRIPTION
### What I did

Allow widening interfaces to addresses:
An interface value can be used anywhere an address is expected, for example:
* `a: addr = token` (where `token: IERC20`)
* Using a public `addr` to implement a method returning an address

Previously the latter was allowed by forcing the getter to return an address, this caused #4721.
The new logic only widens when needed, both cases are allowed:
`asset: public(IERC20)` can implement both `def asset() -> IERC20` and `def asset() -> address`

Fix #3954
Fix #4721
Implement https://github.com/vyperlang/vyper/issues/3701#issuecomment-2046216466 (note: not the issue as a whole, only this comment)

### How I did it

Make interfaces subtypes of address: for any `SomeInterface` an `InterfaceT`: `SomeInterface <: AddressT`
Remove the special case that public interface members return an address

### How to verify it

`pytest`

See added tests

### Commit message

```
before this commit interfaces were allowed in places where an address
was expected in exactly one situation: when using a public interface
member to implement an address-returning method. this commit extends
this capability to all locations: anywhere an address is expected, an
interface instance can be provided.
```

### Description for the changelog

Allow assigning interfaces where addresses are expected
Fix code like `asset: public(IERC20)` not being allowed to implement `def asset() -> IERC20`

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
