### PR TITLE
fix[venom]: fail closed on mixed-root pointers in base ptr analysis

### DIFF
--- a/tests/functional/codegen/features/test_inf_dynarray_runtime.py
+++ b/tests/functional/codegen/features/test_inf_dynarray_runtime.py
@@ -260,6 +260,34 @@ def check() -> DynArray[uint256, INF]:
     assert c.check() == [10, 20, 30]
 
 
+@pytest.mark.parametrize("reassign", [True, False])
+def test_inf_dynarray_internal_param_conditional_reassign_append(get_contract, reassign):
+    # after the `if`, the local's payload pointer is either the caller's `y`
+    # or a fresh buffer; the append writes through that merged pointer
+    code = """
+@internal
+def build(y: DynArray[uint256, INF], reassign: bool) -> DynArray[uint256, INF]:
+    x: DynArray[uint256, INF] = y
+    if reassign:
+        x = [1, 2, 3]
+    x.append(9)
+    return x
+
+@external
+def foo(y: DynArray[uint256, INF], reassign: bool) -> DynArray[uint256, INF]:
+    return self.build(y, reassign)
+
+@external
+def bar(y: DynArray[uint256, INF], reassign: bool) -> uint256:
+    return len(self.build(y, reassign))
+    """
+    c = get_contract(code)
+
+    expected = ([1, 2, 3] if reassign else [7, 8]) + [9]
+    assert c.foo([7, 8], reassign) == expected
+    assert c.bar([7, 8], reassign) == len(expected)
+
+
 def test_inf_dynarray_append_after_kwarg_default(get_contract):
     code = """
 @external

--- a/tests/functional/codegen/features/test_ternary.py
+++ b/tests/functional/codegen/features/test_ternary.py
@@ -180,6 +180,34 @@ def foo(t: bool, a: DynArray[uint256, 3], b: DynArray[uint256, 3]) -> uint256:
     assert c.foo(test, a, b) == (a if test else b)[0]
 
 
+@pytest.mark.parametrize("test", [True, False])
+def test_ternary_local_or_internal_param_subscript(get_contract, test):
+    # inside `pick`, the ternary merges a pointer to the local `x` with the
+    # pointer the caller passed for `y`; the read through it must not be
+    # served from the earlier read of `x[0]`
+    code = """
+@internal
+def pick(y: DynArray[uint256, 3], t: bool) -> uint256:
+    x: DynArray[uint256, 3] = [1, 2]
+    first_x: uint256 = x[0]
+    return first_x + (x if t else y)[0]
+
+@external
+def foo(t: bool, y: DynArray[uint256, 3]) -> uint256:
+    return self.pick(y, t)
+
+@external
+def bar(t: bool, y: DynArray[uint256, 3]) -> uint256:
+    return self.pick(y, t) + 1
+    """
+    c = get_contract(code)
+
+    y = [33, 44]
+    expected = 1 + ([1, 2] if test else y)[0]
+    assert c.foo(test, y) == expected
+    assert c.bar(test, y) == expected + 1
+
+
 tuple_codes = [
     """
 @external

--- a/tests/unit/compiler/venom/test_load_elimination.py
+++ b/tests/unit/compiler/venom/test_load_elimination.py
@@ -696,3 +696,35 @@ def test_aliased_pointer_store_load():
         sink %val
     """
     _check_pre_post(pre, post)
+
+
+@pytest.mark.parametrize("untracked", ["mload 1000", "param"])
+@pytest.mark.parametrize(
+    "store", ["mstore %ptr, 42", "mcopy %ptr, 500, 32", "calldatacopy %ptr, 0, 32"]
+)
+def test_store_through_phi_with_untracked_arm(store, untracked):
+    """
+    `%ptr` merges alloca `%a` with an address the base pointer analysis knows
+    nothing about (a pointer loaded from memory, or a param). Its only pointer
+    fact is `%a`, but the store may hit `%b`, so the cached load of `%b` must
+    be invalidated.
+    """
+    pre = f"""
+    main:
+        %par = param
+        %u = {untracked}
+        %a = alloca 32
+        %b = alloca 32
+        %v1 = mload %b
+        jnz %par, @then, @else
+    then:
+        jmp @join
+    else:
+        jmp @join
+    join:
+        %ptr = phi @then, %a, @else, %u
+        {store}
+        %v2 = mload %b
+        sink %v1, %v2
+    """
+    _check_no_change(pre)

--- a/vyper/venom/analysis/base_ptr_analysis.py
+++ b/vyper/venom/analysis/base_ptr_analysis.py
@@ -265,6 +265,9 @@ class BasePtrAnalysis(IRAnalysis):
         if ptr is None:
             return MemoryLocation(offset=None, size=size)
 
+        if self.pointer_may_include_untracked_root(offset):
+            return MemoryLocation(offset=None, size=size)
+
         return MemoryLocation(offset=ptr.offset, size=size, alloca=ptr.base_alloca)
 
     def get_write_location(self, inst, addr_space: AddrSpace) -> MemoryLocation:


### PR DESCRIPTION
### What I did

Fix a miscompile in the venom pipeline: reading through a pointer that may be either a
local buffer or an internal-function memory parameter forwarded the wrong value.

```vyper
@internal
def pick(y: DynArray[uint256, 3], t: bool) -> uint256:
    x: DynArray[uint256, 3] = [1, 2, 3]
    first_x: uint256 = x[0]
    return first_x + (x if t else y)[0]
```

With `t == False` this returned `first_x + x[0]` instead of `first_x + y[0]`.

### How I did it

`BasePtrAnalysis` builds a phi's pointer set as the union of its arms. An arm with no
pointer facts (a `param`, a pointer reloaded from memory, calldata) contributes nothing,
so a phi mixing one tracked alloca with an untracked address ended up with a single `Ptr`
and `segment_from_ops` reported a fixed location inside that alloca. Every consumer
inherited it: load elimination forwarded a cached load of the alloca to the phi-load, and
with load elimination disabled memory copy elision redirected the same load to the copy
source. Stores and fixed-size copies through such a phi had the mirror problem (only the
alloca's cached loads were invalidated).

`segment_from_ops` now returns an unfixed location when
`pointer_may_include_untracked_root` says the pointer may carry an untracked address,
so all consumers fail closed at the one place the location is produced. The helper is
memoized; it fails closed on def cycles, so a future loop-carried alloca pointer phi
would also become an unknown location (none exist in the corpora below).

### How to verify it

### Commit message

```
`BasePtrAnalysis` builds a phi's pointer set as the union of its arms.
An arm with no pointer facts (an internal function memory `param`, a
pointer reloaded from memory, calldata) contributes nothing, so a phi
mixing one tracked alloca with an untracked address ended up with a
single `Ptr` and `segment_from_ops` reported a fixed location inside
that alloca. Every consumer inherited the wrong location: load
elimination forwarded a cached load of the alloca to the phi-load, and
with load elimination disabled memory copy elision redirected it to the
copy source. Stores and fixed-size copies through such a phi had the
mirror problem, invalidating only the alloca's cached loads.

This miscompiles `(x if t else y)[0]` when `x` is a local buffer and
`y` is a memory parameter of an internal function: with `t == False`
the read returned `x[0]`.

Return an unfixed location from `segment_from_ops` when
`pointer_may_include_untracked_root` reports the pointer may carry an
untracked address, so all consumers fail closed at the one place the
location is produced. The helper is memoized and fails closed on def
cycles, so a loop-carried alloca pointer phi would also become an
unknown location; none occur in snekmate or the examples, whose
bytecode is unchanged at both optimization levels.

Add a load elimination test for stores and copies through a phi with an
untracked arm, and functional tests for the ternary read and for an
unbounded `DynArray` reassigned from a parameter and then appended.
```

### Description for the changelog
