### PR TITLE
feat[venom]: literal bytestring codecopy

### DIFF
--- a/tests/functional/codegen/features/test_assert.py
+++ b/tests/functional/codegen/features/test_assert.py
@@ -1,5 +1,6 @@
 import pytest
 
+from vyper.compiler.settings import OptimizationLevel
 from vyper.exceptions import InvalidType
 
 
@@ -246,3 +247,25 @@ def test() -> int128:
     c = get_contract(code)
     with tx_failed(exc_text="oops"):
         c.test()
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "the argument must be larger than ten, but it was not",
+        "the argument must be larger than ten, but it was not; please retry with a larger value",
+    ],
+)
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_assert_reason_long_literal(get_contract, tx_failed, reason, opt):
+    assert len(reason) > 32
+    code = f"""
+@external
+def foo(a: uint256) -> uint256:
+    assert a > 10, "{reason}"
+    return a
+    """
+    c = get_contract(code, override_opt_level=opt)
+    assert c.foo(11) == 11
+    with tx_failed(exc_text=reason):
+        c.foo(10)

--- a/tests/functional/codegen/types/test_bytes.py
+++ b/tests/functional/codegen/types/test_bytes.py
@@ -1,6 +1,7 @@
 import pytest
 
 from vyper.compiler import compile_code
+from vyper.compiler.settings import OptimizationLevel
 from vyper.exceptions import TypeMismatch
 
 
@@ -391,3 +392,16 @@ def compare(x: Bytes[100]) -> bool:
     assert c.compare(b"world") is False
     assert c.compare(b"") is False
     assert c.compare(b"hello world") is False
+
+
+@pytest.mark.parametrize("n", [32, 33, 63, 64, 65, 96, 97, 100, 200])
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_bytes_literal_return(get_contract, n, opt):
+    data = bytes(range(1, 256))[:n]
+    code = f"""
+@external
+def foo() -> Bytes[{n}]:
+    return x"{data.hex()}"
+    """
+    c = get_contract(code, override_opt_level=opt)
+    assert c.foo() == data

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -3,6 +3,7 @@ import contextlib
 import pytest
 
 from tests.utils import check_precompile_asserts
+from vyper.compiler.settings import OptimizationLevel
 from vyper.evm.opcodes import version_check
 
 
@@ -417,3 +418,82 @@ def foo(x: String[1000000]) -> uint256:
         # depends on EVM version. pre-cancun, will revert due to checking
         # success flag from identity precompile.
         c.foo(calldata, gas=gas_used)
+
+
+# literal lengths around the word boundaries and the codecopy gate
+LITERAL_LENGTHS = [32, 33, 63, 64, 65, 96, 97, 100, 200]
+ALPHABET = "abcdefghijklmnopqrstuvwxyz" * 8
+
+
+@pytest.mark.parametrize("n", LITERAL_LENGTHS)
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_string_literal_return(get_contract, n, opt):
+    s = ALPHABET[:n]
+    code = f"""
+@external
+def foo() -> String[{n}]:
+    return "{s}"
+    """
+    c = get_contract(code, override_opt_level=opt)
+    assert c.foo() == s
+
+
+@pytest.mark.parametrize("n", [65, 100])
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_string_literal_to_storage(get_contract, n, opt):
+    s = ALPHABET[:n]
+    code = f"""
+s: public(String[100])
+
+@external
+def set():
+    self.s = "{s}"
+    """
+    c = get_contract(code, override_opt_level=opt)
+    c.set()
+    assert c.s() == s
+
+
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_string_literal_in_constructor_and_runtime(get_contract, opt):
+    greeting = ALPHABET[:100]
+    tag = ALPHABET[3:67]
+    farewell = ALPHABET[5:101]
+    code = f"""
+greeting: public(String[100])
+TAG: public(immutable(String[64]))
+
+@deploy
+def __init__():
+    self.greeting = "{greeting}"
+    TAG = "{tag}"
+
+@external
+def farewell() -> String[96]:
+    return "{farewell}"
+    """
+    c = get_contract(code, override_opt_level=opt)
+    assert c.greeting() == greeting
+    assert c.TAG() == tag
+    assert c.farewell() == farewell
+
+
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_string_literal_in_internal_function(get_contract, opt):
+    s = ALPHABET[:96]
+    code = f"""
+@internal
+def _msg() -> String[96]:
+    return "{s}"
+
+@external
+def foo() -> String[96]:
+    return self._msg()
+
+@external
+def bar() -> String[96]:
+    return concat(self._msg(), "")
+    """
+    c = get_contract(code, override_opt_level=opt)
+    assert c.foo() == s
+    assert c.bar() == s

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -420,7 +420,7 @@ def foo(x: String[1000000]) -> uint256:
         c.foo(calldata, gas=gas_used)
 
 
-# literal lengths around the word boundaries and the codecopy gate
+# literal lengths around the word boundaries and the codecopy size threshold
 LITERAL_LENGTHS = [32, 33, 63, 64, 65, 96, 97, 100, 200]
 ALPHABET = "abcdefghijklmnopqrstuvwxyz" * 8
 
@@ -456,12 +456,13 @@ def set():
 
 @pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
 def test_string_literal_in_constructor_and_runtime(get_contract, opt):
+    # all three literals are long enough to take the codecopy path
     greeting = ALPHABET[:100]
-    tag = ALPHABET[3:67]
+    tag = ALPHABET[3:99]
     farewell = ALPHABET[5:101]
     code = f"""
 greeting: public(String[100])
-TAG: public(immutable(String[64]))
+TAG: public(immutable(String[96]))
 
 @deploy
 def __init__():
@@ -497,3 +498,28 @@ def bar() -> String[96]:
     c = get_contract(code, override_opt_level=opt)
     assert c.foo() == s
     assert c.bar() == s
+
+
+@pytest.mark.parametrize("opt", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_string_literal_in_internal_function_from_constructor(get_contract, opt):
+    # the internal function is lowered into both the deploy and the runtime
+    # context, each with its own data section for the literal
+    s = ALPHABET[2:98]
+    code = f"""
+s: public(String[96])
+
+@internal
+def _msg() -> String[96]:
+    return "{s}"
+
+@deploy
+def __init__():
+    self.s = self._msg()
+
+@external
+def foo() -> String[96]:
+    return self._msg()
+    """
+    c = get_contract(code, override_opt_level=opt)
+    assert c.s() == s
+    assert c.foo() == s

--- a/tests/unit/compiler/test_bytecode_runtime.py
+++ b/tests/unit/compiler/test_bytecode_runtime.py
@@ -170,34 +170,50 @@ def test_bytecode_signature_deployed(code, get_contract, env):
 
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz" * 4
 
+# every literal is at least 96 bytes, so both optimization levels put it in
+# a data section; the constructor and runtime literals differ so that they
+# can be located in the initcode independently
+GREETING = _ALPHABET[:100]
+TAG = _ALPHABET[4:100]
+FAREWELL = _ALPHABET.upper()[:96]
+
 literals_contract_code = f"""
 greeting: public(String[100])
-TAG: public(immutable(String[64]))
+TAG: public(immutable(String[96]))
 
 @deploy
 def __init__():
-    self.greeting = "{_ALPHABET[:100]}"
-    TAG = "{_ALPHABET[3:67]}"
+    self.greeting = "{GREETING}"
+    TAG = "{TAG}"
 
 @external
-def foo() -> String[96]:
-    return "{_ALPHABET[:96]}"
+def farewell() -> String[96]:
+    return "{FAREWELL}"
 """
 
 
-def test_bytecode_literals_metadata():
-    # constructor and runtime literals may add data sections to both the
-    # deploy and the runtime code; the metadata must stay the initcode tail
+@pytest.mark.parametrize("level", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_bytecode_literals_metadata(level):
+    # constructor and runtime literals add data sections to the deploy and
+    # the runtime code; the metadata must stay the initcode tail
+    settings = Settings(experimental_codegen=True, optimize=level)
     out = vyper.compile_code(
-        literals_contract_code, output_formats=["bytecode_runtime", "bytecode"]
+        literals_contract_code, output_formats=["bytecode_runtime", "bytecode"], settings=settings
     )
     runtime_code = bytes.fromhex(out["bytecode_runtime"].removeprefix("0x"))
     initcode = bytes.fromhex(out["bytecode"].removeprefix("0x"))
 
+    # the runtime literal is the runtime code's only data section (linear
+    # selector dispatch has none); the constructor literals come before the
+    # embedded runtime code, the metadata after it
     assert runtime_code in initcode
+    assert FAREWELL.encode() in runtime_code
+    assert initcode.index(GREETING.encode()) < initcode.index(runtime_code)
+    assert initcode.index(TAG.encode()) < initcode.index(runtime_code)
+
     metadata = _parse_cbor_metadata(initcode)
     _, runtime_len, data_section_lengths, immutables_len, compiler = metadata
     assert runtime_len == len(runtime_code)
-    assert immutables_len == 32 + 64
+    assert data_section_lengths == [96]
+    assert immutables_len == 32 + 96
     assert compiler == {"vyper": list(vyper.version.version_tuple)}
-    assert all(0 < length < runtime_len for length in data_section_lengths)

--- a/tests/unit/compiler/test_bytecode_runtime.py
+++ b/tests/unit/compiler/test_bytecode_runtime.py
@@ -166,3 +166,38 @@ def test_bytecode_signature_deployed(code, get_contract, env):
 
     # runtime_len includes data sections but not immutables
     assert len(deployed_code) == runtime_len + immutables_len
+
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz" * 4
+
+literals_contract_code = f"""
+greeting: public(String[100])
+TAG: public(immutable(String[64]))
+
+@deploy
+def __init__():
+    self.greeting = "{_ALPHABET[:100]}"
+    TAG = "{_ALPHABET[3:67]}"
+
+@external
+def foo() -> String[96]:
+    return "{_ALPHABET[:96]}"
+"""
+
+
+def test_bytecode_literals_metadata():
+    # constructor and runtime literals may add data sections to both the
+    # deploy and the runtime code; the metadata must stay the initcode tail
+    out = vyper.compile_code(
+        literals_contract_code, output_formats=["bytecode_runtime", "bytecode"]
+    )
+    runtime_code = bytes.fromhex(out["bytecode_runtime"].removeprefix("0x"))
+    initcode = bytes.fromhex(out["bytecode"].removeprefix("0x"))
+
+    assert runtime_code in initcode
+    metadata = _parse_cbor_metadata(initcode)
+    _, runtime_len, data_section_lengths, immutables_len, compiler = metadata
+    assert runtime_len == len(runtime_code)
+    assert immutables_len == 32 + 64
+    assert compiler == {"vyper": list(vyper.version.version_tuple)}
+    assert all(0 < length < runtime_len for length in data_section_lengths)

--- a/tests/unit/compiler/test_bytestring_literal.py
+++ b/tests/unit/compiler/test_bytestring_literal.py
@@ -18,23 +18,33 @@ DENSE = bytes(range(1, 256)) * 2
 ALPHABET = "abcdefghijklmnopqrstuvwxyz" * 8
 
 
-def test_push_cost():
-    assert push_cost(0) == 1  # PUSH0
-    assert push_cost(1) == 2  # PUSH1
-    assert push_cost(int.from_bytes(DENSE[:32], "big")) == 33  # PUSH32
-    assert push_cost(2**256 - 1) == 2  # PUSH0, NOT
-    assert push_cost(2**256 - 0x100) == 3  # PUSH1 0xff, NOT
-    assert push_cost(1 << 255) == 5  # PUSH1 1, PUSH1 255, SHL
-    assert push_cost(0x73747576 << 224) == 8  # PUSH4, PUSH1, SHL
+def test_push_cost_reduced():
+    assert push_cost(0, reduced=True) == 1  # PUSH0
+    assert push_cost(1, reduced=True) == 2  # PUSH1
+    assert push_cost(int.from_bytes(DENSE[:32], "big"), reduced=True) == 33  # PUSH32
+    assert push_cost(2**256 - 1, reduced=True) == 2  # PUSH0, NOT
+    assert push_cost(2**256 - 0x100, reduced=True) == 3  # PUSH1 0xff, NOT
+    assert push_cost(1 << 255, reduced=True) == 5  # PUSH1 1, PUSH1 255, SHL
+    assert push_cost(0x73747576 << 224, reduced=True) == 8  # PUSH4, PUSH1, SHL
+
+
+def test_push_cost_plain():
+    # without ReduceLiteralsCodesize every non-zero word is a plain PUSHn
+    assert push_cost(0, reduced=False) == 1
+    assert push_cost(2**256 - 1, reduced=False) == 33
+    assert push_cost(1 << 255, reduced=False) == 33
+    assert push_cost(0x73747576 << 224, reduced=False) == 33
 
 
 def test_chain_bytes():
     # PUSH32, PUSH1 addr, MSTORE per dense word
-    assert chain_bytes(DENSE[:64]) == 2 * 36
-    # the padded tail word is cheap: PUSH1, PUSH1, SHL, PUSH1 addr, MSTORE
-    assert chain_bytes(DENSE[:33]) == 36 + 8
+    assert chain_bytes(DENSE[:64], reduced=True) == 2 * 36
+    assert chain_bytes(DENSE[:64], reduced=False) == 2 * 36
+    # the padded tail word is cheap only with SHL: PUSH1, PUSH1, SHL, PUSH1 addr, MSTORE
+    assert chain_bytes(DENSE[:33], reduced=True) == 36 + 8
+    assert chain_bytes(DENSE[:33], reduced=False) == 36 + 36
     # zero words: PUSH0, PUSH1 addr, MSTORE
-    assert chain_bytes(b"\x00" * 96) == 3 * 4
+    assert chain_bytes(b"\x00" * 96, reduced=False) == 3 * 4
 
 
 def test_codecopy_bytes():
@@ -44,31 +54,46 @@ def test_codecopy_bytes():
     assert codecopy_bytes(100, padded=False) == 100 + 9 + 4  # plus the tail zeroing store
 
 
+# codesize levels: exact item plus tail store, chain priced with NOT/SHL forms
 @pytest.mark.parametrize(
-    "n,padded,expected",
+    "n,expected",
     [
-        (32, True, False),  # single word, never
-        (32, False, False),
-        (33, True, False),  # 73 vs 44
-        (33, False, False),  # 46 vs 44
-        (63, True, False),  # 73 vs 72
-        (63, False, False),  # 76 vs 72
-        (64, True, False),  # 73 vs 72
-        (64, False, False),  # 73 vs 72
-        (65, True, False),  # 105 vs 80
-        (65, False, True),  # 78 vs 80
-        (96, True, True),  # 105 vs 108
-        (96, False, True),  # 105 vs 108
+        (32, False),  # single word, never
+        (33, False),  # 46 vs 44
+        (63, False),  # 76 vs 72
+        (64, False),  # 73 vs 72
+        (65, True),  # 78 vs 80
+        (96, True),  # 105 vs 108
+        (97, True),  # 110 vs 116
+        (100, True),  # 113 vs 119
     ],
 )
-def test_should_codecopy(n, padded, expected):
-    assert should_codecopy(DENSE[:n], padded) is expected
+def test_should_codecopy_codesize(n, expected):
+    assert should_codecopy(DENSE[:n], padded=False, reduced=True) is expected
 
 
-@pytest.mark.parametrize("padded", [True, False])
-def test_should_codecopy_zero_words(padded):
+# gas levels: padded item, chain priced with plain PUSHn only
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (32, False),  # single word, never
+        (33, False),  # 73 vs 72
+        (63, False),  # 73 vs 72
+        (64, False),  # 73 vs 72
+        (65, True),  # 105 vs 108
+        (96, True),  # 105 vs 108
+        (97, True),  # 137 vs 144
+        (100, True),  # 137 vs 144
+    ],
+)
+def test_should_codecopy_gas(n, expected):
+    assert should_codecopy(DENSE[:n], padded=True, reduced=False) is expected
+
+
+@pytest.mark.parametrize("padded,reduced", [(True, False), (False, True)])
+def test_should_codecopy_zero_words(padded, reduced):
     # 3 zero words cost 12 bytes as stores, 105 as a data item
-    assert not should_codecopy(b"\x00" * 96, padded)
+    assert not should_codecopy(b"\x00" * 96, padded, reduced)
 
 
 def _runtime_venom(code: str, level: OptimizationLevel):
@@ -91,6 +116,7 @@ def _instructions(ctx):
     "level,n,expected_item",
     [
         (OptimizationLevel.GAS, 96, ALPHABET[:96].encode()),
+        (OptimizationLevel.GAS, 100, ALPHABET[:100].encode().ljust(128, b"\x00")),
         (OptimizationLevel.CODESIZE, 96, ALPHABET[:96].encode()),
         (OptimizationLevel.CODESIZE, 100, ALPHABET[:100].encode()),
     ],
@@ -123,19 +149,24 @@ def foo() -> String[{n}]:
     between = bb[copy_idx + 1 : length_idx]
     assert not any(Effects.MEMORY in inst.get_write_effects() for inst in between)
 
-    # the last data word is zeroed before the copy, unless the data is
-    # word-aligned
+    # the last data word is zeroed before the copy for an exact item that
+    # is not word-aligned; a padded item needs no tail store
     tail_stores = [inst for inst in bb[:copy_idx] if inst in stores]
-    assert [inst.operands[0] for inst in tail_stores] == ([IRLiteral(0)] if n % 32 else [])
+    needs_tail_store = len(expected_item) % 32 != 0
+    assert [inst.operands[0] for inst in tail_stores] == (
+        [IRLiteral(0)] if needs_tail_store else []
+    )
 
 
-def test_literal_below_gate_keeps_mstore_chain():
+@pytest.mark.parametrize("level", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
+def test_literal_below_gate_keeps_mstore_chain(level):
+    # two words: 73 vs 72 bytes at gas levels, 76 vs 72 at codesize levels
     code = f"""
 @external
-def foo() -> String[100]:
-    return "{ALPHABET[:100]}"
+def foo() -> String[63]:
+    return "{ALPHABET[:63]}"
     """
-    ctx = _runtime_venom(code, OptimizationLevel.GAS)
+    ctx = _runtime_venom(code, level)
     assert len(_literal_sections(ctx)) == 0
     assert not any(inst.opcode == "codecopy" for inst in _instructions(ctx))
 

--- a/tests/unit/compiler/test_bytestring_literal.py
+++ b/tests/unit/compiler/test_bytestring_literal.py
@@ -1,0 +1,182 @@
+import pytest
+
+from vyper.codegen_venom.bytestring_literal import (
+    chain_bytes,
+    codecopy_bytes,
+    push_cost,
+    should_codecopy,
+)
+from vyper.codegen_venom.module import generate_runtime_venom
+from vyper.compiler.phases import CompilerData
+from vyper.compiler.settings import OptimizationLevel, Settings, anchor_settings
+from vyper.venom.basicblock import IRLabel, IRLiteral
+from vyper.venom.effects import Effects
+
+# every word of this is dense: no NOT or SHL shortcut applies
+DENSE = bytes(range(1, 256)) * 2
+
+ALPHABET = "abcdefghijklmnopqrstuvwxyz" * 8
+
+
+def test_push_cost():
+    assert push_cost(0) == 1  # PUSH0
+    assert push_cost(1) == 2  # PUSH1
+    assert push_cost(int.from_bytes(DENSE[:32], "big")) == 33  # PUSH32
+    assert push_cost(2**256 - 1) == 2  # PUSH0, NOT
+    assert push_cost(2**256 - 0x100) == 3  # PUSH1 0xff, NOT
+    assert push_cost(1 << 255) == 5  # PUSH1 1, PUSH1 255, SHL
+    assert push_cost(0x73747576 << 224) == 8  # PUSH4, PUSH1, SHL
+
+
+def test_chain_bytes():
+    # PUSH32, PUSH1 addr, MSTORE per dense word
+    assert chain_bytes(DENSE[:64]) == 2 * 36
+    # the padded tail word is cheap: PUSH1, PUSH1, SHL, PUSH1 addr, MSTORE
+    assert chain_bytes(DENSE[:33]) == 36 + 8
+    # zero words: PUSH0, PUSH1 addr, MSTORE
+    assert chain_bytes(b"\x00" * 96) == 3 * 4
+
+
+def test_codecopy_bytes():
+    assert codecopy_bytes(96, padded=True) == 96 + 9
+    assert codecopy_bytes(100, padded=True) == 128 + 9
+    assert codecopy_bytes(96, padded=False) == 96 + 9
+    assert codecopy_bytes(100, padded=False) == 100 + 9 + 4  # plus the tail zeroing store
+
+
+@pytest.mark.parametrize(
+    "n,padded,expected",
+    [
+        (32, True, False),  # single word, never
+        (32, False, False),
+        (33, True, False),  # 73 vs 44
+        (33, False, False),  # 46 vs 44
+        (63, True, False),  # 73 vs 72
+        (63, False, False),  # 76 vs 72
+        (64, True, False),  # 73 vs 72
+        (64, False, False),  # 73 vs 72
+        (65, True, False),  # 105 vs 80
+        (65, False, True),  # 78 vs 80
+        (96, True, True),  # 105 vs 108
+        (96, False, True),  # 105 vs 108
+    ],
+)
+def test_should_codecopy(n, padded, expected):
+    assert should_codecopy(DENSE[:n], padded) is expected
+
+
+@pytest.mark.parametrize("padded", [True, False])
+def test_should_codecopy_zero_words(padded):
+    # 3 zero words cost 12 bytes as stores, 105 as a data item
+    assert not should_codecopy(b"\x00" * 96, padded)
+
+
+def _runtime_venom(code: str, level: OptimizationLevel):
+    settings = Settings(experimental_codegen=True, optimize=level)
+    compiler_data = CompilerData(code, settings=settings)
+    # `_opt_codesize()` reads the global settings, like the compiler driver
+    with anchor_settings(compiler_data.settings):
+        return generate_runtime_venom(compiler_data.global_ctx, compiler_data.settings)
+
+
+def _literal_sections(ctx):
+    return [s for s in ctx.data_segment if s.label.value.endswith("_literal")]
+
+
+def _instructions(ctx):
+    return [inst for bb in ctx.get_basic_blocks() for inst in bb.instructions]
+
+
+@pytest.mark.parametrize(
+    "level,n,expected_item",
+    [
+        (OptimizationLevel.GAS, 96, ALPHABET[:96].encode()),
+        (OptimizationLevel.CODESIZE, 96, ALPHABET[:96].encode()),
+        (OptimizationLevel.CODESIZE, 100, ALPHABET[:100].encode()),
+    ],
+)
+def test_literal_codecopy_ir(level, n, expected_item):
+    code = f"""
+@external
+def foo() -> String[{n}]:
+    return "{ALPHABET[:n]}"
+    """
+    ctx = _runtime_venom(code, level)
+
+    (section,) = _literal_sections(ctx)
+    (item,) = section.data_items
+    assert item.data == expected_item
+
+    insts = _instructions(ctx)
+    (codecopy,) = [inst for inst in insts if inst.opcode == "codecopy"]
+    size, label, _ = codecopy.operands
+    assert size == IRLiteral(len(expected_item))
+    assert label == section.label
+
+    bb = codecopy.parent.instructions
+    stores = [inst for inst in bb if inst.opcode == "mstore"]
+    # the length store is the last memory write of the sequence: nothing
+    # between the copy and it touches memory
+    (length_store,) = [inst for inst in stores if inst.operands[0] == IRLiteral(n)]
+    copy_idx, length_idx = bb.index(codecopy), bb.index(length_store)
+    assert copy_idx < length_idx
+    between = bb[copy_idx + 1 : length_idx]
+    assert not any(Effects.MEMORY in inst.get_write_effects() for inst in between)
+
+    # the last data word is zeroed before the copy, unless the data is
+    # word-aligned
+    tail_stores = [inst for inst in bb[:copy_idx] if inst in stores]
+    assert [inst.operands[0] for inst in tail_stores] == ([IRLiteral(0)] if n % 32 else [])
+
+
+def test_literal_below_gate_keeps_mstore_chain():
+    code = f"""
+@external
+def foo() -> String[100]:
+    return "{ALPHABET[:100]}"
+    """
+    ctx = _runtime_venom(code, OptimizationLevel.GAS)
+    assert len(_literal_sections(ctx)) == 0
+    assert not any(inst.opcode == "codecopy" for inst in _instructions(ctx))
+
+
+def test_two_literals_two_sections():
+    first = ALPHABET[:96]
+    second = ALPHABET[1:97]
+    code = f"""
+@external
+def foo() -> String[96]:
+    return "{first}"
+
+@external
+def bar() -> String[96]:
+    return "{second}"
+    """
+    ctx = _runtime_venom(code, OptimizationLevel.CODESIZE)
+    sections = _literal_sections(ctx)
+    assert [s.data_items[0].data for s in sections] == [first.encode(), second.encode()]
+    labels = [s.label for s in sections]
+    assert len(set(labels)) == 2
+    assert all(isinstance(label, IRLabel) for label in labels)
+    copies = [inst for inst in _instructions(ctx) if inst.opcode == "codecopy"]
+    assert [inst.operands[1] for inst in copies] == labels
+
+
+def test_literal_in_internal_function_single_section():
+    # the function body is lowered once, so its literal gets one data item
+    # regardless of how many call sites there are
+    code = f"""
+@internal
+def _msg() -> String[96]:
+    return "{ALPHABET[:96]}"
+
+@external
+def foo() -> String[96]:
+    return self._msg()
+
+@external
+def bar() -> String[96]:
+    return self._msg()
+    """
+    ctx = _runtime_venom(code, OptimizationLevel.CODESIZE)
+    assert len(_literal_sections(ctx)) == 1

--- a/tests/unit/compiler/test_bytestring_literal.py
+++ b/tests/unit/compiler/test_bytestring_literal.py
@@ -9,7 +9,7 @@ from vyper.codegen_venom.bytestring_literal import (
 from vyper.codegen_venom.module import generate_runtime_venom
 from vyper.compiler.phases import CompilerData
 from vyper.compiler.settings import OptimizationLevel, Settings, anchor_settings
-from vyper.venom.basicblock import IRLabel, IRLiteral
+from vyper.venom.basicblock import IRLiteral
 from vyper.venom.effects import Effects
 
 # every word of this is dense: no NOT or SHL shortcut applies
@@ -159,7 +159,7 @@ def foo() -> String[{n}]:
 
 
 @pytest.mark.parametrize("level", [OptimizationLevel.GAS, OptimizationLevel.CODESIZE])
-def test_literal_below_gate_keeps_mstore_chain(level):
+def test_literal_below_size_threshold_keeps_mstore_chain(level):
     # two words: 73 vs 72 bytes at gas levels, 76 vs 72 at codesize levels
     code = f"""
 @external
@@ -186,11 +186,10 @@ def bar() -> String[96]:
     ctx = _runtime_venom(code, OptimizationLevel.CODESIZE)
     sections = _literal_sections(ctx)
     assert [s.data_items[0].data for s in sections] == [first.encode(), second.encode()]
-    labels = [s.label for s in sections]
-    assert len(set(labels)) == 2
-    assert all(isinstance(label, IRLabel) for label in labels)
+    first_label, second_label = [s.label for s in sections]
+    assert first_label != second_label
     copies = [inst for inst in _instructions(ctx) if inst.opcode == "codecopy"]
-    assert [inst.operands[1] for inst in copies] == labels
+    assert [inst.operands[1] for inst in copies] == [first_label, second_label]
 
 
 def test_literal_in_internal_function_single_section():

--- a/vyper/codegen_venom/bytestring_literal.py
+++ b/vyper/codegen_venom/bytestring_literal.py
@@ -1,0 +1,73 @@
+"""
+Code size estimates for materializing a constant bytestring in memory:
+a chain of `mstore`s of literal words versus a `codecopy` from a data
+section holding the bytes. Used by `VenomCodegenContext.const_bytestring_value`.
+
+The estimates are biased so that a wrong guess can only keep the chain:
+the chain is priced with the cheapest literal encoding available to
+`ReduceLiteralsCodesize` at any optimization level and PUSH1 addresses,
+the codecopy with a PUSH2 label.
+"""
+
+from vyper.utils import ceil32, evm_not
+
+WORD = 32
+
+# PUSH1 <address> for every store in the chain
+_ADDR_COST = 2
+# PUSH1 <size>, PUSH1 <dst>, PUSH2 <label>, SWAP1, CODECOPY
+_CODECOPY_COST = 2 + 2 + 3 + 1 + 1
+# PUSH0, PUSH1 <address>, MSTORE zeroing the last data word
+_TAIL_STORE_COST = 4
+
+
+def _nbytes(val: int) -> int:
+    return (val.bit_length() + 7) // 8
+
+
+def push_cost(word: int) -> int:
+    """
+    Bytes of the cheapest encoding of a word: PUSHn, PUSH + NOT, or
+    PUSH + PUSH1 + SHL (the forms `ReduceLiteralsCodesize` produces).
+    """
+    assert 0 <= word < 2**256
+    cost = 1 + _nbytes(word)
+    cost = min(cost, 1 + _nbytes(evm_not(word)) + 1)
+    if word != 0:
+        trailing_zero_bytes = ((word & -word).bit_length() - 1) // 8
+        if trailing_zero_bytes > 0:
+            cost = min(cost, 1 + _nbytes(word >> (8 * trailing_zero_bytes)) + 2 + 1)
+    return cost
+
+
+def chain_bytes(data: bytes) -> int:
+    """Code bytes for storing `data` word by word (the length word excluded)."""
+    padded = data.ljust(ceil32(len(data)), b"\x00")
+    words = [int.from_bytes(padded[i : i + WORD], "big") for i in range(0, len(padded), WORD)]
+    return sum(push_cost(word) + _ADDR_COST + 1 for word in words)
+
+
+def codecopy_bytes(length: int, padded: bool) -> int:
+    """
+    Code plus data bytes for copying a `length`-byte literal from the
+    data section. `padded` items hold whole words; exact items need the
+    last word zeroed first unless the length is word-aligned.
+    """
+    if padded:
+        return ceil32(length) + _CODECOPY_COST
+    tail_store = _TAIL_STORE_COST if length % WORD != 0 else 0
+    return length + _CODECOPY_COST + tail_store
+
+
+def should_codecopy(data: bytes, padded: bool) -> bool:
+    """
+    Whether `data` is estimated to be smaller as a codecopy than as an
+    mstore chain. A single word is never worth a data section.
+
+    Runtime gas cannot get worse in the padded form: the chain costs at
+    least 8 gas per word, the codecopy 15 + 3 gas per word, and the size
+    gate only passes for 3 words or more (2 dense words: 73 vs 72 bytes).
+    """
+    if len(data) <= WORD:
+        return False
+    return codecopy_bytes(len(data), padded) < chain_bytes(data)

--- a/vyper/codegen_venom/bytestring_literal.py
+++ b/vyper/codegen_venom/bytestring_literal.py
@@ -4,9 +4,8 @@ a chain of `mstore`s of literal words versus a `codecopy` from a data
 section holding the bytes. Used by `VenomCodegenContext.const_bytestring_value`.
 
 The estimates are biased so that a wrong guess can only keep the chain:
-the chain is priced with the cheapest literal encoding available to
-`ReduceLiteralsCodesize` at any optimization level and PUSH1 addresses,
-the codecopy with a PUSH2 label.
+the chain is priced with the cheapest literal encoding the optimization
+level can produce and PUSH1 addresses, the codecopy with a PUSH2 label.
 """
 
 from vyper.utils import ceil32, evm_not
@@ -25,13 +24,16 @@ def _nbytes(val: int) -> int:
     return (val.bit_length() + 7) // 8
 
 
-def push_cost(word: int) -> int:
+def push_cost(word: int, reduced: bool) -> int:
     """
-    Bytes of the cheapest encoding of a word: PUSHn, PUSH + NOT, or
-    PUSH + PUSH1 + SHL (the forms `ReduceLiteralsCodesize` produces).
+    Bytes of the cheapest encoding of a word: PUSHn, and when `reduced`
+    (the level runs `ReduceLiteralsCodesize`) also PUSH + NOT or
+    PUSH + PUSH1 + SHL.
     """
     assert 0 <= word < 2**256
     cost = 1 + _nbytes(word)
+    if not reduced:
+        return cost
     cost = min(cost, 1 + _nbytes(evm_not(word)) + 1)
     if word != 0:
         trailing_zero_bytes = ((word & -word).bit_length() - 1) // 8
@@ -40,11 +42,11 @@ def push_cost(word: int) -> int:
     return cost
 
 
-def chain_bytes(data: bytes) -> int:
+def chain_bytes(data: bytes, reduced: bool) -> int:
     """Code bytes for storing `data` word by word (the length word excluded)."""
     padded = data.ljust(ceil32(len(data)), b"\x00")
     words = [int.from_bytes(padded[i : i + WORD], "big") for i in range(0, len(padded), WORD)]
-    return sum(push_cost(word) + _ADDR_COST + 1 for word in words)
+    return sum(push_cost(word, reduced) + _ADDR_COST + 1 for word in words)
 
 
 def codecopy_bytes(length: int, padded: bool) -> int:
@@ -59,10 +61,11 @@ def codecopy_bytes(length: int, padded: bool) -> int:
     return length + _CODECOPY_COST + tail_store
 
 
-def should_codecopy(data: bytes, padded: bool) -> bool:
+def should_codecopy(data: bytes, padded: bool, reduced: bool) -> bool:
     """
     Whether `data` is estimated to be smaller as a codecopy than as an
-    mstore chain. A single word is never worth a data section.
+    mstore chain (`reduced`: see `push_cost`). A single word is never
+    worth a data section.
 
     Runtime gas cannot get worse in the padded form: the chain costs at
     least 8 gas per word, the codecopy 15 + 3 gas per word, and the size
@@ -70,4 +73,4 @@ def should_codecopy(data: bytes, padded: bool) -> bool:
     """
     if len(data) <= WORD:
         return False
-    return codecopy_bytes(len(data), padded) < chain_bytes(data)
+    return codecopy_bytes(len(data), padded) < chain_bytes(data, reduced)

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -266,15 +266,17 @@ class VenomCodegenContext:
                 offset = self.builder.add(val.operand, IRLiteral(32 + i))
                 self.builder.mstore(offset, IRLiteral(word))
 
-        # the length store goes last: LoadAnalysis forgets every forwardable
-        # store at a non-mstore memory write, so a codecopy after it would
-        # keep the length from being constant-folded by its consumers
+        # the length store goes last so that loads of the length stay
+        # forwardable no matter how precisely LoadAnalysis models the copy
         self.ptr_store(val.ptr(), IRLiteral(len(data)))
 
         return val
 
     def _codecopy_bytestring_literal(self, ptr: IRVariable, data: bytes, padded: bool) -> None:
         """Copy the data of a constant bytestring from a new data section."""
+        # known limitation: if the literal turns out to be dead, dead store
+        # elimination removes the codecopy but the data item stays in the
+        # bytecode
         item = data
         if padded:
             item = data.ljust(ceil32(len(data)), b"\x00")

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -19,7 +19,7 @@ from vyper.codegen.core import punnable
 from vyper.codegen_venom.buffer import Buffer, Ptr
 from vyper.codegen_venom.bytestring_literal import should_codecopy
 from vyper.codegen_venom.value import VyperValue
-from vyper.compiler.settings import _opt_codesize, _opt_lowering_only_ir
+from vyper.compiler.settings import _opt_codesize, _opt_lowering_only_ir, get_global_settings
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import CompilerPanic, MemoryAllocationException, StateAccessViolation
 from vyper.semantics.data_locations import DataLocation
@@ -39,8 +39,10 @@ from vyper.semantics.types.module import ModuleT
 from vyper.semantics.types.subscriptable import DArrayT, SArrayT
 from vyper.semantics.types.user import StructT
 from vyper.utils import IDENTITY_PRECOMPILE, ceil32
+from vyper.venom import OPTIMIZATION_PASSES
 from vyper.venom.basicblock import IRLabel, IRLiteral, IROperand, IRVariable
 from vyper.venom.builder import VenomBuilder
+from vyper.venom.passes import ReduceLiteralsCodesize
 
 
 class Constancy(Enum):
@@ -63,6 +65,14 @@ class LocalVariable:
             raise CompilerPanic("LocalVariable.value must be located")
         if self.value.location != DataLocation.MEMORY:  # pragma: nocover
             raise CompilerPanic("LocalVariable must be in MEMORY")
+
+
+def _reduced_pushes() -> bool:
+    """Whether the pipeline rewrites literals into the NOT/SHL forms (O3, Os)."""
+    settings = get_global_settings()
+    assert settings is not None and settings.optimize is not None
+    passes = OPTIMIZATION_PASSES[settings.optimize]
+    return any((p[0] if isinstance(p, tuple) else p) is ReduceLiteralsCodesize for p in passes)
 
 
 @dataclass
@@ -239,7 +249,7 @@ class VenomCodegenContext:
         # up identical to the mstore chain. the lowering-only levels keep the
         # chain, they are not meant to optimize.
         padded = not _opt_codesize()
-        if not _opt_lowering_only_ir() and should_codecopy(data, padded):
+        if not _opt_lowering_only_ir() and should_codecopy(data, padded, _reduced_pushes()):
             self._codecopy_bytestring_literal(val.operand, data, padded)
         else:
             for i in range(0, len(data), 32):

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -17,7 +17,9 @@ from typing import Optional, Sequence
 
 from vyper.codegen.core import punnable
 from vyper.codegen_venom.buffer import Buffer, Ptr
+from vyper.codegen_venom.bytestring_literal import should_codecopy
 from vyper.codegen_venom.value import VyperValue
+from vyper.compiler.settings import _opt_codesize, _opt_lowering_only_ir
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import CompilerPanic, MemoryAllocationException, StateAccessViolation
 from vyper.semantics.data_locations import DataLocation
@@ -36,7 +38,7 @@ from vyper.semantics.types.function import ContractFunctionT, StateMutability
 from vyper.semantics.types.module import ModuleT
 from vyper.semantics.types.subscriptable import DArrayT, SArrayT
 from vyper.semantics.types.user import StructT
-from vyper.utils import IDENTITY_PRECOMPILE
+from vyper.utils import IDENTITY_PRECOMPILE, ceil32
 from vyper.venom.basicblock import IRLabel, IRLiteral, IROperand, IRVariable
 from vyper.venom.builder import VenomBuilder
 
@@ -232,14 +234,45 @@ class VenomCodegenContext:
         val = self.new_temporary_value(typ, annotation=annotation)
         assert isinstance(val.operand, IRVariable)
 
+        # the data item is exact at codesize levels (the last word is zeroed
+        # first) and padded to whole words otherwise; either way memory ends
+        # up identical to the mstore chain. the lowering-only levels keep the
+        # chain, they are not meant to optimize.
+        padded = not _opt_codesize()
+        if not _opt_lowering_only_ir() and should_codecopy(data, padded):
+            self._codecopy_bytestring_literal(val.operand, data, padded)
+        else:
+            for i in range(0, len(data), 32):
+                chunk = (data + b"\x00" * 31)[i : i + 32]
+                word = int.from_bytes(chunk, "big")
+                offset = self.builder.add(val.operand, IRLiteral(32 + i))
+                self.builder.mstore(offset, IRLiteral(word))
+
+        # the length store goes last: LoadAnalysis forgets every forwardable
+        # store at a non-mstore memory write, so a codecopy after it would
+        # keep the length from being constant-folded by its consumers
         self.ptr_store(val.ptr(), IRLiteral(len(data)))
-        for i in range(0, len(data), 32):
-            chunk = (data + b"\x00" * 31)[i : i + 32]
-            word = int.from_bytes(chunk, "big")
-            offset = self.builder.add(val.operand, IRLiteral(32 + i))
-            self.builder.mstore(offset, IRLiteral(word))
 
         return val
+
+    def _codecopy_bytestring_literal(self, ptr: IRVariable, data: bytes, padded: bool) -> None:
+        """Copy the data of a constant bytestring from a new data section."""
+        item = data
+        if padded:
+            item = data.ljust(ceil32(len(data)), b"\x00")
+        elif len(data) % 32 != 0:
+            # zero the last data word before the copy so the tail padding
+            # matches what the mstore chain writes
+            last_word = self.builder.add(ptr, IRLiteral(32 + len(data) - len(data) % 32))
+            self.builder.mstore(last_word, IRLiteral(0))
+
+        ctx = self.builder.ctx
+        label = IRLabel(ctx.get_next_label("literal").value, is_symbol=True)
+        ctx.append_data_section(label)
+        ctx.append_data_item(item)
+
+        data_ptr = self.builder.add(ptr, IRLiteral(32))
+        self.builder.codecopy(data_ptr, label, IRLiteral(len(item)))
 
     def dynamic_memory_value(
         self, ptr: IRVariable, typ: VyperType, annotation: Optional[str] = None

--- a/vyper/codegen_venom/context.py
+++ b/vyper/codegen_venom/context.py
@@ -19,7 +19,12 @@ from vyper.codegen.core import punnable
 from vyper.codegen_venom.buffer import Buffer, Ptr
 from vyper.codegen_venom.bytestring_literal import should_codecopy
 from vyper.codegen_venom.value import VyperValue
-from vyper.compiler.settings import _opt_codesize, _opt_lowering_only_ir, get_global_settings
+from vyper.compiler.settings import (
+    OptimizationLevel,
+    _opt_codesize,
+    _opt_lowering_only_ir,
+    get_global_settings,
+)
 from vyper.evm.opcodes import version_check
 from vyper.exceptions import CompilerPanic, MemoryAllocationException, StateAccessViolation
 from vyper.semantics.data_locations import DataLocation
@@ -70,8 +75,11 @@ class LocalVariable:
 def _reduced_pushes() -> bool:
     """Whether the pipeline rewrites literals into the NOT/SHL forms (O3, Os)."""
     settings = get_global_settings()
-    assert settings is not None and settings.optimize is not None
-    passes = OPTIMIZATION_PASSES[settings.optimize]
+    level = settings.optimize if settings is not None else None
+    if level is None:
+        # unset means the default level, as for `_opt_codesize()`
+        level = OptimizationLevel.default()
+    passes = OPTIMIZATION_PASSES[level]
     return any((p[0] if isinstance(p, tuple) else p) is ReduceLiteralsCodesize for p in passes)
 
 

--- a/vyper/codegen_venom/module.py
+++ b/vyper/codegen_venom/module.py
@@ -196,15 +196,6 @@ def generate_deploy_venom(
     # Create deploy IR context
     deploy_ctx = IRContext()
 
-    # Add runtime bytecode as data section
-    deploy_ctx.append_data_section(IRLabel("runtime_begin"))
-    deploy_ctx.append_data_item(runtime_bytecode)
-
-    # Add CBOR metadata if provided
-    if cbor_metadata is not None:
-        deploy_ctx.append_data_section(IRLabel("cbor_metadata"))
-        deploy_ctx.append_data_item(cbor_metadata)
-
     deploy_fn = deploy_ctx.create_function("deploy")
     deploy_ctx.entry_function = deploy_fn  # Mark as entry point
     deploy_builder = VenomBuilder(deploy_ctx, deploy_fn)
@@ -236,6 +227,17 @@ def generate_deploy_venom(
     else:
         # No constructor - just deploy runtime
         _generate_simple_deploy(deploy_builder, len(runtime_bytecode), immutables_len)
+
+    # Add runtime bytecode as data section. This comes after lowering, which
+    # may add data sections of its own (bytestring literals), so that the
+    # metadata stays the last bytes of the initcode.
+    deploy_ctx.append_data_section(IRLabel("runtime_begin"))
+    deploy_ctx.append_data_item(runtime_bytecode)
+
+    # Add CBOR metadata if provided
+    if cbor_metadata is not None:
+        deploy_ctx.append_data_section(IRLabel("cbor_metadata"))
+        deploy_ctx.append_data_item(cbor_metadata)
 
     return deploy_ctx
 


### PR DESCRIPTION
### What I did

Emit constant `Bytes`/`String` literals in `codegen_venom` as a `codecopy` from a
data section instead of a chain of `mstore`s, when a code size estimate says the
copy is smaller. Supersedes #3501 (legacy, closed) and the venom-pass approach
discussed there.

### How I did it

`vyper/codegen_venom/bytestring_literal.py` prices the two forms:

- the mstore chain, using the cheapest literal encoding the current optimization
  level can produce — `ReduceLiteralsCodesize` runs only in the O3 and Os pass
  lists, so PUSH+NOT / PUSH+SHL are priced only there, plain PUSHn otherwise;
- the codecopy, as the data item plus PUSH1 size / PUSH1 dst / PUSH2 label /
  SWAP1 / CODECOPY.

Both estimates are biased towards the chain, so a mispredicted case can only fall
back to today's code. Literals of one word or less never convert.

`const_bytestring_value` then emits either form. The data item is word-padded at
gas levels, and exact plus one `mstore 0` over the last word at codesize levels
(32 bytes of data-section padding costs more than the 4-byte store, but the store
costs gas). Both forms leave memory bit-identical to the mstore chain, which is
required because word-rounded bulk copies (`store_storage`, `_copy_complex_type`)
propagate bytes past the string length into storage. The length store is emitted
after the copy so length `mload`s stay foldable.

`generate_deploy_venom` now appends the `runtime_begin` and `cbor_metadata`
sections after the constructor is lowered, because lowering can now append data
sections of its own and the metadata must stay at the end of the initcode.

Known limitation: if the literal is dead, DSE drops the codecopy but the data item
stays in the bytecode.

### How to verify it

### Commit message

```
every `Bytes`/`String` literal is materialized word by word, one push +
`mstore` per 32 bytes of payload, costing roughly 36 bytes of code per
32 bytes of data. copying the bytes out of a data section instead costs
the data plus ~9 bytes of fixed overhead, so from three dense words up
it is smaller and never more gas.

the gate is a code size estimate rather than a word count, because
`ReduceLiteralsCodesize` turns sparse words into cheap PUSH+NOT/PUSH+SHL
forms that still occupy a full 32 bytes in the data section, and a fixed
threshold regressed exactly the string-heavy contracts it was meant to
help; the estimate is biased towards the chain, so a wrong guess only
leaves today's code. the data item is word-padded at gas levels and
exact plus one `mstore 0` over the last word at codesize levels, both of
which leave memory bit-identical to the chain -- word-rounded bulk
copies propagate bytes past the length into storage, where they are
observable on-chain. the length store now comes after the copy so length
loads keep folding, and the deploy context appends
`runtime_begin`/`cbor_metadata` after lowering so the metadata stays at
the end of the initcode.
```

### Description for the changelog

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
