### PR TITLE
refactor[types]: align integer/bytesM `_id` with bytestring families

### DIFF
--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -117,6 +117,24 @@ def test_block_fail(assert_compile_failed, get_contract, bad_code, exc):
     assert_compile_failed(lambda: get_contract(bad_code), exc)
 
 
+def test_concat_type_mismatch_message_uses_readable_type_names():
+    # `concat`'s accepted `bytesM` type must be shown by its user-facing name,
+    # not the internal `bytes_m` typeclass (nor a `GenericTypeAcceptor` repr).
+    # See issue #4955.
+    code = """
+@external
+def foo() -> Bytes[64]:
+    return concat(123, b"x")
+    """
+    with pytest.raises(TypeMismatch) as exc_info:
+        compiler.compile_code(code)
+
+    message = str(exc_info.value)
+    assert "GenericTypeAcceptor" not in message
+    assert "bytes_m" not in message
+    assert "bytesM" in message
+
+
 valid_list = [
     """
 @external

--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -118,9 +118,6 @@ def test_block_fail(assert_compile_failed, get_contract, bad_code, exc):
 
 
 def test_concat_type_mismatch_message_uses_readable_type_names():
-    # `concat`'s accepted `bytesM` type must be shown by its user-facing name,
-    # not the internal `bytes_m` typeclass (nor a `GenericTypeAcceptor` repr).
-    # See issue #4955.
     code = """
 @external
 def foo() -> Bytes[64]:

--- a/tests/functional/syntax/test_concat.py
+++ b/tests/functional/syntax/test_concat.py
@@ -126,13 +126,12 @@ def test_concat_type_mismatch_message_uses_readable_type_names():
 def foo() -> Bytes[64]:
     return concat(123, b"x")
     """
-    with pytest.raises(TypeMismatch) as exc_info:
+    with pytest.raises(TypeMismatch) as e:
         compiler.compile_code(code)
 
-    message = str(exc_info.value)
-    assert "GenericTypeAcceptor" not in message
-    assert "bytes_m" not in message
-    assert "bytesM" in message
+    assert e.value.message == (
+        "Expected one of Bytes, String, bytesM but literal can only be cast as int104 or uint96."
+    )
 
 
 valid_list = [

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -53,3 +53,38 @@ def foo() -> uint256:
 @pytest.mark.parametrize("good_code", valid_list)
 def test_list_success(good_code):
     assert compile_code(good_code) is not None
+
+
+def test_len_type_mismatch_message_uses_readable_type_names():
+    # `len()`'s accepted types must be shown as `String`, `Bytes`, `DynArray`,
+    # not internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
+    code = """
+@external
+def foo(inp: int128) -> uint256:
+    return len(inp)
+    """
+    with pytest.raises(TypeMismatch) as exc_info:
+        compile_code(code)
+
+    message = str(exc_info.value)
+    assert "GenericTypeAcceptor" not in message
+    assert "String" in message
+    assert "Bytes" in message
+    assert "DynArray" in message
+
+
+def test_index_type_mismatch_message_uses_readable_type_names():
+    # Exercises the `typeclass` fallback of the type-name formatting: `IntegerT`
+    # is parametric so its `_id` is a property, falling back to `typeclass`
+    # ("integer"). The message must not leak `GenericTypeAcceptor(...)`.
+    code = """
+@external
+def foo(x: DynArray[uint256, 3]) -> uint256:
+    return x[b"ab"]
+    """
+    with pytest.raises(TypeMismatch) as exc_info:
+        compile_code(code)
+
+    message = str(exc_info.value)
+    assert "GenericTypeAcceptor" not in message
+    assert "integer" in message

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -74,9 +74,10 @@ def foo(inp: int128) -> uint256:
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # Exercises the `typeclass` fallback of the type-name formatting: `IntegerT`
-    # is parametric so its `_id` is a property, falling back to `typeclass`
-    # ("integer"). The message must not leak `GenericTypeAcceptor(...)`.
+    # Exercises the `_generic_id` fallback of the type-name formatting:
+    # `IntegerT` is parametric so its `_id` is a property with no class-level
+    # value, falling back to `_generic_id` ("integer"). The message must not
+    # leak `GenericTypeAcceptor(...)`.
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -56,36 +56,31 @@ def test_list_success(good_code):
 
 
 def test_len_type_mismatch_message_uses_readable_type_names():
-    # `len()`'s accepted types must be shown as `String`, `Bytes`, `DynArray`,
-    # not internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
+    # `len()`'s accepted types must be shown by their user-facing names, not as
+    # internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
     code = """
 @external
 def foo(inp: int128) -> uint256:
     return len(inp)
     """
-    with pytest.raises(TypeMismatch) as exc_info:
+    with pytest.raises(TypeMismatch) as e:
         compile_code(code)
 
-    message = str(exc_info.value)
-    assert "GenericTypeAcceptor" not in message
-    assert "String" in message
-    assert "Bytes" in message
-    assert "DynArray" in message
+    assert e.value.message == (
+        "Given reference has type int128, expected one of String, Bytes, DynArray"
+    )
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # Exercises the `_generic_id` fallback of the type-name formatting:
-    # `IntegerT` is parametric so its `_id` is a property with no class-level
-    # value, falling back to `_generic_id` ("integer"). The message must not
-    # leak `GenericTypeAcceptor(...)`.
+    # Exercises the `_generic_id` fallback: `IntegerT` is parametric, so its
+    # `_id` is a property with no value at the class level and the name comes
+    # from `_generic_id` ("integer") instead.
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:
     return x[b"ab"]
     """
-    with pytest.raises(TypeMismatch) as exc_info:
+    with pytest.raises(TypeMismatch) as e:
         compile_code(code)
 
-    message = str(exc_info.value)
-    assert "GenericTypeAcceptor" not in message
-    assert "integer" in message
+    assert e.value.message == "Expected integer but literal can only be cast as Bytes[2]."

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -56,8 +56,6 @@ def test_list_success(good_code):
 
 
 def test_len_type_mismatch_message_uses_readable_type_names():
-    # `len()`'s accepted types must be shown by their user-facing names, not as
-    # internal `GenericTypeAcceptor(<class ...>)` reprs. See issue #4955.
     code = """
 @external
 def foo(inp: int128) -> uint256:
@@ -72,9 +70,7 @@ def foo(inp: int128) -> uint256:
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # Exercises the `_generic_id` fallback: `IntegerT` is parametric, so its
-    # `_id` is a property with no value at the class level and the name comes
-    # from `_generic_id` ("integer") instead.
+    # exercises the `_generic_id` fallback (`IntegerT._id` is per-instance)
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:

--- a/tests/functional/syntax/test_len.py
+++ b/tests/functional/syntax/test_len.py
@@ -70,7 +70,8 @@ def foo(inp: int128) -> uint256:
 
 
 def test_index_type_mismatch_message_uses_readable_type_names():
-    # exercises the `_generic_id` fallback (`IntegerT._id` is per-instance)
+    # `IntegerT.any()` renders its class-level `_id` (`integer`), not the
+    # applied per-instance name (`uint256`)
     code = """
 @external
 def foo(x: DynArray[uint256, 3]) -> uint256:

--- a/vyper/semantics/analysis/getters.py
+++ b/vyper/semantics/analysis/getters.py
@@ -46,12 +46,12 @@ def generate_public_variable_getters(vyper_module: vy_ast.Module) -> None:
                 # type as the next arg
                 arg, annotation = annotation.slice.elements  # type: ignore
             elif annotation.value.get("id") == "DynArray":
-                arg = vy_ast.Name(id=type_._id)
+                arg = vy_ast.Name(id=type_.serialization_name)
                 annotation = annotation.slice.elements[0]  # type: ignore
             else:
                 # for other types, build an input arg node from the expected
                 # type and remove the outer `Subscript` from the annotation
-                arg = vy_ast.Name(id=type_._id)
+                arg = vy_ast.Name(id=type_.serialization_name)
                 annotation = annotation.value
             input_nodes.append(vy_ast.arg(arg=f"arg{i}", annotation=arg))
 

--- a/vyper/semantics/types/__init__.py
+++ b/vyper/semantics/types/__init__.py
@@ -23,7 +23,14 @@ def _get_primitive_types():
     # are in the namespace instead of concrete type objects.
     res.extend([BytesT, StringT])
 
-    ret = {t._id: t for t in res}
+    ret = {}
+    for t in res:
+        if isinstance(t, type):
+            # parametrizable bytestring *classes* (e.g. `Bytes` for `Bytes[5]`)
+            # are registered under their declared name.
+            ret[t._id] = t
+        else:
+            ret[t.serialization_name] = t
     ret.update(_get_sequence_types())
 
     return ret

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -17,10 +17,6 @@ from vyper.exceptions import (
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.data_locations import DataLocation
 
-# user-facing spelling for internal `typeclass` identifiers that differ from
-# the syntax users write (e.g. the `bytesM` family: `bytes1`..`bytes32`)
-_TYPECLASS_DISPLAY_NAMES = {"bytes_m": "bytesM"}
-
 
 # Some fake type with an overridden `compare_type` which accepts any RHS
 # type of type `type_`
@@ -30,17 +26,15 @@ class _GenericTypeAcceptor:
 
     def __str__(self):
         # User-facing type name (e.g. `String`, `Bytes`, `DynArray`) used in
-        # error messages, instead of the internal Python class repr. `_id` is a
-        # plain class attribute on most types, but a property on parametric
-        # types (e.g. `IntegerT`, `BytesM_T`), so fall back to `typeclass`
-        # (mapped to its user-facing spelling), then the class name, keeping
-        # this total (never returns a non-string).
+        # error messages, instead of the internal Python class repr. Prefer the
+        # class-level `_id`; parametric types (e.g. `IntegerT`, `BytesM_T`)
+        # define `_id` as a property, so it has no value at the class level that
+        # `.any()` hands us -- fall back to their `_generic_id`.
         name = getattr(self.type_, "_id", None)
         if not isinstance(name, str):
-            typeclass = getattr(self.type_, "typeclass", None)
-            name = _TYPECLASS_DISPLAY_NAMES.get(typeclass, typeclass)
+            name = self.type_._generic_id
         if not isinstance(name, str):
-            name = self.type_.__name__
+            raise CompilerPanic(f"{self.type_.__name__} has no user-facing name")
         return name
 
     def __init__(self, type_):
@@ -102,6 +96,10 @@ class VyperType:
     typeclass: str = None  # type: ignore
 
     _id: str  # rename to `_name`
+    # user-facing name for parametric types whose `_id` is an instance
+    # property (e.g. `bytesM`, `integer`), so it has no value at the class
+    # level. see `_GenericTypeAcceptor.__str__`.
+    _generic_id: str = None  # type: ignore
     _type_members: Optional[Dict] = None
     _valid_literal: Tuple = ()
     _invalid_locations: Tuple = ()
@@ -517,6 +515,8 @@ def map_void(typ: Optional[VyperType]) -> VyperType:
 # position, ex. constructors (events, interfaces and structs), and also
 # certain builtins which take types as parameters
 class TYPE_T(VyperType):
+    _generic_id = "type"
+
     def __init__(self, typedef):
         super().__init__()
 

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -17,12 +17,31 @@ from vyper.exceptions import (
 from vyper.semantics.analysis.levenshtein_utils import get_levenshtein_error_suggestions
 from vyper.semantics.data_locations import DataLocation
 
+# user-facing spelling for internal `typeclass` identifiers that differ from
+# the syntax users write (e.g. the `bytesM` family: `bytes1`..`bytes32`)
+_TYPECLASS_DISPLAY_NAMES = {"bytes_m": "bytesM"}
+
 
 # Some fake type with an overridden `compare_type` which accepts any RHS
 # type of type `type_`
 class _GenericTypeAcceptor:
     def __repr__(self):
         return f"GenericTypeAcceptor({self.type_})"
+
+    def __str__(self):
+        # User-facing type name (e.g. `String`, `Bytes`, `DynArray`) used in
+        # error messages, instead of the internal Python class repr. `_id` is a
+        # plain class attribute on most types, but a property on parametric
+        # types (e.g. `IntegerT`, `BytesM_T`), so fall back to `typeclass`
+        # (mapped to its user-facing spelling), then the class name, keeping
+        # this total (never returns a non-string).
+        name = getattr(self.type_, "_id", None)
+        if not isinstance(name, str):
+            typeclass = getattr(self.type_, "typeclass", None)
+            name = _TYPECLASS_DISPLAY_NAMES.get(typeclass, typeclass)
+        if not isinstance(name, str):
+            name = self.type_.__name__
+        return name
 
     def __init__(self, type_):
         self.type_ = type_

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -25,11 +25,6 @@ class _GenericTypeAcceptor:
         return f"GenericTypeAcceptor({self.type_})"
 
     def __str__(self):
-        # User-facing type name (e.g. `String`, `Bytes`, `DynArray`) used in
-        # error messages, instead of the internal Python class repr. Prefer the
-        # class-level `_id`; parametric types (e.g. `IntegerT`, `BytesM_T`)
-        # define `_id` as a property, so it has no value at the class level that
-        # `.any()` hands us -- fall back to their `_generic_id`.
         name = getattr(self.type_, "_id", None)
         if not isinstance(name, str):
             name = self.type_._generic_id
@@ -96,10 +91,10 @@ class VyperType:
     typeclass: str = None  # type: ignore
 
     _id: str  # rename to `_name`
-    # user-facing name for parametric types whose `_id` is an instance
-    # property (e.g. `bytesM`, `integer`), so it has no value at the class
-    # level. see `_GenericTypeAcceptor.__str__`.
-    _generic_id: str = None  # type: ignore
+    # user-facing name for types whose `_id` is the fully applied type
+    # (e.g. `uint256`, `bytes4`) rather than the type constructor, so there
+    # is no generic name to read off the class. see `_GenericTypeAcceptor`.
+    _generic_id: Optional[str] = None
     _type_members: Optional[Dict] = None
     _valid_literal: Tuple = ()
     _invalid_locations: Tuple = ()
@@ -515,8 +510,6 @@ def map_void(typ: Optional[VyperType]) -> VyperType:
 # position, ex. constructors (events, interfaces and structs), and also
 # certain builtins which take types as parameters
 class TYPE_T(VyperType):
-    _generic_id = "type"
-
     def __init__(self, typedef):
         super().__init__()
 

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -88,10 +88,11 @@ class VyperType:
 
     typeclass: str = None  # type: ignore
 
-    # Name of the type family rendered when a generic type is shown (e.g.
-    # `bool`, `String`, `DynArray`, `bytesM`, `integer`). `serialization_name`
-    # (and thus `__repr__`) appends the applied parameters where the family
-    # is parametric (e.g. `String[5]`, `uint256`, `bytes4`).
+    # Name of the type family (e.g. `bool`, `String`, `DynArray`, `integer`,
+    # `bytesM`). Types whose applied parameters are fused into a single source
+    # token (`uint256`, `bytes4`) expose the applied name via
+    # `serialization_name`; parameterized containers (e.g. `String[5]`,
+    # `DynArray[uint256, 3]`) render the applied name in `__repr__`.
     _id: str
     _type_members: Optional[Dict] = None
     _valid_literal: Tuple = ()

--- a/vyper/semantics/types/base.py
+++ b/vyper/semantics/types/base.py
@@ -25,12 +25,10 @@ class _GenericTypeAcceptor:
         return f"GenericTypeAcceptor({self.type_})"
 
     def __str__(self):
-        name = getattr(self.type_, "_id", None)
-        if not isinstance(name, str):
-            name = self.type_._generic_id
-        if not isinstance(name, str):
-            raise CompilerPanic(f"{self.type_.__name__} has no user-facing name")
-        return name
+        # `.any()` hands us the *class*, whose `_id` names the type family
+        # (e.g. `String`, `bytesM`, `integer`). `TYPE_T` has no `_id` but is
+        # never stringified: its call sites reject a non-type arg first.
+        return self.type_._id
 
     def __init__(self, type_):
         self.type_ = type_
@@ -90,11 +88,11 @@ class VyperType:
 
     typeclass: str = None  # type: ignore
 
-    _id: str  # rename to `_name`
-    # user-facing name for types whose `_id` is the fully applied type
-    # (e.g. `uint256`, `bytes4`) rather than the type constructor, so there
-    # is no generic name to read off the class. see `_GenericTypeAcceptor`.
-    _generic_id: Optional[str] = None
+    # Name of the type family rendered when a generic type is shown (e.g.
+    # `bool`, `String`, `DynArray`, `bytesM`, `integer`). `serialization_name`
+    # (and thus `__repr__`) appends the applied parameters where the family
+    # is parametric (e.g. `String[5]`, `uint256`, `bytes4`).
+    _id: str
     _type_members: Optional[Dict] = None
     _valid_literal: Tuple = ()
     _invalid_locations: Tuple = ()
@@ -147,11 +145,19 @@ class VyperType:
 
     def __repr__(self):
         # TODO: add `pretty()` to the VyperType API?
+        return self.serialization_name
+
+    # The name used to refer to this type as a single source token (AST
+    # `to_dict` "name", namespace key, synthesized getter annotations).
+    # Defaults to `_id`; parametric primitives that fuse the applied
+    # parameters into the name (`uint256`, `bytes4`) override it.
+    @property
+    def serialization_name(self):
         return self._id
 
     # return a dict suitable for serializing in the AST
     def to_dict(self):
-        ret = {"name": self._id}
+        ret = {"name": self.serialization_name}
         if self.decl_node is not None:
             ret["type_decl_node"] = self.decl_node.get_id_dict()
         if self.typeclass is not None:

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -57,6 +57,7 @@ RANGE_1_32 = list(range(1, 33))
 # one-word bytesM with m possible bytes set, e.g. bytes1..bytes32
 class BytesM_T(_PrimT):
     typeclass = "bytes_m"
+    _generic_id = "bytesM"
 
     _valid_literal = (vy_ast.Hex,)
 
@@ -266,6 +267,7 @@ class IntegerT(NumericT):
     """
 
     typeclass = "integer"
+    _generic_id = "integer"
 
     _valid_literal = (vy_ast.Int,)
     _equality_attrs = ("is_signed", "bits")

--- a/vyper/semantics/types/primitives.py
+++ b/vyper/semantics/types/primitives.py
@@ -57,7 +57,7 @@ RANGE_1_32 = list(range(1, 33))
 # one-word bytesM with m possible bytes set, e.g. bytes1..bytes32
 class BytesM_T(_PrimT):
     typeclass = "bytes_m"
-    _generic_id = "bytesM"
+    _id = "bytesM"
 
     _valid_literal = (vy_ast.Hex,)
 
@@ -68,7 +68,7 @@ class BytesM_T(_PrimT):
         self.m: int = m
 
     @property
-    def _id(self):
+    def serialization_name(self):
         return f"bytes{self.m}"
 
     @property
@@ -267,7 +267,7 @@ class IntegerT(NumericT):
     """
 
     typeclass = "integer"
-    _generic_id = "integer"
+    _id = "integer"
 
     _valid_literal = (vy_ast.Int,)
     _equality_attrs = ("is_signed", "bits")
@@ -279,8 +279,8 @@ class IntegerT(NumericT):
         self._is_signed = is_signed
         self._bits = bits
 
-    @cached_property
-    def _id(self):
+    @property
+    def serialization_name(self):
         u = "u" if not self.is_signed else ""
         return f"{u}int{self.bits}"
 


### PR DESCRIPTION
## Description

Follow-up to #5202, implementing the realign suggested by maintainer Sporarum in review: make `IntegerT` and `BytesM_T` consistent with the bytestring types, where `_id` is a class-level *family* name and the fully-applied name is produced by `__repr__`.

- `IntegerT._id` / `BytesM_T._id` are now class attributes (`integer`, `bytesM`) instead of per-instance properties returning the applied name (`uint256`, `bytes4`).
- `__repr__` on `VyperType` now renders the applied name; `_GenericTypeAcceptor.__str__` reads `self.type_._id` directly (the acceptor is handed the *class*).
- The `_generic_id` parallel concept is removed entirely.

Because the applied name is also a load-bearing *source token* (the primitive-type namespace keys, `to_dict()`'s AST `"name"`, and synthesized public-variable getter annotations all need `uint256`/`bytes4`), a new `VyperType.serialization_name` property (defaults to `_id`, overridden by the two parametric primitives) keeps those three uses byte-identical. AST output, error messages, and the namespace are unchanged.

## Changelog

`CHANGELOG entry: null` (internal refactor, no user-facing behavior change)

## Related issues

- Follow-up refactor to #5202

## Notes

This PR is stacked on #5202; once #5202 merges it will be rebased and the diff will shrink to just the realign.

## Manual testing steps

- Existing error-message tests in #5202 (`test_len.py`, `test_concat.py`) still pass.
- Full test suite has an identical result set to the base commit (0 new failures).