### PR TITLE
feat[venom]: amortize unbounded `DynArray` append

### DIFF
--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -207,6 +207,128 @@ def build() -> DynArray[uint256, INF]:
     assert c.build() == [i * i + 7 for i in range(64)]
 
 
+def test_inf_dynarray_append_loop_full_contents(get_contract):
+    code = """
+@external
+def build(n: uint256) -> DynArray[uint256, INF]:
+    x: DynArray[uint256, INF] = []
+    for i: uint256 in range(n, bound=100):
+        x.append(i * 3 + 1)
+    return x
+    """
+
+    c = get_contract(code)
+    for n in [0, 1, 2, 3, 5, 8, 13, 20]:
+        assert c.build(n) == [i * 3 + 1 for i in range(n)]
+
+
+def test_inf_dynarray_append_after_assignment_and_calldata(get_contract):
+    code = """
+@external
+def from_literal() -> DynArray[uint256, INF]:
+    x: DynArray[uint256, INF] = [1, 2, 3]
+    x.append(4)
+    x.append(5)
+    return x
+
+@external
+def from_calldata(x: DynArray[uint256, INF]) -> DynArray[uint256, INF]:
+    y: DynArray[uint256, INF] = x
+    y.append(7)
+    y.append(8)
+    return y
+    """
+
+    c = get_contract(code)
+    assert c.from_literal() == [1, 2, 3, 4, 5]
+    assert c.from_calldata([4, 5, 6]) == [4, 5, 6, 7, 8]
+
+
+def test_inf_dynarray_append_reassign_append(get_contract):
+    code = """
+@external
+def check() -> DynArray[uint256, INF]:
+    x: DynArray[uint256, INF] = [1]
+    x.append(2)
+    x.append(3)
+    x = [10, 20]
+    x.append(30)
+    return x
+    """
+
+    c = get_contract(code)
+    assert c.check() == [10, 20, 30]
+
+
+def test_inf_dynarray_append_after_kwarg_default(get_contract):
+    code = """
+@external
+def build(x: DynArray[uint256, INF] = [12, 34]) -> DynArray[uint256, INF]:
+    y: DynArray[uint256, INF] = x
+    y.append(56)
+    return y
+    """
+
+    c = get_contract(code)
+    assert c.build() == [12, 34, 56]
+    assert c.build([1]) == [1, 56]
+
+
+def test_inf_dynarray_internal_arg_append_does_not_mutate_caller(
+    get_contract, no_inlining_settings
+):
+    code = """
+@internal
+def _extend(x: DynArray[uint256, INF]) -> DynArray[uint256, INF]:
+    x.append(4)
+    x.append(5)
+    return x
+
+@external
+def check() -> (DynArray[uint256, INF], DynArray[uint256, INF]):
+    x: DynArray[uint256, INF] = [1, 2, 3]
+    y: DynArray[uint256, INF] = self._extend(x)
+    return x, y
+    """
+
+    c = get_contract(code, compiler_settings=no_inlining_settings)
+    assert c.check() == ([1, 2, 3], [1, 2, 3, 4, 5])
+
+
+def test_inf_dynarray_two_locals_alternating_append(get_contract):
+    code = """
+@external
+def build(n: uint256) -> (DynArray[uint256, INF], DynArray[uint256, INF]):
+    a: DynArray[uint256, INF] = []
+    b: DynArray[uint256, INF] = []
+    for i: uint256 in range(n, bound=50):
+        a.append(i)
+        b.append(i * 100)
+    return a, b
+    """
+
+    c = get_contract(code)
+    for n in [0, 1, 7, 20]:
+        assert c.build(n) == (list(range(n)), [i * 100 for i in range(n)])
+
+
+def test_inf_dynarray_pop_then_append_full_contents(get_contract):
+    code = """
+@external
+def check() -> DynArray[uint256, INF]:
+    x: DynArray[uint256, INF] = []
+    for i: uint256 in range(6):
+        x.append(i)
+    y: uint256 = x.pop()
+    x.append(y + 100)
+    x.append(200)
+    return x
+    """
+
+    c = get_contract(code)
+    assert c.check() == [0, 1, 2, 3, 4, 105, 200]
+
+
 def test_inf_dynarray_indexed_store(get_contract, tx_failed):
     code = """
 @external

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -128,6 +128,7 @@ class VenomCodegenContext:
     # Size of an unbounded (INF) local's pointer cell: two adjacent words,
     # [payload_ptr][capacity]. See `store_pointer_cell`.
     POINTER_CELL_SIZE = 64
+    POINTER_CELL_CAPACITY_OFFSET = 32
 
     def new_pointer_cell_variable(
         self, name: str, typ: VyperType, mutable: bool = True
@@ -180,7 +181,18 @@ class VenomCodegenContext:
         """
         assert isinstance(cell, IRVariable)
         self.builder.mstore(cell, ptr)
-        self.builder.mstore(self.builder.add(cell, IRLiteral(32)), capacity)
+        capacity_slot = self.builder.add(cell, IRLiteral(self.POINTER_CELL_CAPACITY_OFFSET))
+        self.builder.mstore(capacity_slot, capacity)
+
+    def load_pointer_cell(self, cell: IROperand) -> tuple[IRVariable, IRVariable]:
+        """Load `(ptr, capacity)` from a pointer cell; layout in `store_pointer_cell`."""
+        assert isinstance(cell, IRVariable)
+        ptr = self.builder.mload(cell)
+        capacity_slot = self.builder.add(cell, IRLiteral(self.POINTER_CELL_CAPACITY_OFFSET))
+        capacity = self.builder.mload(capacity_slot)
+        assert isinstance(ptr, IRVariable)
+        assert isinstance(capacity, IRVariable)
+        return ptr, capacity
 
     def register_variable(
         self, name: str, typ: VyperType, ptr: IRVariable, mutable: bool = True

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -164,6 +164,11 @@ class VenomCodegenContext:
         )
         self.variables[name] = var
 
+    def store_pointer_cell(self, cell: IROperand, ptr: IROperand) -> None:
+        """Store a local's current memory pointer into its pointer cell."""
+        assert isinstance(cell, IRVariable)
+        self.builder.mstore(cell, ptr)
+
     def register_variable(
         self, name: str, typ: VyperType, ptr: IRVariable, mutable: bool = True
     ) -> None:

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -133,7 +133,9 @@ class VenomCodegenContext:
     def new_pointer_cell_variable(
         self, name: str, typ: VyperType, mutable: bool = True
     ) -> LocalVariable:
-        """Register a local whose stable memory cell stores its current memory pointer."""
+        """Register a local whose stable memory cell stores its current payload
+        pointer and capacity (see `store_pointer_cell`).
+        """
         buf = self.allocate_buffer(self.POINTER_CELL_SIZE, annotation=f"{name}_ptr")
         value = VyperValue.from_ptr(buf.base_ptr(), typ)
         var = LocalVariable(
@@ -157,7 +159,9 @@ class VenomCodegenContext:
     def register_pointer_cell_variable(
         self, name: str, typ: VyperType, ptr: IRVariable, mutable: bool = True
     ) -> None:
-        """Register an existing memory cell that stores the local's current pointer."""
+        """Register an existing memory cell that stores the local's current payload
+        pointer and capacity (see `store_pointer_cell`).
+        """
         buf = Buffer(_ptr=ptr, size=self.POINTER_CELL_SIZE, annotation=f"{name}_ptr")
         value = VyperValue.from_ptr(buf.base_ptr(), typ)
         var = LocalVariable(
@@ -346,7 +350,11 @@ class VenomCodegenContext:
         return self.dynamic_tuple_frame_value(frame, typ, annotation=annotation)
 
     def load_pointer_cell_value(self, var: LocalVariable) -> VyperValue:
-        """Load the current dynamic memory pointer from a pointer-cell local."""
+        """Load the current payload pointer from a pointer-cell local.
+
+        Only the pointer word is read; the cell also carries capacity
+        (see `store_pointer_cell`).
+        """
         ptr = self.ptr_load(var.value.ptr())
         assert isinstance(ptr, IRVariable)
         return self.dynamic_memory_value(ptr, var.value.typ, annotation=var.name)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -125,11 +125,15 @@ class VenomCodegenContext:
         self.variables[name] = var
         return var
 
+    # Size of an unbounded (INF) local's pointer cell: two adjacent words,
+    # [payload_ptr][capacity]. See `store_pointer_cell`.
+    POINTER_CELL_SIZE = 64
+
     def new_pointer_cell_variable(
         self, name: str, typ: VyperType, mutable: bool = True
     ) -> LocalVariable:
         """Register a local whose stable memory cell stores its current memory pointer."""
-        buf = self.allocate_buffer(32, annotation=f"{name}_ptr")
+        buf = self.allocate_buffer(self.POINTER_CELL_SIZE, annotation=f"{name}_ptr")
         value = VyperValue.from_ptr(buf.base_ptr(), typ)
         var = LocalVariable(
             name=name,
@@ -153,7 +157,7 @@ class VenomCodegenContext:
         self, name: str, typ: VyperType, ptr: IRVariable, mutable: bool = True
     ) -> None:
         """Register an existing memory cell that stores the local's current pointer."""
-        buf = Buffer(_ptr=ptr, size=32, annotation=f"{name}_ptr")
+        buf = Buffer(_ptr=ptr, size=self.POINTER_CELL_SIZE, annotation=f"{name}_ptr")
         value = VyperValue.from_ptr(buf.base_ptr(), typ)
         var = LocalVariable(
             name=name,
@@ -164,10 +168,19 @@ class VenomCodegenContext:
         )
         self.variables[name] = var
 
-    def store_pointer_cell(self, cell: IROperand, ptr: IROperand) -> None:
-        """Store a local's current memory pointer into its pointer cell."""
+    def store_pointer_cell(self, cell: IROperand, ptr: IROperand, capacity: IROperand) -> None:
+        """Store a local's current memory pointer and capacity into its pointer cell.
+
+        The 64-byte cell holds two words: the payload pointer at `cell` and
+        the capacity at `cell + 32`. Capacity is the element count the owned
+        payload has room for; 0 is a sentinel meaning "no owned spare room",
+        which forces reallocation on the next append. Every store except
+        DynArray append passes 0 (Bytes[INF]/String[INF] cells keep it
+        permanently 0 — bytestrings have no append).
+        """
         assert isinstance(cell, IRVariable)
         self.builder.mstore(cell, ptr)
+        self.builder.mstore(self.builder.add(cell, IRLiteral(32)), capacity)
 
     def register_variable(
         self, name: str, typ: VyperType, ptr: IRVariable, mutable: bool = True

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1869,7 +1869,8 @@ class Expr:
 
         new_length = self.builder.add(length, IRLiteral(1))
         self.builder.mstore(new_ptr, new_length)
-        self.ctx.store_pointer_cell(var.value.operand, new_ptr)
+        # the exact-sized payload has room for exactly new_length elements
+        self.ctx.store_pointer_cell(var.value.operand, new_ptr, new_length)
         return VyperValue.from_stack_op(IRLiteral(0), VOID_TYPE)
 
     def _lower_dynarray_pop(self) -> VyperValue:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1809,12 +1809,17 @@ class Expr:
         return VyperValue.from_stack_op(IRLiteral(0), VOID_TYPE)
 
     def _lower_unbounded_dynarray_append(self) -> VyperValue:
-        """Lower append on exact-sized DynArray[..., INF] pointer-cell locals.
+        """Lower append on DynArray[..., INF] pointer-cell locals.
 
-        The current representation keeps no spare capacity: each append
-        allocates the exact new size and copies the old payload before writing
-        the new element. Repeated appends are therefore linear per append and
-        quadratic in aggregate.
+        The pointer cell carries the owned payload capacity next to the
+        payload pointer (see VenomCodegenContext.store_pointer_cell). When
+        the payload has spare room the element is written in place; otherwise
+        a payload of `max(2 * capacity, length + 1)` elements is allocated
+        and the old contents copied over, making repeated appends amortized
+        linear in aggregate. Non-append stores leave capacity at 0, so the
+        first append after an assignment/decode allocates the exact new size
+        (no 2x memory jump on a large ingested array) and doubling starts
+        from there.
         """
         node = self.node
         assert isinstance(node, vy_ast.Call)
@@ -1848,29 +1853,57 @@ class Expr:
         else:
             elem_val = arg_val
 
+        b = self.builder
+
+        cell = var.value.operand
+        assert isinstance(cell, IRVariable)
         old_ptr = self.ctx.ptr_load(var.value.ptr())
         assert isinstance(old_ptr, IRVariable)
-        length = self.builder.mload(old_ptr)
+        length = b.mload(old_ptr)
+        capacity = b.mload(b.add(cell, IRLiteral(32)))
         elem_size = elem_typ.memory_bytes_required
 
-        old_size = self.ctx.dynarray_runtime_size_from_length(length, darray_typ)
-        data_size = self.builder.sub(old_size, IRLiteral(32))
-        new_size = self.ctx.checked_add(old_size, IRLiteral(elem_size))
+        # every payload a pointer cell can reference was allocated with a
+        # checked `32 + length * elem_size`, so recomputing it cannot overflow
+        data_size = b.mul(length, IRLiteral(elem_size))
 
+        target_cell = self.ctx.allocate_buffer(32, annotation="append target ptr")
+        fast_bb = b.create_block("append_fast")
+        grow_bb = b.create_block("append_grow")
+        join_bb = b.create_block("append_join")
+
+        b.jnz(b.lt(length, capacity), fast_bb.label, grow_bb.label)
+
+        b.append_block(fast_bb)
+        b.set_block(fast_bb)
+        b.mstore(target_cell._ptr, old_ptr)
+        b.jmp(join_bb.label)
+
+        b.append_block(grow_bb)
+        b.set_block(grow_bb)
+        doubled = self.ctx.checked_add(capacity, capacity)
+        min_cap = self.ctx.checked_add(length, IRLiteral(1))
+        new_cap = b.select(b.lt(doubled, min_cap), min_cap, doubled)
+        new_size = self.ctx.checked_add(
+            IRLiteral(32), self.ctx.checked_mul(new_cap, IRLiteral(elem_size))
+        )
         new_ptr = self.ctx.allocate_scratch(new_size)
+        old_size = b.add(IRLiteral(32), data_size)
         self.ctx.copy_memory_dynamic(new_ptr, old_ptr, old_size)
+        self.ctx.store_pointer_cell(cell, new_ptr, new_cap)
+        b.mstore(target_cell._ptr, new_ptr)
+        b.jmp(join_bb.label)
 
-        data_ptr = self.builder.add(new_ptr, IRLiteral(32))
-        elem_ptr = self.builder.add(data_ptr, data_size)
+        b.append_block(join_bb)
+        b.set_block(join_bb)
+        target_ptr = b.mload(target_cell._ptr)
+        assert isinstance(target_ptr, IRVariable)
+        elem_ptr = b.add(b.add(target_ptr, IRLiteral(32)), data_size)
         if elem_typ._is_prim_word:
-            self.builder.mstore(elem_ptr, elem_val)
+            b.mstore(elem_ptr, elem_val)
         else:
             self.ctx.store_memory(elem_val, elem_ptr, elem_typ, src_typ=elem_typ)
-
-        new_length = self.builder.add(length, IRLiteral(1))
-        self.builder.mstore(new_ptr, new_length)
-        # the exact-sized payload has room for exactly new_length elements
-        self.ctx.store_pointer_cell(var.value.operand, new_ptr, new_length)
+        b.mstore(target_ptr, b.add(length, IRLiteral(1)))
         return VyperValue.from_stack_op(IRLiteral(0), VOID_TYPE)
 
     def _lower_dynarray_pop(self) -> VyperValue:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1869,7 +1869,7 @@ class Expr:
 
         new_length = self.builder.add(length, IRLiteral(1))
         self.builder.mstore(new_ptr, new_length)
-        self.ctx.ptr_store(var.value.ptr(), new_ptr)
+        self.ctx.store_pointer_cell(var.value.operand, new_ptr)
         return VyperValue.from_stack_op(IRLiteral(0), VOID_TYPE)
 
     def _lower_dynarray_pop(self) -> VyperValue:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1884,9 +1884,7 @@ class Expr:
         doubled = self.ctx.checked_add(capacity, capacity)
         min_cap = self.ctx.checked_add(length, IRLiteral(1))
         new_cap = b.select(b.lt(doubled, min_cap), min_cap, doubled)
-        new_size = self.ctx.checked_add(
-            IRLiteral(32), self.ctx.checked_mul(new_cap, IRLiteral(elem_size))
-        )
+        new_size = self.ctx.dynarray_runtime_size_from_length(new_cap, darray_typ)
         new_ptr = self.ctx.allocate_scratch(new_size)
         old_size = b.add(IRLiteral(32), data_size)
         self.ctx.copy_memory_dynamic(new_ptr, old_ptr, old_size)

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -1857,10 +1857,8 @@ class Expr:
 
         cell = var.value.operand
         assert isinstance(cell, IRVariable)
-        old_ptr = self.ctx.ptr_load(var.value.ptr())
-        assert isinstance(old_ptr, IRVariable)
+        old_ptr, capacity = self.ctx.load_pointer_cell(cell)
         length = b.mload(old_ptr)
-        capacity = b.mload(b.add(cell, IRLiteral(32)))
         elem_size = elem_typ.memory_bytes_required
 
         # every payload a pointer cell can reference was allocated with a

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -1107,7 +1107,7 @@ def _store_abi_arg_to_existing_ptr(
         assert elem_src.location is not None, "src must have a location for ABI decoding"
         hi = _abi_arg_hi(ctx, elem_src.location)
         val = decode_unbounded_sequence_to_scratch(ctx, elem_src, arg.typ, hi, arg.name)
-        ctx.builder.mstore(dst, val.operand)
+        ctx.store_pointer_cell(dst, val.operand)
         return
 
     # Bounded args are capped by the type clamp; no hi bound needed (see above).
@@ -1139,7 +1139,7 @@ def _store_default_arg_to_existing_ptr(
     if is_unbounded_sequence_type(arg.typ):
         default_vv = Expr(default_node, ctx).lower()
         val = ctx.copy_sequence_to_scratch(default_vv, arg.typ, annotation=arg.name)
-        ctx.builder.mstore(dst, val.operand)
+        ctx.store_pointer_cell(dst, val.operand)
         return
 
     if arg.typ._is_prim_word:
@@ -1414,7 +1414,7 @@ def _generate_internal_function(
             ptr = builder.param()
             if is_unbounded_sequence_type(arg.typ):
                 var = codegen_ctx.new_pointer_cell_variable(arg.name, arg.typ, mutable=True)
-                codegen_ctx.ptr_store(var.value.ptr(), ptr)
+                codegen_ctx.store_pointer_cell(var.value.operand, ptr)
             else:
                 codegen_ctx.register_variable(arg.name, arg.typ, ptr, mutable=True)
 

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -1107,7 +1107,7 @@ def _store_abi_arg_to_existing_ptr(
         assert elem_src.location is not None, "src must have a location for ABI decoding"
         hi = _abi_arg_hi(ctx, elem_src.location)
         val = decode_unbounded_sequence_to_scratch(ctx, elem_src, arg.typ, hi, arg.name)
-        ctx.store_pointer_cell(dst, val.operand)
+        ctx.store_pointer_cell(dst, val.operand, IRLiteral(0))
         return
 
     # Bounded args are capped by the type clamp; no hi bound needed (see above).
@@ -1139,7 +1139,7 @@ def _store_default_arg_to_existing_ptr(
     if is_unbounded_sequence_type(arg.typ):
         default_vv = Expr(default_node, ctx).lower()
         val = ctx.copy_sequence_to_scratch(default_vv, arg.typ, annotation=arg.name)
-        ctx.store_pointer_cell(dst, val.operand)
+        ctx.store_pointer_cell(dst, val.operand, IRLiteral(0))
         return
 
     if arg.typ._is_prim_word:
@@ -1218,7 +1218,7 @@ def _create_kwarg_allocas(
     kwarg_vars: dict[str, IRVariable] = {}
     for arg in func_t.keyword_args:
         if is_unbounded_sequence_type(arg.typ):
-            size = 32
+            size = VenomCodegenContext.POINTER_CELL_SIZE
         else:
             size = arg.typ.memory_bytes_required
         ptr = builder.alloca(size)
@@ -1414,7 +1414,7 @@ def _generate_internal_function(
             ptr = builder.param()
             if is_unbounded_sequence_type(arg.typ):
                 var = codegen_ctx.new_pointer_cell_variable(arg.name, arg.typ, mutable=True)
-                codegen_ctx.store_pointer_cell(var.value.operand, ptr)
+                codegen_ctx.store_pointer_cell(var.value.operand, ptr, IRLiteral(0))
             else:
                 codegen_ctx.register_variable(arg.name, arg.typ, ptr, mutable=True)
 

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -187,7 +187,7 @@ class Stmt:
         if not is_unbounded_sequence_type(typ):  # pragma: nocover
             raise CompilerPanic(f"expected unbounded sequence type, got {typ}")
         value = self.ctx.copy_sequence_to_scratch(src, typ, annotation=var.name)
-        self.ctx.ptr_store(var.value.ptr(), value.operand)
+        self.ctx.store_pointer_cell(var.value.operand, value.operand)
 
     def _assign_value(
         self, dst_ptr: Ptr, src: VyperValue, typ, *, src_node: vy_ast.VyperNode

--- a/vyper/codegen_venom/stmt.py
+++ b/vyper/codegen_venom/stmt.py
@@ -187,7 +187,7 @@ class Stmt:
         if not is_unbounded_sequence_type(typ):  # pragma: nocover
             raise CompilerPanic(f"expected unbounded sequence type, got {typ}")
         value = self.ctx.copy_sequence_to_scratch(src, typ, annotation=var.name)
-        self.ctx.store_pointer_cell(var.value.operand, value.operand)
+        self.ctx.store_pointer_cell(var.value.operand, value.operand, IRLiteral(0))
 
     def _assign_value(
         self, dst_ptr: Ptr, src: VyperValue, typ, *, src_node: vy_ast.VyperNode


### PR DESCRIPTION
### What I did

Make `append()` on `DynArray[T, INF]` locals amortized linear. Previously every append reallocated an exact-size payload and copied the whole array, so a loop of n appends was O(n^2).

### How I did it

Widen the pointer cell of INF locals from one word to two: payload pointer and capacity of the owned payload. Append writes in place while `length < capacity`, otherwise allocates `max(2 * capacity, length + 1)` elements and copies. Only append sets a nonzero capacity; every other producer stores 0, which forces the first append to copy (the payload may not be owned, e.g. an internal callee's parameter cell aliasing the caller's buffer) and keeps the first append after a large ingest exact-size rather than doubling.

Three commits: centralize cell stores into `store_pointer_cell`, widen the cell and update all writers, add the capacity-aware append lowering and tests.

### How to verify it

```
uv run pytest tests/functional/codegen/features/test_inf_dynarray_runtime.py --experimental-codegen
```

Append-loop gas, `uint256` elements:

| n | master | this PR |
|---|---|---|
| 100 | 128,706 | 41,573 |
| 1000 | 494,512,315 | 211,452 |

Single append after a 500-element calldata copy: +144 gas (the extra cell word).

### Commit message

```
appending to a `DynArray[T, INF]` local reallocated an exact-size
payload and copied the whole array on every call, so building an array
with n appends did O(n^2) copying. beyond a few hundred elements this
was unusable: 1000 appends of `uint256` cost ~494M gas.

widen the pointer cell of INF locals from one word to two: the payload
pointer and the capacity of the owned payload. append writes in place
while `length < capacity`, otherwise it allocates `max(2 * capacity,
length + 1)` elements and copies, so repeated appends are amortized
linear (1000 appends: ~211k gas).

capacity is only ever set nonzero by append itself; every other producer
(assignment, decode from calldata, kwarg default, internal call
parameter) stores 0. this doubles as an ownership sentinel: a 0-capacity
payload may alias memory the cell does not own (an internal callee's
parameter cell points into the caller's buffer), so the first append
always copies before writing. it also means the first append after
ingesting a large array allocates the exact new size rather than
doubling, avoiding a 2x memory jump on the ingest path; doubling starts
from there.

the cell layout is defined in one place (`store_pointer_cell`) and all
cell writers go through it. `Bytes[INF]`/`String[INF]` cells share the
layout with capacity permanently 0 since bytestrings have no append. all
size arithmetic in the grow path is checked. cost is one extra word per
INF pointer cell and one extra `mstore` per cell store.
```

### Description for the changelog

`append()` on `DynArray[..., INF]` locals is now amortized linear instead of copying the whole array on every call.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
