### PR TITLE
fix[venom]: keep invoke arg copies from multiply assigned vars

### DIFF
--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -307,3 +307,67 @@ def foo() -> Bytes[10]:
 
     c = get_contract(source)
     assert c.foo() == b"\x01\x02"
+
+
+@pytest.mark.parametrize("test", [True, False])
+def test_ternary_as_internal_call_argument(get_contract, test):
+    code = """
+@internal
+def _echo(xs: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
+    return xs
+
+@external
+def direct(c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
+    return self._echo(a if c else b)
+
+@external
+def via_local(
+    c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]
+) -> DynArray[uint256, 5]:
+    xs: DynArray[uint256, 5] = a if c else b
+    return self._echo(xs)
+    """
+    c = get_contract(code)
+    a = [1, 2]
+    b = [3, 4, 5]
+    expected = a if test else b
+    assert c.direct(test, a, b) == expected
+    assert c.via_local(test, a, b) == expected
+
+
+@pytest.mark.parametrize("test", [True, False])
+def test_ternary_as_external_call_argument(get_contract, test):
+    code = """
+interface Echo:
+    def echo(xs: DynArray[uint256, 5]) -> DynArray[uint256, 5]: view
+
+@external
+def echo(xs: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
+    return xs
+
+@external
+def foo(c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
+    return staticcall Echo(self).echo(a if c else b)
+    """
+    c = get_contract(code)
+    a = [1, 2]
+    b = [3, 4, 5]
+    assert c.foo(test, a, b) == (a if test else b)
+
+
+@pytest.mark.parametrize("test", [True, False])
+def test_ternary_as_event_argument(get_contract, get_logs, test):
+    code = """
+event Picked:
+    xs: DynArray[uint256, 5]
+
+@external
+def foo(c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]):
+    log Picked(xs=a if c else b)
+    """
+    c = get_contract(code)
+    a = [1, 2]
+    b = [3, 4, 5]
+    c.foo(test, a, b)
+    (log,) = get_logs(c, "Picked")
+    assert log.args.xs == (a if test else b)

--- a/tests/unit/compiler/venom/test_invoke_arg_copy_forwarding.py
+++ b/tests/unit/compiler/venom/test_invoke_arg_copy_forwarding.py
@@ -786,3 +786,90 @@ def test_internal_return_forwarding_ignores_hidden_fmp_arg():
     assert all(inst.opcode != "mcopy" for inst in insts)
     mload = next(inst for inst in insts if inst.opcode == "mload")
     assert mload.operands[0] == IRVariable("%src")
+
+
+def test_readonly_forwarding_keeps_copy_from_multiply_assigned_source():
+    # the input is not in SSA form: %sel is assigned on both paths, so the
+    # copy source cannot be resolved to a single allocation
+    src = """
+    function caller {
+    caller:
+        %cond = calldataload 0
+        %a = alloca 64
+        %b = alloca 64
+        %tmp = alloca 64
+        jnz %cond, @pick_a, @pick_b
+    pick_a:
+        %sel = %a
+        jmp @join
+    pick_b:
+        %sel = %b
+        jmp @join
+    join:
+        mcopy %tmp, %sel, 64
+        invoke @callee, %tmp
+        stop
+    }
+
+    function callee {
+    callee:
+        %arg = param
+        %retpc = param
+        mload %arg
+        ret %retpc
+    }
+    """
+
+    ctx = _run_copy_forwarding(src)
+    caller = ctx.get_function(IRLabel("caller"))
+    insts = [inst for bb in caller.get_basic_blocks() for inst in bb.instructions]
+
+    mcopy = next(inst for inst in insts if inst.opcode == "mcopy")
+    invoke = next(inst for inst in insts if inst.opcode == "invoke")
+    assert invoke.operands[1] == mcopy.operands[2]
+
+
+def test_internal_return_forwarding_keeps_copy_into_multiply_assigned_destination():
+    # the input is not in SSA form: %dst is assigned on both paths, so the
+    # copy destination cannot be resolved to a single allocation
+    src = """
+    function caller {
+    caller:
+        %cond = calldataload 0
+        %x = alloca 32
+        %y = alloca 32
+        %src = alloca 32
+        jnz %cond, @pick_x, @pick_y
+    pick_x:
+        %dst = %x
+        jmp @join
+    pick_y:
+        %dst = %y
+        jmp @join
+    join:
+        invoke @callee, %src
+        mcopy %dst, %src, 32
+        %v = mload %x
+        sink %v
+    }
+
+    function callee {
+    callee:
+        %retbuf = param
+        %retpc = param
+        mstore %retbuf, 7
+        ret %retpc
+    }
+    """
+
+    def _setup(ctx):
+        callee = ctx.get_function(IRLabel("callee"))
+        callee._has_memory_return_buffer_param = True
+
+    ctx = _run_copy_forwarding(src, setup=_setup)
+    caller = ctx.get_function(IRLabel("caller"))
+    insts = [inst for bb in caller.get_basic_blocks() for inst in bb.instructions]
+
+    assert any(inst.opcode == "mcopy" for inst in insts)
+    mload = next(inst for inst in insts if inst.opcode == "mload")
+    assert mload.operands[0] == IRVariable("%x")

--- a/vyper/venom/passes/internal_return_copy_forwarding.py
+++ b/vyper/venom/passes/internal_return_copy_forwarding.py
@@ -42,7 +42,7 @@ class InternalReturnCopyForwardingPass(InvokeCopyForwardingBase):
 
         dst_root = self._assign_root_var(dst)
         src_root = self._assign_root_var(src)
-        if dst_root == src_root:
+        if dst_root is None or src_root is None or dst_root == src_root:
             return False
 
         dst_root_inst = self.dfg.get_producing_instruction(dst_root)
@@ -60,6 +60,8 @@ class InternalReturnCopyForwardingPass(InvokeCopyForwardingBase):
             return False
 
         dst_aliases = self._collect_assign_aliases(dst_root)
+        if dst_aliases is None:
+            return False
         rewrite_insts: set[IRInstruction] = set()
 
         for _, use, pos in self._iter_alias_use_positions(dst_aliases):
@@ -109,6 +111,8 @@ class InternalReturnCopyForwardingPass(InvokeCopyForwardingBase):
         self, src_root: IRVariable, copy_inst: IRInstruction
     ) -> bool:
         aliases = self._collect_assign_aliases(src_root)
+        if aliases is None:
+            return False
         copy_seen = False
         invoke_sites: set[IRInstruction] = set()
 

--- a/vyper/venom/passes/invoke_copy_forwarding_common.py
+++ b/vyper/venom/passes/invoke_copy_forwarding_common.py
@@ -47,6 +47,22 @@ class InvokeCopyForwardingBase(IRPass):
         self.readonly_memory_args = self.analyses_cache.force_analysis(
             ReadonlyMemoryArgsGlobalAnalysis
         )
+        self._multi_defined_vars = self._collect_multi_defined_vars()
+
+    def _collect_multi_defined_vars(self) -> set[IRVariable]:
+        # the pre-inlining run of these passes sees pre-SSA IR, where a
+        # variable can be assigned on several paths. DFGAnalysis records a
+        # single producer per variable, so an assign chain walked through
+        # such a variable would follow just one of its definitions.
+        seen: set[IRVariable] = set()
+        multi: set[IRVariable] = set()
+        for bb in self.function.get_basic_blocks():
+            for inst in bb.instructions:
+                for out in inst.get_outputs():
+                    if out in seen:
+                        multi.add(out)
+                    seen.add(out)
+        return multi
 
     def _finish(self, changed: bool) -> None:
         if changed:
@@ -107,7 +123,12 @@ class InvokeCopyForwardingBase(IRPass):
 
         return False
 
-    def _collect_assign_aliases(self, root: IRVariable) -> set[IRVariable]:
+    def _collect_assign_aliases(self, root: IRVariable) -> set[IRVariable] | None:
+        """
+        `root` and every variable assigned from it through assign chains,
+        or None when one of those variables is multiply defined and so does
+        not alias `root` on every path.
+        """
         aliases: set[IRVariable] = {root}
         worklist = deque([root])
 
@@ -117,6 +138,8 @@ class InvokeCopyForwardingBase(IRPass):
                 if use.opcode != "assign":
                     continue
                 out = use.output
+                if out in self._multi_defined_vars:
+                    return None
                 if out in aliases:
                     continue
                 aliases.add(out)
@@ -140,13 +163,20 @@ class InvokeCopyForwardingBase(IRPass):
     def _is_assign_output_use(self, use: IRInstruction, operand_pos: int) -> bool:
         return use.opcode == "assign" and operand_pos == 0
 
-    def _assign_root(self, op: IROperand) -> IROperand:
+    def _assign_root(self, op: IROperand) -> IROperand | None:
         if not isinstance(op, IRVariable):
             return op
         return self._assign_root_var(op)
 
-    def _assign_root_var(self, var: IRVariable) -> IRVariable:
+    def _assign_root_var(self, var: IRVariable) -> IRVariable | None:
+        """
+        The variable at the start of `var`'s assign chain, or None when the
+        chain passes through a multiply defined variable, whose root differs
+        per path.
+        """
         while True:
+            if var in self._multi_defined_vars:
+                return None
             inst = self.dfg.get_producing_instruction(var)
             if inst is None or inst.opcode != "assign":
                 return var

--- a/vyper/venom/passes/readonly_invoke_arg_copy_forwarding.py
+++ b/vyper/venom/passes/readonly_invoke_arg_copy_forwarding.py
@@ -42,12 +42,16 @@ class ReadonlyInvokeArgCopyForwardingPass(InvokeCopyForwardingBase):
             return False
 
         root = self._assign_root_var(dst)
+        if root is None:
+            return False
         root_inst = self.dfg.get_producing_instruction(root)
         if root_inst is None or root_inst.opcode != "alloca":
             return False
         dst_alloca = Allocation(root_inst)
 
         aliases = self._collect_assign_aliases(root)
+        if aliases is None:
+            return False
         rewrite_sites: set[tuple[IRInstruction, int]] = set()
 
         for _, use, pos in self._iter_alias_use_positions(aliases):
@@ -82,6 +86,8 @@ class ReadonlyInvokeArgCopyForwardingPass(InvokeCopyForwardingBase):
             return False
 
         src = self._assign_root(copy_inst.operands[1])
+        if src is None:
+            return False
         if isinstance(src, IRVariable) and src in aliases:
             return False
         if isinstance(src, IRVariable) and self._has_mutable_same_source_sibling_arg(
@@ -115,6 +121,6 @@ class ReadonlyInvokeArgCopyForwardingPass(InvokeCopyForwardingBase):
                 if self._is_readonly_invoke_operand(invoke_inst, pos):
                     continue
                 root = self._assign_root(op)
-                if root == src_root:
+                if root is None or root == src_root:
                     return True
         return False


### PR DESCRIPTION
### What I did

Fix a miscompile in the invoke copy forwarding passes: an aggregate ternary passed directly as an internal call argument always received the else arm.

```vyper
@internal
def _echo(xs: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
    return xs

@external
def f(c: bool, a: DynArray[uint256, 5], b: DynArray[uint256, 5]) -> DynArray[uint256, 5]:
    return self._echo(a if c else b)
```

`f(True, [1, 2], [3, 4])` returned `[3, 4]`. Correct at `-Onone`; independent of inlining. Present since the passes started running pre-SSA (#4811).
                                                                                                                                    ### How I did it
                                                                                                                                    `ReadonlyInvokeArgCopyForwardingPass` and `InternalRen once before `MakeSSA`. They walk assign chainsthrough `DFGAnalysis`, which keeps one producing instruction per variable, so a variable assigned in both arms of a branch resolved to only its last definition. The argument was forwardand the copy dropped; the merged variable was thendead at the join, no phi was emitted, and the branch on the condition was removed.                                               
The shared base now collects multiply defined variables up front and fails closed when an assign chain or alias set reaches one, keeping the copy. The post-SSA run is unaffected (the internal return pass had the same defect through amultiply defined alias of the destination and is covered by the same check.

### How to verify it

```
pytest tests/unit/compiler/venom/test_invoke_arg_copy
pytest tests/functional/codegen/features/test_ternary.py --experimental-codegen
```

The two new unit tests and `test_ternary_as_internal_on master. `examples/*.vy` compile to byte-identicalasm vs master.

### Commit message

```
the invoke copy forwarding passes (`ReadonlyInvokeArg
and `InternalReturnCopyForwardingPass`) run once before `MakeSSA`, where
a variable can be assigned on several paths. they wal
through `DFGAnalysis`, which records a single producing instruction per
variable, so for a variable assigned in both arms of
follows only the last definition. for an aggregate ternary passed
directly as an internal call argument this forwarded
else-arm buffer and dropped the copy; the merged variable was then dead
at the join, `MakeSSA` emitted no phi, and later pass
branch on the condition entirely, so the call always received the else
arm. present since the passes started running pre-SSA

collect the multiply defined variables when the pass
closed whenever an assign chain or alias set reaches one: the root is
unknown, so the copy is kept. the post-SSA run is una
set is empty in SSA form. the internal return pass had the same defect
through a multiply defined alias of the destination a
the same check.
```

### Description for the changelog

Fix internal call arguments that are ternary expressiing the wrong arm (venom pipeline).

### Cute Animal Picture

![]()