### PR TITLE
fix[codegen]: preserve consts when pruning dead code

### DIFF
--- a/tests/functional/codegen/features/test_immutable.py
+++ b/tests/functional/codegen/features/test_immutable.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper.compiler.settings import OptimizationLevel
+from vyper.utils import method_id
 
 
 @pytest.mark.parametrize(
@@ -741,3 +742,28 @@ def __init__(arg: uint256):
 
     with tx_failed():
         get_contract(code, arg)
+
+
+@pytest.mark.parametrize(
+    "terminator,revert_reason",
+    [('raise "nope"', "nope"), ('raw_revert(method_id("Nope()"))', method_id("Nope()").hex())],
+)
+def test_always_reverting_constructor_with_immutables(
+    get_contract, tx_failed, terminator, revert_reason
+):
+    # the `deploy` fragment declares the `mem_deploy_end` constant, which is
+    # referenced by the immutable store in the constructor. when the
+    # constructor always reverts, that fragment is unreachable; the
+    # declaration must survive dead code elimination anyway.
+    code = f"""
+V: public(immutable(uint256))
+
+@deploy
+def __init__():
+    self.V = 1
+    {terminator}
+    """
+
+    # deployment reverts, with the revert reason from the constructor
+    with tx_failed(exc_text=revert_reason):
+        get_contract(code)

--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -3,8 +3,8 @@ import pytest
 from vyper.compiler import compile_code
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings
-from vyper.evm.assembler.instructions import PUSHLABEL, Label
-from vyper.evm.assembler.optimizer import _merge_jumpdests
+from vyper.evm.assembler.instructions import CONST, PUSHLABEL, Label
+from vyper.evm.assembler.optimizer import _merge_jumpdests, _prune_unreachable_code
 
 codes = [
     """
@@ -133,3 +133,14 @@ def test_merge_jumpdests():
     asm = [PUSHLABEL(Label("label_0")), "JUMP", "PUSH0", Label("label_0"), Label("_label_0")]
 
     assert _merge_jumpdests(asm) is False, "should not return True as no changes were made"
+
+
+def test_prune_unreachable_code_keeps_consts():
+    # CONST declarations produce no bytecode and can be referenced from
+    # reachable code, so they must not be pruned along with dead code
+    asm = ["REVERT", "PUSH0", CONST("some_const", 5), "PUSH0", Label("label_0")]
+
+    assert _prune_unreachable_code(asm) is True
+    assert asm == ["REVERT", CONST("some_const", 5), Label("label_0")]
+
+    assert _prune_unreachable_code(asm) is False, "should not return True as no changes were made"

--- a/tests/unit/compiler/asm/test_asm_optimizer.py
+++ b/tests/unit/compiler/asm/test_asm_optimizer.py
@@ -3,8 +3,13 @@ import pytest
 from vyper.compiler import compile_code
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings
-from vyper.evm.assembler.instructions import CONST, PUSHLABEL, Label
-from vyper.evm.assembler.optimizer import _merge_jumpdests, _prune_unreachable_code
+from vyper.evm.assembler.instructions import CONST, CONSTREF, PUSH_OFST, PUSHLABEL, Label
+from vyper.evm.assembler.optimizer import (
+    _merge_jumpdests,
+    _prune_unreachable_code,
+    _prune_unused_consts,
+    optimize_assembly,
+)
 
 codes = [
     """
@@ -144,3 +149,37 @@ def test_prune_unreachable_code_keeps_consts():
     assert asm == ["REVERT", CONST("some_const", 5), Label("label_0")]
 
     assert _prune_unreachable_code(asm) is False, "should not return True as no changes were made"
+
+
+def test_prune_unused_consts():
+    asm = [CONST("used", 5), CONST("unused", 6), PUSH_OFST(CONSTREF("used"), 0), Label("label_0")]
+
+    assert _prune_unused_consts(asm) is True
+    assert asm == [CONST("used", 5), PUSH_OFST(CONSTREF("used"), 0), Label("label_0")]
+
+    assert _prune_unused_consts(asm) is False, "should not return True as no changes were made"
+
+
+def test_dead_consts_are_pruned():
+    # a CONST declared in unreachable code survives dead code elimination if
+    # reachable code still refers to it, and is removed otherwise
+    asm = [
+        PUSHLABEL(Label("label_0")),
+        "JUMP",
+        CONST("used", 5),
+        CONST("unused", 6),
+        Label("label_0"),
+        PUSH_OFST(CONSTREF("used"), 0),
+        "STOP",
+    ]
+
+    optimize_assembly(asm)
+
+    assert asm == [
+        PUSHLABEL(Label("label_0")),
+        "JUMP",
+        CONST("used", 5),
+        Label("label_0"),
+        PUSH_OFST(CONSTREF("used"), 0),
+        "STOP",
+    ]

--- a/vyper/evm/assembler/optimizer.py
+++ b/vyper/evm/assembler/optimizer.py
@@ -1,4 +1,5 @@
 from vyper.evm.assembler.instructions import (
+    CONST,
     DATA_ITEM,
     PUSH_OFST,
     PUSHLABEL,
@@ -28,8 +29,17 @@ def _prune_unreachable_code(assembly):
                 # fixup an off-by-one if we made it to the end of the assembly
                 # without finding an jumpdest or sublist
                 j = len(assembly)
-            changed |= j > i + 1
-            del assembly[i + 1 : j]
+
+            # CONST items are declarations, not code -- they contribute no
+            # bytes to the bytecode, and can be referenced (via CONSTREF)
+            # from code which *is* reachable. deleting them would leave a
+            # dangling CONSTREF at symbol resolution time. (this happens with
+            # `mem_deploy_end`, which is declared by the `deploy` fragment --
+            # unreachable when the constructor always reverts -- but
+            # referenced by `iload`/`istore` in the constructor body.)
+            consts = [item for item in assembly[i + 1 : j] if isinstance(item, CONST)]
+            changed |= len(consts) < j - (i + 1)
+            assembly[i + 1 : j] = consts
 
         i += 1
 

--- a/vyper/evm/assembler/optimizer.py
+++ b/vyper/evm/assembler/optimizer.py
@@ -1,5 +1,6 @@
 from vyper.evm.assembler.instructions import (
     CONST,
+    CONSTREF,
     DATA_ITEM,
     PUSH_OFST,
     PUSHLABEL,
@@ -32,11 +33,14 @@ def _prune_unreachable_code(assembly):
 
             # CONST items are declarations, not code -- they contribute no
             # bytes to the bytecode, and can be referenced (via CONSTREF)
-            # from code which *is* reachable. deleting them would leave a
+            # from code which *is* reachable, so they must survive even when
+            # they sit in an unreachable range. deleting them would leave a
             # dangling CONSTREF at symbol resolution time. (this happens with
-            # `mem_deploy_end`, which is declared by the `deploy` fragment --
+            # `mem_deploy_end`, which is declared by the deploy sequence --
             # unreachable when the constructor always reverts -- but
             # referenced by `iload`/`istore` in the constructor body.)
+            # declarations which really are unused are removed by
+            # `_prune_unused_consts`.
             consts = [item for item in assembly[i + 1 : j] if isinstance(item, CONST)]
             changed |= len(consts) < j - (i + 1)
             assembly[i + 1 : j] = consts
@@ -210,6 +214,29 @@ def _prune_unused_jumpdests(assembly):
     return changed
 
 
+def _prune_unused_consts(assembly):
+    # CONST declarations produce no bytecode, so they are only needed if
+    # something still refers to them.
+    changed = False
+
+    used_consts: set[CONSTREF] = set()
+
+    for item in assembly:
+        if isinstance(item, PUSH_OFST) and isinstance(item.label, CONSTREF):
+            used_consts.add(item.label)
+
+    i = 0
+    while i < len(assembly):
+        item = assembly[i]
+        if isinstance(item, CONST) and CONSTREF(item.name) not in used_consts:
+            changed = True
+            del assembly[i]
+        else:
+            i += 1
+
+    return changed
+
+
 def _stack_peephole_opts(assembly):
     changed = False
     i = 0
@@ -263,6 +290,7 @@ def optimize_assembly(assembly):
         changed |= _prune_inefficient_jumps(assembly)
         changed |= _optimize_inefficient_jumps(assembly)
         changed |= _prune_unused_jumpdests(assembly)
+        changed |= _prune_unused_consts(assembly)
         changed |= _stack_peephole_opts(assembly)
 
         if not changed:


### PR DESCRIPTION
### What I did

Fix an codegen bug causing (`KeyError: CONSTREF mem_deploy_end`) when compiling a contract which has an immutable and a constructor that always reverts.

Repro, on master with default settings:

```vyper
V: public(immutable(uint256))

@deploy
def __init__():
    self.V = 1
    raise "nope"
```

```
KeyError: CONSTREF mem_deploy_end
```

### How I did it

### How to verify it

### Commit message

```
`_prune_unreachable_code` deletes every assembly item between an
unconditional terminator and the next JUMPDEST. when the constructor
always reverts, the deploy sequence which follows the constructor body
is unreachable, so it gets pruned. but that sequence also *declares*
`mem_deploy_end`, and the `istore`/`iload` sequences for immutables --
which are in reachable code -- refer to it via CONSTREF. pruning the
declaration leaves the reference dangling and symbol resolution fails.

CONST items are declarations, not code: they emit no bytes and their
position in the assembly list carries no meaning. so rather than
special-casing `mem_deploy_end` or hoisting its declaration out of the
deploy sequence, keep CONST items in place and prune only the items
which actually emit bytecode. this covers any zero-byte declaration that
lands in an unreachable range, not just this one.

only the legacy pipeline is affected -- venom compiles the same contract
fine. `-O none` is also unaffected, since the assembly optimizer does
not run at that level.
```

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
