### PR TITLE
fix[venom]: alias invalidation in remove unused variables pass

### DIFF
--- a/tests/unit/compiler/venom/test_removeunused.py
+++ b/tests/unit/compiler/venom/test_removeunused.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.venom_utils import assert_ctx_eq, parse_from_basic_block
 from vyper.evm.address_space import MEMORY
 from vyper.venom.analysis import MemSSA
@@ -112,3 +114,19 @@ def test_removeunused_invalidates_memory_ssa():
     # with fresh MemorySSA the store has no reader left, so DSE removes it
     DeadStoreElimination(ac, fn).run_pass(MEMORY)
     assert not any(inst.opcode == "mstore" for inst in fn.entry.instructions)
+
+
+@pytest.mark.parametrize(
+    "opcode", ["balance", "selfbalance", "extcodesize", "extcodehash", "returndatasize"]
+)
+def test_removeunused_non_alias_supported_opcodes(opcode):
+    pre = f"""
+    main:
+        %1 = {opcode}
+        stop
+    """
+    post = """
+    main:
+        stop
+    """
+    _check_pre_post(pre, post)

--- a/vyper/venom/analysis/mem_alias.py
+++ b/vyper/venom/analysis/mem_alias.py
@@ -244,3 +244,7 @@ def mem_alias_type_factory(addr_space: AddrSpace) -> type[MemoryAliasAnalysisAbs
         return TransientAliasAnalysis
     else:  # pragma: nocover
         raise ValueError(f"Invalid address space: {addr_space}")
+
+
+def can_create_mem_alias(addr_space: AddrSpace) -> bool:
+    return addr_space in (MEMORY, STORAGE, TRANSIENT)

--- a/vyper/venom/passes/remove_unused_variables.py
+++ b/vyper/venom/passes/remove_unused_variables.py
@@ -1,13 +1,17 @@
+from vyper.evm import address_space
 from vyper.utils import OrderedSet, uniq
+from vyper.venom import effects
 from vyper.venom.analysis import BasePtrAnalysis, DFGAnalysis, LivenessAnalysis
 from vyper.venom.analysis.load_analysis import LoadAnalysis
 from vyper.venom.analysis.mem_alias import (
-    MemoryAliasAnalysis,
     StorageAliasAnalysis,
     TransientAliasAnalysis,
+    can_create_mem_alias,
+    mem_alias_type_factory,
 )
 from vyper.venom.analysis.mem_ssa import MemSSA, StorageSSA, TransientSSA
 from vyper.venom.basicblock import IRInstruction
+from vyper.venom.effects import EMPTY, FMP
 from vyper.venom.passes.base_pass import IRPass
 
 
@@ -19,8 +23,11 @@ class RemoveUnusedVariablesPass(IRPass):
     dfg: DFGAnalysis
     work_list: OrderedSet[IRInstruction]
 
+    invalidate_alias: set[address_space.AddrSpace]
+
     def run_pass(self):
         self.dfg = self.analyses_cache.request_analysis(DFGAnalysis)
+        self.invalidate_alias = set()
 
         work_list = OrderedSet()
         self.work_list = work_list
@@ -45,7 +52,6 @@ class RemoveUnusedVariablesPass(IRPass):
         # invalidations below only cascade to them when the parent is
         # actually cached, but the alias analyses can also be requested
         # (and cached) on their own
-        self.analyses_cache.invalidate_analysis(MemoryAliasAnalysis)
         self.analyses_cache.invalidate_analysis(StorageAliasAnalysis)
         self.analyses_cache.invalidate_analysis(TransientAliasAnalysis)
         self.analyses_cache.invalidate_analysis(LoadAnalysis)
@@ -53,6 +59,9 @@ class RemoveUnusedVariablesPass(IRPass):
         self.analyses_cache.invalidate_analysis(StorageSSA)
         self.analyses_cache.invalidate_analysis(TransientSSA)
         self.analyses_cache.invalidate_analysis(LivenessAnalysis)
+        for space in self.invalidate_alias:
+            alias_analysis = mem_alias_type_factory(space)
+            self.analyses_cache.invalidate_analysis(alias_analysis)
 
     def _process_instruction(self, inst) -> bool:
         outputs = inst.get_outputs()
@@ -71,6 +80,23 @@ class RemoveUnusedVariablesPass(IRPass):
             self.dfg.remove_use(operand, inst)
             new_uses = self.dfg.get_uses(operand)
             self.work_list.addmany(new_uses)
+
+        # instructions that handle FMP can be removed if there is no use for the
+        # since they either bump or set only at the end of the function so the
+        # removal of the instruction will not effect other instructions.
+        # Other write effect should not be removed by this analysis
+        assert inst.get_write_effects() == EMPTY or inst.get_write_effects() == FMP
+        effs = inst.get_read_effects()
+        if effs != EMPTY:
+            for eff in effs:
+                space = effects.to_addr_space(eff)
+                if space is None:
+                    # sanity check
+                    continue
+
+                # Mem alias does not use all address spaces
+                if can_create_mem_alias(space):
+                    self.invalidate_alias.add(space)
 
         inst.make_nop()
         return True


### PR DESCRIPTION
### What I did
Implementation of the fix that was shown by the https://github.com/vyperlang/vyper/pull/5219.

The `load` instructions could be removed by this pass but did no invalidate their respective alias analyses

### How I did it

### How to verify it

### Commit message

Commit message for the final, squashed PR. (Optional, but reviewers will appreciate it! Please see [our commit message style guide](../../master/docs/style-guide.rst#best-practices-1) for what we would ideally like to see in a commit message.)

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
