### PR TITLE
fix[lang]: reject parameterized types used as values

### DIFF
--- a/tests/functional/syntax/exceptions/test_invalid_reference.py
+++ b/tests/functional/syntax/exceptions/test_invalid_reference.py
@@ -44,6 +44,107 @@ a: public(constant(uint256)) = 1
 def foo():
     b: uint256 = self.a
     """,
+    # parameterized types live in the namespace as the type class rather than an
+    # instance, so they used to miss the TYPE_T check and panic on `t.typ`
+    # instead of reporting a bad reference
+    # see https://github.com/vyperlang/vyper/issues/3246
+    """
+@external
+def foo():
+    x: uint256 = Bytes[32]
+    """,
+    """
+@external
+def foo():
+    x: uint256 = String[10]
+    """,
+    """
+@external
+def foo():
+    x: uint256 = DynArray[uint256, 3]
+    """,
+    """
+@external
+def foo():
+    x: uint256 = HashMap[uint256, uint256]
+    """,
+    """
+@external
+def foo() -> uint256:
+    return Bytes[32]
+    """,
+    """
+@external
+def foo() -> Bytes[64]:
+    return abi_encode(Bytes[32])
+    """,
+    # module scope reaches the same guard through constant folding rather than
+    # function body analysis
+    # see https://github.com/vyperlang/vyper/issues/4434
+    """
+MAX: constant(uint256) = DynArray[uint256, 10]
+    """,
+    # an unsubscripted name arrives at types_from_Name directly instead of
+    # through types_from_Subscript
+    """
+@external
+def foo():
+    x: uint256 = DynArray
+    """,
+    # as the index of another subscript
+    # see https://github.com/vyperlang/vyper/issues/4733
+    """
+@external
+def foo(a: uint256[3]) -> uint256:
+    return a[Bytes[32]]
+    """,
+    # attribute access is the one route that asks for types with
+    # include_type_exprs enabled
+    """
+@external
+def foo():
+    x: uint256 = DynArray.foo
+    """,
+    # module level statements resolve names without entering a function body
+    """
+initializes: HashMap
+    """,
+    """
+uses: String
+    """,
+    """
+exports: DynArray
+    """,
+    # a default argument is analyzed with the signature, not the body
+    """
+@external
+def foo(a: uint256 = Bytes[32]):
+    pass
+    """,
+    # keyword arguments take their own validation route
+    """
+struct S:
+    a: uint256
+
+@external
+def foo():
+    s: S = S(a=Bytes[32])
+    """,
+    """
+event E:
+    a: uint256
+
+@external
+def foo():
+    log E(a=Bytes[32])
+    """,
+    # a vararg builtin other than abi_encode, to show the guard is not specific
+    # to one builtin's argument handling
+    """
+@external
+def foo() -> Bytes[64]:
+    return concat(b"a", Bytes[32])
+    """,
 ]
 
 
@@ -51,3 +152,16 @@ def foo():
 def test_invalid_reference_exception(bad_code):
     with pytest.raises(InvalidReference):
         compiler.compile_code(bad_code)
+
+
+def test_parameterized_type_message():
+    # the guard reuses the wording concrete type names already get, so a
+    # regression that routed one of these through a different path would
+    # still raise InvalidReference but with different text
+    code = """
+@external
+def foo():
+    x: uint256 = DynArray[uint256, 3]
+    """
+    with pytest.raises(InvalidReference, match="not a variable or literal: 'DynArray'"):
+        compiler.compile_code(code)

--- a/tests/functional/syntax/exceptions/test_invalid_type_exception.py
+++ b/tests/functional/syntax/exceptions/test_invalid_type_exception.py
@@ -145,3 +145,15 @@ def foo():
     """
     with pytest.raises(InvalidType, match="is not a type"):
         compile_code(code)
+
+
+def test_parameterized_type_as_subscript():
+    # a parameterized type name as a subscript is the same user mistake as any
+    # other non-integer subscript, so it gets the same message
+    code = """
+@external
+def foo():
+    x: Bytes[String] = b""
+    """
+    with pytest.raises(InvalidType, match="Subscript must be a literal integer"):
+        compile_code(code)

--- a/tests/functional/syntax/exceptions/test_structure_exception.py
+++ b/tests/functional/syntax/exceptions/test_structure_exception.py
@@ -114,3 +114,18 @@ interface Bar:
         arg1 = 3
     """,
 ]
+
+
+# a parameterized type name is only a bad reference in value position. in type
+# position it keeps its own message, which says how to parameterize it
+@pytest.mark.parametrize(
+    "bad_code,expected",
+    [
+        ('@external\ndef foo():\n    x: Bytes = b""\n', "without a maximum length"),
+        ("@external\ndef foo():\n    x: DynArray = []\n", "base type and max length"),
+        ("m: HashMap\n", "key type and a value type"),
+    ],
+)
+def test_unparameterized_type_annotation(bad_code, expected):
+    with pytest.raises(StructureException, match=expected):
+        compiler.compile_code(bad_code)

--- a/tests/functional/syntax/exceptions/test_undeclared_definition.py
+++ b/tests/functional/syntax/exceptions/test_undeclared_definition.py
@@ -69,3 +69,15 @@ def test_undeclared_def_exception(bad_code):
     with pytest.raises(UndeclaredDefinition) as e:
         compiler.compile_code(bad_code)
     assert "(hint: )" not in str(e.value)
+
+
+def test_undeclared_name_as_subscript():
+    # get_index_value also catches InvalidReference so a parameterized type name
+    # reports as a bad subscript. that must not hide an undeclared name
+    code = """
+@external
+def foo():
+    x: uint256[NOPE] = [0]
+    """
+    with pytest.raises(UndeclaredDefinition, match="'NOPE' has not been declared"):
+        compiler.compile_code(code)

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -426,6 +426,13 @@ class _ExprAnalyser:
                 # attribute conditions, like Flag.foo or MyStruct({...})
                 return [TYPE_T(t)]
 
+            if isinstance(t, type) and issubclass(t, VyperType):
+                # parameterized types (`Bytes`, `String`, `DynArray`, `HashMap`)
+                # are in the namespace as the class, not an instance, so they
+                # reach here instead of the TYPE_T branch above. they are type
+                # constructors, not values.
+                raise InvalidReference(f"not a variable or literal: '{node.id}'", node)
+
             return [t.typ]
 
         except VyperException as exc:

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -6,6 +6,7 @@ from vyper.exceptions import (
     CompilerPanic,
     FeatureException,
     InstantiationException,
+    InvalidReference,
     InvalidType,
     StructureException,
     UndeclaredDefinition,
@@ -223,8 +224,10 @@ def get_index_value(node: vy_ast.VyperNode) -> LengthUpperBound:
         # this gives a more accurate error in case of e.g. a typo in a constant variable name
         try:
             get_possible_types_from_node(node)
-        except StructureException:
-            # StructureException is a very broad error, better to raise InvalidType in this case
+        except (StructureException, InvalidReference):
+            # StructureException is a very broad error, better to raise InvalidType in this case.
+            # InvalidReference is raised for a parameterized type name (e.g. `Bytes[String]`),
+            # which is the same user mistake as `Bytes[uint256]` and wants the same message.
             pass
         raise InvalidType("Subscript must be a literal integer", node)
 


### PR DESCRIPTION
### What I did

Fixes #3246, fixes #4434. Also covers #4733.

Using a parameterized type (`Bytes`, `String`, `DynArray`, `HashMap`) anywhere a value is expected crashes the compiler instead of reporting a bad reference:

```vyper
@external
def foo():
    x: uint256 = Bytes[32]   # CompilerPanic: type object 'BytesT' has no attribute 'typ'
```

### How I did it

Concrete types are in the namespace as instances (`uint256` is an `IntegerT`), but parameterized types are there as the type *class* (`Bytes` is `BytesT` itself). `_ExprAnalyser.types_from_Name` returns `[t]` for a `TYPE_T` and `[TYPE_T(t)]` for a `VyperType` instance; a class matches neither, so it fell through to the `return [t.typ]` fallback meant for `VarInfo` and read a class attribute that does not exist. The resulting `AttributeError` is not a `VyperException`, so it escaped the check that turns a type expression in value position into `InvalidReference`, and surfaced as a panic.

The fix rejects a type class there with the same `InvalidReference` a concrete type name already raises.

One follow-on: `get_index_value` inspects the subscript first to produce a better message, but caught only `StructureException`, so the new `InvalidReference` escaped it and `Bytes[String]` reported differently from `Bytes[uint256]`. It now catches both, so the annotation-position message is consistent. It is deliberately not widened to `VyperException`, which would swallow `UndeclaredDefinition` and lose the better message for `uint256[NOPE]`.

### How to verify it

Every position below panics on master and raises a clean error with this patch:

```vyper
x: uint256 = Bytes[32]                  # assignment
return Bytes[32]                        # return
abi_encode(Bytes[32])                   # builtin vararg
concat(b"a", Bytes[32])                 # a different vararg builtin
raw_call(t, b"", max_outsize=Bytes[32]) # builtin kwarg
a[Bytes[32]]                            # subscript index
DynArray.foo                            # attribute base
def foo(a: uint256 = Bytes[32]):        # default argument
S(a=Bytes[32])                          # struct kwarg
log E(a=Bytes[32])                      # event kwarg
MAX: constant(uint256) = DynArray[u, 1] # module scope
initializes: HashMap                    # module level statement
x: Bytes[String] = b""                  # annotation subscript
```

I ran a 57-case matrix over the base and the patched tree, each case in a fresh interpreter since the namespace is global: 34 panics before, 0 after, and 22 cases byte-identical either way. Those 22 are 12 legitimate uses that must keep compiling (`empty(Bytes[32])`, `abi_decode(b, Bytes[32])`, `convert(x, String[10])`, annotations, storage `HashMap`, `public(DynArray)`, struct members, nested `DynArray`) and 10 diagnostics that must not change (bare `Bytes`/`DynArray`/`HashMap` annotations keep their own messages, `uint256[NOPE]` keeps `UndeclaredDefinition`, `Bytes[uint256]` keeps `InvalidType`, structs/flags/concrete types keep theirs).

Regression tests go in the existing exception test files. The negative direction is covered too: three tests that unparameterized annotations keep their specific messages, and one that an undeclared name in a subscript still reports `UndeclaredDefinition`. I checked each new test is load-bearing by reverting each change in turn: removing the analysis guard turns 19 red, removing the `get_index_value` catch turns exactly 1 red, and widening that catch to `VyperException` turns exactly 1 red.

Full suite: 13009 passed, 0 failed.

Note for whoever sequences this: #5204 rewrites this function, and I confirmed the panic still reproduces on its head (d5d5bfd6), so the two will conflict on the rename but the bug is not fixed there.

### Commit message

```
Parameterized types (`Bytes`, `String`, `DynArray`, `HashMap`) live in
the namespace as the type class, while concrete types like `uint256`
live there as instances. `types_from_Name` matched neither the TYPE_T
branch nor the VyperType branch for a class, so it fell through to the
`return [t.typ]` fallback meant for VarInfo and read a class attribute
that does not exist. The resulting AttributeError is not a
VyperException, so it escaped the check that turns a type expression in
value position into InvalidReference, and surfaced as an internal
compiler panic instead.

Reject a type class there with the same InvalidReference a concrete type
name already raises. The panic was reachable from every value position:
assignment, return, builtin argument and kwarg, module-scope constant,
struct and event kwargs, default arguments, and the index of another
subscript.

`get_index_value` inspects the subscript first to give a better
diagnostic, but caught only StructureException, so a parameterized type
name in an annotation subscript escaped it. Catch InvalidReference there
as well, so `Bytes[String]` reports the same "Subscript must be a
literal integer" that `Bytes[uint256]` already did. It is deliberately
not widened to VyperException, which would swallow UndeclaredDefinition
and lose the better message for `uint256[NOPE]`.

Fixes GH 3246 and GH 4434
```

### Description for the changelog

Reject a parameterized type name used as a value (e.g. `x: uint256 = Bytes[32]`) with a clear error instead of an internal compiler panic.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()

