### PR TITLE
fix[venom]: type state variable reads with the declared type

### DIFF
--- a/tests/functional/codegen/features/test_state_variable_widening.py
+++ b/tests/functional/codegen/features/test_state_variable_widening.py
@@ -1,0 +1,262 @@
+import pytest
+
+SHORT = [b"a", b"0123456789", b""]
+NESTED = [[1, 2], [], [3]]
+
+
+def test_storage_dynarray_bytes_widening(get_contract):
+    """
+    A `DynArray[Bytes[10], 5]` storage variable read into a
+    `DynArray[Bytes[512], 5]` local, return value or argument used to be
+    copied with the wide element layout, walking past the variable's slots
+    and returning garbage.
+    """
+    code = """
+stored: DynArray[Bytes[10], 5]
+
+@internal
+def _identity(xs: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
+    return xs
+
+@external
+def store(xs: DynArray[Bytes[10], 5]):
+    self.stored = xs
+
+@external
+def via_local() -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = self.stored
+    return ys
+
+@external
+def via_return() -> DynArray[Bytes[512], 5]:
+    return self.stored
+
+@external
+def via_call() -> DynArray[Bytes[512], 5]:
+    return self._identity(self.stored)
+    """
+    c = get_contract(code)
+    c.store(SHORT)
+    assert c.via_local() == SHORT
+    assert c.via_return() == SHORT
+    assert c.via_call() == SHORT
+
+
+def test_storage_nested_dynarray_widening(get_contract):
+    code = """
+stored: DynArray[DynArray[uint256, 2], 3]
+
+@internal
+def _identity(xs: DynArray[DynArray[uint256, 4], 3]) -> DynArray[DynArray[uint256, 4], 3]:
+    return xs
+
+@external
+def store(xs: DynArray[DynArray[uint256, 2], 3]):
+    self.stored = xs
+
+@external
+def via_local() -> DynArray[DynArray[uint256, 4], 3]:
+    ys: DynArray[DynArray[uint256, 4], 3] = self.stored
+    return ys
+
+@external
+def via_return() -> DynArray[DynArray[uint256, 4], 3]:
+    return self.stored
+
+@external
+def via_call() -> DynArray[DynArray[uint256, 4], 3]:
+    return self._identity(self.stored)
+    """
+    c = get_contract(code)
+    c.store(NESTED)
+    assert c.via_local() == NESTED
+    assert c.via_return() == NESTED
+    assert c.via_call() == NESTED
+
+
+def test_storage_tuple_member_widening(get_contract):
+    code = """
+n: uint256
+stored: DynArray[Bytes[10], 3]
+
+@internal
+def _pair() -> (uint256, DynArray[Bytes[512], 3]):
+    return self.n, self.stored
+
+@external
+def store(n: uint256, xs: DynArray[Bytes[10], 3]):
+    self.n = n
+    self.stored = xs
+
+@external
+def via_local() -> (uint256, DynArray[Bytes[512], 3]):
+    t: (uint256, DynArray[Bytes[512], 3]) = (self.n, self.stored)
+    return t
+
+@external
+def via_return() -> (uint256, DynArray[Bytes[512], 3]):
+    return self.n, self.stored
+
+@external
+def via_call() -> (uint256, DynArray[Bytes[512], 3]):
+    return self._pair()
+    """
+    c = get_contract(code)
+    c.store(7, SHORT)
+    assert c.via_local() == (7, SHORT)
+    assert c.via_return() == (7, SHORT)
+    assert c.via_call() == (7, SHORT)
+
+
+@pytest.mark.requires_evm_version("cancun")
+def test_transient_dynarray_bytes_widening(get_contract):
+    code = """
+stored: transient(DynArray[Bytes[10], 5])
+
+@internal
+def _identity(xs: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
+    return xs
+
+@external
+def via_local(xs: DynArray[Bytes[10], 5]) -> DynArray[Bytes[512], 5]:
+    self.stored = xs
+    ys: DynArray[Bytes[512], 5] = self.stored
+    return ys
+
+@external
+def via_return(xs: DynArray[Bytes[10], 5]) -> DynArray[Bytes[512], 5]:
+    self.stored = xs
+    return self.stored
+
+@external
+def via_call(xs: DynArray[Bytes[10], 5]) -> DynArray[Bytes[512], 5]:
+    self.stored = xs
+    return self._identity(self.stored)
+    """
+    c = get_contract(code)
+    assert c.via_local(SHORT) == SHORT
+    assert c.via_return(SHORT) == SHORT
+    assert c.via_call(SHORT) == SHORT
+
+
+def test_immutable_dynarray_bytes_widening(get_contract):
+    """
+    Immutables are copied from the data section with the size of the wide
+    type, so the same widening bug reads past the immutable and skews the
+    element layout.
+    """
+    code = """
+X: immutable(DynArray[Bytes[10], 5])
+
+@deploy
+def __init__(xs: DynArray[Bytes[10], 5]):
+    self.X = xs
+
+@internal
+def _identity(xs: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
+    return xs
+
+@external
+def via_local() -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = self.X
+    return ys
+
+@external
+def via_return() -> DynArray[Bytes[512], 5]:
+    return self.X
+
+@external
+def via_call() -> DynArray[Bytes[512], 5]:
+    return self._identity(self.X)
+
+@external
+def via_bare_name() -> DynArray[Bytes[512], 5]:
+    # deprecated spelling of `self.X`, still accepted
+    return X
+    """
+    c = get_contract(code, SHORT)
+    assert c.via_local() == SHORT
+    assert c.via_return() == SHORT
+    assert c.via_call() == SHORT
+    assert c.via_bare_name() == SHORT
+
+
+def test_immutable_nested_dynarray_widening(get_contract):
+    code = """
+X: immutable(DynArray[DynArray[uint256, 2], 3])
+
+@deploy
+def __init__(xs: DynArray[DynArray[uint256, 2], 3]):
+    self.X = xs
+
+@external
+def via_local() -> DynArray[DynArray[uint256, 4], 3]:
+    ys: DynArray[DynArray[uint256, 4], 3] = self.X
+    return ys
+
+@external
+def via_return() -> DynArray[DynArray[uint256, 4], 3]:
+    return self.X
+    """
+    c = get_contract(code, NESTED)
+    assert c.via_local() == NESTED
+    assert c.via_return() == NESTED
+
+
+def test_module_variable_widening(get_contract, make_input_bundle):
+    lib = """
+X: immutable(DynArray[Bytes[10], 5])
+stored: DynArray[Bytes[10], 5]
+
+@deploy
+def __init__(xs: DynArray[Bytes[10], 5]):
+    self.X = xs
+    self.stored = xs
+    """
+    code = """
+import lib
+
+initializes: lib
+
+@deploy
+def __init__(xs: DynArray[Bytes[10], 5]):
+    lib.__init__(xs)
+
+@internal
+def _identity(xs: DynArray[Bytes[512], 5]) -> DynArray[Bytes[512], 5]:
+    return xs
+
+@external
+def immutable_via_local() -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = lib.X
+    return ys
+
+@external
+def immutable_via_return() -> DynArray[Bytes[512], 5]:
+    return lib.X
+
+@external
+def immutable_via_call() -> DynArray[Bytes[512], 5]:
+    return self._identity(lib.X)
+
+@external
+def storage_via_local() -> DynArray[Bytes[512], 5]:
+    ys: DynArray[Bytes[512], 5] = lib.stored
+    return ys
+
+@external
+def storage_via_return() -> DynArray[Bytes[512], 5]:
+    return lib.stored
+
+@external
+def storage_via_call() -> DynArray[Bytes[512], 5]:
+    return self._identity(lib.stored)
+    """
+    input_bundle = make_input_bundle({"lib.vy": lib})
+    c = get_contract(code, SHORT, input_bundle=input_bundle)
+    assert c.immutable_via_local() == SHORT
+    assert c.immutable_via_return() == SHORT
+    assert c.immutable_via_call() == SHORT
+    assert c.storage_via_local() == SHORT
+    assert c.storage_via_return() == SHORT
+    assert c.storage_via_call() == SHORT

--- a/tests/functional/codegen/features/test_state_variable_widening.py
+++ b/tests/functional/codegen/features/test_state_variable_widening.py
@@ -108,6 +108,49 @@ def via_call() -> (uint256, DynArray[Bytes[512], 3]):
     assert c.via_call() == (7, SHORT)
 
 
+def test_storage_to_storage_widening(get_contract):
+    code = """
+narrow: DynArray[Bytes[10], 3]
+wide: DynArray[Bytes[512], 3]
+
+@external
+def store(xs: DynArray[Bytes[10], 3]):
+    self.narrow = xs
+
+@external
+def widen():
+    self.wide = self.narrow
+
+@external
+def get_wide() -> DynArray[Bytes[512], 3]:
+    return self.wide
+    """
+    c = get_contract(code)
+    c.store(SHORT)
+    c.widen()
+    assert c.get_wide() == SHORT
+
+
+def test_storage_to_unbounded_local(get_contract, experimental_codegen):
+    if not experimental_codegen:
+        pytest.skip("unbounded sequence types require --experimental-codegen")
+    code = """
+arr: DynArray[uint256, 3]
+
+@external
+def store(xs: DynArray[uint256, 3]):
+    self.arr = xs
+
+@external
+def via_local() -> DynArray[uint256, INF]:
+    ys: DynArray[uint256, INF] = self.arr
+    return ys
+    """
+    c = get_contract(code)
+    c.store([1, 2, 3])
+    assert c.via_local() == [1, 2, 3]
+
+
 @pytest.mark.requires_evm_version("cancun")
 def test_transient_dynarray_bytes_widening(get_contract):
     code = """
@@ -171,7 +214,8 @@ def via_call() -> DynArray[Bytes[512], 5]:
 
 @external
 def via_bare_name() -> DynArray[Bytes[512], 5]:
-    # deprecated spelling of `self.X`, still accepted
+    # `X` is a deprecated spelling of `self.X` that is lowered by a different
+    # code path; this pins that path
     return X
     """
     c = get_contract(code, SHORT)
@@ -189,6 +233,10 @@ X: immutable(DynArray[DynArray[uint256, 2], 3])
 def __init__(xs: DynArray[DynArray[uint256, 2], 3]):
     self.X = xs
 
+@internal
+def _identity(xs: DynArray[DynArray[uint256, 4], 3]) -> DynArray[DynArray[uint256, 4], 3]:
+    return xs
+
 @external
 def via_local() -> DynArray[DynArray[uint256, 4], 3]:
     ys: DynArray[DynArray[uint256, 4], 3] = self.X
@@ -197,10 +245,15 @@ def via_local() -> DynArray[DynArray[uint256, 4], 3]:
 @external
 def via_return() -> DynArray[DynArray[uint256, 4], 3]:
     return self.X
+
+@external
+def via_call() -> DynArray[DynArray[uint256, 4], 3]:
+    return self._identity(self.X)
     """
     c = get_contract(code, NESTED)
     assert c.via_local() == NESTED
     assert c.via_return() == NESTED
+    assert c.via_call() == NESTED
 
 
 def test_module_variable_widening(get_contract, make_input_bundle):

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -737,7 +737,7 @@ class Expr:
         # Case 4: Immutable - IMMUTABLES location
         if varinfo.is_immutable:
             # the node's type can be wider than the variable (e.g. when
-            # assigned to a `DynArray[Bytes[512], 5]` local), the data has
+            # assigned to a `DynArray[Bytes[512], 5]` local); the data has
             # the declared type's layout
             ptr = Ptr(
                 operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES
@@ -830,7 +830,7 @@ class Expr:
 
             # the node's type can be wider than the variable (e.g. when
             # assigned to a `DynArray[Bytes[512], 5]` local); the data has
-            # the declared type's layout, so both pointers use `varinfo.typ`
+            # the declared type's layout
 
             # Immutable state variable
             if varinfo.is_immutable:

--- a/vyper/codegen_venom/expr.py
+++ b/vyper/codegen_venom/expr.py
@@ -736,11 +736,13 @@ class Expr:
 
         # Case 4: Immutable - IMMUTABLES location
         if varinfo.is_immutable:
-            typ = node._metadata["type"]
+            # the node's type can be wider than the variable (e.g. when
+            # assigned to a `DynArray[Bytes[512], 5]` local), the data has
+            # the declared type's layout
             ptr = Ptr(
                 operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES
             )
-            return VyperValue.from_ptr(ptr, typ)
+            return VyperValue.from_ptr(ptr, varinfo.typ)
 
         raise CompilerPanic(f"Unknown variable: {varname}")  # pragma: nocover
 
@@ -826,17 +828,21 @@ class Expr:
             if varinfo.is_constant:
                 return Expr(varinfo.decl_node.value, self.ctx).lower()
 
+            # the node's type can be wider than the variable (e.g. when
+            # assigned to a `DynArray[Bytes[512], 5]` local); the data has
+            # the declared type's layout, so both pointers use `varinfo.typ`
+
             # Immutable state variable
             if varinfo.is_immutable:
                 ptr = Ptr(
                     operand=IRLiteral(varinfo.position.position), location=DataLocation.IMMUTABLES
                 )
-                return VyperValue.from_ptr(ptr, typ)
+                return VyperValue.from_ptr(ptr, varinfo.typ)
 
             # Regular storage/transient variable - return location, don't load!
             slot = varinfo.position.position
             ptr = Ptr(operand=IRLiteral(slot), location=varinfo.location)
-            return VyperValue.from_ptr(ptr, typ)
+            return VyperValue.from_ptr(ptr, varinfo.typ)
 
         # Case 6: Interface address (x.address where x is an interface)
         if isinstance(sub_typ, InterfaceT) and attr == "address":


### PR DESCRIPTION
### What I did

Fix a venom-only miscompile when a storage, transient or immutable variable is
read into a wider type, e.g. `ys: DynArray[Bytes[512], 5] = self.stored` with
`stored: DynArray[Bytes[10], 5]`. Same bug family as #5236.

The semantic pass stamps the `self.x` / `lib.X` node with the *expected*
(widened) type. `codegen_venom` used that type to describe the borrowed pointer
to the state variable, but the data has the declared type's layout. Two things
went wrong:

- slot over-read: `load_storage_to_memory` sized the copy loop from the wide
  type (86 slots for `DynArray[Bytes[512], 5]` vs the declared 11), reading
  slots that belong to neighbouring variables;
- layout skew: the copied words were then walked with the wide element stride
  (544 bytes vs 64), so every element after the first was garbage.

For `[b'a', b'0123456789', b'']` this returned `[b'a', b'', b'']`; other shapes
halted out of gas. Immutables had the same defect via
`load_immutable_to_memory`. Legacy codegen is unaffec
these IRnodes with `varinfo.typ`.

### How I did it

Type the pointer returned by `lower_Attribute` (state variable reads) and
`lower_Name` (immutable reads) with the variable's de
`node._metadata["type"]`. The existing typed copies on the consumer side
(`store_memory(..., src_typ=...)`, `_store_complex_ty
return encoding, call args) then widen element-wise. No new copy machinery.

Not covered here: `for x: <wide> in self.stored` copies each element linearly
in `_lower_iter_loop` and has the same class of bug f
widenings. That is a separate code path and will be a separate PR.

### How to verify it

### Commit message

```
state variable reads in codegen_venom wrapped the storage/transient/immutable
pointer with the node's expected type, which can be w
declared type. the storage-to-memory copy then read storage_size_in_words
of the wide type (slots past the variable) and the re
wide element stride, corrupting every element after the first.

type the pointer with varinfo.typ; the existing typed stores widen the
value at the consumer.
```

### Description for the changelog

### Cute Animal Picture

![]()