### PR TITLE
fix[lang]: reject wildcard tuple returns passed as arguments

### DIFF
--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -892,6 +892,96 @@ def get_literal(addr: address) -> DynArray[uint256, 4]:
     assert caller.get_literal(target.address) == [5, 6]
 
 
+@pytest.mark.parametrize(
+    "caller_code",
+    [
+        # wildcard tuple return resolved by the bounded parameter type
+        """
+interface Target:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+    def sink(x: (Bytes[10], DynArray[uint256, 3])): nonpayable
+
+@external
+def forward(addr: address):
+    extcall Target(addr).sink(extcall Target(addr).source())
+        """,
+        # bounded local tuple passed to a wildcard parameter
+        """
+interface Target:
+    def sink(x: (Bytes[10], DynArray[uint256, ...])): nonpayable
+
+@external
+def forward(addr: address):
+    x: (Bytes[10], DynArray[uint256, 3]) = (b"hello", [1, 2, 3])
+    extcall Target(addr).sink(x)
+        """,
+        # wildcard tuple return assigned to a bounded local, then forwarded.
+        # this is the supported way to pass a wildcard tuple return on to a
+        # wildcard parameter, which cannot take the call directly
+        """
+interface Target:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+    def sink(x: (Bytes[10], DynArray[uint256, ...])): nonpayable
+
+@external
+def forward(addr: address):
+    x: (Bytes[10], DynArray[uint256, 3]) = extcall Target(addr).source()
+    extcall Target(addr).sink(x)
+        """,
+    ],
+)
+def test_wildcard_tuple_arg_roundtrip(get_contract, caller_code):
+    target_code = """
+b: Bytes[10]
+xs: DynArray[uint256, 3]
+
+@external
+def source() -> (Bytes[INF], DynArray[uint256, INF]):
+    return b"hello", [1, 2, 3]
+
+@external
+def sink(x: (Bytes[10], DynArray[uint256, 3])):
+    self.b, self.xs = x
+
+@external
+@view
+def stored() -> (Bytes[10], DynArray[uint256, 3]):
+    return self.b, self.xs
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    caller.forward(target.address)
+    assert target.stored() == (b"hello", [1, 2, 3])
+
+
+def test_wildcard_tuple_return_discarded(get_contract):
+    # with no expected type the wildcard tuple return resolves to INF members,
+    # which is a valid return shape, so the discarded call stays legal
+    target_code = """
+calls: public(uint256)
+
+@external
+def source() -> (Bytes[INF], DynArray[uint256, INF]):
+    self.calls += 1
+    return b"hello", [1, 2, 3]
+    """
+
+    caller_code = """
+interface Target:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+
+@external
+def call_source(addr: address):
+    extcall Target(addr).source()
+    """
+
+    target = get_contract(target_code)
+    caller = get_contract(caller_code)
+    caller.call_source(target.address)
+    assert target.calls() == 1
+
+
 def test_inf_dynarray_abi_encode_default_tuple(get_contract):
     payload = [i * 31 for i in range(2001)]
     code = """

--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -915,6 +915,17 @@ def forward(addr: address):
     x: (Bytes[10], DynArray[uint256, 3]) = (b"hello", [1, 2, 3])
     extcall Target(addr).sink(x)
         """,
+        # tuple literal built inline for a wildcard parameter. the wildcard
+        # call return lands on the bounded member and resolves to it
+        """
+interface Target:
+    def source_bytes() -> Bytes[...]: nonpayable
+    def sink(x: (Bytes[10], DynArray[uint256, ...])): nonpayable
+
+@external
+def forward(addr: address):
+    extcall Target(addr).sink((extcall Target(addr).source_bytes(), [1, 2, 3]))
+        """,
         # wildcard tuple return assigned to a bounded local, then forwarded.
         # this is the supported way to pass a wildcard tuple return on to a
         # wildcard parameter, which cannot take the call directly
@@ -938,6 +949,10 @@ xs: DynArray[uint256, 3]
 @external
 def source() -> (Bytes[INF], DynArray[uint256, INF]):
     return b"hello", [1, 2, 3]
+
+@external
+def source_bytes() -> Bytes[INF]:
+    return b"hello"
 
 @external
 def sink(x: (Bytes[10], DynArray[uint256, 3])):

--- a/tests/unit/semantics/types/test_inf.py
+++ b/tests/unit/semantics/types/test_inf.py
@@ -1121,6 +1121,76 @@ def f(a: address, x: Bytes[INF]) -> uint256:
     assert e.value.message == message
 
 
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (
+            """
+interface I:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+    def sink(x: (Bytes[10], DynArray[uint256, ...])): nonpayable
+
+@external
+def f(a: address):
+    extcall I(a).sink(extcall I(a).source())
+    """,
+            "Function arguments cannot contain unbounded sequence types inside aggregate types",
+        ),
+        (
+            """
+interface I:
+    def source() -> (Bytes[...], uint256): nonpayable
+    def sink(x: (Bytes[...], uint256)): nonpayable
+
+@external
+def f(a: address):
+    extcall I(a).sink(extcall I(a).source())
+    """,
+            "Function arguments cannot contain unbounded sequence types inside aggregate types",
+        ),
+        (
+            """
+interface I:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+
+@external
+def f(a: address):
+    print(extcall I(a).source())
+    """,
+            "print arguments cannot contain unbounded sequence types inside aggregate types",
+        ),
+        (
+            """
+interface I:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+
+@external
+def f(a: address, code: Bytes[100]) -> address:
+    return raw_create(code, extcall I(a).source())
+    """,
+            "constructor arguments cannot contain nested unbounded sequence types",
+        ),
+        (
+            """
+interface I:
+    def source() -> (Bytes[...], DynArray[uint256, ...]): nonpayable
+
+@external
+def f(a: address, target: address) -> address:
+    return create_from_blueprint(target, extcall I(a).source())
+    """,
+            "constructor arguments cannot contain nested unbounded sequence types",
+        ),
+    ],
+)
+def test_wildcard_tuple_return_rejected_as_argument(code, message):
+    # without a bounded expected type the wildcard tuple return resolves to a
+    # tuple of INF members, which is not a valid argument type
+    with pytest.raises(StructureException) as e:
+        compiler.compile_code(code, settings=Settings(experimental_codegen=True))
+    assert e.value.message == message
+
+
 def test_wildcard_tuple_return_member_access_compile():
     code = """
 interface I:

--- a/tests/unit/semantics/types/test_inf.py
+++ b/tests/unit/semantics/types/test_inf.py
@@ -1148,6 +1148,45 @@ def f(a: address):
     """,
             "Function arguments cannot contain unbounded sequence types inside aggregate types",
         ),
+        # the wildcard call is an element of a tuple literal
+        (
+            """
+interface I:
+    def source() -> Bytes[...]: view
+    def sink(x: (Bytes[...], uint256)): nonpayable
+
+@external
+def f(a: address):
+    extcall I(a).sink((staticcall I(a).source(), 1))
+    """,
+            "Function arguments cannot contain unbounded sequence types inside aggregate types",
+        ),
+        # only the member receiving the wildcard call is a wildcard
+        (
+            """
+interface I:
+    def source() -> DynArray[uint256, ...]: view
+    def sink(x: (Bytes[10], DynArray[uint256, ...])): nonpayable
+
+@external
+def f(a: address):
+    extcall I(a).sink((b"hi", staticcall I(a).source()))
+    """,
+            "Function arguments cannot contain unbounded sequence types inside aggregate types",
+        ),
+        # the wildcard call is an element of a list literal
+        (
+            """
+interface I:
+    def source() -> Bytes[...]: view
+    def sink(xs: DynArray[Bytes[...], ...]): nonpayable
+
+@external
+def f(a: address):
+    extcall I(a).sink([staticcall I(a).source()])
+    """,
+            "Function arguments cannot contain unbounded sequence types inside aggregate types",
+        ),
         (
             """
 interface I:
@@ -1184,8 +1223,9 @@ def f(a: address, target: address) -> address:
     ],
 )
 def test_wildcard_tuple_return_rejected_as_argument(code, message):
-    # without a bounded expected type the wildcard tuple return resolves to a
-    # tuple of INF members, which is not a valid argument type
+    # without a bounded expected type a wildcard call return resolves to INF,
+    # which is not a valid argument type inside an aggregate. this holds for
+    # the call passed directly and for a call nested in a tuple or list literal
     with pytest.raises(StructureException) as e:
         compiler.compile_code(code, settings=Settings(experimental_codegen=True))
     assert e.value.message == message

--- a/vyper/builtins/_signatures.py
+++ b/vyper/builtins/_signatures.py
@@ -156,7 +156,9 @@ class BuiltinFunctionT(VyperType):
         varargs = node.args[n_known_args:]
         if len(varargs) > 0:
             assert self._has_varargs
-        ret.extend(get_exact_type_from_node(arg) for arg in varargs)
+        # varargs have no declared type, so a wildcard call return has no
+        # bound to resolve against and its wildcards resolve to INF
+        ret.extend(get_exact_type_from_node(arg).resolve_wildcard() for arg in varargs)
         return ret
 
     def infer_kwarg_types(self, node: vy_ast.Call) -> dict[str, VyperType]:

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -1633,7 +1633,7 @@ class RawCreate(_CreateBase):
         bytecode_type = get_possible_types_from_node(node.args[0]).pop()
         if is_bounded_length(bytecode_type.length) and bytecode_type.length > EIP_3860_LIMIT:
             raise TypeMismatch(f"initcode length cannot exceed {EIP_3860_LIMIT}", node.args[0])
-        ctor_arg_types = [get_exact_type_from_node(arg) for arg in node.args[1:]]
+        ctor_arg_types = [get_exact_type_from_node(arg).resolve_wildcard() for arg in node.args[1:]]
         if any(type_contains_nested_unbounded_sequence(t) for t in ctor_arg_types):
             raise StructureException(
                 "constructor arguments cannot contain nested unbounded sequence types", node
@@ -2302,10 +2302,6 @@ class ABIEncode(BuiltinFunctionT):
         "ensure_tuple": KwargSettings(BoolT(), True, require_literal=True),
         "method_id": KwargSettings((BYTES4_T, BytesT(4)), None, require_literal=True),
     }
-
-    def infer_arg_types(self, node, expected_return_typ=None):
-        arg_types = super().infer_arg_types(node, expected_return_typ)
-        return [arg_t.resolve_wildcard() for arg_t in arg_types]
 
     def infer_kwarg_types(self, node):
         ret = {}

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -79,14 +79,29 @@ from vyper.semantics.types.infinity import (
 from vyper.semantics.types.utils import type_from_annotation
 
 
-def _expr_contains_unbounded_sequence(node: vy_ast.VyperNode) -> bool:
-    if isinstance(node, (vy_ast.Tuple, vy_ast.List)):
-        return any(_expr_contains_unbounded_sequence(item) for item in node.elements)
+def _expr_contains_unbounded_sequence(node: vy_ast.VyperNode, typ: VyperType) -> bool:
+    # walk literals alongside the expected type. a literal whose shape does
+    # not match `typ` is rejected later, when it is visited
+    if isinstance(node, vy_ast.Tuple) and isinstance(typ, TupleT):
+        return any(
+            _expr_contains_unbounded_sequence(item, item_typ)
+            for item, item_typ in zip(node.elements, typ.member_types)
+        )
+    if isinstance(node, vy_ast.List) and isinstance(typ, (SArrayT, DArrayT)):
+        return any(
+            _expr_contains_unbounded_sequence(item, typ.value_type) for item in node.elements
+        )
 
     try:
-        return type_contains_unbounded_sequence(get_exact_type_from_node(node))
+        actual_typ = get_exact_type_from_node(node)
     except VyperException:
         return False
+
+    if typ.has_wildcard:
+        # resolve a wildcard call return against the element's expected
+        # type, the same way `ExprVisitor.visit_Call` does for arguments
+        actual_typ = actual_typ.resolve_wildcard()
+    return type_contains_unbounded_sequence(actual_typ)
 
 
 def analyze_functions(vy_module: vy_ast.Module) -> None:
@@ -1052,7 +1067,7 @@ class ExprVisitor(VyperNodeVisitorBase):
 
             for arg, arg_typ in zip(node.args, func_type.argument_types):
                 if isinstance(arg, (vy_ast.Tuple, vy_ast.List)):
-                    has_nested_unbounded = _expr_contains_unbounded_sequence(arg)
+                    has_nested_unbounded = _expr_contains_unbounded_sequence(arg, arg_typ)
                 else:
                     try:
                         actual_arg_typ = get_exact_type_from_node(arg)

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -1059,6 +1059,12 @@ class ExprVisitor(VyperNodeVisitorBase):
                     except VyperException:
                         has_nested_unbounded = False
                     else:
+                        if arg_typ.has_wildcard:
+                            # a wildcard call return resolves to the parameter
+                            # type, unless the parameter is itself a wildcard,
+                            # in which case it resolves to INF (see the
+                            # external call handling below)
+                            actual_arg_typ = actual_arg_typ.resolve_wildcard()
                         has_nested_unbounded = type_contains_nested_unbounded_sequence(
                             actual_arg_typ
                         )


### PR DESCRIPTION
### What I did

Fix https://github.com/vyperlang/vyper/issues/5241. Passing the result of an
external call with a wildcard tuple return type (e.g. `(Bytes[...],
DynArray[uint256, ...])`) directly to a wildcard tuple parameter, to `print`,
`raw_create` or `create_from_blueprint` crashed the venom pipeline with
`CodegenPanic: unsupported operand type(s) for %: 'Inf' and 'int'`. It is now
rejected at analysis with the existing "... arguments cannot contain unbounded
sequence types inside aggregate types" errors.

### How I did it

A wildcard call return is resolved against the expected type when the caller
provides a bounded one, and to `INF` otherwise. The `INF` case is a valid
return shape (a discarded call or a subscript keeps working), but a tuple with
`INF` members is not a valid argument type — the same restriction that
declaration-time checks, memory variables and `abi_encode` already enforce.

The consumer-side argument checks read the argument type with
`get_exact_type_from_node`, which returns the unresolved wildcard type; the
nested-unbounded predicate matches only `INF`, so they never fired and the
resolved tuple reached codegen. `abi_encode` already resolved wildcards before
its check; this PR does the same in the call-argument loop (only when the
parameter itself is a wildcard, so a bounded parameter still resolves the
return to the parameter type) and in the base varargs inference (which
covers `print` and `create_from_blueprint` and subsumes `abi_encode`'s
override) plus `raw_create`'s own constructor-argument list.

This is a semantics fix rather than codegen support: the restriction on
`INF` members inside tuples is documented and applies at every other
argument site. Discarding the call (`extcall foo.source()` as a statement)
and subscripting its result intentionally stay legal and are covered by
tests.

### How to verify it

### Commit message

```
the wildcard-return branch of `visit_Call` resolves a wildcard external
call return against the expected type when the caller provides a bounded
one, and to `INF` otherwise. the `INF` case is fine for a discarded call
or a subscript, where a tuple of `INF` members is a valid return shape,
but not when the value is passed on as an argument: tuples with `INF`
members are not valid argument types (GH 5241).

the consumer-side checks that enforce this (the call argument loop in
`visit_Call`, and the varargs builtins `print`, `raw_create` and
`create_from_blueprint`) all read the argument type with
`get_exact_type_from_node`, which returns the declared, unresolved
wildcard type. the nested-unbounded predicate only matches `INF`, so the
checks never fired and the resolved `INF` tuple reached codegen, which
panics computing the size bound of a `Bytes[INF]` member.

resolve the wildcards before those checks, as `abi_encode` already did,
so the existing checks reject the value with their user-facing message.
the resolution is applied only where the expected type cannot bound the
return: a wildcard parameter, or a vararg. a bounded parameter still
resolves the return to the parameter type, which is validated at its
declaration. `abi_encode`'s own override is subsumed by resolving in the
base varargs inference. discarding the call and subscripting its result
stay legal. codegen support for `INF` tuple arguments was not pursued:
the restriction is documented and applies to every other argument site.
```

### Description for the changelog

Reject wildcard tuple call returns passed as arguments instead of crashing the
compiler.

### Cute Animal Picture

![]()