### PR TITLE
fix[venom]: keep venom memory allocation order deterministic

### DIFF
--- a/tests/functional/venom/test_memory_allocation_stability.py
+++ b/tests/functional/venom/test_memory_allocation_stability.py
@@ -1,0 +1,62 @@
+import os
+import subprocess
+import sys
+
+# the pointers of the `Bytes` locals escape into `self._f`, and each
+# if/else arm gives its local the same live range. the memory allocator
+# must resolve such ties by program order, not by object-identity hash
+# order, which differs between processes.
+CONTRACT = """
+@internal
+def _f(a: Bytes[64]) -> uint256:
+    s: uint256 = 0
+    for i: uint256 in range(len(a), bound=64):
+        s += convert(slice(a, i, 1), uint256)
+    return s
+
+@external
+def foo(x: Bytes[64], y: Bytes[64], flags: bool[4]) -> uint256:
+    n: uint256 = 0
+    if flags[0]:
+        a0: Bytes[64] = x
+        n += self._f(a0)
+    else:
+        b0: Bytes[64] = y
+        n += self._f(b0)
+    if flags[1]:
+        a1: Bytes[64] = x
+        n += self._f(a1)
+    else:
+        b1: Bytes[64] = y
+        n += self._f(b1)
+    if flags[2]:
+        a2: Bytes[64] = x
+        n += self._f(a2)
+    else:
+        b2: Bytes[64] = y
+        n += self._f(b2)
+    if flags[3]:
+        a3: Bytes[64] = x
+        n += self._f(a3)
+    else:
+        b3: Bytes[64] = y
+        n += self._f(b3)
+    return n
+"""
+
+
+def test_memory_allocation_stability(tmp_path):
+    # object-identity hashes are not fixed by PYTHONHASHSEED, so the
+    # bytecode must be compared across fresh compiler processes. varying
+    # the seed changes allocation patterns and thereby object addresses.
+    path = tmp_path / "foo.vy"
+    path.write_text(CONTRACT)
+
+    outputs = set()
+    for seed in range(8):
+        env = {**os.environ, "PYTHONHASHSEED": str(seed)}
+        cmd = [sys.executable, "-m", "vyper", "--experimental-codegen", "-f", "bytecode_runtime"]
+        res = subprocess.run(cmd + [str(path)], env=env, capture_output=True, text=True, check=True)
+        outputs.add(res.stdout.strip())
+
+    assert len(outputs) == 1, f"{len(outputs)} distinct outputs across processes"

--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -15,6 +15,7 @@ from vyper.evm.address_space import (
     AddrSpace,
 )
 from vyper.exceptions import CompilerPanic
+from vyper.utils import OrderedSet
 from vyper.venom.analysis.analysis import IRAnalysis
 from vyper.venom.analysis.cfg import CFGAnalysis
 from vyper.venom.basicblock import IRBasicBlock, IRInstruction, IRLiteral, IROperand, IRVariable
@@ -97,7 +98,7 @@ class BasePtrAnalysis(IRAnalysis):
     pointers.
     """
 
-    var_to_mem: dict[IRVariable, set[Ptr]]
+    var_to_mem: dict[IRVariable, OrderedSet[Ptr]]
     vars_in_allocations: dict[Allocation, set[IRVariable]]
     _untracked_root_memo: dict[IRVariable, bool]
     _untracked_root_active: set[IRVariable]
@@ -132,7 +133,7 @@ class BasePtrAnalysis(IRAnalysis):
         self.new(var, Ptr(allocation, offset))
 
     def new(self, var: IRVariable, ptr: Ptr):
-        self.var_to_mem[var] = {ptr}
+        self.var_to_mem[var] = OrderedSet([ptr])
         if ptr.base_alloca not in self.vars_in_allocations:
             self.vars_in_allocations[ptr.base_alloca] = set()
         self.vars_in_allocations[ptr.base_alloca].add(var)
@@ -149,7 +150,7 @@ class BasePtrAnalysis(IRAnalysis):
         # subsequent bumps/invokes and does not alias any known region.
         if opcode == "bump":
             ptr_out = inst.get_outputs()[0]
-            return self._add_possible_ptrs(ptr_out, {Ptr.from_alloca(inst)})
+            return self._add_possible_ptrs(ptr_out, OrderedSet([Ptr.from_alloca(inst)]))
 
         # `getfmp` (a read of the FMP virtual register) intentionally gets no
         # pointer facts: its output is an *untracked* base, so anything rooted
@@ -161,14 +162,14 @@ class BasePtrAnalysis(IRAnalysis):
             return False
 
         if opcode in ("alloca", "dalloca"):
-            return self._add_possible_ptrs(inst.output, {Ptr.from_alloca(inst)})
+            return self._add_possible_ptrs(inst.output, OrderedSet([Ptr.from_alloca(inst)]))
 
         elif opcode in ("add", "sub"):
             rhs, lhs = inst.operands
-            lhs_ptrs = self.get_possible_ptrs(lhs) if isinstance(lhs, IRVariable) else set()
-            rhs_ptrs = self.get_possible_ptrs(rhs) if isinstance(rhs, IRVariable) else set()
+            lhs_ptrs = self.get_possible_ptrs(lhs) if isinstance(lhs, IRVariable) else OrderedSet()
+            rhs_ptrs = self.get_possible_ptrs(rhs) if isinstance(rhs, IRVariable) else OrderedSet()
 
-            out_ptrs: set[Ptr] = set()
+            out_ptrs: OrderedSet[Ptr] = OrderedSet()
 
             # Preserve exact offsets when one side is a pointer and the other
             # is a known integer literal.
@@ -190,7 +191,7 @@ class BasePtrAnalysis(IRAnalysis):
                 return self._add_possible_ptrs(inst.output, out_ptrs)
 
         elif opcode == "phi":
-            phi_sources = set()
+            phi_sources: OrderedSet[Ptr] = OrderedSet()
             for _, var in inst.phi_operands:
                 assert isinstance(var, IRVariable)  # mypy help
                 var_sources = self.get_possible_ptrs(var)
@@ -202,7 +203,7 @@ class BasePtrAnalysis(IRAnalysis):
 
         return False
 
-    def _add_possible_ptrs(self, var: IRVariable, ptrs: set[Ptr]) -> bool:
+    def _add_possible_ptrs(self, var: IRVariable, ptrs: OrderedSet[Ptr]) -> bool:
         if len(ptrs) == 0:
             return False
 
@@ -212,7 +213,7 @@ class BasePtrAnalysis(IRAnalysis):
         # values on different paths. Keep facts monotonic so a later
         # non-pointer assignment cannot erase a base pointer that may still
         # reach a use through another path.
-        original = self.var_to_mem.get(var, set())
+        original = self.var_to_mem.get(var, OrderedSet())
         new_ptrs = self._normalize_ptrs(original | ptrs)
         if new_ptrs == original:
             return False
@@ -220,12 +221,12 @@ class BasePtrAnalysis(IRAnalysis):
         self.var_to_mem[var] = new_ptrs
         return True
 
-    def _normalize_ptrs(self, ptrs: set[Ptr]) -> set[Ptr]:
+    def _normalize_ptrs(self, ptrs: OrderedSet[Ptr]) -> OrderedSet[Ptr]:
         offsets_by_base: dict[Allocation, set[int | None]] = {}
         for ptr in ptrs:
             offsets_by_base.setdefault(ptr.base_alloca, set()).add(ptr.offset)
 
-        ret: set[Ptr] = set()
+        ret: OrderedSet[Ptr] = OrderedSet()
         for base_alloca, offsets in offsets_by_base.items():
             if len(offsets) == 1:
                 ret.add(Ptr(base_alloca, next(iter(offsets))))
@@ -386,10 +387,10 @@ class BasePtrAnalysis(IRAnalysis):
 
         return MemoryLocation.EMPTY
 
-    def get_possible_ptrs(self, var: IRVariable) -> set[Ptr]:
-        return self.var_to_mem.get(var, set())
+    def get_possible_ptrs(self, var: IRVariable) -> OrderedSet[Ptr]:
+        return self.var_to_mem.get(var, OrderedSet())
 
-    def escaping_allocations(self) -> set[Allocation]:
+    def escaping_allocations(self) -> OrderedSet[Allocation]:
         """
         The allocations whose pointer escapes SSA tracking (see
         `escaping_operands`). Accesses through a re-entered pointer are
@@ -398,7 +399,7 @@ class BasePtrAnalysis(IRAnalysis):
         MemLivenessAnalysis keeps such an `alloca` live to the end of the
         function.
         """
-        escaped: set[Allocation] = set()
+        escaped: OrderedSet[Allocation] = OrderedSet()
         for bb in self.function.get_basic_blocks():
             for inst in bb.instructions:
                 for op in escaping_operands(inst):

--- a/vyper/venom/analysis/mem_liveness.py
+++ b/vyper/venom/analysis/mem_liveness.py
@@ -32,7 +32,7 @@ class MemLivenessAnalysis(IRAnalysis):
     used: dict[IRInstruction, OrderedSet[Allocation]]
     livesets: dict[Allocation, OrderedSet[IRInstruction]]
     # static allocas whose pointer escapes; live to the end of the function
-    escaped: set[Allocation]
+    escaped: OrderedSet[Allocation]
     cfg: CFGAnalysis
 
     def analyze(self):
@@ -63,7 +63,9 @@ class MemLivenessAnalysis(IRAnalysis):
         # reads and kills above are incomplete for it. fail closed: it is
         # live everywhere, i.e. (intersected with `used`) from its first
         # use to the end of the function, and never shares its slot.
-        self.escaped = {a for a in self.base_ptrs.escaping_allocations() if not a.is_dynamic}
+        self.escaped = OrderedSet(
+            a for a in self.base_ptrs.escaping_allocations() if not a.is_dynamic
+        )
         if len(self.escaped) > 0:
             for bb in self.function.get_basic_blocks():
                 for inst in bb.instructions:
@@ -147,12 +149,14 @@ class MemLivenessAnalysis(IRAnalysis):
             self.used[inst] = used.copy()
         return before != used
 
-    def _find_base_ptrs(self, op: Optional[IROperand]) -> set[Ptr]:
+    def _find_base_ptrs(self, op: Optional[IROperand]) -> OrderedSet[Ptr]:
         if op is None or not isinstance(op, IRVariable):
-            return set()
+            return OrderedSet()
         # only static allocas need concretization; dalloca regions live
         # above the static frame and are not tracked by the allocator.
-        return {p for p in self.base_ptrs.get_possible_ptrs(op) if not p.base_alloca.is_dynamic}
+        return OrderedSet(
+            p for p in self.base_ptrs.get_possible_ptrs(op) if not p.base_alloca.is_dynamic
+        )
 
     def _mark_store_locations_live(self):
         # DSE may preserve stores whose liveness it can't disprove (e.g.,


### PR DESCRIPTION
### What I did

Fixes https://github.com/vyperlang/vyper/issues/5245

### How I did it

### How to verify it

### Commit message

```
use `OrderedSet` so `Ptr` and `Allocation` that hash by `IRInstruction` identity
don't result in non-deterministic builds. 
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
