### PR TITLE
refactor[lang]: simplify typing logic around inf

### DIFF
--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -770,6 +770,59 @@ def get_literal(addr: address) -> DynArray[uint256, 4]:
     assert caller.get_literal(target.address) == [5, 6]
 
 
+def test_wildcard_arg_dynamic_element_roundtrip(get_contract):
+    target_code = """
+@external
+def data(x: DynArray[Bytes[10], 5]) -> uint256:
+    return len(x)
+    """
+
+    caller_code = """
+interface Source:
+    def data(x: DynArray[Bytes[10], ...]) -> uint256: nonpayable
+
+@external
+def get_empty(addr: address) -> uint256:
+    return extcall Source(addr).data([])
+
+@external
+def get_bounded(addr: address, xs: DynArray[Bytes[10], 5]) -> uint256:
+    return extcall Source(addr).data(xs)
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    assert caller.get_empty(target.address) == 0
+    assert caller.get_bounded(target.address, [b"abc", b"defg"]) == 2
+
+
+def test_wildcard_arg_user_struct_element_empty(get_contract):
+    target_code = """
+struct S:
+    b: Bytes[10]
+
+@external
+def data(x: DynArray[S, 5]) -> uint256:
+    return len(x)
+    """
+
+    caller_code = """
+struct S:
+    b: Bytes[10]
+
+interface Source:
+    def data(x: DynArray[S, ...]) -> uint256: nonpayable
+
+@external
+def get_empty(addr: address) -> uint256:
+    return extcall Source(addr).data([])
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    assert caller.get_empty(target.address) == 0
+
+
 def test_inf_dynarray_abi_encode_default_tuple(get_contract):
     payload = [i * 31 for i in range(2001)]
     code = """

--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -853,6 +853,27 @@ def get_empty(addr: address) -> uint256:
     assert caller.get_empty(target.address) == 0
 
 
+def test_wildcard_tuple_arg_empty_list_element(get_contract):
+    target_code = """
+@external
+def sink(input: (DynArray[uint256, 3], uint256)) -> uint256:
+    return len(input[0]) + input[1]
+    """
+
+    caller_code = """
+interface Sink:
+    def sink(input: (DynArray[uint256, ...], uint256)) -> uint256: nonpayable
+
+@external
+def do_it(addr: address) -> uint256:
+    return extcall Sink(addr).sink(([], 42))
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    assert caller.do_it(target.address) == 42
+
+
 def test_inf_dynarray_abi_encode_default_tuple(get_contract):
     payload = [i * 31 for i in range(2001)]
     code = """

--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -796,6 +796,36 @@ def get_bounded(addr: address, xs: DynArray[Bytes[10], 5]) -> uint256:
     assert caller.get_bounded(target.address, [b"abc", b"defg"]) == 2
 
 
+@pytest.mark.xfail()
+def test_wildcard_tuple_return_forwarded_to_mixed_tuple_arg(get_contract):
+    target_code = """
+seen: public(uint256)
+
+@external
+def source() -> (Bytes[10], DynArray[uint256, INF]):
+    return b"hello", [1, 2, 3]
+
+@external
+def sink(input: (Bytes[10], DynArray[uint256, INF])):
+    self.seen = len(input[0]) * 100 + len(input[1])
+    """
+
+    caller_code = """
+interface Foo:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+    def sink(input: (Bytes[10], DynArray[uint256, ...])): nonpayable
+
+@external
+def bar(foo: Foo):
+    extcall foo.sink(extcall foo.source())
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    caller.bar(target.address)
+    assert target.seen() == 5 * 100 + 3
+
+
 def test_wildcard_arg_user_struct_element_empty(get_contract):
     target_code = """
 struct S:

--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.evm_backends.abi import abi_decode, abi_encode
 from vyper.compiler import compile_code
+from vyper.exceptions import CodegenPanic
 from vyper.utils import method_id
 
 
@@ -872,6 +873,40 @@ def do_it(addr: address) -> uint256:
     target = get_contract(target_code)
     caller = get_contract(caller_code)
     assert caller.do_it(target.address) == 42
+
+
+@pytest.mark.xfail(raises=CodegenPanic)
+def test_wildcard_arg_ternary_sarray_element(get_contract):
+    target_code = """
+seen: public(uint256)
+
+@external
+def bar() -> DynArray[uint256, 3]:
+    return [1, 2, 3]
+
+@external
+def foo(xs: DynArray[uint256, 3][1]):
+    self.seen = len(xs[0])
+    """
+
+    caller_code = """
+interface I:
+    def bar() -> DynArray[uint256, ...]: nonpayable
+    def foo(xs: DynArray[uint256, ...][1]): nonpayable
+
+@external
+def f(a: address, c: bool, ys: DynArray[uint256, 5][1]):
+    extcall I(a).foo([extcall I(a).bar()] if c else ys)
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+
+    caller.f(target.address, True, [[9, 9]])
+    assert target.seen() == 3
+
+    caller.f(target.address, False, [[9, 9]])
+    assert target.seen() == 2
 
 
 def test_inf_dynarray_abi_encode_default_tuple(get_contract):

--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -797,17 +797,17 @@ def get_bounded(addr: address, xs: DynArray[Bytes[10], 5]) -> uint256:
     assert caller.get_bounded(target.address, [b"abc", b"defg"]) == 2
 
 
-@pytest.mark.xfail()
+@pytest.mark.xfail(raises=CodegenPanic)
 def test_wildcard_tuple_return_forwarded_to_mixed_tuple_arg(get_contract):
     target_code = """
 seen: public(uint256)
 
 @external
-def source() -> (Bytes[10], DynArray[uint256, INF]):
+def source() -> (Bytes[10], DynArray[uint256, 5]):
     return b"hello", [1, 2, 3]
 
 @external
-def sink(input: (Bytes[10], DynArray[uint256, INF])):
+def sink(input: (Bytes[10], DynArray[uint256, 5])):
     self.seen = len(input[0]) * 100 + len(input[1])
     """
 

--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -393,3 +393,27 @@ def foo(c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]):
     c.foo(test, a, b)
     (log,) = get_logs(c, "Picked")
     assert log.args.xs == (a if test else b)
+
+
+@pytest.mark.parametrize("test", [True, False])
+def test_ternary_wildcard_arg_self_arm(get_contract, env, test):
+    target_code = """
+@external
+def sink(input: DynArray[address, 3]) -> DynArray[address, 3]:
+    return input
+    """
+
+    caller_code = """
+interface Sink:
+    def sink(input: DynArray[address, ...]) -> DynArray[address, 3]: nonpayable
+
+@external
+def do_it(addr: address, other: address, b: bool) -> DynArray[address, 3]:
+    return extcall Sink(addr).sink([self] if b else [other])
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    other = env.accounts[1]
+    expected = [caller.address if test else other]
+    assert caller.do_it(target.address, other, test) == expected

--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -355,6 +355,28 @@ def foo(c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]) -> DynArray[u
     assert c.foo(test, a, b) == (a if test else b)
 
 
+def test_ternary_wildcard_arg_empty_arm(get_contract):
+    target_code = """
+@external
+def sink(input: DynArray[Bytes[10], 3]) -> uint256:
+    return len(input)
+    """
+
+    caller_code = """
+interface Sink:
+    def sink(input: DynArray[Bytes[10], ...]) -> uint256: nonpayable
+
+@external
+def do_it(addr: address, b: bool) -> uint256:
+    return extcall Sink(addr).sink([] if b else [b"x"])
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    assert caller.do_it(target.address, True) == 0
+    assert caller.do_it(target.address, False) == 1
+
+
 @pytest.mark.parametrize("test", [True, False])
 def test_ternary_as_event_argument(get_contract, get_logs, test):
     code = """

--- a/tests/unit/semantics/types/test_inf.py
+++ b/tests/unit/semantics/types/test_inf.py
@@ -1052,30 +1052,6 @@ def f(a: address) -> DynArray[Bytes[10], 5]:
     compiler.compile_code(accepted)
 
 
-def test_wildcard_arg_dynamic_element_requires_expected_bound():
-    rejected = """
-interface I:
-    def foo(xs: DynArray[Bytes[10], ...]): nonpayable
-
-@external
-def f(a: address):
-    extcall I(a).foo([])
-    """
-    with pytest.raises(StructureException) as e:
-        compiler.compile_code(rejected)
-    assert e.value.message == "DynArray[..., INF] is only supported with ABI-static element types"
-
-    accepted = """
-interface I:
-    def foo(xs: DynArray[Bytes[10], ...]): nonpayable
-
-@external
-def f(a: address, xs: DynArray[Bytes[10], 5]):
-    extcall I(a).foo(xs)
-    """
-    compiler.compile_code(accepted)
-
-
 @pytest.mark.parametrize("element_type", ["Bytes[...]", "DynArray[uint256, ...]"])
 def test_wildcard_arg_rejects_resolved_unbounded_element(element_type):
     code = f"""

--- a/tests/unit/semantics/types/test_inf.py
+++ b/tests/unit/semantics/types/test_inf.py
@@ -1082,6 +1082,18 @@ def f(a: address):
     compiler.compile_code(code)
 
 
+def test_wildcard_arg_subscripted_list_literal():
+    code = """
+interface I:
+    def foo(xs: DynArray[uint256, ...]): nonpayable
+
+@external
+def f(a: address, xs: DynArray[uint256, 5]):
+    extcall I(a).foo([xs][0])
+    """
+    compiler.compile_code(code)
+
+
 def test_wildcard_tuple_interface_arg_rejects_inf_source():
     code = """
 interface I:

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -786,11 +786,14 @@ class Expr:
         body = Expr(self.expr.body, self.context).ir_node
         orelse = Expr(self.expr.orelse, self.context).ir_node
 
+        def _needs_memory(ir_node: IRnode) -> bool:
+            return ir_node.value == "multi" or ir_node.is_empty_intrinsic
+
         # if they are in the same location, we can skip copying
         # into memory. also for the case where either body or orelse are
-        # literal `multi` values (ex. for tuple or arrays), copy to
-        # memory (to avoid crashing in make_setter, XXX fixme).
-        if body.location != orelse.location or body.value == "multi":
+        # literal `multi`/`~empty` values (ex. for tuple or arrays), copy to
+        # memory (to avoid crashing in make_setter).
+        if body.location != orelse.location or _needs_memory(body) or _needs_memory(orelse):
             body = ensure_in_memory(body, self.context)
             orelse = ensure_in_memory(orelse, self.context)
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -859,15 +859,12 @@ class ExprVisitor(VyperNodeVisitorBase):
             return DArrayT(v, 1)
 
         candidates = [t for t in possible_types if t.is_subtype_of(typ)]
-        if len(candidates) != 1:
-            return typ.resolve_wildcard()
+        assert len(candidates) == 1
 
         actual_typ = candidates[0]
         if actual_typ.has_wildcard:
             actual_typ = actual_typ.resolve_wildcard()
 
-        # sanity check
-        assert actual_typ.is_subtype_of(typ)
         return actual_typ
 
     def visit(self, node, typ):

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -846,7 +846,7 @@ class ExprVisitor(VyperNodeVisitorBase):
         return "module"
 
     def _annotation_type(self, node: vy_ast.VyperNode, typ: VyperType) -> VyperType:
-        if not getattr(typ, "has_wildcard", False):
+        if not typ.has_wildcard:
             return typ
 
         try:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -63,6 +63,8 @@ from vyper.semantics.types import (
     VyperType,
     is_type_t,
     map_void,
+    BytesT,
+    StringT,
 )
 from vyper.semantics.types.function import (
     ContractFunctionT,
@@ -71,6 +73,10 @@ from vyper.semantics.types.function import (
     is_ellipsis_body,
 )
 from vyper.semantics.types.infinity import (
+    INF,
+    WILDCARD,
+    LengthUpperBound,
+    is_bounded_length,
     type_contains_nested_unbounded_sequence,
     type_contains_unbounded_sequence,
     type_contains_unsupported_unbounded_sequence,
@@ -844,33 +850,73 @@ class ExprVisitor(VyperNodeVisitorBase):
             return "function"
         return "module"
 
+    def _interpolate(self, min_t: VyperType, max_t: VyperType) -> VyperType:
+        """
+        Find the smallest type between `min_t` and `max_t` such that it contains no wildcards
+        """
+        def interpolate_length(min_l: LengthUpperBound, max_l: LengthUpperBound) -> int | Inf:
+            if min_l != WILDCARD:
+                return min_l
+            elif max_l != WILDCARD:
+                return max_l
+            else:
+                return INF
+
+        
+        assert min_t.is_subtype_of(max_t)
+
+        if isinstance(min_t, BottomT):
+            return max_t.resolve_wildcard()
+        
+        assert type(min_t) == type(max_t)
+
+        if isinstance(min_t, DArrayT):
+            assert isinstance(max_t, DArrayT)
+            new_vt = self._interpolate(min_t.value_type, max_t.value_type)
+
+            new_l = interpolate_length(min_t.length, max_t.length)
+            DArrayT._validate_unbounded_shape(new_vt, new_l)
+            return DArrayT(new_vt, new_l)
+
+        if isinstance(min_t, BytesT):
+            assert isinstance(max_t, BytesT)
+
+            return BytesT(interpolate_length(min_t.length, max_t.length))
+
+        if isinstance(min_t, StringT):
+            assert isinstance(max_t, StringT)
+
+            return StringT(interpolate_length(min_t.length, max_t.length))
+
+        if isinstance(min_t, TupleT):
+            assert isinstance(max_t, TupleT)
+            return TupleT(tuple(self._interpolate(min_mt, max_mt) for min_mt, max_mt in zip(min_t.member_types, max_t.member_types, strict=True)))
+
+        return min_t
+
+
+
     def _annotation_type(self, node: vy_ast.VyperNode, typ: VyperType) -> VyperType:
         if not typ.has_wildcard:
             return typ
 
         possible_types = get_possible_types_from_node(node)
 
-        ret: VyperType
+        candidates = [t for t in possible_types if t.is_subtype_of(typ)]
+        assert len(candidates) == 1
 
-        if possible_types == [DArrayT(BottomT(), 1)]:
-            # since Never cannot be abi-encoded, use the expected type to know which element type is
-            # required
-            assert isinstance(typ, DArrayT)
-            v = typ.value_type.resolve_wildcard()
-            DArrayT._validate_unbounded_shape(v, 1, node)
-            ret = DArrayT(v, 1)
-        else:
-            # we find the one type that the expression has which is valid
-            # (guaranteed to exist since this is called after `visit_*`)
-            candidates = [t for t in possible_types if t.is_subtype_of(typ)]
-            assert len(candidates) == 1
+        ret = self._interpolate(candidates[0], typ)
 
-            ret = candidates[0].resolve_wildcard()
+        # postconditions:
 
-        # postcondition:
-        # expression type <: ret <: expected type
+        # expression type <: ret
         assert any(t.is_subtype_of(ret) for t in possible_types)
+
+        # ret <: expected type
         assert ret.is_subtype_of(typ)
+
+        # ret is wildcard free
+        assert not ret.has_wildcard
 
         return ret
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -851,13 +851,11 @@ class ExprVisitor(VyperNodeVisitorBase):
 
         possible_types = get_possible_types_from_node(node)
 
-        # use the expected type to disambiguate expressions which have
-        # several possible types on their own (e.g. the literal `[]`), so
-        # that provably bounded expressions get a bounded annotation.
-        if any(isinstance(getattr(t, "value_type", None), BottomT) for t in possible_types):
-            # the empty list literal infers as the single type
-            # `DynArray[Never, 1]`, which matches any expected type and so
-            # disambiguates nothing. enumerate its element types instead.
+        # the empty list literal infers as the single type
+        # `DynArray[Never, 1]`, which cannot be abi-encoded and so
+        # disambiguates nothing. enumerate possible types instead.
+        if possible_types == [DArrayT(BottomT(), 1)]:
+            assert isinstance(typ, DArrayT)
             possible_types = empty_list_candidate_types()
 
         candidates = [t for t in possible_types if t.is_subtype_of(typ)]

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -33,7 +33,6 @@ from vyper.semantics.analysis.base import (
 )
 from vyper.semantics.analysis.common import VyperNodeVisitorBase
 from vyper.semantics.analysis.utils import (
-    empty_list_candidate_types,
     get_common_types,
     get_exact_type_from_node,
     get_expr_info,
@@ -851,12 +850,13 @@ class ExprVisitor(VyperNodeVisitorBase):
 
         possible_types = get_possible_types_from_node(node)
 
-        # the empty list literal infers as the single type
-        # `DynArray[Never, 1]`, which cannot be abi-encoded and so
-        # disambiguates nothing. enumerate possible types instead.
+        # since Never cannot be abi-encoded, use the expected type to know which element type is
+        # required
         if possible_types == [DArrayT(BottomT(), 1)]:
             assert isinstance(typ, DArrayT)
-            possible_types = empty_list_candidate_types()
+            v = typ.value_type.resolve_wildcard()
+            DArrayT._validate_unbounded_shape(v, 1, node)
+            return DArrayT(v, 1)
 
         candidates = [t for t in possible_types if t.is_subtype_of(typ)]
         if len(candidates) != 1:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -849,13 +849,7 @@ class ExprVisitor(VyperNodeVisitorBase):
         if not typ.has_wildcard:
             return typ
 
-        try:
-            possible_types = get_possible_types_from_node(node)
-        except VyperException:
-            # the expression has no standalone type. it already passed
-            # `validate_expected_type`, so resolve the wildcards without
-            # a bound.
-            return typ.resolve_wildcard()
+        possible_types = get_possible_types_from_node(node)
 
         # use the expected type to disambiguate expressions which have
         # several possible types on their own (e.g. the literal `[]`), so

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -866,10 +866,9 @@ class ExprVisitor(VyperNodeVisitorBase):
         if actual_typ.has_wildcard:
             actual_typ = actual_typ.resolve_wildcard()
 
-        if actual_typ.is_subtype_of(typ):
-            return actual_typ
-
-        return typ.resolve_wildcard()
+        # sanity check
+        assert actual_typ.is_subtype_of(typ)
+        return actual_typ
 
     def visit(self, node, typ):
         if typ is not VOID_TYPE and not isinstance(typ, TYPE_T):

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -49,6 +49,7 @@ from vyper.semantics.types import (
     AddressT,
     BoolT,
     BottomT,
+    BytesT,
     DArrayT,
     ErrorT,
     EventT,
@@ -63,8 +64,6 @@ from vyper.semantics.types import (
     VyperType,
     is_type_t,
     map_void,
-    BytesT,
-    StringT,
 )
 from vyper.semantics.types.function import (
     ContractFunctionT,
@@ -75,8 +74,8 @@ from vyper.semantics.types.function import (
 from vyper.semantics.types.infinity import (
     INF,
     WILDCARD,
+    Inf,
     LengthUpperBound,
-    is_bounded_length,
     type_contains_nested_unbounded_sequence,
     type_contains_unbounded_sequence,
     type_contains_unsupported_unbounded_sequence,
@@ -854,6 +853,7 @@ class ExprVisitor(VyperNodeVisitorBase):
         """
         Find the smallest type between `min_t` and `max_t` such that it contains no wildcards
         """
+
         def interpolate_length(min_l: LengthUpperBound, max_l: LengthUpperBound) -> int | Inf:
             if min_l != WILDCARD:
                 return min_l
@@ -862,13 +862,12 @@ class ExprVisitor(VyperNodeVisitorBase):
             else:
                 return INF
 
-        
         assert min_t.is_subtype_of(max_t)
 
         if isinstance(min_t, BottomT):
             return max_t.resolve_wildcard()
-        
-        assert type(min_t) == type(max_t)
+
+        assert type(min_t) is type(max_t)
 
         if isinstance(min_t, DArrayT):
             assert isinstance(max_t, DArrayT)
@@ -890,11 +889,14 @@ class ExprVisitor(VyperNodeVisitorBase):
 
         if isinstance(min_t, TupleT):
             assert isinstance(max_t, TupleT)
-            return TupleT(tuple(self._interpolate(min_mt, max_mt) for min_mt, max_mt in zip(min_t.member_types, max_t.member_types, strict=True)))
+            return TupleT(
+                tuple(
+                    self._interpolate(min_mt, max_mt)
+                    for min_mt, max_mt in zip(min_t.member_types, max_t.member_types, strict=True)
+                )
+            )
 
         return min_t
-
-
 
     def _annotation_type(self, node: vy_ast.VyperNode, typ: VyperType) -> VyperType:
         if not typ.has_wildcard:

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -850,22 +850,29 @@ class ExprVisitor(VyperNodeVisitorBase):
 
         possible_types = get_possible_types_from_node(node)
 
-        # since Never cannot be abi-encoded, use the expected type to know which element type is
-        # required
+        ret: VyperType
+
         if possible_types == [DArrayT(BottomT(), 1)]:
+            # since Never cannot be abi-encoded, use the expected type to know which element type is
+            # required
             assert isinstance(typ, DArrayT)
             v = typ.value_type.resolve_wildcard()
             DArrayT._validate_unbounded_shape(v, 1, node)
-            return DArrayT(v, 1)
+            ret = DArrayT(v, 1)
+        else:
+            # we find the one type that the expression has which is valid
+            # (guaranteed to exist since this is called after `visit_*`)
+            candidates = [t for t in possible_types if t.is_subtype_of(typ)]
+            assert len(candidates) == 1
 
-        candidates = [t for t in possible_types if t.is_subtype_of(typ)]
-        assert len(candidates) == 1
+            ret = candidates[0].resolve_wildcard()
 
-        actual_typ = candidates[0]
-        if actual_typ.has_wildcard:
-            actual_typ = actual_typ.resolve_wildcard()
+        # postcondition:
+        # expression type <: ret <: expected type
+        assert any(t.is_subtype_of(ret) for t in possible_types)
+        assert ret.is_subtype_of(typ)
 
-        return actual_typ
+        return ret
 
     def visit(self, node, typ):
         if typ is not VOID_TYPE and not isinstance(typ, TYPE_T):

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -875,6 +875,12 @@ class ExprVisitor(VyperNodeVisitorBase):
             DArrayT._validate_unbounded_shape(new_vt, new_l)
             return DArrayT(new_vt, new_l)
 
+        if isinstance(min_t, SArrayT):
+            assert isinstance(max_t, SArrayT)
+            new_vt = self._interpolate(min_t.value_type, max_t.value_type)
+
+            return SArrayT(new_vt, min_t.length)
+
         if isinstance(min_t, BytesT):
             assert isinstance(max_t, BytesT)
 

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -867,8 +867,6 @@ class ExprVisitor(VyperNodeVisitorBase):
         if isinstance(min_t, BottomT):
             return max_t.resolve_wildcard()
 
-        assert type(min_t) is type(max_t)
-
         if isinstance(min_t, DArrayT):
             assert isinstance(max_t, DArrayT)
             new_vt = self._interpolate(min_t.value_type, max_t.value_type)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -849,9 +849,13 @@ class ExprVisitor(VyperNodeVisitorBase):
             return "function"
         return "module"
 
-    def _interpolate(self, min_t: VyperType, max_t: VyperType) -> VyperType:
+    def _interpolate(
+        self, min_t: VyperType, max_t: VyperType, *, pos: Optional[vy_ast.VyperNode] = None
+    ) -> VyperType:
         """
         Find the smallest type between `min_t` and `max_t` such that it contains no wildcards
+
+        `pos` is only used for location information in error messages (if present)
         """
 
         def interpolate_length(min_l: LengthUpperBound, max_l: LengthUpperBound) -> int | Inf:
@@ -869,15 +873,15 @@ class ExprVisitor(VyperNodeVisitorBase):
 
         if isinstance(min_t, DArrayT):
             assert isinstance(max_t, DArrayT)
-            new_vt = self._interpolate(min_t.value_type, max_t.value_type)
+            new_vt = self._interpolate(min_t.value_type, max_t.value_type, pos=pos)
 
             new_l = interpolate_length(min_t.length, max_t.length)
-            DArrayT._validate_unbounded_shape(new_vt, new_l)
+            DArrayT._validate_unbounded_shape(new_vt, new_l, node=pos)
             return DArrayT(new_vt, new_l)
 
         if isinstance(min_t, SArrayT):
             assert isinstance(max_t, SArrayT)
-            new_vt = self._interpolate(min_t.value_type, max_t.value_type)
+            new_vt = self._interpolate(min_t.value_type, max_t.value_type, pos=pos)
 
             return SArrayT(new_vt, min_t.length)
 
@@ -895,7 +899,7 @@ class ExprVisitor(VyperNodeVisitorBase):
             assert isinstance(max_t, TupleT)
             return TupleT(
                 tuple(
-                    self._interpolate(min_mt, max_mt)
+                    self._interpolate(min_mt, max_mt, pos=pos)
                     for min_mt, max_mt in zip(min_t.member_types, max_t.member_types, strict=True)
                 )
             )
@@ -911,7 +915,7 @@ class ExprVisitor(VyperNodeVisitorBase):
         candidates = [t for t in possible_types if t.is_subtype_of(typ)]
         assert len(candidates) == 1
 
-        ret = self._interpolate(candidates[0], typ)
+        ret = self._interpolate(candidates[0], typ, pos=node)
 
         # postconditions:
 

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -41,35 +41,6 @@ def _primitive_types():
     return types.PRIMITIVE_TYPES.values()
 
 
-def empty_list_candidate_types():
-    """
-    Enumerate the possible types of the empty list literal `[]`, one per
-    primitive element type.
-
-    `types_from_List` infers `[]` as the single type `DynArray[Never, 1]`,
-    which is enough to typecheck against a concrete expected type, but it
-    erases the element type. Callers which need to match `[]` against an
-    expected type that is not fully concrete (i.e. contains a wildcard) need
-    the enumeration to recover a concrete element type.
-    """
-    ret = []
-    for t in _primitive_types():
-        if isinstance(t, BottomT):
-            # `Never` is a subtype of everything, so it would match any
-            # expected type and disambiguate nothing.
-            continue
-        if not isinstance(t, VyperType):
-            # bytestring typeclasses. their generic acceptor (`BytesT.any()`)
-            # only matches on the expected side of `compare_type`, never as
-            # the given type, so as a candidate it could not match anything.
-            assert isinstance(t, type) and issubclass(t, VyperType), t
-            continue
-        # 1 is minimum possible length for dynarray,
-        # can be assigned to anything
-        ret.append(DArrayT(t, 1))
-    return ret
-
-
 def _validate_op(node, types_list, validation_fn_name):
     if not types_list:
         # TODO raise a better error here: say which types.

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -409,7 +409,14 @@ class _ExprAnalyser:
             ret = []
             for t in types_list:
                 t.validate_index_type(node.slice)
-                ret.append(t.get_subscripted_type(node.slice))
+                elem_t = t.get_subscripted_type(node.slice)
+
+                # skip duplicates, can happen because of `[x][0]`:
+                # `types_list` for `[x]` is `[DArray(T,1), SArray(T, 1)]`
+                # and both `DArray(T,1).get_subscripted_type` and `SArray(T,1).get_subscripted_type`
+                # will return `T`, leading to a duplicate
+                if not _is_type_in_list(elem_t, ret):
+                    ret.append(elem_t)
             return ret
 
         t = self.get_exact_type_from_node(node.value)

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -36,6 +36,10 @@ class _GenericTypeAcceptor:
     def is_equivalent_to(self, other):
         return self.compare_type(other) and other.compare_type(self)
 
+    @property
+    def has_wildcard(self):
+        return False
+
     def compare_type(self, other):
         if isinstance(other, BottomT):
             return True

--- a/vyper/semantics/types/subscriptable.py
+++ b/vyper/semantics/types/subscriptable.py
@@ -171,6 +171,8 @@ class SArrayT(_SequenceT):
 
     _id = "$SArray"
 
+    length: int  # narrows type from parent
+
     def __init__(self, value_type: VyperType, length: int) -> None:
         super().__init__(value_type, length)
 


### PR DESCRIPTION
### What I did


Before #5127, the codegen type of an expression was always the expected type, with #5127 this would no longer work, as the expected type can contain wildcard lengths, which are not encodable (need to be resolved to a finite length or `INF`).
To solve this issue, it added `_annotation_type` which derives an encodable type from the inferred and expected type.

This PR refactors `_annotation_type` to give it nice properties, and to validate its invariants.

Fix #5251

### How I did it

`_interpolate` is added alongside `_annotation_type`,  it finds the smallest type between its two parameters, which contains no wildcards.
This allows us to remove `empty_list_candidate_types` which represented a kind of regression of #5177 (and thus re-introduced similar issues).

To support the above/fix bugs it uncovered, a couple more minor things are done:
* Fix (codegen's) `Expr.parse_IfExp`'s not copying `~empty` into memory.
* Fix `_ExprAnalyser.types_from_Subscript` producing multitypes[^1] containing the same type twice.
* Fix not being able to do `my_type.has_wildcard` because `_GenericTypeAcceptor` didn't have it.
* Let mypy know that a `SArrayT.length` is always an int

### How to verify it

uv run pytest tests/unit/semantics/types/test_inf.py \
    tests/functional/codegen/features/test_inf_dynarray_runtime.py \
    tests/functional/codegen/features/test_ternary.py

### Commit message
```
before d3c150e, the codegen type of an expression was always the
expected type. with d3c150e this no longer works, as the expected type
can now contain wildcard lengths, which are not encodable (need to be
resolved to a finite length or `INF`). to solve this issue, it added
`_annotation_type` which derives an encodable type from the inferred and
expected type.

this commit refactors `_annotation_type` to give it nice properties, and
to validate its invariants:

`_interpolate` finds the smallest type between its two parameters, which
contains no wildcards. this allows us to remove
`empty_list_candidate_types` which represented a kind of regression of
3867629 (and thus re-introduced similar issues).

to support the above/fix bugs it uncovered, a couple more minor things
are done:
* fix (codegen's) `Expr.parse_IfExp`'s not copying `~empty` into memory.
* fix `_ExprAnalyser.types_from_Subscript` producing multitypes[^1]
  containing the same type twice.
* fix not being able to do `my_type.has_wildcard` because
  `_GenericTypeAcceptor` didn't have it.
* let mypy know that `SArrayT.length` is always an int.
```
### Description for the changelog

(refactor of a yet-unrealeased feature: no user-visible change)


### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.magnific.com/premium-vector/cute-kawaii-snake-ouroboros-eating-its-own-tail-space-stars_655299-566.jpg)

[^1]: A list of all possible types for an expression