### PR TITLE
fix[lang]: preserve ABI metadata in array types

### DIFF
--- a/tests/unit/semantics/types/test_abi_roundtrip.py
+++ b/tests/unit/semantics/types/test_abi_roundtrip.py
@@ -126,6 +126,15 @@ def getDeposited() -> uint256:
     return self.deposited
 """
 
+DECIMAL_ARRAYS = """
+#pragma enable-decimals
+
+@external
+@view
+def quote(values: decimal[2]) -> decimal[2][3]:
+    return [values, values, values]
+"""
+
 
 class TestFallbackABIHandling:
     # Not a round-trip: fallback entries are skipped by from_json_abi.
@@ -225,6 +234,15 @@ class TestTupleReturnRoundtrip:
         abi = _compile_abi(TUPLE_RETURN)
         assert len(abi) == 1
         fn = ContractFunctionT.from_abi(abi[0])
+        assert fn.to_toplevel_abi_dict() == [abi[0]]
+
+
+class TestDecimalArrayRoundtrip:
+    def test_function_abi_survives_roundtrip(self):
+        abi = _compile_abi(DECIMAL_ARRAYS)
+        assert len(abi) == 1
+        fn = ContractFunctionT.from_abi(abi[0])
+
         assert fn.to_toplevel_abi_dict() == [abi[0]]
 
 

--- a/tests/unit/semantics/types/test_type_from_abi.py
+++ b/tests/unit/semantics/types/test_type_from_abi.py
@@ -32,6 +32,23 @@ def test_base_types_as_multidimensional_arrays(type_str):
     assert type_t == SArrayT(SArrayT(base_t, 3), 5)
 
 
+@pytest.mark.parametrize("type_str", ["int168[3]", "int168[3][5]"])
+def test_decimal_array_internal_type(type_str):
+    type_t = type_from_abi({"type": type_str, "internalType": "decimal"})
+
+    expected = PRIMITIVE_TYPES["decimal"]
+    for length in (3, 5)[: type_str.count("[")]:
+        expected = SArrayT(expected, length)
+
+    assert type_t == expected
+
+
+def test_int168_array_without_decimal_internal_type():
+    type_t = type_from_abi({"type": "int168[3]"})
+
+    assert type_t == SArrayT(PRIMITIVE_TYPES["int168"], 3)
+
+
 @pytest.mark.parametrize("idx", ["0", "-1", "0x00", "'1'", "foo", "[1]", "(1,)"])
 def test_invalid_index(idx):
     with pytest.raises(UnknownType):

--- a/vyper/semantics/types/utils.py
+++ b/vyper/semantics/types/utils.py
@@ -51,7 +51,9 @@ def type_from_abi(abi_type: dict) -> VyperType:
         except ValueError:
             raise UnknownType(f"ABI type has an invalid length: {type_string}") from None
         try:
-            value_type = type_from_abi({"type": value_type_string})
+            # Preserve metadata which qualifies the base ABI carrier type. In
+            # particular, `internalType` distinguishes decimal from int168.
+            value_type = type_from_abi({**abi_type, "type": value_type_string})
         except UnknownType:
             raise UnknownType(f"ABI contains unknown type: {type_string}") from None
         try:


### PR DESCRIPTION
### What I did

Preserve ABI metadata while recursively decoding fixed-size array types. This
prevents ABI entries for `decimal` arrays from being reconstructed as `int168`
arrays.

### How I did it

Array decoding now carries the original ABI dictionary into the recursive
base-type call while replacing only the `type` field. This retains
`internalType: decimal` through every array dimension. Unit tests cover
one- and two-dimensional decoding, the `int168` fallback, and a complete
compile/ABI/reconstruction round trip.

### How to verify it

```console
$ uv run pytest -q tests/unit/semantics/types
1435 passed, 2 warnings

$ uv run make lint
Success: no issues found in 206 source files
All done! ✨ 🍰 ✨
637 files left unchanged.
Skipped 2 files
```

### Commit message

```text
Array type parsing rebuilt the ABI description using only its type string.
This discarded internalType before parsing the base type, so decimal arrays
were reconstructed as int168 arrays even though scalar decimals were handled
correctly.

Carry the original ABI metadata through recursive array parsing. This
preserves the decimal distinction at every array depth while retaining the
existing int168 fallback when internalType is absent.
```

### Description for the changelog

Fix ABI round trips incorrectly reconstructing decimal array elements as
`int168`.

### Cute Animal Picture

![Red panda](https://upload.wikimedia.org/wikipedia/commons/5/50/RedPandaFullBody.JPG)
