### PR TITLE
feat[codegen]: experimental EIP-7979 subroutines for internal calls

### DIFF
--- a/vyper/codegen/function_definitions/internal_function.py
+++ b/vyper/codegen/function_definitions/internal_function.py
@@ -7,6 +7,7 @@ from vyper.codegen.function_definitions.common import (
 )
 from vyper.codegen.ir_node import IRnode
 from vyper.codegen.stmt import parse_body
+from vyper.evm.opcodes import version_check
 
 
 def generate_ir_for_internal_function(
@@ -58,24 +59,38 @@ def generate_ir_for_internal_function(
     function_entry_label = func_t._ir_info.internal_function_label(context.is_ctor_context)
     cleanup_label = func_t._ir_info.exit_sequence_label
 
+    # EIP-7979: with subroutines, the return address lives on the return
+    # stack: the entry is a CALLDEST, no return_pc is passed on the data
+    # stack, and the cleanup routine ends with RETURNSUB.
+    use_subroutines = version_check(begin="future")
+
     stack_args = ["var_list"]
     if func_t.return_type:
         stack_args += ["return_buffer"]
-    stack_args += ["return_pc"]
+    if not use_subroutines:
+        stack_args += ["return_pc"]
 
     body = [
-        "label",
+        "subroutine" if use_subroutines else "label",
         function_entry_label,
         stack_args,
         ["seq"] + nonreentrant_pre + [parse_body(code.body, context, ensure_terminated=True)],
     ]
 
-    cleanup_routine = [
-        "label",
-        cleanup_label,
-        ["var_list", "return_pc"],
-        ["seq"] + nonreentrant_post + [["exit_to", "return_pc"]],
-    ]
+    if use_subroutines:
+        cleanup_routine = [
+            "label",
+            cleanup_label,
+            ["var_list"],
+            ["seq"] + nonreentrant_post + [["retsub"]],
+        ]
+    else:
+        cleanup_routine = [
+            "label",
+            cleanup_label,
+            ["var_list", "return_pc"],
+            ["seq"] + nonreentrant_post + [["exit_to", "return_pc"]],
+        ]
 
     ir_node = IRnode.from_list(["seq", body, cleanup_routine])
 

--- a/vyper/codegen/ir_node.py
+++ b/vyper/codegen/ir_node.py
@@ -301,7 +301,7 @@ class IRnode:
             # GOTO is a jump with args
             # e.g. (goto my_label x y z) will push x y and z onto the stack,
             # then JUMP to my_label.
-            elif self.value in ("goto", "exit_to"):
+            elif self.value in ("goto", "exit_to", "gosub"):
                 for arg in self.args:
                     assert (
                         arg.valency == 1 or arg.value == "pass"
@@ -309,7 +309,10 @@ class IRnode:
 
                 self.valency = 0
                 self._gas = sum([arg.gas for arg in self.args])
-            elif self.value == "label":
+            elif self.value == "retsub":
+                self.valency = 0
+                self._gas = 5
+            elif self.value in ("label", "subroutine"):
                 assert (
                     self.args[1].value == "var_list"
                 ), f"2nd argument to label must be var_list, {self}"

--- a/vyper/codegen/self_call.py
+++ b/vyper/codegen/self_call.py
@@ -5,6 +5,7 @@ from vyper import ast as vy_ast
 from vyper.codegen.core import _freshname, eval_once_check, make_setter
 from vyper.codegen.ir_node import IRnode
 from vyper.evm.address_space import MEMORY
+from vyper.evm.opcodes import version_check
 from vyper.exceptions import StateAccessViolation
 from vyper.semantics.types.subscriptable import TupleT
 
@@ -112,16 +113,24 @@ def ir_for_self_call(stmt_expr: vy_ast.Call, context):
     else:
         copy_args = make_setter(args_dst, args_as_tuple)
 
-    goto_op = ["goto", func_t._ir_info.internal_function_label(context.is_ctor_context)]
-    # pass return buffer to subroutine
-    if return_buffer is not None:
-        goto_op += [return_buffer]
-    # pass return label to subroutine
-    goto_op.append(["symbol", return_label])
-
+    func_label = func_t._ir_info.internal_function_label(context.is_ctor_context)
     call_sequence: list = ["seq"]
     call_sequence.append(eval_once_check(_freshname(stmt_expr.node_source_code)))
-    call_sequence.extend([copy_args, goto_op, ["label", return_label, ["var_list"], "pass"]])
+    if version_check(begin="future"):
+        # EIP-7979: CALLSUB pushes the return address onto the return stack,
+        # so no return label is passed and none is needed after the call.
+        gosub_op = ["gosub", func_label]
+        if return_buffer is not None:
+            gosub_op += [return_buffer]
+        call_sequence.extend([copy_args, gosub_op])
+    else:
+        goto_op = ["goto", func_label]
+        # pass return buffer to subroutine
+        if return_buffer is not None:
+            goto_op += [return_buffer]
+        # pass return label to subroutine
+        goto_op.append(["symbol", return_label])
+        call_sequence.extend([copy_args, goto_op, ["label", return_label, ["var_list"], "pass"]])
     if return_buffer is not None:
         # push return buffer location to stack
         call_sequence += [return_buffer]

--- a/vyper/evm/assembler/core.py
+++ b/vyper/evm/assembler/core.py
@@ -11,6 +11,7 @@ from vyper.evm.assembler.instructions import (
     AssemblyInstruction,
     DataHeader,
     Label,
+    SubroutineLabel,
     is_label,
 )
 from vyper.evm.assembler.symbols import SYMBOL_SIZE, resolve_symbols
@@ -73,7 +74,8 @@ def _assembly_to_evm(
             ret.extend(bytecode)
 
         elif isinstance(item, Label):
-            jumpdest_opcode = get_opcodes()["JUMPDEST"][0]
+            label_kind = "CALLDEST" if isinstance(item, SubroutineLabel) else "JUMPDEST"
+            jumpdest_opcode = get_opcodes()[label_kind][0]
             assert jumpdest_opcode is not None  # help mypy
             ret.append(jumpdest_opcode)
 

--- a/vyper/evm/assembler/instructions.py
+++ b/vyper/evm/assembler/instructions.py
@@ -20,6 +20,17 @@ class Label:
         return hash(self.label)
 
 
+class SubroutineLabel(Label):
+    """
+    A label that is a subroutine entry (EIP-7979): assembled as CALLDEST
+    instead of JUMPDEST. It is the only valid CALLSUB destination, and also
+    a valid JUMP/JUMPI destination.
+    """
+
+    def __repr__(self):
+        return f"SUBROUTINE LABEL {self.label}"
+
+
 def is_label(i):
     return isinstance(i, Label)
 
@@ -170,6 +181,10 @@ class PUSH_OFST:
 
 def JUMP(label: Label):
     return [PUSHLABEL(label), "JUMP"]
+
+
+def CALLSUB(label: Label):
+    return [PUSHLABEL(label), "CALLSUB"]
 
 
 def JUMPI(label: Label):

--- a/vyper/evm/assembler/optimizer.py
+++ b/vyper/evm/assembler/optimizer.py
@@ -6,12 +6,13 @@ from vyper.evm.assembler.instructions import (
     PUSHLABEL,
     DataHeader,
     Label,
+    SubroutineLabel,
     is_label,
 )
 from vyper.exceptions import CompilerPanic
 from vyper.ir.optimizer import COMMUTATIVE_OPS
 
-_TERMINAL_OPS = ("JUMP", "RETURN", "REVERT", "STOP", "INVALID")
+_TERMINAL_OPS = ("JUMP", "RETURN", "REVERT", "STOP", "INVALID", "RETURNSUB")
 
 
 def _prune_unreachable_code(assembly):
@@ -113,6 +114,14 @@ def _merge_jumpdests(assembly):
                 # (could also remove PUSH_OFST and DATA_ITEM, but doesn't
                 #  affect correctness)
                 new_symbol = assembly[i + 1]
+                # EIP-7979: a CALLSUB may only land on a CALLDEST, so a
+                # subroutine entry can only be replaced by another one;
+                # make the surviving label a subroutine entry.
+                if isinstance(current_symbol, SubroutineLabel) and not isinstance(
+                    new_symbol, SubroutineLabel
+                ):
+                    new_symbol = SubroutineLabel(new_symbol.label)
+                    assembly[i + 1] = new_symbol
                 if new_symbol != current_symbol:
                     for j in range(len(assembly)):
                         if (
@@ -121,7 +130,13 @@ def _merge_jumpdests(assembly):
                         ):
                             assembly[j].label = new_symbol
                             changed = True
-            elif isinstance(assembly[i + 1], PUSHLABEL) and assembly[i + 2] == "JUMP":
+            elif (
+                isinstance(assembly[i + 1], PUSHLABEL)
+                and assembly[i + 2] == "JUMP"
+                # EIP-7979: threading through a subroutine entry would
+                # redirect its CALLSUBs onto a plain label.
+                and not isinstance(current_symbol, SubroutineLabel)
+            ):
                 # LABEL x PUSHLABEL y JUMP
                 # replace all instances of PUSHLABEL x with PUSHLABEL y
                 # (could also remove PUSH_OFST and DATA_ITEM, but doesn't

--- a/vyper/evm/assembler/symbols.py
+++ b/vyper/evm/assembler/symbols.py
@@ -81,6 +81,10 @@ def resolve_symbols(
                 source_map["pc_jump_map"][pc] = "-"
         elif item in ("JUMPI", "JUMPDEST"):
             source_map["pc_jump_map"][pc] = "-"
+        elif item == "CALLSUB":  # EIP-7979: enter an internal function
+            source_map["pc_jump_map"][pc] = "i"
+        elif item == "RETURNSUB":  # EIP-7979: exit an internal function
+            source_map["pc_jump_map"][pc] = "o"
 
         if isinstance(item, CONST):
             continue  # CONST declarations do not go into bytecode

--- a/vyper/evm/opcodes.py
+++ b/vyper/evm/opcodes.py
@@ -11,7 +11,9 @@ from vyper.typing import OpcodeMap
 # 3. Per VIP-3365, we support mainnet fork choice rules up to 3 years old
 #    (and may optionally have forward support for experimental/unreleased
 #    fork choice rules)
-_evm_versions = ("london", "paris", "shanghai", "cancun", "prague")
+# "future" is experimental: instructions proposed for a later fork but not yet
+# scheduled (currently EIP-7979, Call and Return Opcodes for the EVM).
+_evm_versions = ("london", "paris", "shanghai", "cancun", "prague", "future")
 EVM_VERSIONS: dict[str, int] = dict((v, i) for i, v in enumerate(_evm_versions))
 
 DEFAULT_EVM_VERSION = "prague"
@@ -182,6 +184,12 @@ OPCODE_OVERRIDES: dict[str, OpcodeMap] = {
         "MCOPY": (0x5E, 3, 0, 3),
         "TLOAD": (0x5C, 1, 1, 100),
         "TSTORE": (0x5D, 2, 0, 100),
+    },
+    # EIP-7979: call and return opcodes (mid, jumpdest, low)
+    "future": {
+        "CALLSUB": (0xB0, 1, 0, 8),
+        "CALLDEST": (0xB1, 0, 0, 1),
+        "RETURNSUB": (0xB2, 0, 0, 5),
     },
 }
 

--- a/vyper/ir/compile_ir.py
+++ b/vyper/ir/compile_ir.py
@@ -10,6 +10,7 @@ from vyper.codegen.ir_node import IRnode
 from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.assembler.core import assembly_to_evm, get_data_segment_lengths
 from vyper.evm.assembler.instructions import (
+    CALLSUB,
     CONST,
     DATA_ITEM,
     JUMP,
@@ -22,8 +23,8 @@ from vyper.evm.assembler.instructions import (
     TaggedInstruction,
 )
 from vyper.evm.assembler.optimizer import optimize_assembly
-from vyper.evm.assembler.symbols import CONSTREF, Label
-from vyper.evm.opcodes import get_opcodes
+from vyper.evm.assembler.symbols import CONSTREF, Label, SubroutineLabel
+from vyper.evm.opcodes import get_opcodes, version_check
 from vyper.exceptions import CodegenPanic, CompilerPanic
 from vyper.utils import MemoryPositions
 from vyper.version import version_tuple
@@ -104,7 +105,7 @@ def _rewrite_return_sequences(ir_node, label_params=None):
             _t.append(["goto", dest] + more_args)
             ir_node.args = IRnode.from_list(_t, ast_source=ir_node.ast_source).args
 
-    if ir_node.value == "label":
+    if ir_node.value in ("label", "subroutine"):
         label_params = set(t.value for t in ir_node.args[1].args)
 
     for t in args:
@@ -175,6 +176,12 @@ class _IRnodeLowerer:
         self.height = 0
 
         self.global_revert_label = None
+        # EIP-7979 (with EIP-8337 validation in mind): code shared by several
+        # subroutines must be a subroutine entry (CALLDEST), and must not be
+        # shared between subroutine code and top-level code. So the shared
+        # revert block is a CALLDEST, and subroutines get their own.
+        self.subroutine_revert_label = None
+        self.in_subroutine = False
 
         self.data_segments = []
         self.freeze_data_segments = False
@@ -672,6 +679,18 @@ class _IRnodeLowerer:
             o.extend([*JUMP(Label(target))])
             return o
 
+        # EIP-7979: call a subroutine, pushing variable # of arguments onto stack
+        if code.value == "gosub":
+            o = []
+            for i, c in enumerate(reversed(code.args[1:])):
+                o.extend(self._compile_r(c, height + i))
+            target = code.args[0].value
+            assert isinstance(target, str)  # help mypy
+            o.extend([*CALLSUB(Label(target))])
+            return o
+        # EIP-7979: return from the current subroutine
+        if code.value == "retsub":
+            return ["RETURNSUB"]
         if code.value == "djump":
             o = []
             # "djump" compiles to a raw EVM jump instruction
@@ -686,7 +705,8 @@ class _IRnodeLowerer:
             return [PUSHLABEL(Label(label))]
 
         # set a symbol as a location.
-        if code.value == "label":
+        # EIP-7979: "subroutine" is a label assembled as CALLDEST.
+        if code.value in ("label", "subroutine"):
             label_name = code.args[0].value
             assert isinstance(label_name, str)
 
@@ -712,7 +732,11 @@ class _IRnodeLowerer:
                 self.withargs[arg.value] = height
                 height += 1
 
+            old_in_subroutine = self.in_subroutine
+            if code.value == "subroutine":
+                self.in_subroutine = True
             body_asm = self._compile_r(body, height)
+            self.in_subroutine = old_in_subroutine
             # pop_scoped_vars = ["POP"] * height
             # for now, _rewrite_return_sequences forces
             # label params to be consumed implicitly
@@ -720,7 +744,8 @@ class _IRnodeLowerer:
 
             self.withargs = old_withargs
 
-            return [Label(label_name)] + body_asm + pop_scoped_vars
+            label_cls = SubroutineLabel if code.value == "subroutine" else Label
+            return [label_cls(label_name)] + body_asm + pop_scoped_vars
 
         if code.value == "unique_symbol":
             symbol = code.args[0].value
@@ -748,6 +773,8 @@ class _IRnodeLowerer:
         # common revert block
         if self.global_revert_label is not None:
             ret.extend([self.global_revert_label, *PUSH(0), "DUP1", "REVERT"])
+        if self.subroutine_revert_label is not None:
+            ret.extend([self.subroutine_revert_label, *PUSH(0), "DUP1", "REVERT"])
 
         return ret
 
@@ -757,6 +784,16 @@ class _IRnodeLowerer:
         return segment
 
     def _assert_false(self):
+        if version_check(begin="future"):
+            # EIP-7979: the shared failure block is a subroutine entry, and
+            # subroutine code and top-level code do not share one.
+            if self.in_subroutine:
+                if self.subroutine_revert_label is None:
+                    self.subroutine_revert_label = SubroutineLabel(self.mksymbol("revert").label)
+                return JUMPI(self.subroutine_revert_label)
+            if self.global_revert_label is None:
+                self.global_revert_label = SubroutineLabel(self.mksymbol("revert").label)
+            return JUMPI(self.global_revert_label)
         if self.global_revert_label is None:
             self.global_revert_label = self.mksymbol("revert")
         # use a shared failure block for common case of assert(x).

--- a/vyper/utils.py
+++ b/vyper/utils.py
@@ -485,6 +485,9 @@ VALID_IR_MACROS = {
     "label",
     "goto",
     "djump",  # "dynamic jump", i.e. constrained, multi-destination jump
+    "subroutine",  # EIP-7979: a label assembled as CALLDEST
+    "gosub",  # EIP-7979: CALLSUB with args, like goto
+    "retsub",  # EIP-7979: RETURNSUB
     "~extcode",
     "~selfcode",
     "~calldata",


### PR DESCRIPTION
**Draft. A demonstration for the EIP-7979 discussion, not a merge candidate.**

[EIP-7979](https://eips.ethereum.org/EIPS/eip-7979) (proposed for Hegotá) gives the EVM a return stack and three instructions: `CALLSUB`, `CALLDEST`, `RETURNSUB`. This PR makes the legacy pipeline use them for internal function calls under a new experimental EVM version, `future`, so the question "what does it cost Vyper to target this?" has an answer.

```
vyper --evm-version future -f asm_runtime calls.vy
```

## What changes in the generated code

| | today | with `future` |
|---|---|---|
| call | `PUSH ret; [buf]; PUSH f; JUMP` / `ret: JUMPDEST` | `[buf]; PUSH f; CALLSUB` |
| function entry | `f: JUMPDEST` with `return_pc` on the stack | `f: CALLDEST`, `return_buffer` only |
| cleanup | `JUMP` to `return_pc` | `RETURNSUB` |

## Size of the change

138 lines added across ten files, but the calling convention itself is 39 of them (32 without comments), in `self_call.py` and `internal_function.py`. The rest is plumbing: the version and opcodes (10), a `SubroutineLabel` kind assembled as `CALLDEST` (19), three IR ops in the lowerer (47), two guards in the assembly optimizer so a `CALLSUB` is never redirected onto a `JUMPDEST` (19), IR-node valency (7), and registering the ops (3).

## Results on a small contract

`calls.vy` below has a plain internal call, a nested one, and a loop. Runtime under `future`: 4 `CALLSUB`, 3 `RETURNSUB`, 10 `JUMPI`, and **no plain `JUMP`**; the Prague build has 7, all of them calls and returns.

Run on the EIP-7979 reference implementation in execution-specs ([ethereum/execution-specs#3575](https://github.com/ethereum/execution-specs/pull/3575)):

| `compute(a, b)` | Prague | `future` |
|---|---|---|
| (3, 4) → 35 | 4180 gas | 4152 gas |
| (0, 0) → 0 | 3645 | 3617 |
| (10, 5) → 140 | 4313 | 4285 |

Runtime size 260 bytes vs 272. The gas saving per call is the return label's push and landing pad; Vyper passes return values through memory, so nothing else in the convention changes.

The output **validates under [EIP-8337](https://eips.ethereum.org/EIPS/eip-8337)** (static control flow, no underflow), checked with its reference validator ([ethereum/execution-specs#3576](https://github.com/ethereum/execution-specs/pull/3576)). That took one design change: the shared global revert block was reached from the dispatcher and from inside every subroutine — from different entries, and from both framed and unframed code — which the validator rejects. Under `future` the shared revert block is a subroutine entry (`CALLDEST`), and subroutine code has its own. Four bytes. The general rule, for any optimizer targeting these EIPs: shared code must be entered as a subroutine, and must not be shared between subroutine code and top-level code.

## Notes

- IR node names double as raw opcode names, so the IR ops are `gosub`, `retsub` and `subroutine` rather than `callsub` etc.
- The Venom backend is untouched and ignores the new convention.
- Selector-table dispatch is unchanged; with only static `JUMPI`s left in the demo it validates, but a dense selector table's computed jump would not until the EVM has a static multi-way jump.
- Tests: 2,580 of the existing suite pass on the default version; the new version has no tests, since py-evm and revm do not implement the instructions. An evmone implementation is at [ipsilon/evmone#1706](https://github.com/ipsilon/evmone/pull/1706).

## The demo contract

```python
@internal
@pure
def square(x: uint256) -> uint256:
    return x * x

@internal
@pure
def sum_of_squares(a: uint256, b: uint256) -> uint256:
    return self.square(a) + self.square(b)

@internal
@pure
def triangle(n: uint256) -> uint256:
    s: uint256 = 0
    for i: uint256 in range(n, bound=100):
        s += i + 1
    return s

@external
@pure
def compute(a: uint256, b: uint256) -> uint256:
    return self.sum_of_squares(a, b) + self.triangle(b)
```
