### PR TITLE
feat[venom]: invalidate only aliased loads at fixed-size memory copies

### DIFF
--- a/vyper/venom/analysis/load_analysis.py
+++ b/vyper/venom/analysis/load_analysis.py
@@ -21,7 +21,7 @@ from .mem_alias import (
 
 _LatticeKey = IROperand | MemoryLocation
 
-# bulk memory writes whose destination is known when their size is a literal
+# bulk memory writes whose destination operand names the written location
 _MEMORY_COPY_OPS = frozenset(
     ["mcopy", "calldatacopy", "codecopy", "dloadbytes", "returndatacopy", "extcodecopy"]
 )
@@ -231,13 +231,15 @@ class LoadAnalysis(IRAnalysis):
                 return memloc
         return self._normalize_operand(inst.operands[1])
 
-    def _fixed_copy_location(self, inst: IRInstruction, eff: Effects) -> Optional[MemoryLocation]:
+    def _copy_write_location(self, inst: IRInstruction, eff: Effects) -> Optional[MemoryLocation]:
+        # the alias set of a non-fixed location (unknown offset or size inside
+        # an allocation, or no allocation at all) already covers every
+        # location it may overlap, so there is no need to require a fixed
+        # location here: a dynamic-size copy into an allocation only
+        # invalidates that allocation, an unknown destination everything
         if eff != Effects.MEMORY or inst.opcode not in _MEMORY_COPY_OPS:
             return None
-        memloc = self.base_ptrs.get_write_location(inst, self.space)
-        if not memloc.is_fixed:
-            return None
-        return memloc
+        return self.base_ptrs.get_write_location(inst, self.space)
 
     def _handle_bb(
         self, eff: Effects | str, load_opcode: str, store_opcode: str | None, bb: IRBasicBlock
@@ -260,10 +262,10 @@ class LoadAnalysis(IRAnalysis):
                 lattice.remove_aliases(memloc, alias_set)
                 lattice[ptr] = OrderedSet([val])
             elif isinstance(eff, Effects) and eff in inst.get_write_effects():
-                # a fixed-size memory copy is a store to a known location:
+                # a memory copy is a store to its destination location:
                 # drop what it may alias, exactly like an mstore. anything
-                # else (calls, unknown sizes) clobbers everything
-                copy_loc = self._fixed_copy_location(inst, eff)
+                # else (calls, invokes) clobbers everything
+                copy_loc = self._copy_write_location(inst, eff)
                 if copy_loc is None:
                     lattice.clear()
                 else:

--- a/vyper/venom/analysis/load_analysis.py
+++ b/vyper/venom/analysis/load_analysis.py
@@ -20,6 +20,11 @@ from .mem_alias import (
 )
 
 _LatticeKey = IROperand | MemoryLocation
+
+# bulk memory writes whose destination is known when their size is a literal
+_MEMORY_COPY_OPS = frozenset(
+    ["mcopy", "calldatacopy", "codecopy", "dloadbytes", "returndatacopy", "extcodecopy"]
+)
 _GetMemloc = Callable[[_LatticeKey], MemoryLocation]
 
 
@@ -226,6 +231,14 @@ class LoadAnalysis(IRAnalysis):
                 return memloc
         return self._normalize_operand(inst.operands[1])
 
+    def _fixed_copy_location(self, inst: IRInstruction, eff: Effects) -> Optional[MemoryLocation]:
+        if eff != Effects.MEMORY or inst.opcode not in _MEMORY_COPY_OPS:
+            return None
+        memloc = self.base_ptrs.get_write_location(inst, self.space)
+        if not memloc.is_fixed:
+            return None
+        return memloc
+
     def _handle_bb(
         self, eff: Effects | str, load_opcode: str, store_opcode: str | None, bb: IRBasicBlock
     ) -> bool:
@@ -247,7 +260,17 @@ class LoadAnalysis(IRAnalysis):
                 lattice.remove_aliases(memloc, alias_set)
                 lattice[ptr] = OrderedSet([val])
             elif isinstance(eff, Effects) and eff in inst.get_write_effects():
-                lattice.clear()
+                # a fixed-size memory copy is a store to a known location:
+                # drop what it may alias, exactly like an mstore. anything
+                # else (calls, unknown sizes) clobbers everything
+                copy_loc = self._fixed_copy_location(inst, eff)
+                if copy_loc is None:
+                    lattice.clear()
+                else:
+                    self.mem_alias.ensure_analyzed(copy_loc)
+                    alias_set = self.mem_alias.get_alias_set(copy_loc)
+                    assert alias_set is not None
+                    lattice.remove_aliases(copy_loc, alias_set)
 
         if bb not in self.bb_to_lattice or self.bb_to_lattice[bb] != lattice:
             self.bb_to_lattice[bb] = lattice


### PR DESCRIPTION
### What I did

`LoadAnalysis` used to forget every forwardable store as soon as it saw any memory write
that was not an `mstore`, including `mcopy`, `codecopy`, `calldatacopy`, `dloadbytes`,
`returndatacopy` and `extcodecopy`. For a copy with a known destination and a literal
size, it now removes only the entries that may alias the written interval, the same way
the `mstore` branch already does. Copies with an unknown destination or size still clear
everything.

### How I did it

One new branch in `LoadAnalysis` next to the existing `mstore` case: look up the
instruction's write location through `BasePtrAnalysis`; if it is fixed, call
`remove_aliases` on it, otherwise fall back to `clear()`. The set of opcodes is the
memory-copy instructions whose only write effect is `MEMORY`.

### How to verify it

### Commit message

```
invalidate only aliased loads at fixed-size memory copies
```

### Description for the changelog

