### PR TITLE
fix[lang]: isolate compiler state by context

### DIFF
--- a/tests/unit/compiler/test_context_isolation.py
+++ b/tests/unit/compiler/test_context_isolation.py
@@ -1,0 +1,58 @@
+import concurrent.futures
+import threading
+
+import vyper.codegen.context as codegen_context
+from vyper.codegen import core
+from vyper.compiler.settings import Settings, anchor_settings, get_global_settings
+from vyper.semantics.namespace import Namespace, get_namespace, override_global_namespace
+
+
+def _run_in_parallel(fn, args):
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(args)) as executor:
+        return list(executor.map(fn, args))
+
+
+def test_settings_are_isolated_between_threads():
+    barrier = threading.Barrier(2)
+    settings = (Settings(evm_version="london"), Settings(evm_version="cancun"))
+
+    def worker(thread_settings):
+        with anchor_settings(thread_settings):
+            barrier.wait()
+            current = get_global_settings()
+            barrier.wait()
+
+        return current, get_global_settings()
+
+    results = _run_in_parallel(worker, settings)
+
+    assert [current for current, _ in results] == list(settings)
+    assert all(restored is None for _, restored in results)
+
+
+def test_namespaces_are_isolated_between_threads():
+    barrier = threading.Barrier(2)
+    namespaces = (Namespace(), Namespace())
+
+    def worker(namespace):
+        with override_global_namespace(namespace):
+            barrier.wait()
+            current = get_namespace()
+            barrier.wait()
+
+        return current
+
+    assert _run_in_parallel(worker, namespaces) == list(namespaces)
+
+
+def test_codegen_counters_are_isolated_between_threads():
+    barrier = threading.Barrier(2)
+
+    def worker(_):
+        core.reset_names()
+        barrier.wait()
+        result = core._freshname("label"), codegen_context._generate_alloca_id()
+        barrier.wait()
+        return result
+
+    assert _run_in_parallel(worker, (None, None)) == [("label1", 1), ("label1", 1)]

--- a/vyper/codegen/context.py
+++ b/vyper/codegen/context.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 import enum
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -15,15 +16,18 @@ class Constancy(enum.Enum):
     Constant = 1
 
 
-_alloca_id = 0
+_alloca_id = contextvars.ContextVar("alloca_id", default=0)
 
 
 def _generate_alloca_id():
     # note: this gets reset between compiler runs by codegen.core.reset_names
-    global _alloca_id
+    alloca_id = _alloca_id.get() + 1
+    _alloca_id.set(alloca_id)
+    return alloca_id
 
-    _alloca_id += 1
-    return _alloca_id
+
+def reset_alloca_id():
+    _alloca_id.set(0)
 
 
 @dataclass(frozen=True)

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -1,3 +1,5 @@
+import contextvars
+
 import vyper.codegen.context as ctx
 from vyper.codegen.ir_node import Encoding, IRnode
 from vyper.compiler.settings import _opt_codesize, _opt_gas, _opt_lowering_only_ir
@@ -943,22 +945,19 @@ def check_assign(left, right):
         FAIL()
 
 
-_label = 0
+_label = contextvars.ContextVar("codegen_label", default=0)
 
 
 # TODO might want to coalesce with Context.fresh_varname
 def _freshname(name):
-    global _label
-    _label += 1
-    return f"{name}{_label}"
+    label = _label.get() + 1
+    _label.set(label)
+    return f"{name}{label}"
 
 
 def reset_names():
-    global _label
-    _label = 0
-
-    # could be refactored
-    ctx._alloca_id = 0
+    _label.set(0)
+    ctx.reset_alloca_id()
 
 
 # returns True if t is ABI encoded and is a type that needs any kind of

--- a/vyper/compiler/settings.py
+++ b/vyper/compiler/settings.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 import dataclasses
 import os
 from dataclasses import dataclass
@@ -275,19 +276,21 @@ def merge_settings(
     return Settings(**values)
 
 
-# CMC 2024-04-10 do we need it to be Optional?
-_settings = None
+# Compiler settings are ambient because they are consumed throughout the
+# pipeline. Keep them local to the current execution context so concurrent
+# compilations cannot observe one another's settings.
+_settings: contextvars.ContextVar[Optional[Settings]] = contextvars.ContextVar(
+    "compiler_settings", default=None
+)
 
 
 def get_global_settings() -> Optional[Settings]:
-    return _settings
+    return _settings.get()
 
 
 def set_global_settings(new_settings: Optional[Settings]) -> None:
     assert isinstance(new_settings, Settings) or new_settings is None
-
-    global _settings
-    _settings = new_settings
+    _settings.set(new_settings)
 
 
 # could maybe refactor this, but it is easier for now than threading settings
@@ -298,13 +301,11 @@ def anchor_settings(new_settings: Settings) -> Generator:
     Set the globally available settings for the duration of this context manager
     """
     assert new_settings is not None
-    global _settings
+    token = _settings.set(new_settings)
     try:
-        tmp = get_global_settings()
-        set_global_settings(new_settings)
         yield
     finally:
-        set_global_settings(tmp)
+        _settings.reset(token)
 
 
 # These three partition OptimizationLevel for frontend code-shape decisions.
@@ -322,15 +323,15 @@ assert set(_OPT_CODESIZE_LEVELS + _OPT_GAS_LEVELS + _OPT_LOWERING_ONLY_LEVELS) =
 
 
 def _opt_codesize():
-    return _settings.optimize in _OPT_CODESIZE_LEVELS
+    return get_global_settings().optimize in _OPT_CODESIZE_LEVELS
 
 
 def _opt_gas():
-    return _settings.optimize in _OPT_GAS_LEVELS
+    return get_global_settings().optimize in _OPT_GAS_LEVELS
 
 
 def _opt_lowering_only_ir():
-    return _settings.optimize in _OPT_LOWERING_ONLY_LEVELS
+    return get_global_settings().optimize in _OPT_LOWERING_ONLY_LEVELS
 
 
 def _is_debug_mode():

--- a/vyper/semantics/namespace.py
+++ b/vyper/semantics/namespace.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 
 from vyper.ast.identifiers import validate_identifier
 from vyper.exceptions import CompilerPanic, NamespaceCollision, UndeclaredDefinition
@@ -97,26 +98,26 @@ class Namespace(dict):
             raise NamespaceCollision(msg, prev_decl=prev_decl)
 
 
+_namespace: contextvars.ContextVar[Namespace | None] = contextvars.ContextVar(
+    "namespace", default=None
+)
+
+
 def get_namespace():
     """
     Get the global namespace object.
     """
-    global _namespace
-    try:
-        return _namespace
-    except NameError:
-        _namespace = Namespace()
-        return _namespace
+    namespace = _namespace.get()
+    if namespace is None:
+        namespace = Namespace()
+        _namespace.set(namespace)
+    return namespace
 
 
 @contextlib.contextmanager
 def override_global_namespace(ns):
-    global _namespace
-    tmp = _namespace
+    token = _namespace.set(ns)
     try:
-        # clobber global namespace
-        _namespace = ns
         yield
     finally:
-        # unclobber
-        _namespace = tmp
+        _namespace.reset(token)


### PR DESCRIPTION
### What I did

Isolate ambient compiler settings, semantic namespaces, and codegen counters
between concurrent compilation contexts.

Previously, overlapping `compile_code()` calls in the same process could
observe another request's EVM target or semantic namespace. This could silently
emit bytecode for the wrong fork or bind a storage expression to a declaration
from another compilation. Concurrent resets of the codegen counters could also
make generation nondeterministic.

### How I did it

The ambient settings and namespace now use `ContextVar`, with context-manager
tokens restoring the exact prior value after nested overrides. The label and
allocation counters are context-local as well, and the allocation counter now
has an explicit reset helper.

Barrier-based tests force settings, namespaces, and counters to overlap in two
threads and verify that each compilation context retains its own values.

### How to verify it

```console
$ uv run pytest -q tests/unit/compiler/test_context_isolation.py
3 passed

$ uv run pytest -q tests/unit/compiler tests/unit/semantics/test_namespace.py
2345 passed, 1 skipped, 11 xfailed

$ uv run pytest -q tests/functional/codegen -m 'not fuzzing'
4246 passed, 341 skipped, 17 xfailed

$ uv run make lint
Success: no issues found in 206 source files
All done! ✨ 🍰 ✨
638 files left unchanged.
Skipped 2 files
```

### Commit message

```text
Compiler settings, semantic namespaces, and codegen counters were stored in
process-wide globals. Overlapping compilations could therefore consume another
request's EVM target or namespace, while counter resets could make output
nondeterministic.

Store ambient compiler state in context variables and restore nested settings
and namespace overrides with tokens. Each thread or task now receives
independent state without changing the existing compiler APIs.
```

### Description for the changelog

Isolate compiler settings, semantic namespaces, and codegen counters between
concurrent compilations.

### Cute Animal Picture

![Red panda](https://upload.wikimedia.org/wikipedia/commons/5/50/RedPandaFullBody.JPG)
