### PR TITLE
chore[ci]: add scope for types and type-checker

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -37,6 +37,7 @@ jobs:
           # stdlib: changes to the stdlib
           # ux: language changes (UX)
           # parser: parser changes
+          # types: types/typer changes
           # tool: integration
           # ir: (old) IR/codegen changes
           # codegen: lowering from vyper AST to codegen
@@ -51,6 +52,7 @@ jobs:
             builtins
             ux
             parser
+            types
             tool
             ir
             codegen


### PR DESCRIPTION
### What I did

Add a scope for commit titles about types/typer changes

### How I did it

Did it by doing it

### How to verify it

Rename this pr to `chore[types]...` and notice it still passes CI

### Commit message

```
this commit adds a scope for commit titles about types/typer changes
```

### Description for the changelog

(ci change, no user-facing change)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
