### PR TITLE
fix[codegen]: widen ternary arms to the result type layout

### DIFF
--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -139,26 +139,6 @@ def bar(c: bool, a: String[3], b: String[64]) -> String[64]:
     assert c.bar(False, "abc", "y" * 64) == "y" * 64
 
 
-# a ternary passed straight to an internal call returns the second arm even
-# when the condition is true, also for arms of identical type
-@pytest.mark.xfail(strict=True)
-def test_ternary_as_internal_call_argument(get_contract):
-    code = """
-@internal
-def _echo(xs: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
-    return xs
-
-@external
-def foo(
-    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
-) -> DynArray[Bytes[512], 5]:
-    return self._echo(a if c else b)
-    """
-    c = get_contract(code)
-    assert c.foo(True, SHORT, LONG) == SHORT
-    assert c.foo(False, SHORT, LONG) == LONG
-
-
 def test_ternary_as_event_argument(get_contract, get_logs):
     code = """
 event Picked:

--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -357,15 +357,15 @@ def whole(
     return self._short(a) if c else self._long(b)
 
 @external
-def member(
-    c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
+def member_flipped(
+    c: bool, a: DynArray[DynArray[uint256, 4], 3], b: DynArray[DynArray[uint256, 2], 3]
 ) -> DynArray[DynArray[uint256, 4], 3]:
-    return (self._long(b) if c else self._short(a))[1]
+    return (self._long(a) if c else self._short(b))[1]
     """
     a = [[1, 2], [3], []]
     b = [[4, 5, 6, 7], [], [8]]
     c = get_contract(code)
     assert c.whole(True, a, b) == ([1], a)
     assert c.whole(False, a, b) == ([2], b)
-    assert c.member(True, a, b) == b
-    assert c.member(False, a, b) == a
+    assert c.member_flipped(True, b, a) == b
+    assert c.member_flipped(False, b, a) == a

--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -1,3 +1,5 @@
+import pytest
+
 from vyper.compiler import compile_code
 
 SHORT = [b"a", b"0123456789", b""]
@@ -281,3 +283,89 @@ def from_locals_flipped(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint
     assert c.from_calls_flipped(False, b"abc", b"x" * 40) == (b"abc", 1)
     assert c.from_locals_flipped(True, b"abc", b"x" * 40) == (b"x" * 40, 2)
     assert c.from_locals_flipped(False, b"abc", b"x" * 40) == (b"abc", 1)
+
+
+def test_tuple_with_unbounded_member_ternary(get_contract, experimental_codegen):
+    if not experimental_codegen:
+        pytest.skip("unbounded sequence types require --experimental-codegen")
+
+    code = """
+@internal
+def _short(a: DynArray[Bytes[10], 5]) -> (DynArray[uint256, INF], DynArray[Bytes[10], 5]):
+    return ([1, 2], a)
+
+@internal
+def _long(b: DynArray[Bytes[512], 5]) -> (DynArray[uint256, INF], DynArray[Bytes[512], 5]):
+    return ([3], b)
+
+@external
+def whole(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> (DynArray[uint256, INF], DynArray[Bytes[512], 5]):
+    return self._short(a) if c else self._long(b)
+
+@external
+def whole_flipped(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> (DynArray[uint256, INF], DynArray[Bytes[512], 5]):
+    return self._long(b) if c else self._short(a)
+
+@external
+def member(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    return (self._short(a) if c else self._long(b))[1]
+
+@external
+def member_flipped(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    return (self._long(b) if c else self._short(a))[1]
+    """
+    c = get_contract(code)
+    assert c.whole(True, SHORT, LONG) == ([1, 2], SHORT)
+    assert c.whole(False, SHORT, LONG) == ([3], LONG)
+    assert c.whole_flipped(True, SHORT, LONG) == ([3], LONG)
+    assert c.whole_flipped(False, SHORT, LONG) == ([1, 2], SHORT)
+    assert c.member(True, SHORT, LONG) == SHORT
+    assert c.member(False, SHORT, LONG) == LONG
+    assert c.member_flipped(True, SHORT, LONG) == LONG
+    assert c.member_flipped(False, SHORT, LONG) == SHORT
+
+
+def test_tuple_with_unbounded_member_nested_ternary(get_contract, experimental_codegen):
+    if not experimental_codegen:
+        pytest.skip("unbounded sequence types require --experimental-codegen")
+
+    code = """
+@internal
+def _short(
+    a: DynArray[DynArray[uint256, 2], 3]
+) -> (DynArray[uint256, INF], DynArray[DynArray[uint256, 2], 3]):
+    return ([1], a)
+
+@internal
+def _long(
+    b: DynArray[DynArray[uint256, 4], 3]
+) -> (DynArray[uint256, INF], DynArray[DynArray[uint256, 4], 3]):
+    return ([2], b)
+
+@external
+def whole(
+    c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
+) -> (DynArray[uint256, INF], DynArray[DynArray[uint256, 4], 3]):
+    return self._short(a) if c else self._long(b)
+
+@external
+def member(
+    c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
+) -> DynArray[DynArray[uint256, 4], 3]:
+    return (self._long(b) if c else self._short(a))[1]
+    """
+    a = [[1, 2], [3], []]
+    b = [[4, 5, 6, 7], [], [8]]
+    c = get_contract(code)
+    assert c.whole(True, a, b) == ([1], a)
+    assert c.whole(False, a, b) == ([2], b)
+    assert c.member(True, a, b) == b
+    assert c.member(False, a, b) == a

--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -1,0 +1,206 @@
+import pytest
+
+from vyper.compiler import compile_code
+
+
+@pytest.fixture(autouse=True)
+def _venom_only(experimental_codegen):
+    if not experimental_codegen:
+        pytest.skip("requires --experimental-codegen")
+
+
+SHORT = [b"a", b"0123456789", b""]
+LONG = [b"x" * 512, b"", b"0123456789" * 20]
+
+
+def test_dynarray_bytes_widening(get_contract):
+    code = """
+@external
+def via_local(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = a if c else b
+    return ys
+
+@external
+def via_return(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    return a if c else b
+    """
+    c = get_contract(code)
+    assert c.via_local(True, SHORT, LONG) == SHORT
+    assert c.via_local(False, SHORT, LONG) == LONG
+    assert c.via_return(True, SHORT, LONG) == SHORT
+    assert c.via_return(False, SHORT, LONG) == LONG
+
+
+def test_dynarray_arms_of_different_widths(get_contract):
+    code = """
+@external
+def foo(
+    c: bool, a: DynArray[Bytes[10], 4], b: DynArray[Bytes[40], 4]
+) -> DynArray[Bytes[512], 4]:
+    return a if c else b
+    """
+    a = [b"a", b"0123456789", b"", b"xyz"]
+    b = [b"q" * 40, b"", b"0123456789" * 4]
+    c = get_contract(code)
+    assert c.foo(True, a, b) == a
+    assert c.foo(False, a, b) == b
+
+
+def test_nested_dynarray_widening(get_contract):
+    code = """
+@external
+def foo(
+    c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
+) -> DynArray[DynArray[uint256, 4], 3]:
+    return a if c else b
+    """
+    a = [[1, 2], [], [3]]
+    b = [[4, 5, 6, 7], [8]]
+    c = get_contract(code)
+    assert c.foo(True, a, b) == a
+    assert c.foo(False, a, b) == b
+
+
+def test_dynarray_string_widening(get_contract):
+    code = """
+@external
+def foo(
+    c: bool, a: DynArray[String[5], 3], b: DynArray[String[100], 3]
+) -> DynArray[String[100], 3]:
+    ys: DynArray[String[100], 3] = a if c else b
+    return ys
+    """
+    a = ["hello", "", "hi"]
+    b = ["0123456789" * 10, "x"]
+    c = get_contract(code)
+    assert c.foo(True, a, b) == a
+    assert c.foo(False, a, b) == b
+
+
+def test_static_array_of_dynarray_widening(get_contract):
+    code = """
+@external
+def foo(
+    c: bool, a: DynArray[uint256, 2][2], b: DynArray[uint256, 4][2]
+) -> DynArray[uint256, 4][2]:
+    return a if c else b
+    """
+    a = [[1, 2], [3]]
+    b = [[4, 5, 6, 7], [8]]
+    c = get_contract(code)
+    assert c.foo(True, a, b) == a
+    assert c.foo(False, a, b) == b
+
+
+def test_same_type_ternary(get_contract, compiler_settings):
+    code = """
+@external
+def foo(
+    c: bool, a: DynArray[Bytes[512], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = a if c else b
+    return ys
+
+@external
+def bar(c: bool, a: DynArray[uint256, 2], b: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
+    return a if c else b
+    """
+    c = get_contract(code)
+    assert c.foo(True, SHORT, LONG) == SHORT
+    assert c.foo(False, SHORT, LONG) == LONG
+    assert c.bar(True, [1, 2], [3, 4, 5, 6, 7]) == [1, 2]
+    assert c.bar(False, [1, 2], [3, 4, 5, 6, 7]) == [3, 4, 5, 6, 7]
+
+    # the arms already have the element layout of the result, so neither
+    # arm is converted element by element
+    ir = compile_code(code, output_formats=["ir_runtime"], settings=compiler_settings)
+    assert "typed_dyn_copy" not in str(ir["ir_runtime"])
+
+
+def test_bytestring_ternary(get_contract):
+    code = """
+@external
+def foo(c: bool, a: Bytes[10], b: Bytes[20]) -> Bytes[20]:
+    return a if c else b
+
+@external
+def bar(c: bool, a: String[3], b: String[64]) -> String[64]:
+    s: String[64] = a if c else b
+    return s
+    """
+    c = get_contract(code)
+    assert c.foo(True, b"0123456789", b"x" * 20) == b"0123456789"
+    assert c.foo(False, b"0123456789", b"x" * 20) == b"x" * 20
+    assert c.bar(True, "abc", "y" * 64) == "abc"
+    assert c.bar(False, "abc", "y" * 64) == "y" * 64
+
+
+# a ternary passed straight to an internal call returns the second arm even
+# when the condition is true, also for arms of identical type
+@pytest.mark.xfail(strict=True)
+def test_ternary_as_internal_call_argument(get_contract):
+    code = """
+@internal
+def _echo(xs: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
+    return xs
+
+@external
+def foo(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    return self._echo(a if c else b)
+    """
+    c = get_contract(code)
+    assert c.foo(True, SHORT, LONG) == SHORT
+    assert c.foo(False, SHORT, LONG) == LONG
+
+
+def test_ternary_as_event_argument(get_contract, get_logs):
+    code = """
+event Picked:
+    xs: DynArray[Bytes[512], 5]
+
+@external
+def foo(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
+    log Picked(xs=a if c else b)
+    """
+    c = get_contract(code)
+
+    c.foo(True, SHORT, LONG)
+    (log,) = get_logs(c, "Picked")
+    assert log.args.xs == SHORT
+
+    c.foo(False, SHORT, LONG)
+    (log,) = get_logs(c, "Picked")
+    assert log.args.xs == LONG
+
+
+def test_tuple_ternary(get_contract):
+    code = """
+@internal
+def _short(a: Bytes[10]) -> (Bytes[10], uint256):
+    return a, 1
+
+@internal
+def _long(b: Bytes[40]) -> (Bytes[40], uint256):
+    return b, 2
+
+@external
+def from_calls(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
+    return self._short(a) if c else self._long(b)
+
+@external
+def from_locals(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
+    x: (Bytes[10], uint256) = (a, 1)
+    y: (Bytes[40], uint256) = (b, 2)
+    return x if c else y
+    """
+    c = get_contract(code)
+    assert c.from_calls(True, b"abc", b"x" * 40) == (b"abc", 1)
+    assert c.from_calls(False, b"abc", b"x" * 40) == (b"x" * 40, 2)
+    assert c.from_locals(True, b"abc", b"x" * 40) == (b"abc", 1)
+    assert c.from_locals(False, b"abc", b"x" * 40) == (b"x" * 40, 2)

--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -23,26 +23,26 @@ def via_return(
 
 @external
 def via_local_flipped(
-    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+    c: bool, a: DynArray[Bytes[512], 5], b: DynArray[Bytes[10], 5]
 ) -> DynArray[Bytes[512], 5]:
-    ys: DynArray[Bytes[512], 5] = b if c else a
+    ys: DynArray[Bytes[512], 5] = a if c else b
     return ys
 
 @external
 def via_return_flipped(
-    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+    c: bool, a: DynArray[Bytes[512], 5], b: DynArray[Bytes[10], 5]
 ) -> DynArray[Bytes[512], 5]:
-    return b if c else a
+    return a if c else b
     """
     c = get_contract(code)
     assert c.via_local(True, SHORT, LONG) == SHORT
     assert c.via_local(False, SHORT, LONG) == LONG
     assert c.via_return(True, SHORT, LONG) == SHORT
     assert c.via_return(False, SHORT, LONG) == LONG
-    assert c.via_local_flipped(True, SHORT, LONG) == LONG
-    assert c.via_local_flipped(False, SHORT, LONG) == SHORT
-    assert c.via_return_flipped(True, SHORT, LONG) == LONG
-    assert c.via_return_flipped(False, SHORT, LONG) == SHORT
+    assert c.via_local_flipped(True, LONG, SHORT) == LONG
+    assert c.via_local_flipped(False, LONG, SHORT) == SHORT
+    assert c.via_return_flipped(True, LONG, SHORT) == LONG
+    assert c.via_return_flipped(False, LONG, SHORT) == SHORT
 
 
 def test_dynarray_arms_of_different_widths(get_contract):
@@ -55,17 +55,17 @@ def foo(
 
 @external
 def flipped(
-    c: bool, a: DynArray[Bytes[10], 4], b: DynArray[Bytes[40], 4]
+    c: bool, a: DynArray[Bytes[40], 4], b: DynArray[Bytes[10], 4]
 ) -> DynArray[Bytes[512], 4]:
-    return b if c else a
+    return a if c else b
     """
     a = [b"a", b"0123456789", b"", b"xyz"]
     b = [b"q" * 40, b"", b"0123456789" * 4]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
-    assert c.flipped(True, a, b) == b
-    assert c.flipped(False, a, b) == a
+    assert c.flipped(True, b, a) == b
+    assert c.flipped(False, b, a) == a
 
 
 def test_nested_dynarray_widening(get_contract):
@@ -78,17 +78,17 @@ def foo(
 
 @external
 def flipped(
-    c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
+    c: bool, a: DynArray[DynArray[uint256, 4], 3], b: DynArray[DynArray[uint256, 2], 3]
 ) -> DynArray[DynArray[uint256, 4], 3]:
-    return b if c else a
+    return a if c else b
     """
     a = [[1, 2], [], [3]]
     b = [[4, 5, 6, 7], [8]]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
-    assert c.flipped(True, a, b) == b
-    assert c.flipped(False, a, b) == a
+    assert c.flipped(True, b, a) == b
+    assert c.flipped(False, b, a) == a
 
 
 def test_dynarray_string_widening(get_contract):
@@ -102,9 +102,9 @@ def foo(
 
 @external
 def flipped(
-    c: bool, a: DynArray[String[5], 3], b: DynArray[String[100], 3]
+    c: bool, a: DynArray[String[100], 3], b: DynArray[String[5], 3]
 ) -> DynArray[String[100], 3]:
-    ys: DynArray[String[100], 3] = b if c else a
+    ys: DynArray[String[100], 3] = a if c else b
     return ys
     """
     a = ["hello", "", "hi"]
@@ -112,8 +112,8 @@ def flipped(
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
-    assert c.flipped(True, a, b) == b
-    assert c.flipped(False, a, b) == a
+    assert c.flipped(True, b, a) == b
+    assert c.flipped(False, b, a) == a
 
 
 def test_static_array_of_dynarray_widening(get_contract):
@@ -126,17 +126,17 @@ def foo(
 
 @external
 def flipped(
-    c: bool, a: DynArray[uint256, 2][2], b: DynArray[uint256, 4][2]
+    c: bool, a: DynArray[uint256, 4][2], b: DynArray[uint256, 2][2]
 ) -> DynArray[uint256, 4][2]:
-    return b if c else a
+    return a if c else b
     """
     a = [[1, 2], [3]]
     b = [[4, 5, 6, 7], [8]]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
-    assert c.flipped(True, a, b) == b
-    assert c.flipped(False, a, b) == a
+    assert c.flipped(True, b, a) == b
+    assert c.flipped(False, b, a) == a
 
 
 def _ternaries(ir_node, source):
@@ -193,12 +193,12 @@ def bar(c: bool, a: String[3], b: String[64]) -> String[64]:
     return s
 
 @external
-def foo_flipped(c: bool, a: Bytes[10], b: Bytes[20]) -> Bytes[20]:
-    return b if c else a
+def foo_flipped(c: bool, a: Bytes[20], b: Bytes[10]) -> Bytes[20]:
+    return a if c else b
 
 @external
-def bar_flipped(c: bool, a: String[3], b: String[64]) -> String[64]:
-    s: String[64] = b if c else a
+def bar_flipped(c: bool, a: String[64], b: String[3]) -> String[64]:
+    s: String[64] = a if c else b
     return s
     """
     c = get_contract(code)
@@ -206,10 +206,10 @@ def bar_flipped(c: bool, a: String[3], b: String[64]) -> String[64]:
     assert c.foo(False, b"0123456789", b"x" * 20) == b"x" * 20
     assert c.bar(True, "abc", "y" * 64) == "abc"
     assert c.bar(False, "abc", "y" * 64) == "y" * 64
-    assert c.foo_flipped(True, b"0123456789", b"x" * 20) == b"x" * 20
-    assert c.foo_flipped(False, b"0123456789", b"x" * 20) == b"0123456789"
-    assert c.bar_flipped(True, "abc", "y" * 64) == "y" * 64
-    assert c.bar_flipped(False, "abc", "y" * 64) == "abc"
+    assert c.foo_flipped(True, b"x" * 20, b"0123456789") == b"x" * 20
+    assert c.foo_flipped(False, b"x" * 20, b"0123456789") == b"0123456789"
+    assert c.bar_flipped(True, "y" * 64, "abc") == "y" * 64
+    assert c.bar_flipped(False, "y" * 64, "abc") == "abc"
 
 
 def test_ternary_as_event_argument(get_contract, get_logs):
@@ -222,8 +222,8 @@ def foo(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
     log Picked(xs=a if c else b)
 
 @external
-def flipped(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
-    log Picked(xs=b if c else a)
+def flipped(c: bool, a: DynArray[Bytes[512], 5], b: DynArray[Bytes[10], 5]):
+    log Picked(xs=a if c else b)
     """
     c = get_contract(code)
 
@@ -235,11 +235,11 @@ def flipped(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
     (log,) = get_logs(c, "Picked")
     assert log.args.xs == LONG
 
-    c.flipped(True, SHORT, LONG)
+    c.flipped(True, LONG, SHORT)
     (log,) = get_logs(c, "Picked")
     assert log.args.xs == LONG
 
-    c.flipped(False, SHORT, LONG)
+    c.flipped(False, LONG, SHORT)
     (log,) = get_logs(c, "Picked")
     assert log.args.xs == SHORT
 
@@ -265,24 +265,24 @@ def from_locals(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
     return x if c else y
 
 @external
-def from_calls_flipped(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
-    return self._long(b) if c else self._short(a)
+def from_calls_flipped(c: bool, a: Bytes[40], b: Bytes[10]) -> (Bytes[40], uint256):
+    return self._long(a) if c else self._short(b)
 
 @external
-def from_locals_flipped(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
-    x: (Bytes[10], uint256) = (a, 1)
-    y: (Bytes[40], uint256) = (b, 2)
-    return y if c else x
+def from_locals_flipped(c: bool, a: Bytes[40], b: Bytes[10]) -> (Bytes[40], uint256):
+    x: (Bytes[40], uint256) = (a, 2)
+    y: (Bytes[10], uint256) = (b, 1)
+    return x if c else y
     """
     c = get_contract(code)
     assert c.from_calls(True, b"abc", b"x" * 40) == (b"abc", 1)
     assert c.from_calls(False, b"abc", b"x" * 40) == (b"x" * 40, 2)
     assert c.from_locals(True, b"abc", b"x" * 40) == (b"abc", 1)
     assert c.from_locals(False, b"abc", b"x" * 40) == (b"x" * 40, 2)
-    assert c.from_calls_flipped(True, b"abc", b"x" * 40) == (b"x" * 40, 2)
-    assert c.from_calls_flipped(False, b"abc", b"x" * 40) == (b"abc", 1)
-    assert c.from_locals_flipped(True, b"abc", b"x" * 40) == (b"x" * 40, 2)
-    assert c.from_locals_flipped(False, b"abc", b"x" * 40) == (b"abc", 1)
+    assert c.from_calls_flipped(True, b"x" * 40, b"abc") == (b"x" * 40, 2)
+    assert c.from_calls_flipped(False, b"x" * 40, b"abc") == (b"abc", 1)
+    assert c.from_locals_flipped(True, b"x" * 40, b"abc") == (b"x" * 40, 2)
+    assert c.from_locals_flipped(False, b"x" * 40, b"abc") == (b"abc", 1)
 
 
 def test_tuple_with_unbounded_member_ternary(get_contract, experimental_codegen):
@@ -306,9 +306,9 @@ def whole(
 
 @external
 def whole_flipped(
-    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+    c: bool, a: DynArray[Bytes[512], 5], b: DynArray[Bytes[10], 5]
 ) -> (DynArray[uint256, INF], DynArray[Bytes[512], 5]):
-    return self._long(b) if c else self._short(a)
+    return self._long(a) if c else self._short(b)
 
 @external
 def member(
@@ -318,19 +318,19 @@ def member(
 
 @external
 def member_flipped(
-    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+    c: bool, a: DynArray[Bytes[512], 5], b: DynArray[Bytes[10], 5]
 ) -> DynArray[Bytes[512], 5]:
-    return (self._long(b) if c else self._short(a))[1]
+    return (self._long(a) if c else self._short(b))[1]
     """
     c = get_contract(code)
     assert c.whole(True, SHORT, LONG) == ([1, 2], SHORT)
     assert c.whole(False, SHORT, LONG) == ([3], LONG)
-    assert c.whole_flipped(True, SHORT, LONG) == ([3], LONG)
-    assert c.whole_flipped(False, SHORT, LONG) == ([1, 2], SHORT)
+    assert c.whole_flipped(True, LONG, SHORT) == ([3], LONG)
+    assert c.whole_flipped(False, LONG, SHORT) == ([1, 2], SHORT)
     assert c.member(True, SHORT, LONG) == SHORT
     assert c.member(False, SHORT, LONG) == LONG
-    assert c.member_flipped(True, SHORT, LONG) == LONG
-    assert c.member_flipped(False, SHORT, LONG) == SHORT
+    assert c.member_flipped(True, LONG, SHORT) == LONG
+    assert c.member_flipped(False, LONG, SHORT) == SHORT
 
 
 def test_tuple_with_unbounded_member_nested_ternary(get_contract, experimental_codegen):

--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -18,12 +18,29 @@ def via_return(
     c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
 ) -> DynArray[Bytes[512], 5]:
     return a if c else b
+
+@external
+def via_local_flipped(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = b if c else a
+    return ys
+
+@external
+def via_return_flipped(
+    c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]
+) -> DynArray[Bytes[512], 5]:
+    return b if c else a
     """
     c = get_contract(code)
     assert c.via_local(True, SHORT, LONG) == SHORT
     assert c.via_local(False, SHORT, LONG) == LONG
     assert c.via_return(True, SHORT, LONG) == SHORT
     assert c.via_return(False, SHORT, LONG) == LONG
+    assert c.via_local_flipped(True, SHORT, LONG) == LONG
+    assert c.via_local_flipped(False, SHORT, LONG) == SHORT
+    assert c.via_return_flipped(True, SHORT, LONG) == LONG
+    assert c.via_return_flipped(False, SHORT, LONG) == SHORT
 
 
 def test_dynarray_arms_of_different_widths(get_contract):
@@ -33,12 +50,20 @@ def foo(
     c: bool, a: DynArray[Bytes[10], 4], b: DynArray[Bytes[40], 4]
 ) -> DynArray[Bytes[512], 4]:
     return a if c else b
+
+@external
+def flipped(
+    c: bool, a: DynArray[Bytes[10], 4], b: DynArray[Bytes[40], 4]
+) -> DynArray[Bytes[512], 4]:
+    return b if c else a
     """
     a = [b"a", b"0123456789", b"", b"xyz"]
     b = [b"q" * 40, b"", b"0123456789" * 4]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
+    assert c.flipped(True, a, b) == b
+    assert c.flipped(False, a, b) == a
 
 
 def test_nested_dynarray_widening(get_contract):
@@ -48,12 +73,20 @@ def foo(
     c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
 ) -> DynArray[DynArray[uint256, 4], 3]:
     return a if c else b
+
+@external
+def flipped(
+    c: bool, a: DynArray[DynArray[uint256, 2], 3], b: DynArray[DynArray[uint256, 4], 3]
+) -> DynArray[DynArray[uint256, 4], 3]:
+    return b if c else a
     """
     a = [[1, 2], [], [3]]
     b = [[4, 5, 6, 7], [8]]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
+    assert c.flipped(True, a, b) == b
+    assert c.flipped(False, a, b) == a
 
 
 def test_dynarray_string_widening(get_contract):
@@ -64,12 +97,21 @@ def foo(
 ) -> DynArray[String[100], 3]:
     ys: DynArray[String[100], 3] = a if c else b
     return ys
+
+@external
+def flipped(
+    c: bool, a: DynArray[String[5], 3], b: DynArray[String[100], 3]
+) -> DynArray[String[100], 3]:
+    ys: DynArray[String[100], 3] = b if c else a
+    return ys
     """
     a = ["hello", "", "hi"]
     b = ["0123456789" * 10, "x"]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
+    assert c.flipped(True, a, b) == b
+    assert c.flipped(False, a, b) == a
 
 
 def test_static_array_of_dynarray_widening(get_contract):
@@ -79,12 +121,20 @@ def foo(
     c: bool, a: DynArray[uint256, 2][2], b: DynArray[uint256, 4][2]
 ) -> DynArray[uint256, 4][2]:
     return a if c else b
+
+@external
+def flipped(
+    c: bool, a: DynArray[uint256, 2][2], b: DynArray[uint256, 4][2]
+) -> DynArray[uint256, 4][2]:
+    return b if c else a
     """
     a = [[1, 2], [3]]
     b = [[4, 5, 6, 7], [8]]
     c = get_contract(code)
     assert c.foo(True, a, b) == a
     assert c.foo(False, a, b) == b
+    assert c.flipped(True, a, b) == b
+    assert c.flipped(False, a, b) == a
 
 
 def _ternaries(ir_node, source):
@@ -125,7 +175,8 @@ def bar(c: bool, a: DynArray[uint256, 2], b: DynArray[uint256, 5]) -> DynArray[u
         for ternary in ternaries:
             _, body, orelse = ternary.args
             # each arm is the variable itself, not a copy of it
-            assert body.is_literal and orelse.is_literal
+            assert body.is_literal
+            assert orelse.is_literal
 
 
 def test_bytestring_ternary(get_contract):
@@ -138,12 +189,25 @@ def foo(c: bool, a: Bytes[10], b: Bytes[20]) -> Bytes[20]:
 def bar(c: bool, a: String[3], b: String[64]) -> String[64]:
     s: String[64] = a if c else b
     return s
+
+@external
+def foo_flipped(c: bool, a: Bytes[10], b: Bytes[20]) -> Bytes[20]:
+    return b if c else a
+
+@external
+def bar_flipped(c: bool, a: String[3], b: String[64]) -> String[64]:
+    s: String[64] = b if c else a
+    return s
     """
     c = get_contract(code)
     assert c.foo(True, b"0123456789", b"x" * 20) == b"0123456789"
     assert c.foo(False, b"0123456789", b"x" * 20) == b"x" * 20
     assert c.bar(True, "abc", "y" * 64) == "abc"
     assert c.bar(False, "abc", "y" * 64) == "y" * 64
+    assert c.foo_flipped(True, b"0123456789", b"x" * 20) == b"x" * 20
+    assert c.foo_flipped(False, b"0123456789", b"x" * 20) == b"0123456789"
+    assert c.bar_flipped(True, "abc", "y" * 64) == "y" * 64
+    assert c.bar_flipped(False, "abc", "y" * 64) == "abc"
 
 
 def test_ternary_as_event_argument(get_contract, get_logs):
@@ -154,6 +218,10 @@ event Picked:
 @external
 def foo(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
     log Picked(xs=a if c else b)
+
+@external
+def flipped(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
+    log Picked(xs=b if c else a)
     """
     c = get_contract(code)
 
@@ -164,6 +232,14 @@ def foo(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]):
     c.foo(False, SHORT, LONG)
     (log,) = get_logs(c, "Picked")
     assert log.args.xs == LONG
+
+    c.flipped(True, SHORT, LONG)
+    (log,) = get_logs(c, "Picked")
+    assert log.args.xs == LONG
+
+    c.flipped(False, SHORT, LONG)
+    (log,) = get_logs(c, "Picked")
+    assert log.args.xs == SHORT
 
 
 def test_tuple_ternary(get_contract):
@@ -185,9 +261,23 @@ def from_locals(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
     x: (Bytes[10], uint256) = (a, 1)
     y: (Bytes[40], uint256) = (b, 2)
     return x if c else y
+
+@external
+def from_calls_flipped(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
+    return self._long(b) if c else self._short(a)
+
+@external
+def from_locals_flipped(c: bool, a: Bytes[10], b: Bytes[40]) -> (Bytes[40], uint256):
+    x: (Bytes[10], uint256) = (a, 1)
+    y: (Bytes[40], uint256) = (b, 2)
+    return y if c else x
     """
     c = get_contract(code)
     assert c.from_calls(True, b"abc", b"x" * 40) == (b"abc", 1)
     assert c.from_calls(False, b"abc", b"x" * 40) == (b"x" * 40, 2)
     assert c.from_locals(True, b"abc", b"x" * 40) == (b"abc", 1)
     assert c.from_locals(False, b"abc", b"x" * 40) == (b"x" * 40, 2)
+    assert c.from_calls_flipped(True, b"abc", b"x" * 40) == (b"x" * 40, 2)
+    assert c.from_calls_flipped(False, b"abc", b"x" * 40) == (b"abc", 1)
+    assert c.from_locals_flipped(True, b"abc", b"x" * 40) == (b"x" * 40, 2)
+    assert c.from_locals_flipped(False, b"abc", b"x" * 40) == (b"abc", 1)

--- a/tests/functional/codegen/features/test_ternary_widening.py
+++ b/tests/functional/codegen/features/test_ternary_widening.py
@@ -1,13 +1,4 @@
-import pytest
-
 from vyper.compiler import compile_code
-
-
-@pytest.fixture(autouse=True)
-def _venom_only(experimental_codegen):
-    if not experimental_codegen:
-        pytest.skip("requires --experimental-codegen")
-
 
 SHORT = [b"a", b"0123456789", b""]
 LONG = [b"x" * 512, b"", b"0123456789" * 20]
@@ -96,7 +87,14 @@ def foo(
     assert c.foo(False, a, b) == b
 
 
-def test_same_type_ternary(get_contract, compiler_settings):
+def _ternaries(ir_node, source):
+    if ir_node.value == "if" and ir_node.annotation == source:
+        yield ir_node
+    for arg in ir_node.args:
+        yield from _ternaries(arg, source)
+
+
+def test_same_type_ternary(get_contract, compiler_settings, experimental_codegen):
     code = """
 @external
 def foo(
@@ -118,7 +116,16 @@ def bar(c: bool, a: DynArray[uint256, 2], b: DynArray[uint256, 5]) -> DynArray[u
     # the arms already have the element layout of the result, so neither
     # arm is converted element by element
     ir = compile_code(code, output_formats=["ir_runtime"], settings=compiler_settings)
-    assert "typed_dyn_copy" not in str(ir["ir_runtime"])
+    ir = ir["ir_runtime"]
+    if experimental_codegen:
+        assert "typed_dyn_copy" not in str(ir)
+    else:
+        ternaries = list(_ternaries(ir, "a if c else b"))
+        assert len(ternaries) == 2
+        for ternary in ternaries:
+            _, body, orelse = ternary.args
+            # each arm is the variable itself, not a copy of it
+            assert body.is_literal and orelse.is_literal
 
 
 def test_bytestring_ternary(get_contract):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1224,6 +1224,32 @@ def _complex_make_setter(left, right, hi=None):
         return b1.resolve(b2.resolve(IRnode.from_list(ret)))
 
 
+def same_memory_layout(src_typ, dst_typ):
+    """
+    Return True if memory laid out as `src_typ` reads correctly as `dst_typ`.
+
+    Compatible types can differ in element or member layout, e.g.
+    DynArray[Bytes[10], 5] vs DynArray[Bytes[512], 5] (element stride 64
+    vs 544). A wider bytestring bound or DynArray capacity at the top level
+    does not change the layout of the data that is present.
+    """
+    if isinstance(dst_typ, (DArrayT, SArrayT)):
+        assert isinstance(src_typ, (DArrayT, SArrayT))
+        pairs = [(src_typ.value_type, dst_typ.value_type)]
+    elif isinstance(dst_typ, TupleT):
+        assert isinstance(src_typ, TupleT)
+        pairs = list(zip(src_typ.member_types, dst_typ.member_types))
+    else:
+        # primitive words, bytestrings ([length][data]) and (nominal) structs
+        return True
+
+    # nested values also need equal sizes: they determine strides and offsets
+    return all(
+        s.memory_bytes_required == d.memory_bytes_required and same_memory_layout(s, d)
+        for s, d in pairs
+    )
+
+
 def ensure_in_memory(ir_var, context):
     """
     Ensure a variable is in memory. This is useful for functions
@@ -1235,8 +1261,9 @@ def ensure_in_memory(ir_var, context):
     return create_memory_copy(ir_var, context)
 
 
-def create_memory_copy(ir_var, context):
-    typ = ir_var.typ
+def create_memory_copy(ir_var, context, typ=None):
+    if typ is None:
+        typ = ir_var.typ
     buf = context.new_internal_variable(typ)
     do_copy = make_setter(buf, ir_var)
     return IRnode.from_list(["seq", do_copy, buf], typ=typ, location=MEMORY)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1224,9 +1224,9 @@ def _complex_make_setter(left, right, hi=None):
         return b1.resolve(b2.resolve(IRnode.from_list(ret)))
 
 
-def same_memory_layout(src_typ, dst_typ):
+def punnable(src_typ, dst_typ):
     """
-    Return True if memory laid out as `src_typ` reads correctly as `dst_typ`.
+    Return True if memory laid out as `src_typ` can be read (punned) as `dst_typ`.
 
     Compatible types can differ in element or member layout, e.g.
     DynArray[Bytes[10], 5] vs DynArray[Bytes[512], 5] (element stride 64
@@ -1238,15 +1238,16 @@ def same_memory_layout(src_typ, dst_typ):
         pairs = [(src_typ.value_type, dst_typ.value_type)]
     elif isinstance(dst_typ, TupleT):
         assert isinstance(src_typ, TupleT)
-        pairs = list(zip(src_typ.member_types, dst_typ.member_types))
+        n = len(dst_typ.member_types)
+        assert len(src_typ.member_types) == n
+        pairs = [(src_typ.member_types[i], dst_typ.member_types[i]) for i in range(n)]
     else:
         # primitive words, bytestrings ([length][data]) and (nominal) structs
         return True
 
     # nested values also need equal sizes: they determine strides and offsets
     return all(
-        s.memory_bytes_required == d.memory_bytes_required and same_memory_layout(s, d)
-        for s, d in pairs
+        s.memory_bytes_required == d.memory_bytes_required and punnable(s, d) for s, d in pairs
     )
 
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -22,8 +22,8 @@ from vyper.codegen.core import (
     make_setter,
     pop_dyn_array,
     potential_overlap,
+    punnable,
     read_write_overlap,
-    same_memory_layout,
     sar,
     shl,
     shr,
@@ -792,7 +792,7 @@ class Expr:
             # an arm can be narrower than the result type (e.g. DynArray[Bytes[10], 5]
             # for a DynArray[Bytes[512], 5] result). the result is read with the
             # result type's layout, so convert such arms element by element.
-            if same_memory_layout(arm.typ, typ):
+            if punnable(arm.typ, typ):
                 return arm
             return create_memory_copy(arm, self.context, typ=typ)
 

--- a/vyper/codegen/expr.py
+++ b/vyper/codegen/expr.py
@@ -8,6 +8,7 @@ from vyper.codegen.core import (
     append_dyn_array,
     check_assign,
     clamp,
+    create_memory_copy,
     data_location_to_address_space,
     dummy_node_for_type,
     ensure_in_memory,
@@ -22,6 +23,7 @@ from vyper.codegen.core import (
     pop_dyn_array,
     potential_overlap,
     read_write_overlap,
+    same_memory_layout,
     sar,
     shl,
     shr,
@@ -783,8 +785,19 @@ class Expr:
         test = Expr.parse_value_expr(self.expr.test, self.context)
         assert test.typ == BoolT()  # sanity check
 
-        body = Expr(self.expr.body, self.context).ir_node
-        orelse = Expr(self.expr.orelse, self.context).ir_node
+        typ = self.expr._metadata["type"]
+
+        def parse_arm(node):
+            arm = Expr(node, self.context).ir_node
+            # an arm can be narrower than the result type (e.g. DynArray[Bytes[10], 5]
+            # for a DynArray[Bytes[512], 5] result). the result is read with the
+            # result type's layout, so convert such arms element by element.
+            if same_memory_layout(arm.typ, typ):
+                return arm
+            return create_memory_copy(arm, self.context, typ=typ)
+
+        body = parse_arm(self.expr.body)
+        orelse = parse_arm(self.expr.orelse)
 
         # if they are in the same location, we can skip copying
         # into memory. also for the case where either body or orelse are
@@ -798,7 +811,6 @@ class Expr:
         # check this once compare_type has no side effects:
         # assert body.typ.compare_type(orelse.typ)
 
-        typ = self.expr._metadata["type"]
         location = body.location
         return IRnode.from_list(["if", test, body, orelse], typ=typ, location=location)
 

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, Sequence
 
+from vyper.codegen.core import same_memory_layout
 from vyper.codegen_venom.buffer import Buffer, Ptr
 from vyper.codegen_venom.value import VyperValue
 from vyper.evm.opcodes import version_check
@@ -566,36 +567,11 @@ class VenomCodegenContext:
         self.store_vyper_value(vv, ret.operand, typ)
         return ret
 
-    @classmethod
-    def same_memory_layout(cls, src_typ: VyperType, dst_typ: VyperType) -> bool:
-        """Return True if memory laid out as `src_typ` reads correctly as `dst_typ`.
-
-        Compatible types can differ in element or member layout, e.g.
-        DynArray[Bytes[10], 5] vs DynArray[Bytes[512], 5] (element stride 64
-        vs 544). A wider bytestring bound or DynArray capacity at the top level
-        does not change the layout of the data that is present.
-        """
-        if isinstance(dst_typ, (DArrayT, SArrayT)):
-            assert isinstance(src_typ, (DArrayT, SArrayT))
-            pairs = [(src_typ.value_type, dst_typ.value_type)]
-        elif isinstance(dst_typ, TupleT):
-            assert isinstance(src_typ, TupleT)
-            pairs = list(zip(src_typ.member_types, dst_typ.member_types))
-        else:
-            # primitive words, bytestrings ([length][data]) and (nominal) structs
-            return True
-
-        # nested values also need equal sizes: they determine strides and offsets
-        return all(
-            s.memory_bytes_required == d.memory_bytes_required and cls.same_memory_layout(s, d)
-            for s, d in pairs
-        )
-
     def ensure_memory_layout(
         self, vv: VyperValue, typ: VyperType, annotation: Optional[str] = None
     ) -> VyperValue:
         """Return `vv` laid out as `typ`, copying only when the layouts differ."""
-        if self.same_memory_layout(vv.typ, typ):
+        if same_memory_layout(vv.typ, typ):
             return vv
 
         ret = self.new_temporary_value(typ, annotation=annotation)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, Sequence
 
-from vyper.codegen.core import same_memory_layout
+from vyper.codegen.core import punnable
 from vyper.codegen_venom.buffer import Buffer, Ptr
 from vyper.codegen_venom.value import VyperValue
 from vyper.evm.opcodes import version_check
@@ -571,7 +571,7 @@ class VenomCodegenContext:
         self, vv: VyperValue, typ: VyperType, annotation: Optional[str] = None
     ) -> VyperValue:
         """Return `vv` laid out as `typ`, copying only when the layouts differ."""
-        if same_memory_layout(vv.typ, typ):
+        if punnable(vv.typ, typ):
             return vv
 
         ret = self.new_temporary_value(typ, annotation=annotation)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -566,6 +566,45 @@ class VenomCodegenContext:
         self.store_vyper_value(vv, ret.operand, typ)
         return ret
 
+    @classmethod
+    def same_memory_layout(cls, src_typ: VyperType, dst_typ: VyperType) -> bool:
+        """Return True if memory laid out as `src_typ` reads correctly as `dst_typ`.
+
+        Compatible types can differ in element or member layout, e.g.
+        DynArray[Bytes[10], 5] vs DynArray[Bytes[512], 5] (element stride 64
+        vs 544). A wider bytestring bound or DynArray capacity at the top level
+        does not change the layout of the data that is present.
+        """
+        if isinstance(dst_typ, (DArrayT, SArrayT)):
+            assert isinstance(src_typ, (DArrayT, SArrayT))
+            pairs = [(src_typ.value_type, dst_typ.value_type)]
+        elif isinstance(dst_typ, TupleT):
+            assert isinstance(src_typ, TupleT)
+            pairs = list(zip(src_typ.member_types, dst_typ.member_types))
+        else:
+            # primitive words, bytestrings ([length][data]) and (nominal) structs
+            return True
+
+        # nested values also need equal sizes: they determine strides and offsets
+        return all(
+            s.memory_bytes_required == d.memory_bytes_required and cls.same_memory_layout(s, d)
+            for s, d in pairs
+        )
+
+    def ensure_memory_layout(
+        self, vv: VyperValue, typ: VyperType, annotation: Optional[str] = None
+    ) -> VyperValue:
+        """Return `vv` laid out as `typ`, copying only when the layouts differ."""
+        if self.same_memory_layout(vv.typ, typ):
+            return vv
+
+        ret = self.new_temporary_value(typ, annotation=annotation)
+        assert isinstance(ret.operand, IRVariable)
+        # not store_vyper_value: its `src_typ != typ` check is always False for
+        # tuples (TupleT.__eq__ compares the empty `members` dict).
+        self._store_memory_typed(ret.operand, typ, self.unwrap(vv), vv.typ)
+        return ret
+
     def snapshot_value_for_delayed_use(
         self,
         vv: VyperValue,

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -281,7 +281,10 @@ class VenomCodegenContext:
         assert self.is_dynamic_tuple_frame_type(typ)
 
         if self.is_dynamic_tuple_frame_type(vv.typ):
-            return vv
+            assert isinstance(vv.typ, TupleT)
+            if self._frame_members_punnable(vv.typ, typ):
+                return vv
+            return self._dynamic_tuple_frame_from_frame(vv, typ, annotation=annotation)
 
         if not isinstance(vv.typ, TupleT):  # pragma: nocover
             raise CompilerPanic(f"expected tuple default value, got {vv.typ}")
@@ -313,6 +316,47 @@ class VenomCodegenContext:
 
             self.builder.mstore(cell, value)
             src_offset += src_member_t.memory_bytes_required
+
+        return self.dynamic_tuple_frame_value(frame, typ, annotation=annotation)
+
+    @staticmethod
+    def _frame_members_punnable(src_typ: TupleT, dst_typ: TupleT) -> bool:
+        # frame cells hold a word or a pointer, so member sizes do not matter
+        # for the frame itself, only each member's own layout
+        n = len(dst_typ.member_types)
+        assert len(src_typ.member_types) == n
+        return all(punnable(src_typ.member_types[i], dst_typ.member_types[i]) for i in range(n))
+
+    def _dynamic_tuple_frame_from_frame(
+        self, vv: VyperValue, typ: TupleT, annotation: Optional[str] = None
+    ) -> VyperValue:
+        """Rebuild a frame of a narrower tuple type in the layout of `typ`.
+
+        A member can be narrower than the corresponding member of `typ`
+        (e.g. DynArray[Bytes[10], 5] vs DynArray[Bytes[512], 5]) and its
+        data is read with the wider layout, so such members are copied.
+        """
+        assert isinstance(vv.typ, TupleT)
+        assert isinstance(vv.operand, IRVariable)
+        members = self.dynamic_tuple_frame_values(vv.operand, vv.typ, annotation=annotation)
+        frame = self.allocate_scratch(IRLiteral(self.dynamic_tuple_frame_size(typ)))
+
+        for i, dst_member_t in enumerate(typ.member_types):
+            cell = self.builder.add(frame, IRLiteral(i * 32))
+            member_vv = members[i]
+            if dst_member_t._is_prim_word:
+                value = member_vv.operand
+            else:
+                # unbounded members only have ABI-static elements, so they
+                # never need a copy
+                assert not is_unbounded_sequence_type(dst_member_t) or punnable(
+                    member_vv.typ, dst_member_t
+                )
+                member_vv = self.ensure_memory_layout(
+                    member_vv, dst_member_t, annotation=annotation
+                )
+                value = self.unwrap(member_vv)
+            self.builder.mstore(cell, value)
 
         return self.dynamic_tuple_frame_value(frame, typ, annotation=annotation)
 

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -926,7 +926,13 @@ class Expr:
                     arm_vv, result_typ, annotation="ternary"
                 )
                 return frame_vv.operand
-            return Expr(expr_node, self.ctx).lower_value()
+            # arms may be narrower than the result type (e.g. DynArray[Bytes[10], 5]
+            # for a DynArray[Bytes[512], 5] result), and the result pointer is read
+            # with the result type's layout
+            arm_vv = self.ctx.ensure_memory_layout(
+                Expr(expr_node, self.ctx).lower(), result_typ, annotation="ternary"
+            )
+            return self.ctx.unwrap(arm_vv)
 
         # Process then branch
         self.builder.append_block(then_block)


### PR DESCRIPTION
### What I did

Fix a silent miscompile in both codegen pipelines: a ternary (`x if c else y`) over an aggregate returned data laid out per the arm's type but read with the widened result type. For example

```vyper
@external
def f(c: bool, a: DynArray[Bytes[10], 5], b: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
    return a if c else b
```

returned `[b"a", b"", b""]` for `a = [b"a", b"0123456789", b""]`. Same for nested DynArray capacity widening, static arrays of DynArrays, String elements and tuple members (via locals or internal call results). Legacy and venom codegen are both affected.

### How I did it

Each arm is converted to the result layout inside its own branch, before the join. Legacy `parse_IfExp` copies the arm into an internal variable of the result type with `make_setter`; venom `lower_IfExp` uses its typed memory store. Both already widen element-wise.

The gate is a shared structural layout check, `same_memory_layout` in `codegen/core.py`, not type equality. Same-type arms, bytestring arms with different bounds, capacity-only widening and unbounded result types produce byte-identical IR to master on both pipelines.

### How to verify it

### Commit message

```
both codegen pipelines lower a ternary by lowering each arm to a pointer
into the arm's own memory layout and typing the result with the expected
(widened) type that semantic analysis stamps on the node. semantic
analysis only stamps the root node; the arms keep their exact types.
when an arm is narrower than the result -- e.g. `DynArray[Bytes[10], 5]`
for a `DynArray[Bytes[512], 5]` result -- every consumer walks the
narrow data with the wide element stride and reads garbage. the same
happens for nested dynarray capacity, static arrays of dynarrays, string
elements and widened tuple members reached through locals or internal
call results. the legacy pipeline (`parse_IfExp`) and the venom pipeline
(`lower_IfExp`) have the same defect.

convert each arm to the result layout inside its own branch, before the
join, so the result pointer genuinely has the result type's layout.
legacy does this with `make_setter` into an internal variable of the
result type; venom with its typed memory store. both already widen
element-wise. the gate is a shared structural layout check
(`same_memory_layout` in codegen/core.py) comparing element and member
layout of dynarrays, static arrays and tuples, rather than type
equality: same-type arms, bytestring arms with different bounds,
capacity-only widening and unbounded result types stay copy-free and
produce identical IR, and the check works for tuples even though
`TupleT.__eq__` always returns True.
```

### Description for the changelog

Fix ternary expressions over aggregates whose arms are narrower than the result type.

### Cute Animal Picture

![]()