### PR TITLE
refactor[parser]: remove `ParserException`

### DIFF
--- a/tests/unit/ast/test_parser.py
+++ b/tests/unit/ast/test_parser.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from tests.ast_utils import deepequals
@@ -5,7 +7,9 @@ from vyper.ast.parse import parse_to_ast
 from vyper.compiler import compile_code
 from vyper.exceptions import SyntaxException
 
-_NULL_BYTE_MSG = "source code string cannot contain null bytes"
+_NULL_BYTE_MSG = (
+    f"source code {'string ' if sys.version_info < (3, 12) else ''}cannot contain null bytes"
+)
 
 
 def test_ast_equal():

--- a/tests/unit/ast/test_parser.py
+++ b/tests/unit/ast/test_parser.py
@@ -2,7 +2,10 @@ import pytest
 
 from tests.ast_utils import deepequals
 from vyper.ast.parse import parse_to_ast
+from vyper.compiler import compile_code
 from vyper.exceptions import SyntaxException
+
+_NULL_BYTE_MSG = "source code string cannot contain null bytes"
 
 
 def test_ast_equal():
@@ -53,3 +56,50 @@ def f():
     annotation = exc.annotations[0]
     assert (annotation.lineno, annotation.col_offset) == (3, 4)
     assert annotation.full_source_code == code
+
+
+def test_null_byte_in_main_file():
+    code = "a: uint256 = 1\x00\n"
+    with pytest.raises(SyntaxException) as exc_info:
+        compile_code(code)
+    assert exc_info.value.message == _NULL_BYTE_MSG
+
+
+def test_null_byte_in_imported_module(make_input_bundle):
+    lib = """
+@internal
+def foo() -> uint256:
+    return 1\x00
+"""
+    main = """
+import lib
+
+@external
+def bar() -> uint256:
+    return lib.foo()
+"""
+    input_bundle = make_input_bundle({"lib.vy": lib})
+    with pytest.raises(SyntaxException) as exc_info:
+        compile_code(main, input_bundle=input_bundle)
+    assert exc_info.value.message == _NULL_BYTE_MSG
+
+
+def test_null_byte_in_interface_file(make_input_bundle):
+    ifoo = """
+@external
+def foo():
+    ...\x00
+"""
+    main = """
+import ifoo
+
+implements: ifoo
+
+@external
+def foo():
+    pass
+"""
+    input_bundle = make_input_bundle({"ifoo.vyi": ifoo})
+    with pytest.raises(SyntaxException) as exc_info:
+        compile_code(main, input_bundle=input_bundle)
+    assert exc_info.value.message == _NULL_BYTE_MSG

--- a/tests/unit/ast/test_parser.py
+++ b/tests/unit/ast/test_parser.py
@@ -7,9 +7,10 @@ from vyper.ast.parse import parse_to_ast
 from vyper.compiler import compile_code
 from vyper.exceptions import SyntaxException
 
-_NULL_BYTE_MSG = (
-    f"source code {'string ' if sys.version_info < (3, 12) else ''}cannot contain null bytes"
-)
+if sys.version_info < (3, 12):
+    _NULL_BYTE_MSG = "source code string cannot contain null bytes"
+else:
+    _NULL_BYTE_MSG = "source code cannot contain null bytes"
 
 
 def test_ast_equal():

--- a/vyper/ast/parse.py
+++ b/vyper/ast/parse.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from vyper.ast import nodes as vy_ast
 from vyper.ast.pre_parser import PreParser
-from vyper.exceptions import CompilerPanic, ParserException, SyntaxException
+from vyper.exceptions import CompilerPanic, SyntaxException
 from vyper.utils import sha256sum
 from vyper.warnings import Deprecation, vyper_warn
 
@@ -71,8 +71,6 @@ def _parse_to_ast(
     list
         Untyped, unoptimized Vyper AST nodes.
     """
-    if "\x00" in vyper_source:
-        raise ParserException("No null bytes (\\x00) allowed in the source code.")
     pre_parser = PreParser(is_interface)
     pre_parser.parse(vyper_source)
 

--- a/vyper/ast/pre_parser.py
+++ b/vyper/ast/pre_parser.py
@@ -267,6 +267,8 @@ class PreParser:
             self._parse(code)
         except TokenError as e:
             raise SyntaxException(e.args[0], code, e.args[1][0], e.args[1][1]) from e
+        except SyntaxError as e:
+            raise SyntaxException(e.args[0], code, e.lineno, e.offset) from e
 
     def _parse(self, code: str):
         adjustments: dict = {}

--- a/vyper/exceptions.py
+++ b/vyper/exceptions.py
@@ -365,10 +365,6 @@ class JSONError(Exception):
         self.col_offset = col_offset
 
 
-class ParserException(Exception):
-    """Contract source cannot be parsed."""
-
-
 class BadArchive(Exception):
     """Bad archive"""
 


### PR DESCRIPTION
### What I did

Remove `ParserException`
The one error that used it is now a `SyntaxException`

### How I did it

It was only used for a single error: when a source file contains null bytes
Since the python parser already checks for it, we can instead rely on that

### How to verify it

See new tests in tests/unit/ast/test_parser.py

### Commit message

```
`ParserException` was only used when a source file contains null bytes.
this was checked before running the python parser, which emits a similar
error message. this commit removes `ParserException` by leveraging that
fact, as a result the error goes from `ParserException("No null bytes
(\\x00) allowed in the source code.")` to `SyntaxException("source code
string cannot contain null bytes")`
```

### Description for the changelog

(refactor, no visible change)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
